### PR TITLE
feat(transformer): support transforming static import and export to commonjs

### DIFF
--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -4,7 +4,10 @@ mod utils;
 
 use crate::commonjs::options::CommonjsOptions;
 use crate::context::Ctx;
-use oxc_ast::ast::{BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, PropertyKey, TSTypeAnnotation};
+use oxc_ast::ast::{
+    BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration,
+    ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, PropertyKey, TSTypeAnnotation,
+};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
 use utils::import;
@@ -99,11 +102,19 @@ impl<'a> Traverse<'a> for Commonjs<'a> {
         };
     }
 
-    fn enter_export_default_declaration(&mut self, node: &mut ExportDefaultDeclaration<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn enter_export_default_declaration(
+        &mut self,
+        node: &mut ExportDefaultDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         todo!()
     }
 
-    fn enter_export_named_declaration(&mut self, node: &mut ExportNamedDeclaration<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn enter_export_named_declaration(
+        &mut self,
+        node: &mut ExportNamedDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         todo!()
     }
 }

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -1,0 +1,101 @@
+mod options;
+mod types;
+mod utils;
+
+use crate::commonjs::options::CommonjsOptions;
+use crate::context::Ctx;
+use oxc_ast::ast::{
+    BindingPattern, ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, PropertyKey,
+    TSTypeAnnotation, TSTypeParameterInstantiation, VariableDeclarationKind,
+};
+use oxc_span::{Atom, SPAN};
+use oxc_traverse::{Traverse, TraverseCtx};
+
+pub struct Commonjs<'a> {
+    ctx: Ctx<'a>,
+    options: CommonjsOptions,
+}
+
+impl<'a> Commonjs<'a> {
+    pub fn new(options: CommonjsOptions, ctx: Ctx<'a>) -> Self {
+        Self { ctx, options }
+    }
+}
+
+impl<'a> Traverse<'a> for Commonjs<'a> {
+    fn enter_import_declaration(
+        &mut self,
+        node: &mut ImportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let stmt = match &node.specifiers {
+            None => utils::create_empty_require(&node.source.value, &self.ctx.ast),
+            Some(specifiers) => {
+                let star_specifier = specifiers.iter().find(|specifier| {
+                    matches!(specifier, ImportDeclarationSpecifier::ImportNamespaceSpecifier(_))
+                });
+                if let Some(specifier) = star_specifier {
+                    utils::create_namespaced_require(
+                        &node.source.value,
+                        match specifier {
+                            ImportDeclarationSpecifier::ImportNamespaceSpecifier(ns) => {
+                                ns.local.name.as_str()
+                            }
+                            _ => unreachable!(),
+                        },
+                        &self.ctx.ast,
+                        false,
+                    )
+                } else {
+                    let assignees: Vec<(PropertyKey<'a>, BindingPattern<'a>)> = specifiers
+                        .iter()
+                        .map(|specifier| match specifier {
+                            ImportDeclarationSpecifier::ImportDefaultSpecifier(decl) => (
+                                self.ctx.ast.property_key_identifier_name(SPAN, "default"),
+                                self.ctx.ast.binding_pattern(
+                                    self.ctx.ast.binding_pattern_kind_binding_identifier(
+                                        SPAN,
+                                        &decl.local.name,
+                                    ),
+                                    None::<TSTypeAnnotation>,
+                                    false,
+                                ),
+                            ),
+                            ImportDeclarationSpecifier::ImportSpecifier(decl) => (
+                                match &decl.imported {
+                                    ModuleExportName::IdentifierName(name) => self
+                                        .ctx
+                                        .ast
+                                        .property_key_identifier_name(SPAN, name.name.as_str()),
+                                    ModuleExportName::StringLiteral(literal) => {
+                                        self.ctx.ast.property_key_expression(
+                                            self.ctx
+                                                .ast
+                                                .expression_string_literal(SPAN, &literal.value),
+                                        )
+                                    }
+                                    _ => unreachable!(),
+                                },
+                                self.ctx.ast.binding_pattern(
+                                    self.ctx.ast.binding_pattern_kind_binding_identifier(
+                                        SPAN,
+                                        &decl.local.name,
+                                    ),
+                                    None::<TSTypeAnnotation>,
+                                    false,
+                                ),
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect();
+                    utils::create_general_require(
+                        &node.source.value,
+                        assignees,
+                        &self.ctx.ast,
+                        false,
+                    )
+                }
+            }
+        };
+    }
+}

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -4,8 +4,9 @@ mod utils;
 
 use crate::commonjs::options::CommonjsOptions;
 use crate::commonjs::utils::export::{
-    create_declared_named_exports, create_default_exports, create_listed_named_exports,
-    create_reexported_named_exports,
+    create_declared_named_exports, create_default_exports, create_export_star_exports,
+    create_listed_named_exports, create_reexported_named_exports,
+    create_renamed_export_star_exports,
 };
 use crate::context::Ctx;
 use oxc_allocator::CloneIn;
@@ -133,6 +134,22 @@ impl<'a> Traverse<'a> for Commonjs<'a> {
         } else {
             let specifiers = node.specifiers.clone_in(self.ctx.ast.allocator);
             create_listed_named_exports(specifiers, &self.ctx.ast)
+        };
+    }
+
+    fn enter_export_all_declaration(
+        &mut self,
+        node: &mut ExportAllDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let stmt = if let Some(reexported) = &node.exported {
+            create_renamed_export_star_exports(
+                node.source.value.as_str(),
+                reexported.clone_in(self.ctx.ast.allocator),
+                &self.ctx.ast,
+            )
+        } else {
+            create_export_star_exports(node.source.value.as_str(), &self.ctx.ast)
         };
     }
 }

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -21,12 +21,12 @@ use utils::import;
 
 pub struct Commonjs<'a> {
     ctx: Ctx<'a>,
-    _options: CommonjsOptions,
+    options: CommonjsOptions,
 }
 
 impl<'a> Commonjs<'a> {
     pub fn new(options: CommonjsOptions, ctx: Ctx<'a>) -> Self {
-        Self { ctx, _options: options }
+        Self { ctx, options }
     }
 }
 
@@ -167,6 +167,9 @@ impl<'a> Commonjs<'a> {
 
 impl<'a> Traverse<'a> for Commonjs<'a> {
     fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        if !self.options.transform_import_and_export {
+            return;
+        }
         let mut latest = self.ctx.ast.vec();
 
         for stmt in self.ctx.ast.move_vec(&mut program.body) {

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -126,11 +126,7 @@ impl<'a> Traverse<'a> for Commonjs<'a> {
             create_declared_named_exports(decl.clone_in(self.ctx.ast.allocator), &self.ctx.ast)
         } else if let Some(src) = &node.source {
             let specifiers = node.specifiers.clone_in(self.ctx.ast.allocator);
-            create_reexported_named_exports(
-                specifiers,
-                src.clone_in(self.ctx.ast.allocator),
-                &self.ctx.ast,
-            )
+            create_reexported_named_exports(specifiers, src.value.as_str(), &self.ctx.ast)
         } else {
             let specifiers = node.specifiers.clone_in(self.ctx.ast.allocator);
             create_listed_named_exports(specifiers, &self.ctx.ast)

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -10,7 +10,11 @@ use crate::commonjs::utils::export::{
 };
 use crate::context::Ctx;
 use oxc_allocator::CloneIn;
-use oxc_ast::ast::{BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, Program, PropertyKey, Statement, TSTypeAnnotation};
+use oxc_ast::ast::{
+    BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration,
+    ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, Program, PropertyKey,
+    Statement, TSTypeAnnotation,
+};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
 use utils::import;
@@ -155,7 +159,7 @@ impl<'a> Commonjs<'a> {
 impl<'a> Traverse<'a> for Commonjs<'a> {
     fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         let mut latest = self.ctx.ast.vec();
-        
+
         for stmt in self.ctx.ast.move_vec(&mut program.body) {
             match stmt {
                 Statement::ImportDeclaration(s) => {
@@ -177,7 +181,7 @@ impl<'a> Traverse<'a> for Commonjs<'a> {
                 }
             }
         }
-        
+
         program.body = latest;
     }
 }

--- a/crates/oxc_transformer/src/commonjs/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/mod.rs
@@ -2,15 +2,14 @@ mod options;
 mod types;
 mod utils;
 
+use oxc_allocator::CloneIn;
 use crate::commonjs::options::CommonjsOptions;
 use crate::context::Ctx;
-use oxc_ast::ast::{
-    BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration,
-    ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, PropertyKey, TSTypeAnnotation,
-};
+use oxc_ast::ast::{BindingPattern, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, PropertyKey, TSTypeAnnotation};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
 use utils::import;
+use crate::commonjs::utils::export::{create_declared_named_exports, create_default_exports, create_listed_named_exports, create_reexported_named_exports};
 
 pub struct Commonjs<'a> {
     ctx: Ctx<'a>,
@@ -102,19 +101,20 @@ impl<'a> Traverse<'a> for Commonjs<'a> {
         };
     }
 
-    fn enter_export_default_declaration(
-        &mut self,
-        node: &mut ExportDefaultDeclaration<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        todo!()
+    fn enter_export_default_declaration(&mut self, node: &mut ExportDefaultDeclaration<'a>, ctx: &mut TraverseCtx<'a>) {
+        let expr = node.declaration.clone_in(self.ctx.ast.allocator);
+        let stmt = create_default_exports(expr.into_expression(), &self.ctx.ast);
     }
 
-    fn enter_export_named_declaration(
-        &mut self,
-        node: &mut ExportNamedDeclaration<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        todo!()
+    fn enter_export_named_declaration(&mut self, node: &mut ExportNamedDeclaration<'a>, ctx: &mut TraverseCtx<'a>) {
+        let stmt = if let Some(decl) = &node.declaration {
+            create_declared_named_exports(decl.clone_in(self.ctx.ast.allocator), &self.ctx.ast)
+        } else if let Some(src) = &node.source {
+            let specifiers = node.specifiers.clone_in(self.ctx.ast.allocator);
+            create_reexported_named_exports(specifiers, src.clone_in(self.ctx.ast.allocator), &self.ctx.ast)
+        } else {
+            let specifiers = node.specifiers.clone_in(self.ctx.ast.allocator);
+            create_listed_named_exports(specifiers, &self.ctx.ast)
+        };
     }
 }

--- a/crates/oxc_transformer/src/commonjs/options.rs
+++ b/crates/oxc_transformer/src/commonjs/options.rs
@@ -10,4 +10,6 @@ pub struct CommonjsOptions {
     pub loose: bool,
     #[serde(skip)]
     pub strict: bool,
+    #[serde(skip)]
+    pub transform_import_and_export: bool,
 }

--- a/crates/oxc_transformer/src/commonjs/options.rs
+++ b/crates/oxc_transformer/src/commonjs/options.rs
@@ -1,0 +1,13 @@
+use crate::commonjs::types::import_interop::ImportInterop;
+use serde::Deserialize;
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommonjsOptions {
+    #[serde(skip)]
+    pub import_interop: ImportInterop,
+    #[serde(skip)]
+    pub loose: bool,
+    #[serde(skip)]
+    pub strict: bool,
+}

--- a/crates/oxc_transformer/src/commonjs/types/import_interop.rs
+++ b/crates/oxc_transformer/src/commonjs/types/import_interop.rs
@@ -1,0 +1,24 @@
+use serde::Deserialize;
+use std::str::FromStr;
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum ImportInterop {
+    #[default]
+    Babel,
+    Node,
+    None,
+}
+
+impl FromStr for ImportInterop {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "babel" => Ok(Self::Babel),
+            "node" => Ok(Self::Node),
+            "none" => Ok(Self::None),
+            _ => Err(()),
+        }
+    }
+}

--- a/crates/oxc_transformer/src/commonjs/types/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod import_interop;

--- a/crates/oxc_transformer/src/commonjs/utils.rs
+++ b/crates/oxc_transformer/src/commonjs/utils.rs
@@ -1,0 +1,107 @@
+use oxc_ast::ast::{
+    BindingPattern, BindingRestElement, Expression, ImportDeclarationSpecifier, ModuleExportName,
+    PropertyKey, Statement, TSTypeAnnotation, TSTypeParameterInstantiation,
+    VariableDeclarationKind,
+};
+use oxc_ast::AstBuilder;
+use oxc_span::{Atom, SPAN};
+
+fn create_require<'a>(target: &str, builder: &'a AstBuilder) -> Expression<'a> {
+    builder.expression_call(
+        SPAN,
+        builder.expression_identifier_reference(SPAN, "require"),
+        None::<TSTypeParameterInstantiation>,
+        builder.vec1(builder.argument_expression(builder.expression_string_literal(SPAN, target))),
+        false,
+    )
+}
+
+/// Generate the `require` bond for a given target.
+/// e.g. for `fs`:
+/// ```js
+/// require('fs')
+/// ```
+///
+/// It can be transformed from:
+///
+/// ```js
+/// import 'fs'
+/// ```
+pub fn create_empty_require<'a>(target: &str, builder: &'a AstBuilder) -> Statement<'a> {
+    builder.statement_expression(SPAN, create_require(target, builder))
+}
+
+/// Generate a namespaced `require` bond for a given target and assignee.
+/// e.g. for `fs`:
+/// ```js
+/// const fs = require('fs')
+/// ```
+///
+/// It can be transformed from:
+///
+/// ```js
+/// import * as fs from 'fs'
+/// ```
+pub fn create_namespaced_require<'a>(
+    target: &str,
+    assignee: &str,
+    builder: &'a AstBuilder,
+    const_bindings: bool,
+) -> Statement<'a> {
+    let bindings =
+        if const_bindings { VariableDeclarationKind::Const } else { VariableDeclarationKind::Var };
+    builder.statement_declaration(builder.declaration_variable(
+        SPAN,
+        bindings,
+        builder.vec1(builder.variable_declarator(
+            SPAN,
+            bindings,
+            builder.binding_pattern(
+                builder.binding_pattern_kind_binding_identifier(SPAN, assignee),
+                None::<TSTypeAnnotation>,
+                false,
+            ),
+            Some(create_require(target, builder)),
+            false,
+        )),
+        false,
+    ))
+}
+
+pub fn create_general_require<'a>(
+    target: &str,
+    assignees: Vec<(PropertyKey<'a>, BindingPattern<'a>)>, // (property, imported)
+    builder: &'a AstBuilder,
+    const_bindings: bool,
+) -> Statement<'a> {
+    let bindings =
+        if const_bindings { VariableDeclarationKind::Const } else { VariableDeclarationKind::Var };
+    builder.statement_declaration(builder.declaration_variable(
+        SPAN,
+        bindings,
+        builder.vec1(builder.variable_declarator(
+            SPAN,
+            bindings,
+            builder.binding_pattern(
+                builder.binding_pattern_kind_object_pattern(
+                    SPAN,
+                    {
+                        let mut items = builder.vec();
+                        for (property, imported) in assignees {
+                            items.push(
+                                builder.binding_property(SPAN, property, imported, false, false),
+                            );
+                        }
+                        items
+                    },
+                    None::<BindingRestElement>,
+                ),
+                None::<TSTypeAnnotation>,
+                false,
+            ),
+            Some(create_require(target, builder)),
+            false,
+        )),
+        false,
+    ))
+}

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -1,6 +1,5 @@
 //! It is not `amd define`, but for `Object.defineProperty` related codes.
 
-use std::borrow::Cow;
 use oxc_ast::ast::{
     BindingRestElement, Expression, FormalParameterKind, FunctionType, IdentifierReference,
     PropertyKind, Statement, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
@@ -9,17 +8,18 @@ use oxc_ast::ast::{
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
 use oxc_syntax::identifier;
+use std::borrow::Cow;
 
 /// Generates `Object.defineProperty` call for a given target.
-/// 
+///
 /// Useful when re-exporting:
-/// 
+///
 /// ```js
 /// export { foo as bar } from './foobar.js'
 /// ```
-/// 
+///
 /// It can be transformed from:
-/// 
+///
 /// ```js
 /// Object.defineProperty(exports, 'bar', {
 ///   enumerable: true,
@@ -48,7 +48,9 @@ pub fn create_object_define_property<'a>(
                 builder
                     .argument_expression(builder.expression_identifier_reference(SPAN, "exports")),
             );
-            items.push(builder.argument_expression(builder.expression_from_identifier_reference(target)));
+            items.push(
+                builder.argument_expression(builder.expression_from_identifier_reference(target)),
+            );
             items.push(builder.argument_expression(builder.expression_object(
                 SPAN,
                 {
@@ -120,8 +122,9 @@ pub fn legitimize_identifier_name(name: &str) -> Cow<str> {
     }
 
     if first_invalid_char_index.is_none() {
-        first_invalid_char_index =
-            chars_indices.find(|(_idx, char)| !identifier::is_identifier_part(*char)).map(|(idx, _)| idx);
+        first_invalid_char_index = chars_indices
+            .find(|(_idx, char)| !identifier::is_identifier_part(*char))
+            .map(|(idx, _)| idx);
     }
 
     if let Some(first_invalid_char_index) = first_invalid_char_index {

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -1,6 +1,10 @@
 //! It is not `amd define`, but for `Object.defineProperty` related codes.
 
-use oxc_ast::ast::{BindingRestElement, Expression, FormalParameterKind, FunctionType, ModuleExportName, PropertyKind, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation};
+use oxc_ast::ast::{
+    BindingRestElement, Expression, FormalParameterKind, FunctionType, ModuleExportName,
+    PropertyKind, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
+    TSTypeParameterInstantiation,
+};
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
 use oxc_syntax::identifier;
@@ -44,13 +48,15 @@ pub fn create_object_define_property<'a>(
                 builder
                     .argument_expression(builder.expression_identifier_reference(SPAN, "exports")),
             );
-            items.push(
-                builder.argument_expression(match target {
-                    ModuleExportName::IdentifierReference(id) => builder.expression_from_identifier_reference(id),
-                    ModuleExportName::StringLiteral(id) => builder.expression_from_string_literal(id),
-                    ModuleExportName::IdentifierName(id) => builder.expression_string_literal(SPAN, id.name.as_str())
-                }),
-            );
+            items.push(builder.argument_expression(match target {
+                ModuleExportName::IdentifierReference(id) => {
+                    builder.expression_from_identifier_reference(id)
+                }
+                ModuleExportName::StringLiteral(id) => builder.expression_from_string_literal(id),
+                ModuleExportName::IdentifierName(id) => {
+                    builder.expression_string_literal(SPAN, id.name.as_str())
+                }
+            }));
             items.push(builder.argument_expression(builder.expression_object(
                 SPAN,
                 {

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -1,10 +1,6 @@
 //! It is not `amd define`, but for `Object.defineProperty` related codes.
 
-use oxc_ast::ast::{
-    BindingRestElement, Expression, FormalParameterKind, FunctionType, IdentifierReference,
-    PropertyKind, Statement, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
-    TSTypeParameterInstantiation,
-};
+use oxc_ast::ast::{BindingRestElement, Expression, FormalParameterKind, FunctionType, IdentifierReference, ModuleExportName, PropertyKind, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation};
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
 use oxc_syntax::identifier;
@@ -29,7 +25,7 @@ use std::borrow::Cow;
 /// })
 /// ```
 pub fn create_object_define_property<'a>(
-    target: IdentifierReference<'a>,
+    target: ModuleExportName<'a>,
     expression: Expression<'a>,
     builder: &'a AstBuilder,
 ) -> Expression<'a> {
@@ -49,7 +45,11 @@ pub fn create_object_define_property<'a>(
                     .argument_expression(builder.expression_identifier_reference(SPAN, "exports")),
             );
             items.push(
-                builder.argument_expression(builder.expression_from_identifier_reference(target)),
+                builder.argument_expression(match target {
+                    ModuleExportName::IdentifierReference(id) => builder.expression_from_identifier_reference(id),
+                    ModuleExportName::StringLiteral(id) => builder.expression_from_string_literal(id),
+                    ModuleExportName::IdentifierName(id) => builder.expression_string_literal(SPAN, id.name.as_str())
+                }),
             );
             items.push(builder.argument_expression(builder.expression_object(
                 SPAN,

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -1,6 +1,6 @@
 //! It is not `amd define`, but for `Object.defineProperty` related codes.
 
-use oxc_ast::ast::{BindingRestElement, Expression, FormalParameterKind, FunctionType, IdentifierReference, ModuleExportName, PropertyKind, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation};
+use oxc_ast::ast::{BindingRestElement, Expression, FormalParameterKind, FunctionType, ModuleExportName, PropertyKind, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation};
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
 use oxc_syntax::identifier;

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -112,8 +112,8 @@ pub fn create_object_define_property<'a>(
     )
 }
 
-/// Port from `rolldown`: https://github.com/rolldown/rolldown/blob/main/crates/rolldown_utils/src/ecma_script.rs#L16-L51.
-pub fn legitimize_identifier_name(name: &str) -> Cow<str> {
+/// Port from `rolldown`: <https://github.com/rolldown/rolldown/blob/main/crates/rolldown_utils/src/ecma_script.rs#L16-L51>.
+fn legitimize_identifier_name(name: &str) -> Cow<str> {
     let mut legitimized = String::new();
     let mut chars_indices = name.char_indices();
 

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -1,0 +1,142 @@
+//! It is not `amd define`, but for `Object.defineProperty` related codes.
+
+use std::borrow::Cow;
+use oxc_ast::ast::{
+    BindingRestElement, Expression, FormalParameterKind, FunctionType, IdentifierReference,
+    PropertyKind, Statement, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
+    TSTypeParameterInstantiation,
+};
+use oxc_ast::AstBuilder;
+use oxc_span::SPAN;
+use oxc_syntax::identifier;
+
+/// Generates `Object.defineProperty` call for a given target.
+/// 
+/// Useful when re-exporting:
+/// 
+/// ```js
+/// export { foo as bar } from './foobar.js'
+/// ```
+/// 
+/// It can be transformed from:
+/// 
+/// ```js
+/// Object.defineProperty(exports, 'bar', {
+///   enumerable: true,
+///   get: function () {
+///     return foobar.foo;
+///   }
+/// })
+/// ```
+pub fn create_object_define_property<'a>(
+    target: IdentifierReference<'a>,
+    expression: Expression<'a>,
+    builder: &'a AstBuilder,
+) -> Expression<'a> {
+    builder.expression_call(
+        SPAN,
+        builder.expression_member(builder.member_expression_static(
+            SPAN,
+            builder.expression_identifier_reference(SPAN, "Object"),
+            builder.identifier_name(SPAN, "defineProperty"),
+            false,
+        )),
+        None::<TSTypeParameterInstantiation>,
+        {
+            let mut items = builder.vec();
+            items.push(
+                builder
+                    .argument_expression(builder.expression_identifier_reference(SPAN, "exports")),
+            );
+            items.push(builder.argument_expression(builder.expression_from_identifier_reference(target)));
+            items.push(builder.argument_expression(builder.expression_object(
+                SPAN,
+                {
+                    let mut items = builder.vec();
+                    items.push(builder.object_property_kind_object_property(
+                        SPAN,
+                        PropertyKind::Init,
+                        builder.property_key_identifier_name(SPAN, "enumerable"),
+                        builder.expression_boolean_literal(SPAN, true),
+                        None,
+                        false,
+                        false,
+                        false,
+                    ));
+                    items.push(builder.object_property_kind_object_property(
+                        SPAN,
+                        PropertyKind::Init,
+                        builder.property_key_identifier_name(SPAN, "get"),
+                        builder.expression_function(
+                            FunctionType::FunctionExpression,
+                            SPAN,
+                            None,
+                            false,
+                            false,
+                            false,
+                            None::<TSTypeParameterDeclaration>,
+                            None::<TSThisParameter>,
+                            builder.formal_parameters(
+                                SPAN,
+                                FormalParameterKind::FormalParameter,
+                                builder.vec(),
+                                None::<BindingRestElement>,
+                            ),
+                            None::<TSTypeAnnotation>,
+                            Some(builder.function_body(
+                                SPAN,
+                                builder.vec(),
+                                builder.vec1(builder.statement_return(SPAN, Some(expression))),
+                            )),
+                        ),
+                        None,
+                        false,
+                        false,
+                        false,
+                    ));
+                    items
+                },
+                None,
+            )));
+            items
+        },
+        false,
+    )
+}
+
+/// Port from `rolldown`: https://github.com/rolldown/rolldown/blob/main/crates/rolldown_utils/src/ecma_script.rs#L16-L51.
+pub fn legitimize_identifier_name(name: &str) -> Cow<str> {
+    let mut legitimized = String::new();
+    let mut chars_indices = name.char_indices();
+
+    let mut first_invalid_char_index = None;
+
+    if let Some((idx, first_char)) = chars_indices.next() {
+        if identifier::is_identifier_start(first_char) {
+            // Nothing we need to do
+        } else {
+            first_invalid_char_index = Some(idx);
+        }
+    }
+
+    if first_invalid_char_index.is_none() {
+        first_invalid_char_index =
+            chars_indices.find(|(_idx, char)| !identifier::is_identifier_part(*char)).map(|(idx, _)| idx);
+    }
+
+    if let Some(first_invalid_char_index) = first_invalid_char_index {
+        let (first_valid_part, rest_part) = name.split_at(first_invalid_char_index);
+        legitimized.push_str(first_valid_part);
+        for char in rest_part.chars() {
+            if identifier::is_identifier_part(char) {
+                legitimized.push(char);
+            } else {
+                legitimized.push('_');
+            }
+        }
+
+        return Cow::Owned(legitimized);
+    }
+
+    Cow::Borrowed(name)
+}

--- a/crates/oxc_transformer/src/commonjs/utils/define.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/define.rs
@@ -113,7 +113,7 @@ pub fn create_object_define_property<'a>(
 }
 
 /// Port from `rolldown`: <https://github.com/rolldown/rolldown/blob/main/crates/rolldown_utils/src/ecma_script.rs#L16-L51>.
-fn legitimize_identifier_name(name: &str) -> Cow<str> {
+pub fn legitimize_identifier_name(name: &str) -> Cow<str> {
     let mut legitimized = String::new();
     let mut chars_indices = name.char_indices();
 

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -96,7 +96,7 @@ pub fn create_default_exports<'a>(
     } else {
         create_exports_with_assignment(
             builder.vec1((
-                "default",
+                "_default",
                 builder.module_export_name_identifier_name(SPAN, "_default"),
                 declaration,
             )),

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -97,7 +97,7 @@ pub fn create_default_exports<'a>(
         create_exports_with_assignment(
             builder.vec1((
                 "_default",
-                builder.module_export_name_identifier_name(SPAN, "_default"),
+                builder.module_export_name_identifier_name(SPAN, "default"),
                 declaration,
             )),
             VariableDeclarationKind::Var,
@@ -250,21 +250,21 @@ pub fn create_reexported_named_exports<'a>(
                 builder.expression_member(match specifier.local {
                     ModuleExportName::IdentifierName(name) => builder.member_expression_static(
                         SPAN,
-                        builder.expression_identifier_reference(SPAN, "exports"),
+                        builder.expression_identifier_reference(SPAN, ident.as_str()),
                         name,
                         false,
                     ),
                     ModuleExportName::StringLiteral(literal) => builder.member_expression_computed(
                         SPAN,
-                        builder.expression_identifier_reference(SPAN, "exports"),
+                        builder.expression_identifier_reference(SPAN, ident.as_str()),
                         builder.expression_from_string_literal(literal),
                         false,
                     ),
-                    ModuleExportName::IdentifierReference(ident) => {
+                    ModuleExportName::IdentifierReference(reference) => {
                         builder.member_expression_computed(
                             SPAN,
-                            builder.expression_identifier_reference(SPAN, "exports"),
-                            builder.expression_from_identifier_reference(ident),
+                            builder.expression_identifier_reference(SPAN, ident.as_str()),
+                            builder.expression_from_identifier_reference(reference),
                             false,
                         )
                     }
@@ -384,14 +384,14 @@ pub fn create_export_star_exports<'a>(
                                 SPAN,
                                 builder.expression_identifier_reference(SPAN, "key"),
                                 BinaryOperator::In,
-                                builder.expression_identifier_reference(SPAN, "exports"),
+                                builder.expression_identifier_reference(SPAN, ident.as_str()),
                             ),
                             LogicalOperator::And,
                             builder.expression_binary(
                                 SPAN,
                                 builder.expression_member(builder.member_expression_computed(
                                     SPAN,
-                                    builder.expression_identifier_reference(SPAN, "exports"),
+                                    builder.expression_identifier_reference(SPAN, ident.as_str()),
                                     builder.expression_identifier_reference(SPAN, "key"),
                                     false,
                                 )),

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -305,122 +305,125 @@ pub fn create_export_star_exports<'a>(
     )));
     // 2. Iterate the exports and assign them.
 
-    builder.expression_call(
+    result.push(builder.statement_expression(
         SPAN,
-        builder.expression_member(builder.member_expression_static(
+        builder.expression_call(
             SPAN,
-            builder.expression_call(
+            builder.expression_member(builder.member_expression_static(
                 SPAN,
-                builder.expression_member(builder.member_expression_static(
+                builder.expression_call(
                     SPAN,
-                    builder.expression_identifier_reference(SPAN, "Object"),
-                    builder.identifier_name(SPAN, "keys"),
-                    false,
-                )),
-                None::<TSTypeParameterInstantiation>,
-                builder.vec1(builder.argument_expression(
-                    builder.expression_identifier_reference(SPAN, ident.as_str()),
-                )),
-                false,
-            ),
-            builder.identifier_name(SPAN, "forEach"),
-            false,
-        )),
-        None::<TSTypeParameterInstantiation>,
-        builder.vec1(builder.argument_expression(builder.expression_function(
-            FunctionType::FunctionExpression,
-            SPAN,
-            None,
-            false,
-            false,
-            false,
-            None::<TSTypeParameterDeclaration>,
-            None::<TSThisParameter>,
-            builder.formal_parameters(
-                SPAN,
-                FormalParameterKind::FormalParameter,
-                builder.vec1(builder.formal_parameter(
-                    SPAN,
-                    builder.vec(),
-                    builder.binding_pattern(
-                        builder.binding_pattern_kind_binding_identifier(SPAN, "key"),
-                        None::<TSTypeAnnotation>,
+                    builder.expression_member(builder.member_expression_static(
+                        SPAN,
+                        builder.expression_identifier_reference(SPAN, "Object"),
+                        builder.identifier_name(SPAN, "keys"),
                         false,
-                    ),
-                    None::<TSAccessibility>,
+                    )),
+                    None::<TSTypeParameterInstantiation>,
+                    builder.vec1(builder.argument_expression(
+                        builder.expression_identifier_reference(SPAN, ident.as_str()),
+                    )),
                     false,
-                    false,
-                )),
-                None::<BindingRestElement>,
-            ),
-            None::<TSTypeAnnotation>,
-            Some(builder.function_body(SPAN, builder.vec(), {
-                let mut items = builder.vec();
-                items.push(builder.statement_if(
+                ),
+                builder.identifier_name(SPAN, "forEach"),
+                false,
+            )),
+            None::<TSTypeParameterInstantiation>,
+            builder.vec1(builder.argument_expression(builder.expression_function(
+                FunctionType::FunctionExpression,
+                SPAN,
+                None,
+                false,
+                false,
+                false,
+                None::<TSTypeParameterDeclaration>,
+                None::<TSThisParameter>,
+                builder.formal_parameters(
                     SPAN,
-                    builder.expression_logical(
+                    FormalParameterKind::FormalParameter,
+                    builder.vec1(builder.formal_parameter(
                         SPAN,
-                        builder.expression_binary(
-                            SPAN,
-                            builder.expression_identifier_reference(SPAN, "key"),
-                            BinaryOperator::StrictEquality,
-                            builder.expression_string_literal(SPAN, "default"),
+                        builder.vec(),
+                        builder.binding_pattern(
+                            builder.binding_pattern_kind_binding_identifier(SPAN, "key"),
+                            None::<TSTypeAnnotation>,
+                            false,
                         ),
-                        LogicalOperator::Or,
-                        builder.expression_binary(
-                            SPAN,
-                            builder.expression_identifier_reference(SPAN, "key"),
-                            BinaryOperator::StrictEquality,
-                            builder.expression_string_literal(SPAN, "__esModule"),
-                        ),
-                    ),
-                    builder.statement_return(SPAN, None),
-                    None,
-                ));
-                items.push(builder.statement_if(
-                    SPAN,
-                    builder.expression_logical(
+                        None::<TSAccessibility>,
+                        false,
+                        false,
+                    )),
+                    None::<BindingRestElement>,
+                ),
+                None::<TSTypeAnnotation>,
+                Some(builder.function_body(SPAN, builder.vec(), {
+                    let mut items = builder.vec();
+                    items.push(builder.statement_if(
                         SPAN,
-                        builder.expression_binary(
+                        builder.expression_logical(
                             SPAN,
-                            builder.expression_identifier_reference(SPAN, "key"),
-                            BinaryOperator::In,
-                            builder.expression_identifier_reference(SPAN, "exports"),
-                        ),
-                        LogicalOperator::And,
-                        builder.expression_binary(
-                            SPAN,
-                            builder.expression_member(builder.member_expression_computed(
+                            builder.expression_binary(
                                 SPAN,
+                                builder.expression_identifier_reference(SPAN, "key"),
+                                BinaryOperator::StrictEquality,
+                                builder.expression_string_literal(SPAN, "default"),
+                            ),
+                            LogicalOperator::Or,
+                            builder.expression_binary(
+                                SPAN,
+                                builder.expression_identifier_reference(SPAN, "key"),
+                                BinaryOperator::StrictEquality,
+                                builder.expression_string_literal(SPAN, "__esModule"),
+                            ),
+                        ),
+                        builder.statement_return(SPAN, None),
+                        None,
+                    ));
+                    items.push(builder.statement_if(
+                        SPAN,
+                        builder.expression_logical(
+                            SPAN,
+                            builder.expression_binary(
+                                SPAN,
+                                builder.expression_identifier_reference(SPAN, "key"),
+                                BinaryOperator::In,
                                 builder.expression_identifier_reference(SPAN, "exports"),
-                                builder.expression_identifier_reference(SPAN, "key"),
-                                false,
-                            )),
-                            BinaryOperator::StrictEquality,
-                            builder.expression_member(builder.member_expression_computed(
+                            ),
+                            LogicalOperator::And,
+                            builder.expression_binary(
                                 SPAN,
-                                builder.expression_identifier_reference(SPAN, ident.as_str()),
-                                builder.expression_identifier_reference(SPAN, "key"),
-                                false,
-                            )),
+                                builder.expression_member(builder.member_expression_computed(
+                                    SPAN,
+                                    builder.expression_identifier_reference(SPAN, "exports"),
+                                    builder.expression_identifier_reference(SPAN, "key"),
+                                    false,
+                                )),
+                                BinaryOperator::StrictEquality,
+                                builder.expression_member(builder.member_expression_computed(
+                                    SPAN,
+                                    builder.expression_identifier_reference(SPAN, ident.as_str()),
+                                    builder.expression_identifier_reference(SPAN, "key"),
+                                    false,
+                                )),
+                            ),
                         ),
-                    ),
-                    builder.statement_return(SPAN, None),
-                    None,
-                ));
-                items.push(builder.statement_expression(
-                    SPAN,
-                    create_object_define_property(
-                        builder.identifier_reference(SPAN, ident.as_str()),
-                        builder.expression_identifier_reference(SPAN, "key"),
-                        builder,
-                    ),
-                ));
-                items
-            })),
-        ))),
-        false,
-    );
+                        builder.statement_return(SPAN, None),
+                        None,
+                    ));
+                    items.push(builder.statement_expression(
+                        SPAN,
+                        create_object_define_property(
+                            builder.identifier_reference(SPAN, ident.as_str()),
+                            builder.expression_identifier_reference(SPAN, "key"),
+                            builder,
+                        ),
+                    ));
+                    items
+                })),
+            ))),
+            false,
+        ),
+    ));
     result
 }
 

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -67,7 +67,7 @@ fn create_exports_with_assignment<'a>(
                     ),
                     Some(create_exports(target, declaration, builder)),
                     false,
-                ))
+                ));
             }
             decls
         },
@@ -126,7 +126,7 @@ pub fn create_declared_named_exports<'a>(
                                 },
                                 builder,
                             ),
-                        ))
+                        ));
                     }
                     _ => unreachable!(),
                 }
@@ -219,12 +219,12 @@ pub fn create_listed_named_exports<'a>(
 ///
 pub fn create_reexported_named_exports<'a>(
     specifiers: Vec<'a, ExportSpecifier<'a>>,
-    source: StringLiteral<'a>,
+    source: &'a str,
     builder: &'a AstBuilder,
 ) -> Vec<'a, Statement<'a>> {
     let mut result = builder.vec();
     // TODO deconflict the name
-    let ident = legitimize_identifier_name(source.value.as_str()).to_string();
+    let ident = legitimize_identifier_name(source).to_string();
     // 1. Generate require
     result.push(builder.statement_declaration(builder.declaration_variable(
         SPAN,
@@ -237,7 +237,7 @@ pub fn create_reexported_named_exports<'a>(
                 None::<TSTypeAnnotation>,
                 false,
             ),
-            Some(create_require(source.value.as_str(), builder)),
+            Some(create_require(source, builder)),
             false,
         )),
         false,

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -99,17 +99,26 @@ pub fn create_named_exports<'a>(
     builder: &'a AstBuilder,
     kind: VariableDeclarationKind,
 ) -> Vec<'a, Statement<'a>> {
-    let graph = match declaration {
+    match declaration {
         Declaration::VariableDeclaration(decls) => {
-            decls.declarations.iter().map(|decl| {
+            let mut result = builder.vec();
+            for &decl in decls.unbox().declarations.iter() {
                 match &decl.id.kind {
                     BindingPatternKind::BindingIdentifier(id) => {
-                        (id.name.as_str(), builder.module_export_name_identifier_name(SPAN, id.name.as_str()), decl.init.iter().clone().next().unwrap_or(&builder.void_0()))
+                        result.push(builder.statement_expression(
+                            SPAN,
+                            create_exports(
+                                builder.module_export_name_identifier_name(SPAN, id.name.as_str()),
+                                decl.init.unwrap_or(builder.void_0()),
+                                builder,
+                            ),
+                        ))
                     }
                     _ => unreachable!()
                 }
-            }).collect::<Vec<(&str, ModuleExportName<'a>, Expression<'a>)>>()
+            }
+            result
         }
         _ => todo!()
-    };
+    }
 }

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -3,7 +3,7 @@ use crate::commonjs::utils::import::create_require;
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::ast::{
     BindingPatternKind, BindingRestElement, Declaration, ExportSpecifier, Expression,
-    FormalParameterKind, FunctionType, ModuleExportName, Statement, StringLiteral, TSAccessibility,
+    FormalParameterKind, FunctionType, ModuleExportName, Statement, TSAccessibility,
     TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation,
     VariableDeclarationKind,
 };
@@ -246,10 +246,7 @@ pub fn create_reexported_named_exports<'a>(
         result.push(builder.statement_expression(
             SPAN,
             create_object_define_property(
-                match specifier.exported {
-                    ModuleExportName::IdentifierReference(id) => id.clone_in(builder.allocator),
-                    _ => unreachable!(),
-                },
+                specifier.exported,
                 builder.expression_member(match specifier.local {
                     ModuleExportName::IdentifierName(name) => builder.member_expression_static(
                         SPAN,
@@ -413,7 +410,9 @@ pub fn create_export_star_exports<'a>(
                     items.push(builder.statement_expression(
                         SPAN,
                         create_object_define_property(
-                            builder.identifier_reference(SPAN, ident.as_str()),
+                            builder.module_export_name_from_identifier_reference(
+                                builder.identifier_reference(SPAN, ident.as_str()),
+                            ),
                             builder.expression_identifier_reference(SPAN, "key"),
                             builder,
                         ),

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -384,14 +384,14 @@ pub fn create_export_star_exports<'a>(
                                 SPAN,
                                 builder.expression_identifier_reference(SPAN, "key"),
                                 BinaryOperator::In,
-                                builder.expression_identifier_reference(SPAN, ident.as_str()),
+                                builder.expression_identifier_reference(SPAN, "exports"),
                             ),
                             LogicalOperator::And,
                             builder.expression_binary(
                                 SPAN,
                                 builder.expression_member(builder.member_expression_computed(
                                     SPAN,
-                                    builder.expression_identifier_reference(SPAN, ident.as_str()),
+                                    builder.expression_identifier_reference(SPAN, "exports"),
                                     builder.expression_identifier_reference(SPAN, "key"),
                                     false,
                                 )),

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -1,7 +1,9 @@
+use crate::commonjs::utils::define::{create_object_define_property, legitimize_identifier_name};
+use crate::commonjs::utils::import::create_require;
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::ast::{
-    BindingPatternKind, Declaration, Expression, ModuleExportName, Statement, TSTypeAnnotation,
-    VariableDeclarationKind,
+    BindingPatternKind, Declaration, ExportSpecifier, Expression, ModuleExportName, Statement,
+    StringLiteral, TSTypeAnnotation, TSTypeParameterInstantiation, VariableDeclarationKind,
 };
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
@@ -102,10 +104,9 @@ pub fn create_default_exports<'a>(
     }
 }
 
-pub fn create_named_exports<'a>(
+pub fn create_declared_named_exports<'a>(
     declaration: Declaration<'a>,
     builder: &'a AstBuilder,
-    kind: VariableDeclarationKind,
 ) -> Vec<'a, Statement<'a>> {
     match declaration {
         Declaration::VariableDeclaration(decls) => {
@@ -176,4 +177,102 @@ pub fn create_named_exports<'a>(
         }
         _ => todo!(),
     }
+}
+
+/// Generate the `exports` bond for all listed exports, which uses `export { foo, bar, bar_foo as foobar }`.
+/// It should be transformed to:
+///
+/// ```js
+/// exports.foo = foo
+/// exports.bar = bar
+/// exports.foobar = bar_foo
+/// ```
+pub fn create_listed_named_exports<'a>(
+    specifiers: Vec<'a, ExportSpecifier<'a>>,
+    builder: &'a AstBuilder,
+) -> Vec<'a, Statement<'a>> {
+    let mut result = builder.vec();
+    for specifier in specifiers {
+        result.push(builder.statement_expression(
+            SPAN,
+            create_exports(
+                specifier.exported,
+                match specifier.local {
+                    ModuleExportName::IdentifierReference(id) => {
+                        builder.expression_from_identifier_reference(id)
+                    }
+                    _ => unreachable!(),
+                },
+                builder,
+            ),
+        ));
+    }
+    result
+}
+
+/// Generate the `exports` bond for all renamed exports, which uses `export * as foo from 'bar'`.
+/// It should be transformed to:
+///
+/// ```js
+///
+pub fn create_reexported_named_exports<'a>(
+    specifiers: Vec<'a, ExportSpecifier<'a>>,
+    source: StringLiteral<'a>,
+    builder: &'a AstBuilder,
+) -> Vec<'a, Statement<'a>> {
+    let mut result = builder.vec();
+    // TODO deconflict the name
+    let ident = legitimize_identifier_name(source.value.as_str()).to_string();
+    // 1. Generate require
+    result.push(builder.statement_declaration(builder.declaration_variable(
+        SPAN,
+        VariableDeclarationKind::Const,
+        builder.vec1(builder.variable_declarator(
+            SPAN,
+            VariableDeclarationKind::Const,
+            builder.binding_pattern(
+                builder.binding_pattern_kind_binding_identifier(SPAN, ident.as_str()),
+                None::<TSTypeAnnotation>,
+                false,
+            ),
+            Some(create_require(source.value.as_str(), builder)),
+            false,
+        )),
+        false,
+    )));
+    for specifier in specifiers {
+        result.push(builder.statement_expression(
+            SPAN,
+            create_object_define_property(
+                match specifier.exported {
+                    ModuleExportName::IdentifierReference(id) => id.clone_in(builder.allocator),
+                    _ => unreachable!(),
+                },
+                builder.expression_member(match specifier.local {
+                    ModuleExportName::IdentifierName(name) => builder.member_expression_static(
+                        SPAN,
+                        builder.expression_identifier_reference(SPAN, "exports"),
+                        name,
+                        false,
+                    ),
+                    ModuleExportName::StringLiteral(literal) => builder.member_expression_computed(
+                        SPAN,
+                        builder.expression_identifier_reference(SPAN, "exports"),
+                        builder.expression_from_string_literal(literal),
+                        false,
+                    ),
+                    ModuleExportName::IdentifierReference(ident) => {
+                        builder.member_expression_computed(
+                            SPAN,
+                            builder.expression_identifier_reference(SPAN, "exports"),
+                            builder.expression_from_identifier_reference(ident),
+                            false,
+                        )
+                    }
+                }),
+                builder,
+            ),
+        ))
+    }
+    result
 }

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -1,0 +1,115 @@
+use oxc_allocator::Vec;
+use oxc_ast::ast::{BindingPattern, BindingPatternKind, BindingRestElement, Declaration, ExportDefaultDeclaration, Expression, ModuleExportName, PropertyKey, Statement, TSTypeAnnotation, TSTypeParameterInstantiation, VariableDeclarationKind};
+use oxc_ast::AstBuilder;
+use oxc_span::SPAN;
+use oxc_syntax::operator::AssignmentOperator;
+
+fn create_exports<'a>(
+    target: ModuleExportName<'a>,
+    declaration: Expression<'a>,
+    builder: &'a AstBuilder,
+) -> Expression<'a> {
+    let member_expression = match target {
+        ModuleExportName::IdentifierName(name) => builder.member_expression_static(
+            SPAN,
+            builder.expression_identifier_reference(SPAN, "exports"),
+            name,
+            false,
+        ),
+        ModuleExportName::StringLiteral(literal) => builder.member_expression_computed(
+            SPAN,
+            builder.expression_identifier_reference(SPAN, "exports"),
+            builder.expression_from_string_literal(literal),
+            false,
+        ),
+        ModuleExportName::IdentifierReference(_) => unreachable!(),
+    };
+    builder.expression_assignment(
+        SPAN,
+        AssignmentOperator::Assign,
+        builder.assignment_target_simple(
+            builder.simple_assignment_target_member_expression(member_expression),
+        ),
+        declaration,
+    )
+}
+
+fn create_exports_with_assignment<'a>(
+    assigns: Vec<(&str, ModuleExportName<'a>, Expression<'a>)>,
+    kind: VariableDeclarationKind,
+    builder: &'a AstBuilder,
+) -> Statement<'a> {
+    builder.statement_declaration(builder.declaration_variable(
+        SPAN,
+        kind,
+        {
+            let mut decls = builder.vec();
+            for (assignee, target, declaration) in assigns {
+                decls.push(builder.variable_declarator(
+                    SPAN,
+                    kind,
+                    builder.binding_pattern(
+                        builder.binding_pattern_kind_binding_identifier(SPAN, assignee),
+                        None::<TSTypeAnnotation>,
+                        false,
+                    ),
+                    Some(create_exports(target, declaration, builder)),
+                    false,
+                ))
+            }
+            decls
+        },
+        false,
+    ))
+}
+
+/// Generate the default `exports` bond for a given declaration.
+/// e.g. for `export default foo`:
+/// ```js
+/// exports.default = foo
+/// ```
+pub fn create_default_exports<'a>(
+    declaration: Expression<'a>,
+    builder: &'a AstBuilder,
+) -> Statement<'a> {
+    if declaration.is_identifier_reference() {
+        builder.statement_expression(
+            SPAN,
+            create_exports(
+                builder.module_export_name_identifier_name(SPAN, "default"),
+                declaration,
+                builder,
+            ),
+        )
+    } else {
+        create_exports_with_assignment(
+            builder.vec1((
+                "default",
+                builder.module_export_name_identifier_name(SPAN, "_default"),
+                declaration,
+            )),
+            VariableDeclarationKind::Var,
+            builder,
+        )
+    }
+}
+
+pub fn create_named_exports<'a>(
+    declaration: Declaration<'a>,
+    builder: &'a AstBuilder,
+    kind: VariableDeclarationKind,
+) -> Vec<'a, Statement<'a>> {
+    let graph = match declaration {
+        Declaration::VariableDeclaration(decls) => {
+            decls.declarations.iter().map(|decl| {
+                match &decl.id.kind {
+                    BindingPatternKind::BindingIdentifier(id) => {
+                        (id.name.as_str(), builder.module_export_name_identifier_name(SPAN, id.name.as_str()), decl.init.iter().clone().next().unwrap_or(&builder.void_0()))
+                    }
+                    _ => unreachable!()
+                }
+            }).collect::<Vec<(&str, ModuleExportName<'a>, Expression<'a>)>>()
+        }
+        _ => todo!()
+    };
+}

--- a/crates/oxc_transformer/src/commonjs/utils/export.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/export.rs
@@ -177,7 +177,7 @@ pub fn create_declared_named_exports<'a>(
             }
             result
         }
-        _ => todo!(),
+        _ => unreachable!(),
     }
 }
 

--- a/crates/oxc_transformer/src/commonjs/utils/import.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/import.rs
@@ -5,7 +5,7 @@ use oxc_ast::ast::{
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
 
-fn create_require<'a>(target: &str, builder: &'a AstBuilder) -> Expression<'a> {
+pub fn create_require<'a>(target: &str, builder: &'a AstBuilder) -> Expression<'a> {
     builder.expression_call(
         SPAN,
         builder.expression_identifier_reference(SPAN, "require"),

--- a/crates/oxc_transformer/src/commonjs/utils/import.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/import.rs
@@ -18,13 +18,11 @@ pub fn create_require<'a>(target: &str, builder: &'a AstBuilder) -> Expression<'
 /// Generate the `require` bond for a given target.
 /// e.g. for `fs`:
 /// ```js
-/// require('fs')
-/// ```
-///
-/// It can be transformed from:
-///
-/// ```js
 /// import 'fs'
+/// ```
+/// It can be transformed to:
+/// ```js
+/// require('fs')
 /// ```
 pub fn create_empty_require<'a>(target: &str, builder: &'a AstBuilder) -> Statement<'a> {
     builder.statement_expression(SPAN, create_require(target, builder))
@@ -33,13 +31,11 @@ pub fn create_empty_require<'a>(target: &str, builder: &'a AstBuilder) -> Statem
 /// Generate a namespaced `require` bond for a given target and assignee.
 /// e.g. for `fs`:
 /// ```js
-/// const fs = require('fs')
-/// ```
-///
-/// It can be transformed from:
-///
-/// ```js
 /// import * as fs from 'fs'
+/// ```
+/// It can be transformed to:
+/// ```js
+/// const fs = require('fs')
 /// ```
 pub fn create_namespaced_require<'a>(
     target: &str,

--- a/crates/oxc_transformer/src/commonjs/utils/import.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/import.rs
@@ -1,10 +1,9 @@
 use oxc_ast::ast::{
-    BindingPattern, BindingRestElement, Expression, ImportDeclarationSpecifier, ModuleExportName,
-    PropertyKey, Statement, TSTypeAnnotation, TSTypeParameterInstantiation,
-    VariableDeclarationKind,
+    BindingPattern, BindingRestElement, Expression, PropertyKey, Statement, TSTypeAnnotation,
+    TSTypeParameterInstantiation, VariableDeclarationKind,
 };
 use oxc_ast::AstBuilder;
-use oxc_span::{Atom, SPAN};
+use oxc_span::SPAN;
 
 fn create_require<'a>(target: &str, builder: &'a AstBuilder) -> Expression<'a> {
     builder.expression_call(
@@ -68,7 +67,7 @@ pub fn create_namespaced_require<'a>(
     ))
 }
 
-pub fn create_general_require<'a>(
+pub fn create_named_require<'a>(
     target: &str,
     assignees: Vec<(PropertyKey<'a>, BindingPattern<'a>)>, // (property, imported)
     builder: &'a AstBuilder,

--- a/crates/oxc_transformer/src/commonjs/utils/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod export;
+pub mod import;

--- a/crates/oxc_transformer/src/commonjs/utils/mod.rs
+++ b/crates/oxc_transformer/src/commonjs/utils/mod.rs
@@ -1,2 +1,3 @@
+mod define;
 pub mod export;
 pub mod import;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -405,6 +405,7 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.enter_export_named_declaration(node, ctx);
+        self.x1_commonjs.enter_export_named_declaration(node, ctx);
     }
 
     fn enter_ts_export_assignment(

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -13,6 +13,7 @@ mod compiler_assumptions;
 mod context;
 mod options;
 // Presets: <https://babel.dev/docs/presets>
+mod commonjs;
 mod env;
 mod es2015;
 mod es2016;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -45,6 +45,7 @@ use oxc_span::{SourceType, SPAN};
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 use regexp::RegExp;
 
+use crate::commonjs::Commonjs;
 pub use crate::{
     compiler_assumptions::CompilerAssumptions,
     env::{EnvOptions, Targets},
@@ -59,7 +60,6 @@ use crate::{
     react::React,
     typescript::TypeScript,
 };
-use crate::commonjs::Commonjs;
 
 pub struct TransformerReturn {
     pub errors: std::vec::Vec<OxcDiagnostic>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -59,6 +59,7 @@ use crate::{
     react::React,
     typescript::TypeScript,
 };
+use crate::commonjs::Commonjs;
 
 pub struct TransformerReturn {
     pub errors: std::vec::Vec<OxcDiagnostic>,
@@ -70,6 +71,7 @@ pub struct Transformer<'a> {
     ctx: Ctx<'a>,
     // NOTE: all callbacks must run in order.
     x0_typescript: TypeScript<'a>,
+    x1_commonjs: Commonjs<'a>,
     x1_react: React<'a>,
     x2_es2021: ES2021<'a>,
     x2_es2020: ES2020<'a>,
@@ -100,6 +102,7 @@ impl<'a> Transformer<'a> {
         Self {
             ctx: Rc::clone(&ctx),
             x0_typescript: TypeScript::new(options.typescript, Rc::clone(&ctx)),
+            x1_commonjs: Commonjs::new(options.commonjs, Rc::clone(&ctx)),
             x1_react: React::new(options.react, Rc::clone(&ctx)),
             x2_es2021: ES2021::new(options.es2021, Rc::clone(&ctx)),
             x2_es2020: ES2020::new(options.es2020, Rc::clone(&ctx)),
@@ -130,8 +133,9 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     }
 
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x1_react.exit_program(program, ctx);
         self.x0_typescript.exit_program(program, ctx);
+        self.x1_react.exit_program(program, ctx);
+        self.x1_commonjs.exit_program(program, ctx);
         self.x3_es2015.exit_program(program, ctx);
     }
 

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use oxc_diagnostics::{Error, OxcDiagnostic};
 use serde_json::{from_value, json, Value};
 
+use crate::commonjs::options::CommonjsOptions;
 use crate::{
     compiler_assumptions::CompilerAssumptions,
     env::{can_enable_plugin, EnvOptions, Versions},
@@ -18,7 +19,6 @@ use crate::{
     typescript::TypeScriptOptions,
     ReactRefreshOptions,
 };
-use crate::commonjs::options::CommonjsOptions;
 
 /// <https://babel.dev/docs/options>
 #[derive(Debug, Default, Clone)]
@@ -54,7 +54,7 @@ pub struct TransformOptions {
     pub es2020: ES2020Options,
 
     pub es2021: ES2021Options,
-    
+
     pub commonjs: CommonjsOptions,
 }
 

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -89,10 +89,7 @@ impl TransformOptions {
             es2019: ES2019Options { optional_catch_binding: true },
             es2020: ES2020Options { nullish_coalescing_operator: true },
             es2021: ES2021Options { logical_assignment_operators: true },
-            commonjs: CommonjsOptions {
-                transform_import_and_export: false,
-                ..Default::default()
-            }
+            commonjs: CommonjsOptions { transform_import_and_export: false, ..Default::default() },
         }
     }
 

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -18,6 +18,7 @@ use crate::{
     typescript::TypeScriptOptions,
     ReactRefreshOptions,
 };
+use crate::commonjs::options::CommonjsOptions;
 
 /// <https://babel.dev/docs/options>
 #[derive(Debug, Default, Clone)]
@@ -53,6 +54,8 @@ pub struct TransformOptions {
     pub es2020: ES2020Options,
 
     pub es2021: ES2021Options,
+    
+    pub commonjs: CommonjsOptions,
 }
 
 impl TransformOptions {

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -89,6 +89,10 @@ impl TransformOptions {
             es2019: ES2019Options { optional_catch_binding: true },
             es2020: ES2020Options { nullish_coalescing_operator: true },
             es2021: ES2021Options { logical_assignment_operators: true },
+            commonjs: CommonjsOptions {
+                transform_import_and_export: false,
+                ..Default::default()
+            }
         }
     }
 

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: a709f989
 
 semantic_typescript Summary:
 AST Parsed     : 6479/6479 (100.00%)
-Positive Passed: 3259/6479 (50.30%)
+Positive Passed: 2671/6479 (41.23%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -139,6 +139,14 @@ Unresolved references mismatch:
 after transform: ["Date", "undefined"]
 rebuilt        : ["console", "fs", "process", "undefined"]
 
+tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I", "T"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -201,6 +209,42 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["M"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["N"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["N", "R", "X", "_M"]
+rebuilt        : ScopeId(1): ["N", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+
 tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExtendedMapper", "ExtendedMapper1", "ExtendedMapper2", "a", "a1", "a2", "a3", "b", "b1", "b2", "b3", "check", "check1", "check2", "check3", "test", "test1", "test2", "test3"]
@@ -252,6 +296,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Color"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
 semantic error: Missing SymbolId: D
 Missing SymbolId: _D
@@ -285,6 +337,20 @@ tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.t
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "E", "non identifier"]
+rebuilt        : ScopeId(2): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
 semantic error: Bindings mismatch:
@@ -425,6 +491,17 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(5)]
 rebuilt        : SymbolId(1): []
 
+tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Configurable", "Constructor"]
+rebuilt        : ScopeId(0): ["Configurable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "base"]
+rebuilt        : ScopeId(1): ["base"]
+
 tasks/coverage/typescript/tests/cases/compiler/amdModuleConstEnumUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "CharCode"]
@@ -440,6 +517,17 @@ tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Constructor", "Timestamped", "wrapClass"]
+rebuilt        : ScopeId(0): ["Timestamped", "wrapClass"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(5): ["Base", "TBase"]
+rebuilt        : ScopeId(4): ["Base"]
 
 tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
 semantic error: Missing SymbolId: M
@@ -633,10 +721,13 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "arr", "depth"]
 rebuilt        : ScopeId(1): ["arr", "depth"]
 
+tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInferenceDeclarations.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "arr", "depth"]
+rebuilt        : ScopeId(1): ["arr", "depth"]
+
 tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
-semantic error: Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
+semantic error: Expected `(` but found `await`
 
 tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
 semantic error: Bindings mismatch:
@@ -1440,9 +1531,6 @@ rebuilt        : ScopeId(13): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(28), ReferenceId(32), ReferenceId(33), ReferenceId(36), ReferenceId(38), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
 rebuilt        : SymbolId(1): [ReferenceId(24), ReferenceId(28), ReferenceId(31)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(29): [ReferenceId(30), ReferenceId(31)]
-rebuilt        : SymbolId(25): [ReferenceId(25)]
 
 tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 semantic error: Bindings mismatch:
@@ -1486,6 +1574,11 @@ tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(17), ScopeId(33), ScopeId(45), ScopeId(51)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(32), ScopeId(44), ScopeId(50)]
+
+tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Broken", "TypeB"]
+rebuilt        : ScopeId(0): ["Broken"]
 
 tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 semantic error: Bindings mismatch:
@@ -1668,6 +1761,14 @@ Unresolved references mismatch:
 after transform: ["this"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/circularInstantiationExpression.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved reference IDs mismatch for "foo":
+after transform: [ReferenceId(1), ReferenceId(3)]
+rebuilt        : [ReferenceId(0)]
+
 tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
@@ -1675,6 +1776,11 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Capitalize", "foo2"]
 rebuilt        : ["foo2"]
+
+tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Db", "foo"]
+rebuilt        : ScopeId(0): ["foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
 semantic error: Missing SymbolId: _maker
@@ -1940,6 +2046,23 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 
+tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "Class", "Fields", "OutputFrom", "Pretty", "Schema", "Self", "Type"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(18)]
+rebuilt        : SymbolId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("Class")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: ["JSON", "string"]
+rebuilt        : ["Class", "JSON", "string"]
+
 tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
@@ -1979,6 +2102,88 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(3)]
 
+tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: b
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Missing SymbolId: m2
+Missing SymbolId: _m2
+Missing SymbolId: m3
+Missing SymbolId: _m3
+Missing ReferenceId: _m3
+Missing ReferenceId: c
+Missing ReferenceId: _m3
+Missing ReferenceId: ib2
+Missing ReferenceId: m3
+Missing ReferenceId: m3
+Missing ReferenceId: _m2
+Missing ReferenceId: _m2
+Missing ReferenceId: m2
+Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(17), SymbolId(18), SymbolId(22), SymbolId(26)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(9), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(19)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(14), ScopeId(15), ScopeId(19), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(31), ScopeId(35)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(22)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+Bindings mismatch:
+after transform: ScopeId(15): ["_m", "b", "d", "ib"]
+rebuilt        : ScopeId(11): ["_m", "b", "d"]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
+rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(14), SymbolId(31)]
+rebuilt        : ScopeId(14): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(20): [SymbolId(15), SymbolId(16), SymbolId(32)]
+rebuilt        : ScopeId(15): [SymbolId(12), SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(31): [ScopeId(32), ScopeId(33), ScopeId(34)]
+rebuilt        : ScopeId(20): [ScopeId(21)]
+Scope children mismatch:
+after transform: ScopeId(35): [ScopeId(36), ScopeId(37), ScopeId(38)]
+rebuilt        : ScopeId(22): [ScopeId(23)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(7): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(13): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(13): [ReferenceId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(14): [ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("m1")
+rebuilt        : ReferenceId(17): Some("m1")
+Unresolved references mismatch:
+after transform: ["m1"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
 semantic error: Missing SymbolId: M
 Missing SymbolId: _M
@@ -1993,9 +2198,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(9)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
@@ -2173,6 +2375,32 @@ rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "Action", "B", "a", "actionA", "actionB", "b", "call", "printFn"]
+rebuilt        : ScopeId(0): ["actionA", "actionB", "call", "printFn"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(6): ["TName", "TPayload", "action", "fn"]
+rebuilt        : ScopeId(1): ["action", "fn"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(24), ReferenceId(29)]
+rebuilt        : SymbolId(0): [ReferenceId(11)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): [ReferenceId(25), ReferenceId(32)]
+rebuilt        : SymbolId(1): [ReferenceId(14)]
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("a")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("b")
+rebuilt        : ReferenceId(4): None
+Unresolved references mismatch:
+after transform: ["console", "fab", "foo"]
+rebuilt        : ["a", "b", "console", "fab", "foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
 semantic error: Bindings mismatch:
@@ -2582,9 +2810,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
@@ -3067,8 +3292,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Color", "b", "g", "r"]
 rebuilt        : ScopeId(1): ["Color"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -3094,13 +3319,375 @@ Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
 
+tasks/coverage/typescript/tests/cases/compiler/commentsCommentParsing.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsDottedModuleName.ts
+semantic error: Missing SymbolId: outerModule
+Missing SymbolId: _outerModule
+Missing SymbolId: InnerModule
+Missing SymbolId: _InnerModule
+Missing ReferenceId: _InnerModule
+Missing ReferenceId: b
+Missing ReferenceId: InnerModule
+Missing ReferenceId: InnerModule
+Missing ReferenceId: _outerModule
+Missing ReferenceId: _outerModule
+Missing ReferenceId: outerModule
+Missing ReferenceId: outerModule
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsEnums.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Colors", "Cornflower", "FancyPink"]
+rebuilt        : ScopeId(1): ["Colors"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules2.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules3.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/commentsFormatting.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: c2
+Missing ReferenceId: _m
+Missing ReferenceId: c3
+Missing ReferenceId: _m
+Missing ReferenceId: c4
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(5): [ReferenceId(7)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsInheritance.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["c1", "c1_i", "c2", "c2_i", "c3", "c3_i", "c4", "c4_i", "i1", "i1_i", "i2", "i2_i", "i3", "i3_i"]
+rebuilt        : ScopeId(0): ["c1", "c1_i", "c2", "c2_i", "c3", "c3_i", "c4", "c4_i", "i1_i", "i2_i", "i3_i"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(11), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(33)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(16), ScopeId(22)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsInterface.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["i1", "i1_i", "i2", "i2_i", "i2_i_fnfoo", "i2_i_fnfoo_r", "i2_i_foo", "i2_i_foo_r", "i2_i_i2_ii", "i2_i_i2_si", "i2_i_n", "i2_i_nc_fnfoo", "i2_i_nc_fnfoo_r", "i2_i_nc_foo", "i2_i_nc_foo_r", "i2_i_nc_x", "i2_i_r", "i2_i_x", "i3", "i3_i", "nc_i1", "nc_i1_i"]
+rebuilt        : ScopeId(0): ["i1_i", "i2_i", "i2_i_fnfoo", "i2_i_fnfoo_r", "i2_i_foo", "i2_i_foo_r", "i2_i_i2_ii", "i2_i_i2_si", "i2_i_n", "i2_i_nc_fnfoo", "i2_i_nc_fnfoo_r", "i2_i_nc_foo", "i2_i_nc_foo_r", "i2_i_nc_x", "i2_i_r", "i2_i_x", "i3_i", "nc_i1_i"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsModules.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
+semantic error: Missing SymbolId: multiM
+Missing SymbolId: _multiM
+Missing ReferenceId: _multiM
+Missing ReferenceId: b
+Missing ReferenceId: multiM
+Missing ReferenceId: multiM
+Missing SymbolId: _multiM2
+Missing ReferenceId: _multiM2
+Missing ReferenceId: c
+Missing ReferenceId: _multiM2
+Missing ReferenceId: e
+Missing ReferenceId: multiM
+Missing ReferenceId: multiM
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(5): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("multiM")
+rebuilt        : ReferenceId(10): Some("multiM")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("multiM")
+rebuilt        : ReferenceId(11): Some("multiM")
+
+tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleSingleFile.ts
+semantic error: Missing SymbolId: multiM
+Missing SymbolId: _multiM
+Missing ReferenceId: _multiM
+Missing ReferenceId: b
+Missing ReferenceId: _multiM
+Missing ReferenceId: d
+Missing ReferenceId: multiM
+Missing ReferenceId: multiM
+Missing SymbolId: _multiM2
+Missing ReferenceId: _multiM2
+Missing ReferenceId: c
+Missing ReferenceId: _multiM2
+Missing ReferenceId: e
+Missing ReferenceId: multiM
+Missing ReferenceId: multiM
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(5): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("multiM")
+rebuilt        : ReferenceId(12): Some("multiM")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("multiM")
+rebuilt        : ReferenceId(13): Some("multiM")
+
 tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Component", "JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Component", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Component", "JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["Component", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["c", "c1", "c1_i_1", "c1_i_2", "c2", "c2_i_1", "c2_i_2", "c3", "c3_i_1", "c3_i_2", "c4", "c4_i_1", "c4_i_2", "c5", "c5_i_1", "c5_i_2", "c_i", "f1", "f2", "f3", "f4", "i1", "i1_i", "i2", "i2_i", "i3", "i3_i", "i4"]
+rebuilt        : ScopeId(0): ["c", "c1", "c1_i_1", "c1_i_2", "c2", "c2_i_1", "c2_i_2", "c3", "c3_i_1", "c3_i_2", "c4", "c4_i_1", "c4_i_2", "c5", "c5_i_1", "c5_i_2", "c_i", "f1", "f2", "f3", "f4", "i1_i", "i2_i", "i3_i"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(27), ScopeId(30), ScopeId(33), ScopeId(36), ScopeId(52), ScopeId(56), ScopeId(60), ScopeId(64), ScopeId(68)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19)]
+Scope children mismatch:
+after transform: ScopeId(36): [ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51)]
+rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+Scope children mismatch:
+after transform: ScopeId(52): [ScopeId(53), ScopeId(54), ScopeId(55)]
+rebuilt        : ScopeId(11): [ScopeId(12)]
+Scope children mismatch:
+after transform: ScopeId(56): [ScopeId(57), ScopeId(58), ScopeId(59)]
+rebuilt        : ScopeId(13): [ScopeId(14)]
+Scope children mismatch:
+after transform: ScopeId(60): [ScopeId(61), ScopeId(62), ScopeId(63)]
+rebuilt        : ScopeId(15): [ScopeId(16)]
+Scope children mismatch:
+after transform: ScopeId(64): [ScopeId(65), ScopeId(66), ScopeId(67)]
+rebuilt        : ScopeId(17): [ScopeId(18)]
+Scope children mismatch:
+after transform: ScopeId(68): [ScopeId(69), ScopeId(70), ScopeId(71)]
+rebuilt        : ScopeId(19): [ScopeId(20)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["U", "a"]
+rebuilt        : ScopeId(2): ["a"]
+Bindings mismatch:
+after transform: ScopeId(3): ["U", "a"]
+rebuilt        : ScopeId(3): ["a"]
+Bindings mismatch:
+after transform: ScopeId(4): ["U", "a"]
+rebuilt        : ScopeId(4): ["a"]
+Bindings mismatch:
+after transform: ScopeId(5): ["U", "a"]
+rebuilt        : ScopeId(5): ["a"]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "a", "b"]
+rebuilt        : ScopeId(6): ["a", "b"]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: b
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Bindings mismatch:
+after transform: ScopeId(0): ["c", "color", "foo", "fooVar", "i", "i1", "i1_i", "m1", "myVariable", "shade", "x"]
+rebuilt        : ScopeId(0): ["c", "color", "foo", "fooVar", "i", "i1_i", "m1", "myVariable", "shade"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(10), ScopeId(13), ScopeId(17)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(8), ScopeId(11)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Bindings mismatch:
+after transform: ScopeId(13): ["_m", "b", "m2"]
+rebuilt        : ScopeId(8): ["_m", "b"]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(13): [ScopeId(14), ScopeId(16)]
+rebuilt        : ScopeId(8): [ScopeId(9)]
+Bindings mismatch:
+after transform: ScopeId(17): ["blue", "color", "green", "red"]
+rebuilt        : ScopeId(11): ["color"]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(0x0)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(11): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(11): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(17): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(16)]
+rebuilt        : SymbolId(13): [ReferenceId(17), ReferenceId(18)]
+
+tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: b
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Bindings mismatch:
+after transform: ScopeId(0): ["c", "foo", "fooVar", "i", "i1", "i1_i", "m1", "myVariable", "x"]
+rebuilt        : ScopeId(0): ["c", "foo", "fooVar", "i", "i1_i", "m1", "myVariable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(10), ScopeId(13)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(8)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Bindings mismatch:
+after transform: ScopeId(13): ["_m", "b", "m2"]
+rebuilt        : ScopeId(8): ["_m", "b"]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(13): [ScopeId(14), ScopeId(16)]
+rebuilt        : ScopeId(8): [ScopeId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(11): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(11): [ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -3128,8 +3715,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["AutomationMode", "LOCATION", "NONE", "SYSTEM", "TIME"]
 rebuilt        : ScopeId(1): ["AutomationMode"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -3232,6 +3819,54 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(14): [ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31)]
 rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(27), ReferenceId(28)]
 
+tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeWidening.ts
+semantic error: Missing ReferenceId: E
+Missing ReferenceId: E
+Missing ReferenceId: E
+Missing ReferenceId: E
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "E", "E2", "MyDeclaredEnum", "MyEnum", "c1", "c2", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
+rebuilt        : ScopeId(0): ["C", "E", "MyEnum", "c1", "c2", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "D", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["A", "B", "C", "MyEnum"]
+rebuilt        : ScopeId(7): ["MyEnum"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(35), ReferenceId(37), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(46), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(78)]
+rebuilt        : SymbolId(0): [ReferenceId(13), ReferenceId(14), ReferenceId(18), ReferenceId(23), ReferenceId(24), ReferenceId(31), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(61): [ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77)]
+rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(51): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(42): SymbolFlags(FunctionScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(49): Some("E2")
+rebuilt        : ReferenceId(48): None
+Reference symbol mismatch:
+after transform: ReferenceId(66): Some("MyDeclaredEnum")
+rebuilt        : ReferenceId(69): None
+Reference symbol mismatch:
+after transform: ReferenceId(68): Some("MyDeclaredEnum")
+rebuilt        : ReferenceId(71): None
+Unresolved references mismatch:
+after transform: ["computed", "const"]
+rebuilt        : ["E2", "MyDeclaredEnum"]
+
 tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
 semantic error: Missing SymbolId: NS
 Missing SymbolId: _NS
@@ -3253,6 +3888,14 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("NS")
 rebuilt        : ReferenceId(2): Some("NS")
+
+tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["O"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 semantic error: Bindings mismatch:
@@ -3378,6 +4021,14 @@ Unresolved references mismatch:
 after transform: ["Field"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["JSONSchema4"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExcludeWithDefault", "ExtractWithDefault", "TemplatedConditional", "fn1", "fn10", "fn11", "fn12", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8", "fn9", "x", "z", "zee"]
@@ -3461,6 +4112,55 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/constDeclarations2.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "C", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "E2"]
+rebuilt        : ScopeId(2): ["E2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/typescript/tests/cases/compiler/constEnumExternalModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -3472,18 +4172,15 @@ Missing ReferenceId: foo
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
@@ -3501,15 +4198,12 @@ Missing ReferenceId: foo
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -3531,20 +4225,17 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "foo"]
 rebuilt        : ScopeId(1): ["foo"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
 rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -3572,21 +4263,15 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -3602,15 +4287,12 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -4244,6 +4926,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
 
+tasks/coverage/typescript/tests/cases/compiler/constructorTypeWithTypeParameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T", "X", "Y", "anotherVar"]
+rebuilt        : ScopeId(0): ["anotherVar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(11)]
@@ -4672,14 +5362,14 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsxFileName", "_reactJsxRuntime", "a", "y"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "a", "y"]
+after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsx", "_jsxFileName", "a", "y"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "a", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(21), ScopeId(22)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Unresolved references mismatch:
-after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "require", "undefined"]
-rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
+after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "undefined"]
+rebuilt        : ["App4", "app", "app2", "app3", "foo", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
 semantic error: Bindings mismatch:
@@ -4740,6 +5430,14 @@ Unresolved references mismatch:
 after transform: ["AsyncGenerator", "Generator", "Promise"]
 rebuilt        : ["Promise"]
 
+tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Box", "Observable", "bb1", "bb2", "bn1", "bn2", "x"]
+rebuilt        : ScopeId(0): ["bb1", "bb2", "bn1", "bn2", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ADT", "invoke", "kind"]
@@ -4755,8 +5453,8 @@ rebuilt        : ScopeId(1): ["arg"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Elements", "Props", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Elements", "Props", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
@@ -4838,6 +5536,26 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Record", "test"]
 rebuilt        : ["test"]
+
+tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "Action", "B", "ab", "x"]
+rebuilt        : ScopeId(0): ["A", "B", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(10), ReferenceId(14)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(3), ReferenceId(12)]
+rebuilt        : SymbolId(1): [ReferenceId(6)]
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("ab")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Symbol", "f"]
+rebuilt        : ["Symbol", "ab", "f"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
 semantic error: Bindings mismatch:
@@ -5086,8 +5804,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "One", "Two"]
 rebuilt        : ScopeId(1): ["Choice"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -5146,6 +5864,83 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
 rebuilt        : [ReferenceId(0), ReferenceId(9)]
+
+tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "ACaller", "ALL_BARS", "ArgMap", "B", "BAR_LOOKUP", "BCaller", "BarLookup", "Baz", "Config", "DataEntry", "Ev", "FieldMap", "Foo", "Foo1", "FormField", "Func", "Funcs", "HandlerMap", "KeyOfOriginal", "Keys", "LetterCaller", "LetterMap", "MappedFromOriginal", "MyObj", "NestedKeyOfOriginalFor", "Original", "RecordMap", "RenderFunc", "RenderFuncMap", "SameKeys", "SelectFieldData", "TextFieldData", "TypeMap", "UnionRecord", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "process", "processEvents", "processRecord", "r1", "r2", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent", "xx"]
+rebuilt        : ScopeId(0): ["ALL_BARS", "BAR_LOOKUP", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "process", "processEvents", "processRecord", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(27), ScopeId(28), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(37), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(70), ScopeId(71), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(79), ScopeId(80), ScopeId(81), ScopeId(82), ScopeId(83), ScopeId(84)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35)]
+Bindings mismatch:
+after transform: ScopeId(4): ["K", "rec"]
+rebuilt        : ScopeId(1): ["rec"]
+Bindings mismatch:
+after transform: ScopeId(15): ["K", "field", "renderFn"]
+rebuilt        : ScopeId(5): ["field", "renderFn"]
+Bindings mismatch:
+after transform: ScopeId(24): ["K", "data"]
+rebuilt        : ScopeId(8): ["data"]
+Bindings mismatch:
+after transform: ScopeId(30): ["K", "caller", "letter"]
+rebuilt        : ScopeId(11): ["caller", "letter"]
+Bindings mismatch:
+after transform: ScopeId(37): ["K", "events"]
+rebuilt        : ScopeId(12): ["events"]
+Bindings mismatch:
+after transform: ScopeId(41): ["K", "callback", "name", "once"]
+rebuilt        : ScopeId(16): ["callback", "name", "once"]
+Bindings mismatch:
+after transform: ScopeId(46): ["ArgMap", "Keys", "apply", "funs", "x1", "x2"]
+rebuilt        : ScopeId(21): ["apply", "funs", "x1", "x2"]
+Scope children mismatch:
+after transform: ScopeId(46): [ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
+rebuilt        : ScopeId(21): [ScopeId(22), ScopeId(23), ScopeId(24)]
+Bindings mismatch:
+after transform: ScopeId(52): ["K", "args", "fn", "funKey"]
+rebuilt        : ScopeId(24): ["args", "fn", "funKey"]
+Bindings mismatch:
+after transform: ScopeId(57): ["K", "arg", "funcs", "key"]
+rebuilt        : ScopeId(25): ["arg", "funcs", "key"]
+Bindings mismatch:
+after transform: ScopeId(58): ["K", "arg", "func", "funcs", "key"]
+rebuilt        : ScopeId(26): ["arg", "func", "funcs", "key"]
+Bindings mismatch:
+after transform: ScopeId(59): ["K", "arg", "func", "funcs", "key"]
+rebuilt        : ScopeId(27): ["arg", "func", "funcs", "key"]
+Bindings mismatch:
+after transform: ScopeId(60): ["K", "x", "y"]
+rebuilt        : ScopeId(28): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(62): ["K", "k", "myObj", "myObj2"]
+rebuilt        : ScopeId(29): ["k", "myObj", "myObj2"]
+Bindings mismatch:
+after transform: ScopeId(66): ["T", "f", "prop"]
+rebuilt        : ScopeId(32): ["f", "prop"]
+Bindings mismatch:
+after transform: ScopeId(80): ["K", "N", "key", "mappedFromOriginal", "nestedKey", "original"]
+rebuilt        : ScopeId(33): ["key", "mappedFromOriginal", "nestedKey", "original"]
+Bindings mismatch:
+after transform: ScopeId(82): ["T", "assertedCheck", "defaultValue", "key", "userConfig", "userValue"]
+rebuilt        : ScopeId(34): ["assertedCheck", "defaultValue", "key", "userConfig", "userValue"]
+Bindings mismatch:
+after transform: ScopeId(84): ["K", "k", "o"]
+rebuilt        : ScopeId(35): ["k", "o"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(137): [ReferenceId(232)]
+rebuilt        : SymbolId(74): []
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("r1")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("r2")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(96): Some("xx")
+rebuilt        : ReferenceId(28): None
+Unresolved references mismatch:
+after transform: ["DocumentEventMap", "Partial", "ReadonlyArray", "Record", "Required", "bar", "console", "const", "document", "makeCompleteLookupMapping", "undefined"]
+rebuilt        : ["bar", "console", "document", "makeCompleteLookupMapping", "r1", "r2", "undefined", "xx"]
 
 tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
 semantic error: Missing SymbolId: M
@@ -5272,6 +6067,14 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(10)]
 rebuilt        : SymbolId(6): []
 
+tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["MainModule", "SubModule"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
@@ -5286,10 +6089,3012 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(3): [ReferenceId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["test"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["SubModule"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileCallSignatures.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ICallSignature", "ICallSignatureWithOverloads", "ICallSignatureWithOwnTypeParametes", "ICallSignatureWithParameters", "ICallSignatureWithRestParameters", "ICallSignatureWithTypeParameters"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileConstructSignatures.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IConstructSignature", "IConstructSignatureWithOverloads", "IConstructSignatureWithOwnTypeParametes", "IConstructSignatureWithParameters", "IConstructSignatureWithRestParameters", "IConstructSignatureWithTypeParameters"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileConstructors.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(7): [ScopeId(8)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "c", "e"]
+rebuilt        : ScopeId(1): ["e"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "c", "e1"]
+rebuilt        : ScopeId(1): ["e1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["a", "b", "c", "e2"]
+rebuilt        : ScopeId(2): ["e2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["a", "b", "c", "e3"]
+rebuilt        : ScopeId(3): ["e3"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["a", "b", "c", "d", "e", "e4"]
+rebuilt        : ScopeId(4): ["e4"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["Friday", "Saturday", "Sunday", "Weekend days", "e5"]
+rebuilt        : ScopeId(5): ["e5"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "D", "I", "J"]
+rebuilt        : ScopeId(0): ["A", "B", "D"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(2)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(3)]
+rebuilt        : SymbolId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithPrivateOverloadedFunction.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "I", "X"]
+rebuilt        : ScopeId(0): ["C", "X"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["x"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
+Bindings mismatch:
+after transform: ScopeId(11): ["T", "a"]
+rebuilt        : ScopeId(8): ["a"]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Base", "Baz", "Derived", "IBar", "IFoo"]
+rebuilt        : ScopeId(0): ["Base", "Baz", "Derived"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(3), ReferenceId(7)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(0), ReferenceId(6), ReferenceId(8)]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
+semantic error: Missing SymbolId: C
+Missing SymbolId: _C
+Missing ReferenceId: _C
+Missing ReferenceId: A
+Missing ReferenceId: _C
+Missing ReferenceId: B
+Missing ReferenceId: _C
+Missing ReferenceId: F
+Missing ReferenceId: _C
+Missing ReferenceId: F2
+Missing ReferenceId: _C
+Missing ReferenceId: F3
+Missing ReferenceId: _C
+Missing ReferenceId: F4
+Missing ReferenceId: _C
+Missing ReferenceId: F5
+Missing ReferenceId: _C
+Missing ReferenceId: F6
+Missing ReferenceId: _C
+Missing ReferenceId: D
+Missing ReferenceId: C
+Missing ReferenceId: C
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "x"]
+rebuilt        : ScopeId(0): ["C", "a", "b", "c", "d", "e", "f", "g", "h", "j", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(10), SymbolId(13), SymbolId(16), SymbolId(18), SymbolId(21), SymbolId(36)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(15)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "x"]
+rebuilt        : ScopeId(4): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "x"]
+rebuilt        : ScopeId(5): ["x"]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "x"]
+rebuilt        : ScopeId(6): ["x"]
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "x"]
+rebuilt        : ScopeId(7): ["x"]
+Bindings mismatch:
+after transform: ScopeId(8): ["T"]
+rebuilt        : ScopeId(8): []
+Bindings mismatch:
+after transform: ScopeId(9): ["T", "x"]
+rebuilt        : ScopeId(9): ["x"]
+Bindings mismatch:
+after transform: ScopeId(10): ["T"]
+rebuilt        : ScopeId(10): []
+Bindings mismatch:
+after transform: ScopeId(12): ["T"]
+rebuilt        : ScopeId(12): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(16)]
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10), ReferenceId(17)]
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(8): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(10): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(12): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): []
+rebuilt        : SymbolId(13): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(21): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(15): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(21): []
+rebuilt        : SymbolId(15): [ReferenceId(18)]
+Reference symbol mismatch:
+after transform: ReferenceId(23): Some("C")
+rebuilt        : ReferenceId(21): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(24): Some("C")
+rebuilt        : ReferenceId(22): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(25): Some("C")
+rebuilt        : ReferenceId(23): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(26): Some("C")
+rebuilt        : ReferenceId(24): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("C")
+rebuilt        : ReferenceId(25): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(28): Some("C")
+rebuilt        : ReferenceId(26): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("C")
+rebuilt        : ReferenceId(27): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(37): Some("C")
+rebuilt        : ReferenceId(28): Some("C")
+Reference symbol mismatch:
+after transform: ReferenceId(41): Some("C")
+rebuilt        : ReferenceId(29): Some("C")
+Unresolved references mismatch:
+after transform: ["Array", "C"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
+semantic error: Missing SymbolId: templa
+Missing SymbolId: _templa2
+Missing SymbolId: dom
+Missing SymbolId: _dom2
+Missing SymbolId: mvc
+Missing SymbolId: _mvc2
+Missing ReferenceId: _mvc2
+Missing ReferenceId: AbstractElementController
+Missing ReferenceId: mvc
+Missing ReferenceId: mvc
+Missing ReferenceId: _dom2
+Missing ReferenceId: _dom2
+Missing ReferenceId: dom
+Missing ReferenceId: dom
+Missing ReferenceId: _templa2
+Missing ReferenceId: _templa2
+Missing ReferenceId: templa
+Missing ReferenceId: templa
+Missing SymbolId: _templa3
+Missing SymbolId: dom
+Missing SymbolId: _dom3
+Missing SymbolId: mvc
+Missing SymbolId: _mvc3
+Missing SymbolId: composite
+Missing SymbolId: _composite
+Missing ReferenceId: _composite
+Missing ReferenceId: AbstractCompositeElementController
+Missing ReferenceId: composite
+Missing ReferenceId: composite
+Missing ReferenceId: _mvc3
+Missing ReferenceId: _mvc3
+Missing ReferenceId: mvc
+Missing ReferenceId: mvc
+Missing ReferenceId: _dom3
+Missing ReferenceId: _dom3
+Missing ReferenceId: dom
+Missing ReferenceId: dom
+Missing ReferenceId: _templa3
+Missing ReferenceId: _templa3
+Missing ReferenceId: templa
+Missing ReferenceId: templa
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(15), ScopeId(19), ScopeId(24)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(16), SymbolId(28)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(20): [SymbolId(17), SymbolId(29)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(21): [SymbolId(18), SymbolId(30)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(21): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(22): ["ModelType"]
+rebuilt        : ScopeId(4): []
+Binding symbols mismatch:
+after transform: ScopeId(24): [SymbolId(20), SymbolId(31)]
+rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(21), SymbolId(32)]
+rebuilt        : ScopeId(7): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(26): [SymbolId(22), SymbolId(33)]
+rebuilt        : ScopeId(8): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(27): [SymbolId(23), SymbolId(34)]
+rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(27): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(28): ["ModelType"]
+rebuilt        : ScopeId(10): []
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): []
+rebuilt        : SymbolId(6): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(23): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): []
+rebuilt        : SymbolId(14): [ReferenceId(15)]
+Reference symbol mismatch:
+after transform: ReferenceId(11): None
+rebuilt        : ReferenceId(0): Some("templa")
+Reference symbol mismatch:
+after transform: ReferenceId(16): None
+rebuilt        : ReferenceId(13): Some("templa")
+Unresolved references mismatch:
+after transform: ["IElementController", "mvc", "templa"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing SymbolId: c
+Missing SymbolId: _c
+Missing ReferenceId: _c
+Missing ReferenceId: c
+Missing ReferenceId: c
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: m
+Missing ReferenceId: m
+Missing SymbolId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("m")
+rebuilt        : ReferenceId(8): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("a")
+rebuilt        : ReferenceId(9): Some("a")
+
+tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["List", "mod1", "moo"]
+rebuilt        : ScopeId(0): ["List"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileIndexSignatures.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IBothIndexSignature", "IIndexSignatureWithTypeParameter", "INumberIndexSignature", "IStringIndexSignature"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileMethods.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I1", "c1"]
+rebuilt        : ScopeId(0): ["c1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(26)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("m1")
+rebuilt        : ReferenceId(4): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m1")
+rebuilt        : ReferenceId(5): Some("m1")
+
+tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
+semantic error: Missing SymbolId: A
+Missing SymbolId: _A2
+Missing SymbolId: B
+Missing SymbolId: _B
+Missing SymbolId: C
+Missing SymbolId: _C2
+Missing ReferenceId: _C2
+Missing ReferenceId: W
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _B
+Missing ReferenceId: _B
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A2
+Missing ReferenceId: _A2
+Missing ReferenceId: A
+Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileOptionalInterfaceMethod.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IContext", "c1"]
+rebuilt        : ScopeId(0): ["c1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Unresolved references mismatch:
+after transform: ["Array"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileRestParametersOfFunctionAndFunctionType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationArrayType.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: g
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(17)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("m")
+rebuilt        : ReferenceId(8): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("m")
+rebuilt        : ReferenceId(9): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m")
+rebuilt        : ReferenceId(12): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("m")
+rebuilt        : ReferenceId(13): Some("m")
+Unresolved references mismatch:
+after transform: ["m"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationStringLiteral.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTupleType.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: g
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7), ReferenceId(10)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("m")
+rebuilt        : ReferenceId(7): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("m")
+rebuilt        : ReferenceId(10): Some("m")
+Unresolved references mismatch:
+after transform: ["m"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeAlias.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["m"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeQuery.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: g
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("m")
+rebuilt        : ReferenceId(8): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("m")
+rebuilt        : ReferenceId(9): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m")
+rebuilt        : ReferenceId(12): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("m")
+rebuilt        : ReferenceId(13): Some("m")
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeReference.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: g
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("m")
+rebuilt        : ReferenceId(8): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("m")
+rebuilt        : ReferenceId(9): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m")
+rebuilt        : ReferenceId(12): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("m")
+rebuilt        : ReferenceId(13): Some("m")
+Unresolved references mismatch:
+after transform: ["m"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: g
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
+rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(13)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("m")
+rebuilt        : ReferenceId(7): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("m")
+rebuilt        : ReferenceId(9): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m")
+rebuilt        : ReferenceId(11): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("m")
+rebuilt        : ReferenceId(14): Some("m")
+Unresolved references mismatch:
+after transform: ["m"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: public1
+Missing SymbolId: m2
+Missing SymbolId: _m2
+Missing ReferenceId: _m2
+Missing ReferenceId: public2
+Missing ReferenceId: m2
+Missing ReferenceId: m2
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(15)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(16)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
+rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(7): [ReferenceId(13)]
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("m2")
+rebuilt        : ReferenceId(10): Some("m2")
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("m2")
+rebuilt        : ReferenceId(11): Some("m2")
+Unresolved references mismatch:
+after transform: ["m2"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorParameterOfFunction.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: public1
+Missing ReferenceId: _m
+Missing ReferenceId: foo3
+Missing ReferenceId: _m
+Missing ReferenceId: foo4
+Missing ReferenceId: _m
+Missing ReferenceId: foo13
+Missing ReferenceId: _m
+Missing ReferenceId: foo14
+Missing SymbolId: m2
+Missing SymbolId: _m2
+Missing ReferenceId: _m2
+Missing ReferenceId: public2
+Missing ReferenceId: m2
+Missing ReferenceId: m2
+Missing ReferenceId: _m
+Missing ReferenceId: foo113
+Missing ReferenceId: _m
+Missing ReferenceId: foo114
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(20), SymbolId(30)]
+rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(8): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(10): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(16): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(17): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): []
+rebuilt        : SymbolId(18): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(22): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(22): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(25): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(27): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(25): []
+rebuilt        : SymbolId(27): [ReferenceId(20)]
+Symbol flags mismatch:
+after transform: SymbolId(27): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): []
+rebuilt        : SymbolId(29): [ReferenceId(23)]
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("m2")
+rebuilt        : ReferenceId(18): Some("m2")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("m2")
+rebuilt        : ReferenceId(21): Some("m2")
+Unresolved references mismatch:
+after transform: ["m2"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.ts
+semantic error: Missing SymbolId: m
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: public1
+Missing ReferenceId: _m
+Missing ReferenceId: foo3
+Missing ReferenceId: _m
+Missing ReferenceId: foo4
+Missing ReferenceId: _m
+Missing ReferenceId: foo13
+Missing ReferenceId: _m
+Missing ReferenceId: foo14
+Missing SymbolId: m2
+Missing SymbolId: _m2
+Missing ReferenceId: _m2
+Missing ReferenceId: public2
+Missing ReferenceId: m2
+Missing ReferenceId: m2
+Missing ReferenceId: _m
+Missing ReferenceId: foo113
+Missing ReferenceId: _m
+Missing ReferenceId: foo114
+Missing ReferenceId: m
+Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(12), SymbolId(18)]
+rebuilt        : ScopeId(12): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(7): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(10): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(11): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): []
+rebuilt        : SymbolId(14): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(17): [ReferenceId(20)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(18): [ReferenceId(23)]
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("m2")
+rebuilt        : ReferenceId(18): Some("m2")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("m2")
+rebuilt        : ReferenceId(21): Some("m2")
+Unresolved references mismatch:
+after transform: ["m2"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeAlias.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeLiteral.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorVariableDeclaration.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeofClass.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["days", "friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
+rebuilt        : ScopeId(1): ["days"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(18)]
+rebuilt        : SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(17)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(4)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(6)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(8), ReferenceId(9), ReferenceId(10)]
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: c
+Missing ReferenceId: _m
+Missing ReferenceId: e
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["e", "holiday", "weekday", "weekend"]
+rebuilt        : ScopeId(3): ["e"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m1")
+rebuilt        : ReferenceId(13): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("m1")
+rebuilt        : ReferenceId(14): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("m1")
+rebuilt        : ReferenceId(15): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("m1")
+rebuilt        : ReferenceId(16): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("m1")
+rebuilt        : ReferenceId(17): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("m1")
+rebuilt        : ReferenceId(18): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("m1")
+rebuilt        : ReferenceId(19): Some("m1")
+Unresolved references mismatch:
+after transform: ["m1"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
+semantic error: Missing SymbolId: X
+Missing SymbolId: _X
+Missing SymbolId: Y
+Missing SymbolId: _Y
+Missing SymbolId: base
+Missing SymbolId: _base
+Missing ReferenceId: _base
+Missing ReferenceId: W
+Missing ReferenceId: base
+Missing ReferenceId: base
+Missing ReferenceId: _Y
+Missing ReferenceId: _Y
+Missing ReferenceId: Y
+Missing ReferenceId: Y
+Missing ReferenceId: _X
+Missing ReferenceId: _X
+Missing ReferenceId: X
+Missing ReferenceId: X
+Missing SymbolId: _X2
+Missing SymbolId: Y
+Missing SymbolId: _Y2
+Missing SymbolId: base
+Missing SymbolId: _base2
+Missing SymbolId: Z
+Missing SymbolId: _Z
+Missing ReferenceId: _Z
+Missing ReferenceId: W
+Missing ReferenceId: Z
+Missing ReferenceId: Z
+Missing ReferenceId: _base2
+Missing ReferenceId: _base2
+Missing ReferenceId: base
+Missing ReferenceId: base
+Missing ReferenceId: _Y2
+Missing ReferenceId: _Y2
+Missing ReferenceId: Y
+Missing ReferenceId: Y
+Missing ReferenceId: _X2
+Missing ReferenceId: _X2
+Missing ReferenceId: X
+Missing ReferenceId: X
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "X"]
+rebuilt        : ScopeId(0): ["X"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(13)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(14)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(7), SymbolId(15)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(8), SymbolId(16)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(9), SymbolId(17)]
+rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(10), SymbolId(18)]
+rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(11), SymbolId(19)]
+rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(13): ["TValue"]
+rebuilt        : ScopeId(9): []
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(14): [ReferenceId(15)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("X")
+rebuilt        : ReferenceId(13): Some("X")
+
+tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
+semantic error: Missing SymbolId: A
+Missing SymbolId: _A
+Missing SymbolId: B
+Missing SymbolId: _B
+Missing ReferenceId: _B
+Missing ReferenceId: EventManager
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A
+Missing ReferenceId: _A
+Missing ReferenceId: A
+Missing ReferenceId: A
+Missing SymbolId: _A2
+Missing SymbolId: B
+Missing SymbolId: _B2
+Missing SymbolId: C
+Missing SymbolId: _C
+Missing ReferenceId: _C
+Missing ReferenceId: ContextMenu
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _B2
+Missing ReferenceId: _B2
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A2
+Missing ReferenceId: _A2
+Missing ReferenceId: A
+Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(6), SymbolId(11)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(7), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(8), SymbolId(13)]
+rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(10): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(10): [ReferenceId(10)]
+
+tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
+semantic error: Missing SymbolId: X
+Missing SymbolId: _X2
+Missing SymbolId: A
+Missing SymbolId: _A2
+Missing SymbolId: B
+Missing SymbolId: _B
+Missing SymbolId: C
+Missing SymbolId: _C2
+Missing ReferenceId: _C2
+Missing ReferenceId: W
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _B
+Missing ReferenceId: _B
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A2
+Missing ReferenceId: _A2
+Missing ReferenceId: A
+Missing ReferenceId: A
+Missing ReferenceId: _X2
+Missing ReferenceId: _X2
+Missing ReferenceId: X
+Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(12)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(13)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(6), SymbolId(14)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "W", "_C2"]
+rebuilt        : ScopeId(4): ["W", "_C2"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(4): [ScopeId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(8): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["X"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
+semantic error: Missing SymbolId: X
+Missing SymbolId: _X2
+Missing SymbolId: A
+Missing SymbolId: _A2
+Missing SymbolId: B
+Missing SymbolId: _B
+Missing SymbolId: C
+Missing SymbolId: _C2
+Missing ReferenceId: _C2
+Missing ReferenceId: W
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _B
+Missing ReferenceId: _B
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A2
+Missing ReferenceId: _A2
+Missing ReferenceId: A
+Missing ReferenceId: A
+Missing ReferenceId: _X2
+Missing ReferenceId: _X2
+Missing ReferenceId: X
+Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
+rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(8): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
+semantic error: Missing SymbolId: X
+Missing SymbolId: _X2
+Missing SymbolId: A
+Missing SymbolId: _A2
+Missing SymbolId: B
+Missing SymbolId: _B
+Missing SymbolId: C
+Missing SymbolId: _C2
+Missing ReferenceId: _C2
+Missing ReferenceId: W
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _B
+Missing ReferenceId: _B
+Missing ReferenceId: B
+Missing ReferenceId: B
+Missing ReferenceId: _A2
+Missing ReferenceId: _A2
+Missing ReferenceId: A
+Missing ReferenceId: A
+Missing ReferenceId: _X2
+Missing ReferenceId: _X2
+Missing ReferenceId: X
+Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
+rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(8): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["X"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: E
+Missing ReferenceId: _M
+Missing ReferenceId: D
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C", "D", "E", "I1", "I2", "_M"]
+rebuilt        : ScopeId(1): ["C", "D", "E", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(11)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5)]
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/declInput.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 10, end: 13 }
+rebuilt        : SymbolId(0): Span { start: 26, end: 29 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 26, end: 29 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["bar", "bar2"]
+rebuilt        : ScopeId(0): ["bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: E
+Missing ReferenceId: _M
+Missing ReferenceId: D
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C", "D", "E", "I1", "I2", "_M"]
+rebuilt        : ScopeId(1): ["C", "D", "E", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ThingB"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["FlatpickrFn", "fp"]
+rebuilt        : ScopeId(0): ["fp"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I", "O", "fn"]
+rebuilt        : ScopeId(0): ["fn"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Unresolved references mismatch:
+after transform: ["Omit"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Array"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["BoundedInteger", "Brand", "toBoundedInteger"]
+rebuilt        : ScopeId(0): ["toBoundedInteger"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(4): ["LowerBound", "UpperBound", "bounds"]
+rebuilt        : ScopeId(1): ["bounds"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ConvertLocaleConfig", "GetLocalesOptions", "LocaleConfig", "LocaleData", "getLocales"]
+rebuilt        : ScopeId(0): ["getLocales"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "app", "defaultLocalesConfig", "name", "userLocalesConfig"]
+rebuilt        : ScopeId(1): ["app", "defaultLocalesConfig", "name", "userLocalesConfig"]
+Unresolved references mismatch:
+after transform: ["Partial", "Record"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Named", "duplicateIndetifiers", "duplicateIndetifiers2", "duplicateIndetifiers3", "notReferenced", "shadowedVariable", "value"]
+rebuilt        : ScopeId(0): ["duplicateIndetifiers", "duplicateIndetifiers2", "duplicateIndetifiers3", "notReferenced", "shadowedVariable", "value"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): [ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(11): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundlePreservesHasNoDefaultLibDirective.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Result", "T"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Error"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "P", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
+rebuilt        : ScopeId(0): ["C", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "P", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
+rebuilt        : ScopeId(0): ["C", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "R", "vLiteral", "vNumberLiteral", "vStringLiteral"]
+rebuilt        : ScopeId(0): ["C", "vLiteral", "vNumberLiteral", "vStringLiteral"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberNameConflict.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(2)]
+rebuilt        : SymbolId(4): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(3)]
+rebuilt        : SymbolId(6): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberNameConflict2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Hello", "World"]
+rebuilt        : ScopeId(1): ["Hello"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["Hello1", "World1"]
+rebuilt        : ScopeId(2): ["Hello1"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Symbol", "const"]
+rebuilt        : ["Symbol"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AnyConstructor", "AnyFunction", "Base", "Mixin", "MixinHelperFunc", "XmlElement2"]
+rebuilt        : ScopeId(0): ["Base", "Mixin", "XmlElement2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(11), ReferenceId(13), ReferenceId(14)]
+rebuilt        : SymbolId(1): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ExportedClass1", "ExportedClass2", "ExportedClass3", "ExportedClass4", "PrivateInterface"]
+rebuilt        : ScopeId(0): ["ExportedClass1", "ExportedClass2", "ExportedClass3", "ExportedClass4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ExportedClass1", "ExportedClass2", "PrivateInterface"]
+rebuilt        : ScopeId(0): ["ExportedClass1", "ExportedClass2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Context", "Key"]
+rebuilt        : ScopeId(0): ["Key"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["EnumExample", "TEST"]
+rebuilt        : ScopeId(1): ["EnumExample"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyName1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IData", "c"]
+rebuilt        : ScopeId(0): ["c"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Enum", "Type"]
+rebuilt        : ScopeId(0): ["Enum"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "Enum"]
+rebuilt        : ScopeId(1): ["Enum"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringPrivacyError.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Collection", "Field", "subFun"]
+rebuilt        : ScopeId(1): ["subFun"]
+Unresolved references mismatch:
+after transform: ["FlatArray"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Promise", "add"]
+rebuilt        : ["add"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
+semantic error: Missing SymbolId: Translation
+Missing SymbolId: _Translation
+Missing ReferenceId: _Translation
+Missing ReferenceId: Translation
+Missing ReferenceId: Translation
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3)]
+rebuilt        : ScopeId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol span mismatch:
+after transform: SymbolId(1): Span { start: 129, end: 147 }
+rebuilt        : SymbolId(2): Span { start: 198, end: 216 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 198, end: 216 }]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["In", "InexactOptionals", "Out", "baddts", "foo"]
+rebuilt        : ScopeId(0): ["baddts", "foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(9): ["A"]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(4): ["a", "b", "p"]
+rebuilt        : ScopeId(2): ["a", "b"]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction | Interface)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 17, end: 22 }
+rebuilt        : SymbolId(0): Span { start: 171, end: 176 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 171, end: 176 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction | Interface)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction)
+Symbol span mismatch:
+after transform: SymbolId(1): Span { start: 93, end: 97 }
+rebuilt        : SymbolId(3): Span { start: 237, end: 241 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(9)]
+rebuilt        : SymbolId(3): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 237, end: 241 }]
+rebuilt        : SymbolId(3): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Rank", "Suit"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Component", "getComp"]
+rebuilt        : ScopeId(0): ["getComp"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignment.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Buzz", "bar", "foo"]
+rebuilt        : ScopeId(0): ["bar", "foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Buzz", "bar", "foo"]
+rebuilt        : ScopeId(0): ["bar", "foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "U"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "c"]
+rebuilt        : ScopeId(2): ["c"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ExportedClass", "ExportedInterface", "LocalClass", "LocalInterface", "MyClass", "MyClass2", "MyClass3", "MyClass4", "getExportedClass", "getLocalClass"]
+rebuilt        : ScopeId(0): ["ExportedClass", "LocalClass", "MyClass", "MyClass2", "MyClass3", "MyClass4", "getExportedClass", "getLocalClass"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "U"]
+rebuilt        : ScopeId(2): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "c"]
+rebuilt        : ScopeId(3): ["c"]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "c"]
+rebuilt        : ScopeId(4): ["c"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
+semantic error: Missing SymbolId: Test
+Missing SymbolId: _Test
+Missing ReferenceId: _Test
+Missing ReferenceId: SomeClass
+Missing ReferenceId: _Test
+Missing ReferenceId: Derived
+Missing ReferenceId: _Test
+Missing ReferenceId: getClass
+Missing ReferenceId: Test
+Missing ReferenceId: Test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Derived", "IFace", "SomeClass", "_Test", "getClass"]
+rebuilt        : ScopeId(1): ["Derived", "SomeClass", "_Test", "getClass"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(1)]
+rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(7)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitFBoundedTypeParams.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "result", "value"]
+rebuilt        : ScopeId(1): ["result", "value"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Tany", "X", "Y", "f1", "f2", "f3", "f4", "prop11", "prop12", "prop2", "prop3", "prop4"]
+rebuilt        : ScopeId(0): ["X", "Y", "f1", "f2", "f3", "f4", "prop11", "prop12", "prop2", "prop3", "prop4"]
+Bindings mismatch:
+after transform: ScopeId(1): ["A"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(4): ["Tany"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["Tany"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(6): ["A", "B"]
+rebuilt        : ScopeId(6): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(19)]
+rebuilt        : SymbolId(7): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefaultExportClassExtendingExpression01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "Greeter", "GreeterConstructor", "getGreeterBase"]
+rebuilt        : ScopeId(0): ["A", "getGreeterBase"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["_whatever", "a", "getA"]
+rebuilt        : ScopeId(0): ["a", "getA"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["_whatever", "a", "getA"]
+rebuilt        : ScopeId(0): ["a", "getA"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./parent", "ParentThing", "child1"]
+rebuilt        : ScopeId(0): ["child1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Named", "createNamed"]
+rebuilt        : ScopeId(0): ["createNamed"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "AsClassProperty", "AsFunctionType", "AsObjectProperty", "a1", "a2", "a3", "a4", "a4Return", "a4oReturn", "aObj", "b1", "b2", "b3", "b4", "b4Return", "b4oReturn", "bObj", "c1", "c2", "c3", "c4", "c4Return", "c4oReturn", "cObj", "d1", "d2", "d3", "d4", "d4Return", "explicitlyTypedFunction", "explicitlyTypedVariable", "fromParameter"]
+rebuilt        : ScopeId(0): ["A", "AsClassProperty", "a1", "a2", "a3", "a4", "aObj", "b1", "b2", "b3", "b4", "bObj", "c1", "c2", "c3", "c4", "cObj", "d1", "d2", "d3", "d4", "explicitlyTypedFunction", "explicitlyTypedVariable", "fromParameter"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(37), ScopeId(40), ScopeId(43), ScopeId(44), ScopeId(49), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(37), ScopeId(42), ScopeId(44), ScopeId(45), ScopeId(46)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(28)]
+rebuilt        : SymbolId(8): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(31)]
+rebuilt        : SymbolId(10): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): [ReferenceId(52)]
+rebuilt        : SymbolId(25): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): [ReferenceId(55)]
+rebuilt        : SymbolId(27): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(46): [ReferenceId(76)]
+rebuilt        : SymbolId(42): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(48): [ReferenceId(79)]
+rebuilt        : SymbolId(44): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(68): [ReferenceId(101)]
+rebuilt        : SymbolId(62): []
+Unresolved references mismatch:
+after transform: ["ReturnType", "globalThis"]
+rebuilt        : ["globalThis"]
+Unresolved reference IDs mismatch for "globalThis":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(24), ReferenceId(25), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(47), ReferenceId(49), ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(64), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(90), ReferenceId(91), ReferenceId(94), ReferenceId(95), ReferenceId(102), ReferenceId(104), ReferenceId(105), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122)]
+rebuilt        : [ReferenceId(4), ReferenceId(9), ReferenceId(14), ReferenceId(19), ReferenceId(24), ReferenceId(29), ReferenceId(37), ReferenceId(43)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
+semantic error: Unresolved references mismatch:
+after transform: ["NS"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Covariant", "DataFirst", "DataLast", "Invariant", "Kind", "SK", "SemiApplicative", "SemiProduct", "TypeClass", "TypeLambda", "Types", "URI", "dual", "zipRight", "zipWith"]
+rebuilt        : ScopeId(0): ["SK", "zipRight", "zipWith"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
+Bindings mismatch:
+after transform: ScopeId(13): ["A", "B", "_", "b"]
+rebuilt        : ScopeId(1): ["_", "b"]
+Bindings mismatch:
+after transform: ScopeId(14): ["A", "B", "C", "E1", "E2", "F", "O1", "O2", "R1", "R2"]
+rebuilt        : ScopeId(2): ["F"]
+Bindings mismatch:
+after transform: ScopeId(15): ["A", "B", "C", "E1", "E2", "O1", "O2", "R1", "R2", "f", "self", "that"]
+rebuilt        : ScopeId(3): ["f", "self", "that"]
+Bindings mismatch:
+after transform: ScopeId(17): ["B", "E1", "E2", "F", "O1", "O2", "R1", "R2", "_"]
+rebuilt        : ScopeId(5): ["F"]
+Bindings mismatch:
+after transform: ScopeId(18): ["B", "E1", "E2", "O1", "O2", "R1", "R2", "_", "self", "that"]
+rebuilt        : ScopeId(6): ["self", "that"]
+Symbol flags mismatch:
+after transform: SymbolId(55): SymbolFlags(FunctionScopedVariable | TypeParameter)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(55): Span { start: 2588, end: 2589 }
+rebuilt        : SymbolId(4): Span { start: 2610, end: 2631 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(55): [ReferenceId(159), ReferenceId(161), ReferenceId(170), ReferenceId(176), ReferenceId(185), ReferenceId(191), ReferenceId(200), ReferenceId(210), ReferenceId(216), ReferenceId(225), ReferenceId(233), ReferenceId(234)]
+rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(55): [Span { start: 2610, end: 2631 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(80): SymbolFlags(FunctionScopedVariable | TypeParameter)
+rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(80): Span { start: 3332, end: 3333 }
+rebuilt        : SymbolId(11): Span { start: 3354, end: 3375 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(80): [ReferenceId(242), ReferenceId(244), ReferenceId(250), ReferenceId(256), ReferenceId(265), ReferenceId(271), ReferenceId(277), ReferenceId(287), ReferenceId(293), ReferenceId(299), ReferenceId(308)]
+rebuilt        : SymbolId(11): [ReferenceId(11)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(80): [Span { start: 3354, end: 3375 }]
+rebuilt        : SymbolId(11): []
+Reference symbol mismatch:
+after transform: ReferenceId(208): Some("dual")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(285): Some("dual")
+rebuilt        : ReferenceId(9): None
+Unresolved references mismatch:
+after transform: ["Array", "IArguments", "Iterable", "Parameters", "Types"]
+rebuilt        : ["dual"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitIndexTypeArray.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "keys"]
+rebuilt        : ScopeId(1): ["keys"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType2.ts
+semantic error: Unresolved references mismatch:
+after transform: ["undefined"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "Foo", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias8.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "returnSomeGlobalValue", "x"]
+rebuilt        : ScopeId(0): ["returnSomeGlobalValue", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias9.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "returnSomeGlobalValue", "x"]
+rebuilt        : ScopeId(0): ["returnSomeGlobalValue", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Obj", "obj"]
+rebuilt        : ScopeId(1): ["obj"]
+Bindings mismatch:
+after transform: ScopeId(2): ["Obj", "obj"]
+rebuilt        : ScopeId(2): ["obj"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitKeywordDestructuring.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["P", "f1", "f2", "f3", "f4", "f5"]
+rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassDeclarationMixin.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Constructor", "Filter", "FilteredThing", "Mixed", "Unmixed", "mixin"]
+rebuilt        : ScopeId(0): ["Filter", "FilteredThing", "Mixed", "Unmixed", "mixin"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
+Bindings mismatch:
+after transform: ScopeId(3): ["B", "Base", "PrivateMixed"]
+rebuilt        : ScopeId(1): ["Base", "PrivateMixed"]
+Bindings mismatch:
+after transform: ScopeId(6): ["C", "FilterMixin", "ctor"]
+rebuilt        : ScopeId(4): ["FilterMixin", "ctor"]
+Scope children mismatch:
+after transform: ScopeId(7): [ScopeId(8)]
+rebuilt        : ScopeId(5): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassHasRequiredDeclare.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(1): SymbolFlags(Export | Class)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 25, end: 26 }
+rebuilt        : SymbolId(1): Span { start: 78, end: 79 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 78, end: 79 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(2): SymbolFlags(Export | Class)
+Symbol span mismatch:
+after transform: SymbolId(3): Span { start: 128, end: 129 }
+rebuilt        : SymbolId(2): Span { start: 149, end: 150 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(3): [Span { start: 149, end: 150 }]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AllArg", "Fns", "Map", "fn"]
+rebuilt        : ScopeId(0): ["fn"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "sliceIndex"]
+rebuilt        : ScopeId(1): ["sliceIndex"]
+Unresolved references mismatch:
+after transform: ["Parameters", "Record"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "arg"]
+rebuilt        : ScopeId(1): ["arg"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitMergedAliasWithConst.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Color", "Colors"]
+rebuilt        : ScopeId(0): ["Color"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 100, end: 105 }]
+rebuilt        : SymbolId(0): []
+Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["bar"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["func"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitMonorepoBaseUrl.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PluginConfig"]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithAlias.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
+semantic error: Missing SymbolId: Bar
+Missing SymbolId: _Bar
+Missing ReferenceId: _Bar
+Missing ReferenceId: biz
+Missing ReferenceId: Bar
+Missing ReferenceId: Bar
+Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "Foo"]
+rebuilt        : ScopeId(0): ["Bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Members", "Part1", "Part2"]
+rebuilt        : ScopeId(1): []
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(5)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedGenerics.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "g", "p"]
+rebuilt        : ScopeId(1): ["g", "p"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "x", "y"]
+rebuilt        : ScopeId(2): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3)]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(5), ReferenceId(7)]
+rebuilt        : SymbolId(4): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Test", "TestType", "bar"]
+rebuilt        : ScopeId(0): ["Test", "bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "C", "Test"]
+rebuilt        : ScopeId(1): ["Test"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Unresolved references mismatch:
+after transform: ["Extract"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitNonExportedBindingPattern.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AliasType", "AliasType2", "AliasType3", "c", "foo", "getFoo", "getNested", "renamed"]
+rebuilt        : ScopeId(0): ["c", "foo", "getFoo", "getNested", "renamed"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(5)]
+rebuilt        : SymbolId(4): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 71, end: 83 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMethod.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitOverloadedPrivateInference.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(3): [ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "U", "fn"]
+rebuilt        : ScopeId(4): ["fn"]
+Unresolved references mismatch:
+after transform: ["true"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(5)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4)]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["N", "PrivateSpecialString", "SpecialString", "o"]
+rebuilt        : ScopeId(0): ["o"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Unresolved references mismatch:
+after transform: ["N"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Scalar", "scalar"]
+rebuilt        : ScopeId(0): ["scalar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Scalar", "scalar"]
+rebuilt        : ScopeId(0): ["scalar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Evt"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreservesHasNoDefaultLibDirective.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Array", "Boolean", "Foo", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
+rebuilt        : ScopeId(0): ["Foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["CtorT", "ctor"]
+rebuilt        : ScopeId(1): ["ctor"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "func", "result", "rfunc"]
+rebuilt        : ScopeId(2): ["a", "b", "c", "d", "e", "func", "result", "rfunc"]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "f"]
+rebuilt        : ScopeId(4): ["f"]
+Bindings mismatch:
+after transform: ScopeId(5): ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "func", "result", "rfunc"]
+rebuilt        : ScopeId(5): ["a", "b", "c", "d", "e", "func", "result", "rfunc"]
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "f"]
+rebuilt        : ScopeId(7): ["f"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(11)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29)]
+rebuilt        : SymbolId(9): [ReferenceId(9)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(32): [ReferenceId(57), ReferenceId(58)]
+rebuilt        : SymbolId(20): [ReferenceId(20)]
+Unresolved references mismatch:
+after transform: ["Array"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
+semantic error: Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Q", "T", "create", "fun", "fun2"]
+rebuilt        : ScopeId(0): ["create", "fun", "fun2"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Power", "power"]
+rebuilt        : ScopeId(0): ["power"]
+Bindings mismatch:
+after transform: ScopeId(1): ["Num", "PowerOf", "num", "powerOf"]
+rebuilt        : ScopeId(1): ["num", "powerOf"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["FooOptions", "foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "a", "o1", "o2", "o3", "o4", "u"]
+rebuilt        : ScopeId(0): ["a", "o1", "o2", "o3", "o4", "u"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(1): []
+Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["E", "i"]
+rebuilt        : ScopeId(1): ["i"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "foo", "global", "someMethod"]
+rebuilt        : ScopeId(0): ["Foo", "foo", "someMethod"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["CustomSelect1", "CustomSelect2", "Props"]
+rebuilt        : ScopeId(0): ["CustomSelect1", "CustomSelect2"]
+Bindings mismatch:
+after transform: ScopeId(1): ["Option", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Bindings mismatch:
+after transform: ScopeId(2): ["Option", "x"]
+rebuilt        : ScopeId(2): ["x"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "f"]
+rebuilt        : ScopeId(0): ["f"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0)]
+rebuilt        : SymbolId(3): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Client", "UpdatedClient", "createClient"]
+rebuilt        : ScopeId(0): ["createClient"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(3): ["D", "clientDef"]
+rebuilt        : ScopeId(1): ["clientDef"]
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4)]
+rebuilt        : ScopeId(1): []
+Unresolved references mismatch:
+after transform: ["Record"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["0-17", "18-22", "23-27", "28-34", "35-44", "45-59", "60-150", "AgeGroups"]
+rebuilt        : ScopeId(1): ["AgeGroups"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "ITest", "TestEnum"]
+rebuilt        : ScopeId(0): ["A", "TestEnum"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Test1", "Test2", "TestEnum"]
+rebuilt        : ScopeId(1): ["TestEnum"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitSymlinkPaths.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["NotificationRequest", "NotificationResponse", "getNotification"]
+rebuilt        : ScopeId(0): ["getNotification"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithCompositeOption.ts
 semantic error: Bindings mismatch:
@@ -5299,6 +9104,182 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X", "fn"]
+rebuilt        : ScopeId(0): ["fn"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTransitiveImportOfHtmlDeclarationItem.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTripleSlashReferenceAmbientModule.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Url"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTupleRestSignatureLeadingVariadic.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["TFirstArgs", "TLastArg", "args"]
+rebuilt        : ScopeId(1): ["args"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "Foo", "y"]
+rebuilt        : ScopeId(0): ["y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Baa", "Bar", "Baz", "y"]
+rebuilt        : ScopeId(0): ["y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "bar"]
+rebuilt        : ScopeId(0): ["bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
+rebuilt        : ScopeId(0): ["foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
+rebuilt        : ScopeId(0): ["foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters6.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
+rebuilt        : ScopeId(0): ["foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameInOuterScope.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "a", "a2", "a3", "a4", "b", "b2"]
+rebuilt        : ScopeId(0): ["A", "a", "a2", "a3", "a4", "b", "b2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "x"]
+rebuilt        : ScopeId(2): ["x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "x"]
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(4): ["A", "x"]
+rebuilt        : ScopeId(4): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["A", "x"]
+rebuilt        : ScopeId(5): ["x"]
+Bindings mismatch:
+after transform: ScopeId(7): ["B", "x"]
+rebuilt        : ScopeId(6): ["x"]
+Bindings mismatch:
+after transform: ScopeId(8): ["B", "x"]
+rebuilt        : ScopeId(7): ["x"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameReusedInOverloads.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Base", "Derived", "Derived2", "Foo"]
+rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(13)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
+rebuilt        : SymbolId(1): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(10)]
+rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "inner", "x"]
+rebuilt        : ScopeId(1): ["inner", "x"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "y"]
+rebuilt        : ScopeId(2): ["y"]
+Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
+semantic error: Unresolved references mismatch:
+after transform: ["this"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitUnnessesaryTypeReferenceNotAdded.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IEntry", "baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
+rebuilt        : ScopeId(0): ["baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
+Unresolved references mismatch:
+after transform: ["Promise", "console", "const", "fetch"]
+rebuilt        : ["console", "fetch"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IEntry", "baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
+rebuilt        : ScopeId(0): ["baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
+Unresolved references mismatch:
+after transform: ["Promise", "console", "const", "fetch"]
+rebuilt        : ["console", "fetch"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["bar", "goodDeclaration", "shouldBeElided", "shouldReuseLocalName"]
+rebuilt        : ScopeId(0): ["bar", "goodDeclaration"]
+
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithComposite.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
@@ -5306,6 +9287,111 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Experiment", "Name", "createExperiment"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("createExperiment")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["createExperiment"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Experiment", "Name", "createExperiment"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("createExperiment")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["createExperiment"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["MutableRefObject", "useCsvParser", "useRef"]
+rebuilt        : ScopeId(0): ["useCsvParser", "useRef"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "current"]
+rebuilt        : ScopeId(1): ["current"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Error", "undefined"]
+rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Error2", "undefined"]
+rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Error2", "undefined"]
+rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Error", "undefined"]
+rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
+semantic error: Missing SymbolId: foo
+Missing SymbolId: _foo
+Missing ReferenceId: _foo
+Missing ReferenceId: foo
+Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/declarationMaps.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(5)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 230, end: 323 }]
+rebuilt        : SymbolId(0): []
+Unresolved references mismatch:
+after transform: ["m2"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
 semantic error: Bindings mismatch:
@@ -5323,6 +9409,75 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/declarationNoDanglingGenerics.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(3): ["TKind", "kind"]
+rebuilt        : ScopeId(3): ["kind"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationQuotedMembers.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["example", "mapped"]
+rebuilt        : ScopeId(0): ["example"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("mapped")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["mapped"]
+
+tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["DOMNode"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Node"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Hash", "StringHash", "StringHash2"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Foo"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Key", "Value", "p1", "p2", "p3", "testRecFun", "updateIfChanged"]
+rebuilt        : ScopeId(0): ["p1", "p2", "p3", "testRecFun", "updateIfChanged"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "reduce", "t"]
+rebuilt        : ScopeId(1): ["reduce", "t"]
+Bindings mismatch:
+after transform: ScopeId(4): ["U", "set", "u", "update"]
+rebuilt        : ScopeId(2): ["set", "u", "update"]
+Bindings mismatch:
+after transform: ScopeId(6): ["K", "key"]
+rebuilt        : ScopeId(4): ["key"]
+Bindings mismatch:
+after transform: ScopeId(10): ["T", "parent"]
+rebuilt        : ScopeId(8): ["parent"]
+Bindings mismatch:
+after transform: ScopeId(11): ["U", "child"]
+rebuilt        : ScopeId(9): ["child"]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(16), ReferenceId(34), ReferenceId(51), ReferenceId(54)]
+rebuilt        : [ReferenceId(0), ReferenceId(6), ReferenceId(11)]
+
 tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
 semantic error: Missing SymbolId: ab
 Bindings mismatch:
@@ -5335,6 +9490,14 @@ Reference symbol mismatch:
 after transform: ReferenceId(1): Some("ab")
 rebuilt        : ReferenceId(1): Some("ab")
 
+tasks/coverage/typescript/tests/cases/compiler/declareDottedModuleName.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["M", "T"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["express"]
@@ -5344,6 +9507,46 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "RegExp", "express"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(5)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 230, end: 323 }]
+rebuilt        : SymbolId(0): []
+Unresolved references mismatch:
+after transform: ["m2"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(1): Span { start: 238, end: 331 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(5)]
+rebuilt        : SymbolId(1): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 238, end: 331 }]
+rebuilt        : SymbolId(1): []
+Unresolved references mismatch:
+after transform: ["m2"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
@@ -5533,6 +9736,31 @@ Unresolved references mismatch:
 after transform: ["Function", "PropertyDescriptor"]
 rebuilt        : ["console"]
 
+tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConditionalTypes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "T0", "T1"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(102), ScopeId(103)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["BufferPool", "Enum", "TypeMap"]
+rebuilt        : ScopeId(0): ["BufferPool"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(4): ["E", "M"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(5): ["K", "_", "array"]
+rebuilt        : ScopeId(2): ["_", "array"]
+Unresolved references mismatch:
+after transform: ["ArrayLike", "Extract", "Record"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "R", "S", "T", "X", "_S", "a1", "a2", "b"]
@@ -5543,6 +9771,50 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial", "true"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["MyComponent", "Props", "Things", "make"]
+rebuilt        : ScopeId(0): ["MyComponent", "make"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["CTor", "P", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
+semantic error: Missing SymbolId: Something
+Missing SymbolId: _Something
+Missing ReferenceId: _Something
+Missing ReferenceId: Something
+Missing ReferenceId: Something
+Bindings mismatch:
+after transform: ScopeId(0): ["MyComponent", "Props", "Something", "Things", "make", "me"]
+rebuilt        : ScopeId(0): ["MyComponent", "Something", "make", "me"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["CTor", "P", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3)]
+rebuilt        : ScopeId(1): []
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(11), SymbolId(12), SymbolId(13)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 semantic error: Scope children mismatch:
@@ -5600,6 +9872,20 @@ Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 23, end: 26 }]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["OptionalNullableString", "allowsNull", "cond", "f", "foo1", "foo2", "foo3", "foo4", "g", "removeNothing", "removeUndefinedButNotFalse", "total"]
+rebuilt        : ScopeId(0): ["allowsNull", "f", "foo1", "foo2", "foo3", "foo4", "g", "removeNothing", "removeUndefinedButNotFalse", "total"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(36): Some("cond")
+rebuilt        : ReferenceId(35): None
+Unresolved references mismatch:
+after transform: ["undefined"]
+rebuilt        : ["cond", "undefined"]
+
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "And", "AndBit", "Bit", "Equals", "Extends", "FilterByStringValue", "FilteredRes1", "FilteredValuesMatchNever", "IsLiteral", "IsNumberLiteral", "Not", "Or", "T0", "T1", "T2", "T3", "T4", "T5", "T6", "TestBit", "TestBitRes", "Values"]
@@ -5620,6 +9906,31 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), Sc
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["First", "ObjectHasKey", "StringContains", "T1", "T2", "f2", "f3"]
+rebuilt        : ScopeId(0): ["f2", "f3"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(9): ["A", "a"]
+rebuilt        : ScopeId(1): ["a"]
+Unresolved references mismatch:
+after transform: ["Extract", "f1"]
+rebuilt        : ["f1"]
+
+tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "D", "DeepError", "DeepOK", "E", "Juxtapose", "ObjectHasKey", "StringContains"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Extract"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayWithinTuple.ts
@@ -5797,6 +10108,17 @@ Unresolved references mismatch:
 after transform: ["Promise", "get"]
 rebuilt        : ["get"]
 
+tasks/coverage/typescript/tests/cases/compiler/destructureOptionalParameter.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["QueryMetadata", "QueryMetadataFactory", "Type", "f2"]
+rebuilt        : ScopeId(0): ["f2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Unresolved references mismatch:
+after transform: ["ParameterDecorator"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "bar", "key", "lorem", "obj"]
@@ -5893,14 +10215,14 @@ Bindings mismatch:
 after transform: ScopeId(21): ["Num", "Str", "Types"]
 rebuilt        : ScopeId(17): ["Types"]
 Scope flags mismatch:
-after transform: ScopeId(21): ScopeFlags(0x0)
-rebuilt        : ScopeId(17): ScopeFlags(Function)
+after transform: ScopeId(21): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(17): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(44): ["BarEnum", "bar1", "bar2"]
 rebuilt        : ScopeId(28): ["BarEnum"]
 Scope flags mismatch:
-after transform: ScopeId(44): ScopeFlags(0x0)
-rebuilt        : ScopeId(28): ScopeFlags(Function)
+after transform: ScopeId(44): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(28): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(20): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
@@ -6065,6 +10387,29 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Error", "GraphQLError", "ReadonlyArray", "getVariableValues"]
 rebuilt        : ["getVariableValues"]
+
+tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["IData", "IListItemData", "ListItem", "ListItemVariant", "Menu", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["ListItem", "ListItemVariant", "Menu", "_jsx", "_jsxFileName"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["MenuItemVariant", "data", "listItemVariant"]
+rebuilt        : ScopeId(1): ["data", "listItemVariant"]
+Bindings mismatch:
+after transform: ScopeId(4): ["Avatar", "ListItemVariant", "OneLine"]
+rebuilt        : ScopeId(2): ["ListItemVariant"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(12), ReferenceId(21)]
+rebuilt        : SymbolId(5): [ReferenceId(1), ReferenceId(11)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
 semantic error: Bindings mismatch:
@@ -6272,23 +10617,14 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(7)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): []
@@ -6615,6 +10951,26 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 
+tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T0", "T3", "c0", "c1", "s0"]
+rebuilt        : ScopeId(0): ["c0", "c1", "s0"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5), ReferenceId(9)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(6), ReferenceId(10)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(7), ReferenceId(11)]
+rebuilt        : SymbolId(2): []
+Unresolved references mismatch:
+after transform: ["Symbol", "T1", "T2"]
+rebuilt        : ["Symbol"]
+
 tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 semantic error: 'with' statements are not allowed
 
@@ -6623,6 +10979,23 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Constructor", "FooItem", "Test", "WithTags", "circularReference", "simpleExample", "test"]
+rebuilt        : ScopeId(0): ["FooItem", "Test", "WithTags", "circularReference", "simpleExample", "test"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(13)]
+Bindings mismatch:
+after transform: ScopeId(10): ["Base", "T"]
+rebuilt        : ScopeId(9): ["Base"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(8), ReferenceId(12)]
+rebuilt        : SymbolId(5): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_object.ts
 semantic error: Bindings mismatch:
@@ -6824,6 +11197,11 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
+tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "i"]
+rebuilt        : ScopeId(0): ["Foo"]
+
 tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
@@ -6863,6 +11241,25 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["mAmbient"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEmitInitializerHasImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["Enum", "Value1", "Value2"]
+rebuilt        : ScopeId(1): ["Enum"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+
 tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Mode", "Open"]
@@ -6892,6 +11289,17 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsObjectPropertiesInDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["LEFT_BUTTON", "MIDDLE_BUTTON", "MouseButton", "NO_BUTTON", "RIGHT_BUTTON", "XBUTTON1_BUTTON", "XBUTTON2_BUTTON"]
+rebuilt        : ScopeId(1): ["MouseButton"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
 semantic error: Bindings mismatch:
@@ -6961,20 +11369,20 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "MyEnum"]
 rebuilt        : ScopeId(1): ["MyEnum"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "B", "C", "MyStringEnum"]
 rebuilt        : ScopeId(2): ["MyStringEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "C", "MyStringEnumWithEmpty"]
 rebuilt        : ScopeId(3): ["MyStringEnumWithEmpty"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -8927,6 +13335,44 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultClassDeclaration4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultFunctionDeclaration3.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultFunctionDeclaration4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["bar"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["func"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/es5ExportEqualsDts.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 82, end: 83 }]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "ChildClassWithoutConstructor", "GetSetMonster", "IFoo", "ImplementsInterface", "OverloadedMonster", "PrototypeMonster", "SplatMonster", "Statics", "SuperChild", "SuperParent", "Visibility", "ccwc", "foo", "m1", "m2", "m3", "m4", "m5", "m6", "stat", "x", "y"]
@@ -8982,6 +13428,12 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(21)]
 
+tasks/coverage/typescript/tests/cases/compiler/es6ExportAll.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/es6ExportAllInEs5.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
 tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
@@ -8992,14 +13444,141 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseInEs5.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifierInEs5.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingAmd.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingDts.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "b", "defaultBinding1", "defaultBinding2", "defaultBinding3", "defaultBinding4", "defaultBinding5", "defaultBinding6", "m", "x", "x1", "y", "z"]
+rebuilt        : ScopeId(0): ["a", "b", "m", "x", "x1", "y", "z"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
+rebuilt        : ScopeId(0): ["defaultBinding", "x"]
+
 tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
+rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
+rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
+rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
+rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
+
 tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportNoNamedExports.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
+rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInEs5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInExportAssignment.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: c
+Missing ReferenceId: a
+Missing ReferenceId: a
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "C2", "I", "I2"]
+rebuilt        : ScopeId(0): ["C", "C2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseNonInstantiatedModule.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["i"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 semantic error: Missing SymbolId: m1
@@ -9020,15 +13599,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)
 Binding symbols mismatch:
 after transform: ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(13): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(26): [SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(26): [SymbolId(7), SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
-after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(26): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(3): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
@@ -9066,15 +13639,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(20)]
 rebuilt        : ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(21)]
 rebuilt        : ScopeId(2): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -9114,50 +13681,44 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
+after transform: ScopeId(7): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
+after transform: ScopeId(8): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -9206,50 +13767,44 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
+after transform: ScopeId(7): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
+after transform: ScopeId(8): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -9298,50 +13853,44 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
+after transform: ScopeId(7): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
+after transform: ScopeId(8): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -9389,27 +13938,27 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(4)]
 rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(8)]
 rebuilt        : SymbolId(8): [ReferenceId(11), ReferenceId(14)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("m1")
 rebuilt        : ReferenceId(16): Some("m1")
@@ -9541,6 +14090,47 @@ Unresolved references mismatch:
 after transform: ["Symbol", "const", "true"]
 rebuilt        : ["Symbol"]
 
+tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(11), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 44, end: 47 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["TestNull", "TestNull2", "TestUndefined", "testNull", "testNull2", "testUndefined"]
+rebuilt        : ScopeId(0): ["testNull", "testNull2", "testUndefined"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
+
+tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["TestSymb", "symb", "test"]
+rebuilt        : ScopeId(0): ["symb", "test"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["TestSymb", "symb"]
+rebuilt        : ScopeId(0): ["symb"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -9599,6 +14189,17 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
+tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["T"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -9626,6 +14227,17 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
+tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Constructor", "MyBaseClass"]
+rebuilt        : ScopeId(0): ["MyBaseClass"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(1): []
+
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
 semantic error: Missing SymbolId: A
 Missing SymbolId: _A
@@ -9639,11 +14251,8 @@ Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -9822,8 +14431,128 @@ tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
+tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
 tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
+semantic error: Missing SymbolId: MsPortalFx
+Missing SymbolId: _MsPortalFx
+Missing SymbolId: ViewModels
+Missing SymbolId: _ViewModels
+Missing SymbolId: Dialogs
+Missing SymbolId: _Dialogs
+Missing ReferenceId: _Dialogs
+Missing ReferenceId: DialogResult
+Missing ReferenceId: _Dialogs
+Missing ReferenceId: someExportedFunction
+Missing ReferenceId: _Dialogs
+Missing ReferenceId: MessageBoxButtons
+Missing ReferenceId: Dialogs
+Missing ReferenceId: Dialogs
+Missing ReferenceId: _ViewModels
+Missing ReferenceId: _ViewModels
+Missing ReferenceId: ViewModels
+Missing ReferenceId: ViewModels
+Missing ReferenceId: _MsPortalFx
+Missing ReferenceId: _MsPortalFx
+Missing ReferenceId: MsPortalFx
+Missing ReferenceId: MsPortalFx
+Missing SymbolId: _MsPortalFx2
+Missing SymbolId: ViewModels
+Missing SymbolId: _ViewModels2
+Missing ReferenceId: _ViewModels2
+Missing ReferenceId: SomeUsagesOfTheseConsts
+Missing ReferenceId: ViewModels
+Missing ReferenceId: ViewModels
+Missing ReferenceId: _MsPortalFx2
+Missing ReferenceId: _MsPortalFx2
+Missing ReferenceId: MsPortalFx
+Missing ReferenceId: MsPortalFx
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(27)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(28)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["DialogResult", "DialogResultCallback", "MessageBoxButtons", "_Dialogs", "someExportedFunction"]
+rebuilt        : ScopeId(3): ["DialogResult", "MessageBoxButtons", "_Dialogs", "someExportedFunction"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
+Bindings mismatch:
+after transform: ScopeId(4): ["Abort", "Cancel", "DialogResult", "Ignore", "No", "Ok", "Retry", "Yes"]
+rebuilt        : ScopeId(4): ["DialogResult"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["AbortRetryIgnore", "MessageBoxButtons", "OK", "OKCancel", "RetryCancel", "YesNo", "YesNoCancel"]
+rebuilt        : ScopeId(6): ["MessageBoxButtons"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(20), SymbolId(30)]
+rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["Callback", "DialogButtons", "ReExportedEnum", "SomeUsagesOfTheseConsts", "_ViewModels2"]
+rebuilt        : ScopeId(8): ["SomeUsagesOfTheseConsts", "_ViewModels2"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(6): [ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): []
+rebuilt        : SymbolId(8): [ReferenceId(18)]
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(9): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): []
+rebuilt        : SymbolId(14): [ReferenceId(51)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("ReExportedEnum")
+rebuilt        : ReferenceId(44): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("DialogButtons")
+rebuilt        : ReferenceId(47): None
+Unresolved references mismatch:
+after transform: ["Dialogs", "MsPortalFx", "console"]
+rebuilt        : ["DialogButtons", "ReExportedEnum", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -9840,6 +14569,21 @@ Unresolved references mismatch:
 after transform: ["A", "B"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["X"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -9851,8 +14595,8 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function | TypeAlias)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
 Symbol span mismatch:
 after transform: SymbolId(0): Span { start: 12, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 73, end: 76 }
@@ -10165,6 +14909,86 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
+semantic error: Missing ReferenceId: Infinity
+Missing ReferenceId: Infinity
+Missing SymbolId: X
+Missing SymbolId: _X
+Missing ReferenceId: _X
+Missing ReferenceId: f
+Missing ReferenceId: X
+Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "Foo"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "_X", "f"]
+rebuilt        : ScopeId(2): ["_X", "f"]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(4): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("X")
+rebuilt        : ReferenceId(12): Some("X")
+Unresolved references mismatch:
+after transform: ["Error"]
+rebuilt        : ["Error", "Infinity"]
+
+tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
+semantic error: Missing ReferenceId: Infinity
+Missing ReferenceId: Infinity
+Missing SymbolId: X
+Missing SymbolId: _X
+Missing ReferenceId: _X
+Missing ReferenceId: f
+Missing ReferenceId: X
+Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7), SymbolId(8)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(6)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "Foo"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "_X", "f"]
+rebuilt        : ScopeId(2): ["_X", "f"]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(4): [ReferenceId(9)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("X")
+rebuilt        : ReferenceId(12): Some("X")
+
 tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
@@ -10432,6 +15256,38 @@ tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
+semantic error: Missing SymbolId: m2
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: foo
+Missing ReferenceId: m2
+Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(38), SymbolId(45)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(33), SymbolId(34), SymbolId(36), SymbolId(41)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(15)]
+Binding symbols mismatch:
+after transform: ScopeId(14): [SymbolId(39), SymbolId(46)]
+rebuilt        : ScopeId(12): [SymbolId(37), SymbolId(38)]
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(39): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(39): []
+rebuilt        : SymbolId(38): [ReferenceId(15)]
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("m2")
+rebuilt        : ReferenceId(18): Some("m2")
+Unresolved references mismatch:
+after transform: ["Object"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
 semantic error: Unresolved references mismatch:
@@ -10897,6 +15753,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/genericArray0.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["U", "ys"]
+rebuilt        : ScopeId(1): ["ys"]
+
 tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -11075,6 +15936,38 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["First", "Second", "SubFirst", "SubFirstMore", "hasAFoo", "thing"]
 rebuilt        : ScopeId(1): ["hasAFoo", "thing"]
 
+tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
+semantic error: Missing SymbolId: bar
+Missing SymbolId: _bar
+Missing ReferenceId: _bar
+Missing ReferenceId: Foo
+Missing ReferenceId: bar
+Missing ReferenceId: bar
+Bindings mismatch:
+after transform: ScopeId(0): ["bar", "foo"]
+rebuilt        : ScopeId(0): ["bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["foo"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 semantic error: Missing SymbolId: Portal
 Missing SymbolId: _Portal
@@ -11248,6 +16141,44 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(19): [ReferenceId(4), ReferenceId(7)]
 rebuilt        : SymbolId(19): [ReferenceId(2), ReferenceId(74)]
 
+tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/genericClasses1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "Foo", "v1", "w", "y", "z"]
+rebuilt        : ScopeId(0): ["C", "v1", "w", "y", "z"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(5)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(5)]
+rebuilt        : SymbolId(1): []
+
 tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A"]
@@ -11261,6 +16192,46 @@ rebuilt        : ScopeId(4): ["f", "retval", "x", "y"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(16), ReferenceId(19), ReferenceId(25), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
+
+tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
+semantic error: Missing SymbolId: Foo
+Missing SymbolId: _Foo
+Missing ReferenceId: _Foo
+Missing ReferenceId: B
+Missing ReferenceId: _Foo
+Missing ReferenceId: A
+Missing ReferenceId: Foo
+Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("Foo")
+rebuilt        : ReferenceId(6): Some("Foo")
+Unresolved references mismatch:
+after transform: ["Foo"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 semantic error: Bindings mismatch:
@@ -11292,6 +16263,17 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 semantic error: Missing SymbolId: EndGate
@@ -11482,6 +16464,21 @@ rebuilt        : ScopeId(2): ["test"]
 Unresolved references mismatch:
 after transform: ["String"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/genericFunctions0.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "x"]
+rebuilt        : ScopeId(1): ["x"]
+
+tasks/coverage/typescript/tests/cases/compiler/genericFunctions1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "x"]
+rebuilt        : ScopeId(1): ["x"]
+
+tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 semantic error: Bindings mismatch:
@@ -12112,6 +17109,58 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3)]
 rebuilt        : SymbolId(3): []
 
+tasks/coverage/typescript/tests/cases/compiler/generics0.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["G", "v2", "z"]
+rebuilt        : ScopeId(0): ["v2", "z"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "G", "v1", "v2", "v4"]
+rebuilt        : ScopeId(0): ["v1", "v2", "v4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/generics2NoError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "G", "v1", "v2", "v4"]
+rebuilt        : ScopeId(0): ["v1", "v2", "v4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/generics3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "X", "Y", "a", "b"]
+rebuilt        : ScopeId(0): ["C", "a", "b"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "X", "Y", "a", "b"]
+rebuilt        : ScopeId(0): ["C", "a", "b"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["K", "M", "N", "R", "S", "T", "U", "combine", "foo"]
@@ -12251,6 +17300,15 @@ rebuilt        : ScopeId(0): ["a", "b", "foo", "obj"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+
+tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit3.ts
+semantic error: Missing SymbolId: mod
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("mod")
+rebuilt        : ReferenceId(1): Some("mod")
 
 tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
 semantic error: Bindings mismatch:
@@ -12394,6 +17452,26 @@ Unresolved references mismatch:
 after transform: ["Extract", "Omit", "RequestInit"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Equals", "f1"]
+rebuilt        : ScopeId(0): ["f1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(8): ["T1", "T2"]
+rebuilt        : ScopeId(2): []
+Scope children mismatch:
+after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(15)]
+rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+Unresolved references mismatch:
+after transform: ["State", "true"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Sequence"]
@@ -12498,12 +17576,60 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
+semantic error: Missing SymbolId: My
+Missing SymbolId: _My
+Missing SymbolId: Internal
+Missing SymbolId: _Internal
+Missing ReferenceId: _Internal
+Missing ReferenceId: getThing
+Missing ReferenceId: _Internal
+Missing ReferenceId: WhichThing
+Missing ReferenceId: Internal
+Missing ReferenceId: Internal
+Missing ReferenceId: _My
+Missing ReferenceId: _My
+Missing ReferenceId: My
+Missing ReferenceId: My
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(4): ["A", "B", "C", "WhichThing"]
+rebuilt        : ScopeId(4): ["WhichThing"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(5): [ReferenceId(10)]
+
 tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 semantic error: Bindings mismatch:
@@ -12515,6 +17641,10 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
 semantic error: Bindings mismatch:
@@ -12642,6 +17772,20 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["MakeItWork", "fail1", "fail2", "fn", "works1", "works2"]
+rebuilt        : ScopeId(0): ["fail1", "fail2", "fn", "works1", "works2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "x"]
+rebuilt        : ScopeId(2): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -13132,6 +18276,11 @@ Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 
+tasks/coverage/typescript/tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
 tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["KeysWithoutStringIndex", "RemoveIdxSgn", "test"]
@@ -13427,6 +18576,40 @@ Bindings mismatch:
 after transform: ScopeId(1): ["T", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
 
+tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "x1", "x2", "y1", "y2"]
+rebuilt        : ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "y1", "y2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("x1")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("x2")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Partial", "Required", "test"]
+rebuilt        : ["test", "x1", "x2"]
+
+tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "x1", "x2", "y1", "y2"]
+rebuilt        : ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "y1", "y2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("x1")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("x2")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Partial", "Required", "test"]
+rebuilt        : ["test", "x1", "x2"]
+
 tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a2", "a3", "a4", "obj", "param2", "query", "x1", "x2", "x3", "x4"]
@@ -13576,6 +18759,37 @@ tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Args", "_"]
 rebuilt        : ScopeId(1): ["_"]
+
+tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Type", "Type2", "inferPipe", "inferPipe2", "out", "out2", "t", "t2"]
+rebuilt        : ScopeId(0): ["out", "out2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(11), ScopeId(13)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("t")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("t2")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["ReturnType", "parseInt"]
+rebuilt        : ["parseInt", "t", "t2"]
+
+tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ObjectTypeComposer", "User"]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("User")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("User")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["User"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
 semantic error: Bindings mismatch:
@@ -13928,6 +19142,20 @@ Unresolved references mismatch:
 after transform: ["Extract"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Obj", "processedInternally1", "processedInternally2", "test1", "test2", "wrappedTest1", "wrappedTest2"]
+rebuilt        : ScopeId(0): ["processedInternally1", "processedInternally2", "test1", "test2", "wrappedTest1", "wrappedTest2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(1): ["K", "T", "k", "obj"]
+rebuilt        : ScopeId(1): ["k", "obj"]
+Bindings mismatch:
+after transform: ScopeId(2): ["K", "T", "k", "obj"]
+rebuilt        : ScopeId(2): ["k", "obj"]
+
 tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Name", "RelationFields", "ShouldA"]
@@ -14178,9 +19406,6 @@ rebuilt        : ScopeId(1): ["value", "values"]
 Bindings mismatch:
 after transform: ScopeId(25): ["ComponentClass", "CreateElementChildren", "InferFunctionTypes", "_N"]
 rebuilt        : ScopeId(8): ["InferFunctionTypes", "_N"]
-Scope flags mismatch:
-after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(25): [ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37)]
 rebuilt        : ScopeId(8): [ScopeId(9), ScopeId(10), ScopeId(11)]
@@ -14242,6 +19467,14 @@ rebuilt        : ScopeId(0): ["c", "d"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+
+tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X", "Y", "Z", "x1", "x2"]
+rebuilt        : ScopeId(0): ["x1", "x2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
 semantic error: Missing SymbolId: A
@@ -14654,6 +19887,14 @@ Unresolved references mismatch:
 after transform: ["ReturnType"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mover", "MoverShaker", "Shaker"]
@@ -14677,6 +19918,387 @@ rebuilt        : ScopeId(0): ["v"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/interfaceWithOptionalProperty.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/interfacedecl.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a", "a0", "a1", "a2", "b", "c", "c1", "d", "instance2"]
+rebuilt        : ScopeId(0): ["c1", "instance2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: x
+Missing SymbolId: _x
+Missing ReferenceId: _x
+Missing ReferenceId: c
+Missing ReferenceId: x
+Missing ReferenceId: x
+Missing SymbolId: xc
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("x")
+rebuilt        : ReferenceId(5): Some("x")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("xc")
+rebuilt        : ReferenceId(6): Some("xc")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: x
+Missing SymbolId: _x
+Missing ReferenceId: _x
+Missing ReferenceId: c
+Missing ReferenceId: x
+Missing ReferenceId: x
+Missing SymbolId: xc
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("x")
+rebuilt        : ReferenceId(5): Some("x")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("xc")
+rebuilt        : ReferenceId(6): Some("xc")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: weekend
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
+rebuilt        : ScopeId(2): ["weekend"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(8)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("a")
+rebuilt        : ReferenceId(11): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(12): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: weekend
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
+rebuilt        : ScopeId(2): ["weekend"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(8)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("a")
+rebuilt        : ReferenceId(11): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(12): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: foo
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("a")
+rebuilt        : ReferenceId(5): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(6): Some("b")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("b")
+rebuilt        : ReferenceId(7): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: foo
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("a")
+rebuilt        : ReferenceId(5): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(6): Some("b")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("b")
+rebuilt        : ReferenceId(7): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing SymbolId: b
+Missing SymbolId: _b
+Missing ReferenceId: _b
+Missing ReferenceId: c
+Missing ReferenceId: b
+Missing ReferenceId: b
+Missing ReferenceId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("a")
+rebuilt        : ReferenceId(8): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(9): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: a
+Missing SymbolId: _a
+Missing SymbolId: b
+Missing SymbolId: _b
+Missing ReferenceId: _b
+Missing ReferenceId: c
+Missing ReferenceId: b
+Missing ReferenceId: b
+Missing ReferenceId: _a
+Missing ReferenceId: _a
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("a")
+rebuilt        : ReferenceId(8): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("b")
+rebuilt        : ReferenceId(9): Some("b")
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: b
+Bindings mismatch:
+after transform: ScopeId(0): ["a", "b", "x"]
+rebuilt        : ScopeId(0): ["b", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: b
+Bindings mismatch:
+after transform: ScopeId(0): ["a", "b", "x"]
+rebuilt        : ScopeId(0): ["b", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithExport.ts
+semantic error: Missing SymbolId: b
+Bindings mismatch:
+after transform: ScopeId(0): ["a", "b", "x"]
+rebuilt        : ScopeId(0): ["b", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
+semantic error: Missing SymbolId: b
+Bindings mismatch:
+after transform: ScopeId(0): ["a", "b", "x"]
+rebuilt        : ScopeId(0): ["b", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -14997,6 +20619,219 @@ Unresolved references mismatch:
 after transform: ["Windows"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
+semantic error: Missing SymbolId: schema
+Missing SymbolId: _schema
+Missing ReferenceId: _schema
+Missing ReferenceId: createValidator1
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema2
+Missing ReferenceId: _schema2
+Missing ReferenceId: createValidator2
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema3
+Missing ReferenceId: _schema3
+Missing ReferenceId: createValidator3
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema4
+Missing ReferenceId: _schema4
+Missing ReferenceId: createValidator4
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema5
+Missing ReferenceId: _schema5
+Missing ReferenceId: createValidator5
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema6
+Missing ReferenceId: _schema6
+Missing ReferenceId: createValidator6
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema7
+Missing ReferenceId: _schema7
+Missing ReferenceId: createValidator7
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema8
+Missing ReferenceId: _schema8
+Missing ReferenceId: createValidator8
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Missing SymbolId: _schema9
+Missing ReferenceId: _schema9
+Missing ReferenceId: T
+Missing ReferenceId: schema
+Missing ReferenceId: schema
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(29)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "schema"]
+rebuilt        : ScopeId(2): ["schema"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(30)]
+rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "schema"]
+rebuilt        : ScopeId(4): ["schema"]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(31)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(6): [ScopeId(7)]
+rebuilt        : ScopeId(6): []
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(10), SymbolId(32)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(9): [ScopeId(10)]
+rebuilt        : ScopeId(8): []
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(13), SymbolId(33)]
+rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(12): [ScopeId(13)]
+rebuilt        : ScopeId(10): []
+Binding symbols mismatch:
+after transform: ScopeId(14): [SymbolId(16), SymbolId(34)]
+rebuilt        : ScopeId(11): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(15): ["T", "schema"]
+rebuilt        : ScopeId(12): ["schema"]
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(19), SymbolId(35)]
+rebuilt        : ScopeId(13): [SymbolId(19), SymbolId(20)]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(17): ["T", "schema"]
+rebuilt        : ScopeId(14): ["schema"]
+Binding symbols mismatch:
+after transform: ScopeId(18): [SymbolId(22), SymbolId(36)]
+rebuilt        : ScopeId(15): [SymbolId(22), SymbolId(23)]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(19): ["T", "schema"]
+rebuilt        : ScopeId(16): ["schema"]
+Binding symbols mismatch:
+after transform: ScopeId(20): [SymbolId(25), SymbolId(37)]
+rebuilt        : ScopeId(17): [SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(22): ["T"]
+rebuilt        : ScopeId(19): []
+Bindings mismatch:
+after transform: ScopeId(23): ["T", "v"]
+rebuilt        : ScopeId(20): ["v"]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(5): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(8): [ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(11): [ReferenceId(17)]
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(14): [ReferenceId(22)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(17): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): []
+rebuilt        : SymbolId(20): [ReferenceId(32)]
+Symbol flags mismatch:
+after transform: SymbolId(22): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(22): []
+rebuilt        : SymbolId(23): [ReferenceId(37)]
+Symbol flags mismatch:
+after transform: SymbolId(25): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(26): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(25): []
+rebuilt        : SymbolId(26): [ReferenceId(42)]
+Unresolved references mismatch:
+after transform: ["Array", "undefined"]
+rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
+semantic error: Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsStrictBuiltinIteratorReturn.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "x1", "x10", "x11", "x12", "x13", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
+rebuilt        : ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
+Unresolved references mismatch:
+after transform: ["BuiltinIteratorReturn", "Iterable", "IterableIterator"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E2"]
@@ -15043,8 +20878,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["E", "X"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -15142,14 +20977,10 @@ Unresolved references mismatch:
 after transform: ["shouldBeIdentity"]
 rebuilt        : ["p1", "shouldBeIdentity"]
 
-tasks/coverage/typescript/tests/cases/compiler/jsFileClassSelfReferencedProperty.ts
-semantic error: Cannot use export statement outside a module
-
-tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationRestParamJsDocFunction.ts
-semantic error: Cannot use export statement outside a module
-
 tasks/coverage/typescript/tests/cases/compiler/jsFileESModuleWithEnumTag.ts
-semantic error: Cannot use export statement outside a module
+semantic error: Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
 semantic error: Bindings mismatch:
@@ -15162,9 +20993,6 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
-tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash.ts
-semantic error: Cannot use export statement outside a module
-
 tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "data", "fn"]
@@ -15175,8 +21003,8 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Component", "MyComponent", "RouteProps", "_jsxFileName", "_reactJsxRuntime", "global"]
-rebuilt        : ScopeId(0): ["MyComponent", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Component", "MyComponent", "RouteProps", "_jsx", "_jsxFileName", "global"]
+rebuilt        : ScopeId(0): ["MyComponent", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(14), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
@@ -15184,8 +21012,8 @@ Bindings mismatch:
 after transform: ScopeId(15): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["Component", "Readonly", "require"]
-rebuilt        : ["Component", "require"]
+after transform: ["Component", "Readonly"]
+rebuilt        : ["Component"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 semantic error: Bindings mismatch:
@@ -15197,9 +21025,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(2): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 semantic error: Bindings mismatch:
@@ -15223,19 +21048,16 @@ rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "NoticeList", "Props", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["NoticeList", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "NoticeList", "Props", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["NoticeList", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ElemClass", "JSX", "_jsxFileName", "_reactJsxRuntime", "elem"]
-rebuilt        : ScopeId(0): ["ElemClass", "_jsxFileName", "_reactJsxRuntime", "elem"]
+after transform: ScopeId(0): ["ElemClass", "JSX", "_jsx", "_jsxFileName", "elem"]
+rebuilt        : ScopeId(0): ["ElemClass", "_jsx", "_jsxFileName", "elem"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -15243,8 +21065,8 @@ Bindings mismatch:
 after transform: ScopeId(9): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
+after transform: ["JSX"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
@@ -15265,8 +21087,8 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["React", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
 semantic error: Missing SymbolId: Element
@@ -15307,14 +21129,11 @@ rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Props", "React", "Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
-rebuilt        : ScopeId(0): ["Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
+after transform: ScopeId(0): ["Props", "React", "Wrapper", "_jsx", "_jsxFileName", "element"]
+rebuilt        : ScopeId(0): ["Wrapper", "_jsx", "_jsxFileName", "element"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
 semantic error: Bindings mismatch:
@@ -15418,17 +21237,17 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "otherProps"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["_jsx", "_jsxFileName", "otherProps"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("otherProps")
-rebuilt        : ReferenceId(4): None
+rebuilt        : ReferenceId(3): None
 Unresolved references mismatch:
-after transform: ["GenericComponent", "Omit", "omit", "require"]
-rebuilt        : ["GenericComponent", "omit", "otherProps", "require"]
+after transform: ["GenericComponent", "Omit", "omit"]
+rebuilt        : ["GenericComponent", "omit", "otherProps"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
 semantic error: Bindings mismatch:
@@ -15472,19 +21291,14 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Record", "require"]
-rebuilt        : ["require"]
-
-tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
+after transform: ["Record"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
 semantic error: Bindings mismatch:
@@ -15547,30 +21361,30 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "react", "tag"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "tag"]
+after transform: ScopeId(0): ["_jsx", "_jsxFileName", "react", "tag"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "tag"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Function", "require"]
-rebuilt        : ["require"]
+after transform: ["Function"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "Repro", "Select", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Repro", "Select", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["React", "Repro", "Select", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["Repro", "Select", "_jsx", "_jsxFileName"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(2): [ReferenceId(4)]
+rebuilt        : SymbolId(2): [ReferenceId(3)]
 Unresolved references mismatch:
-after transform: ["Parameters", "Partial", "require"]
-rebuilt        : ["require"]
+after transform: ["Parameters", "Partial"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -15712,6 +21526,9 @@ tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 semantic error: Missing SymbolId: A
@@ -15977,6 +21794,14 @@ Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(4), ReferenceId(6)]
 rebuilt        : [ReferenceId(4)]
 
+tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Point", "increment"]
+rebuilt        : ScopeId(0): ["increment"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
 tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Boxify", "Hmm", "MustBeArray", "T1", "T2", "T3", "T4", "T5", "X"]
@@ -16040,6 +21865,51 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+
+tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericIndexedAccess.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["P", "Test", "TypeHandlers", "Types", "TypesMap", "onSomeEvent", "typeHandlers"]
+rebuilt        : ScopeId(0): ["Test", "onSomeEvent", "typeHandlers"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "entry", "name"]
+rebuilt        : ScopeId(3): ["entry", "name"]
+Bindings mismatch:
+after transform: ScopeId(13): ["T", "p"]
+rebuilt        : ScopeId(7): ["p"]
+Unresolved references mismatch:
+after transform: ["console", "true"]
+rebuilt        : ["console"]
+
+tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["PrivateMapped"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "schema"]
+rebuilt        : ScopeId(1): ["schema"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "schema"]
+rebuilt        : ScopeId(2): ["schema"]
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4)]
+rebuilt        : ScopeId(2): []
+Unresolved references mismatch:
+after transform: ["Record", "Required"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
 semantic error: Bindings mismatch:
@@ -16170,6 +22040,14 @@ rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
 after transform: ["Readonly", "TupleSchema", "ZodEnum"]
 rebuilt        : ["TupleSchema"]
+
+tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Exclude"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 semantic error: Bindings mismatch:
@@ -16312,27 +22190,15 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(5): [SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
 rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(5): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(9): SymbolFlags(Class)
@@ -16760,6 +22626,19 @@ Reference flags mismatch:
 after transform: ReferenceId(12): ReferenceFlags(Write)
 rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
 
+tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["SubModule"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x"]
@@ -17074,6 +22953,30 @@ Unresolved references mismatch:
 after transform: ["D3"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./observable", "Observable"]
+rebuilt        : ScopeId(0): ["Observable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./observable", "Observable"]
+rebuilt        : ScopeId(0): ["Observable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./observable", "Observable"]
+rebuilt        : ScopeId(0): ["Observable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
@@ -17114,6 +23017,14 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Observable", "observable"]
+rebuilt        : ScopeId(0): ["Observable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./observable", "Observable"]
@@ -17130,6 +23041,46 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "global", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "global", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "global"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["global"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./f1", "A", "B"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
 semantic error: Missing SymbolId: I
 Missing SymbolId: C
@@ -17139,6 +23090,31 @@ rebuilt        : ScopeId(0): ["A", "C", "I"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports5.ts
+semantic error: Missing SymbolId: I
+Missing SymbolId: C
+Bindings mismatch:
+after transform: ScopeId(0): ["./f1", "A", "B", "C", "I", "N"]
+rebuilt        : ScopeId(0): ["A", "C", "I"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports6.ts
+semantic error: Missing SymbolId: I
+Missing SymbolId: C
+Bindings mismatch:
+after transform: ScopeId(0): ["./f1", "A", "B", "C", "I", "N"]
+rebuilt        : ScopeId(0): ["A", "C", "I"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Observable", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule2.ts
 semantic error: Bindings mismatch:
@@ -17172,6 +23148,43 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsBundledOutput1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./m1", "Cls"]
+rebuilt        : ScopeId(0): ["Cls"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./a", "A", "B", "Cls"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./a", "A", "B"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./a", "A", "Cls"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "a", "b", "c"]
+rebuilt        : ScopeId(0): ["a", "b", "c"]
+
 tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
@@ -17180,14 +23193,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(7): ["A", "E1"]
 rebuilt        : ScopeId(7): ["E1"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
+after transform: ScopeId(7): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["B", "E2"]
 rebuilt        : ScopeId(8): ["E2"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
+after transform: ScopeId(8): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable | Export)
@@ -17197,6 +23210,14 @@ rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Account", "Account2"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -17387,6 +23408,17 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["outer"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["outer"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -17995,6 +24027,14 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(6): []
 rebuilt        : SymbolId(9): [ReferenceId(9)]
 
+tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -18047,6 +24087,12 @@ Unresolved references mismatch:
 after transform: ["ng"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
 tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ICallback", "f1", "f2", "load"]
@@ -18062,6 +24108,10 @@ rebuilt        : ScopeId(0): ["a", "b", "i", "i1", "i2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -18131,6 +24181,14 @@ rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(5)]
 rebuilt        : SymbolId(2): []
+
+tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
 semantic error: Missing SymbolId: M
@@ -18230,6 +24288,14 @@ rebuilt        : ReferenceId(8): Some("A")
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["M"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 semantic error: Bindings mismatch:
@@ -18610,6 +24676,53 @@ Unresolved references mismatch:
 after transform: ["Array", "takeArray"]
 rebuilt        : ["takeArray"]
 
+tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["EmptyString", "Falsy", "MyDiscriminatedUnion", "TEST_CASES", "Union", "assertRelationIsNullOrStringArray", "broken", "check1", "check2", "example1", "example2", "example3", "f1", "f1x", "f2", "fx1", "fx10", "fx2", "fx3", "fx4", "fx5", "isEmpty", "test", "test1", "test3", "v1", "v2", "working", "workingAgain"]
+rebuilt        : ScopeId(0): ["TEST_CASES", "assertRelationIsNullOrStringArray", "check1", "check2", "example1", "example2", "example3", "f1", "f1x", "f2", "fx1", "fx10", "fx2", "fx3", "fx4", "fx5", "isEmpty", "test", "test1", "test3", "v1", "v2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(21), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(38), ScopeId(41), ScopeId(46), ScopeId(49), ScopeId(54), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(80)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(12), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(23), ScopeId(26), ScopeId(31), ScopeId(34), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(57), ScopeId(60)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "x"]
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "x"]
+rebuilt        : ScopeId(5): ["x"]
+Bindings mismatch:
+after transform: ScopeId(17): ["T", "c", "obj"]
+rebuilt        : ScopeId(9): ["c", "obj"]
+Reference symbol mismatch:
+after transform: ReferenceId(117): Some("working")
+rebuilt        : ReferenceId(97): None
+Reference symbol mismatch:
+after transform: ReferenceId(118): Some("working")
+rebuilt        : ReferenceId(98): None
+Reference symbol mismatch:
+after transform: ReferenceId(119): Some("working")
+rebuilt        : ReferenceId(99): None
+Reference symbol mismatch:
+after transform: ReferenceId(121): Some("broken")
+rebuilt        : ReferenceId(101): None
+Reference symbol mismatch:
+after transform: ReferenceId(122): Some("broken")
+rebuilt        : ReferenceId(102): None
+Reference symbol mismatch:
+after transform: ReferenceId(123): Some("broken")
+rebuilt        : ReferenceId(103): None
+Reference symbol mismatch:
+after transform: ReferenceId(125): Some("workingAgain")
+rebuilt        : ReferenceId(105): None
+Reference symbol mismatch:
+after transform: ReferenceId(126): Some("workingAgain")
+rebuilt        : ReferenceId(106): None
+Reference symbol mismatch:
+after transform: ReferenceId(127): Some("workingAgain")
+rebuilt        : ReferenceId(107): None
+Unresolved references mismatch:
+after transform: ["Record", "X", "XS", "Y", "YS", "assert", "isA", "isEmptyArray", "isEmptyStrOrUndefined", "isEmptyString", "isFalsy", "isMaybeEmptyArray", "isMaybeEmptyString", "isMaybeZero", "isMyDiscriminatedUnion", "isXSorY", "isZero", "undefined"]
+rebuilt        : ["assert", "broken", "isA", "isEmptyArray", "isEmptyStrOrUndefined", "isEmptyString", "isFalsy", "isMaybeEmptyArray", "isMaybeEmptyString", "isMaybeZero", "isMyDiscriminatedUnion", "isXSorY", "isZero", "undefined", "working", "workingAgain"]
+
 tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BorkedType", "FixedType", "WorkingType", "borked", "fixed", "working"]
@@ -18792,8 +24905,8 @@ Bindings mismatch:
 after transform: ScopeId(14): ["DISPATCH", "GatewayOpcode", "HEARTBEAT", "HEARTBEAT_ACK", "HELLO", "IDENTIFY", "INVALID_SESSION", "PRESENCE_UPDATE", "RECONNECT", "REQUEST_GUILD_MEMBERS", "RESUME", "VOICE_STATE_UPDATE"]
 rebuilt        : ScopeId(5): ["GatewayOpcode"]
 Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
+after transform: ScopeId(14): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(14): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | Export)
@@ -18898,6 +25011,17 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IListenable", "ObservableValue", "notifyListeners"]
@@ -18936,6 +25060,14 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["decorator"]
+
+tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringInPrivateMethod.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Arg", "Bar"]
+rebuilt        : ScopeId(0): ["Bar"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctionExpressionAssignment.ts
 semantic error: Bindings mismatch:
@@ -19014,6 +25146,17 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(8)]
 rebuilt        : SymbolId(3): []
+
+tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["EnhancedPrisma", "PrismaClient", "TPrismaClientCtor", "enhancePrisma"]
+rebuilt        : ScopeId(0): ["EnhancedPrisma", "PrismaClient"]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("enhancePrisma")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["enhancePrisma"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -19188,6 +25331,17 @@ Bindings mismatch:
 after transform: ScopeId(8): ["T", "U", "x", "z"]
 rebuilt        : ScopeId(3): ["x", "z"]
 
+tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "x", "y"]
+rebuilt        : ScopeId(1): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "x"]
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "obj"]
+rebuilt        : ScopeId(5): ["obj"]
+
 tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ordering", "Query", "QueryHandler", "StateNodesConfig", "StateSchema"]
@@ -19267,6 +25421,69 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
+
+tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
+semantic error: Missing ReferenceId: N1
+Missing ReferenceId: N1
+Missing ReferenceId: N2
+Missing ReferenceId: N2
+Bindings mismatch:
+after transform: ScopeId(0): ["Bins1", "Bins2", "E", "E1", "E2", "N1", "N2", "T1", "b1", "b2", "e", "e1", "e2", "x"]
+rebuilt        : ScopeId(0): ["E1", "N1", "N2", "b1", "b2", "e", "e1", "e2", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(12)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(1): ["E1", "ONE", "THREE", "TWO"]
+rebuilt        : ScopeId(1): ["E1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "B", "N1"]
+rebuilt        : ScopeId(2): ["N1"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["C", "D", "N2"]
+rebuilt        : ScopeId(3): ["N2"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(32)]
+rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): [ReferenceId(18), ReferenceId(38)]
+rebuilt        : SymbolId(6): [ReferenceId(23)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(31): [ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37)]
+rebuilt        : SymbolId(7): [ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): [ReferenceId(19), ReferenceId(44)]
+rebuilt        : SymbolId(8): [ReferenceId(31)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(32): [ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43)]
+rebuilt        : SymbolId(9): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30)]
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("E2")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(22): Some("E")
+rebuilt        : ReferenceId(32): None
+Unresolved references mismatch:
+after transform: ["val"]
+rebuilt        : ["E", "E2"]
 
 tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint3.ts
 semantic error: Symbol reference IDs mismatch:
@@ -19360,6 +25577,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/objectLiteralDeclarationGeneration1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+
 tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Nums", "Strs", "TestNums", "TestStrs", "a", "an", "b", "bn", "m", "n", "um", "un", "ux", "uz", "x", "y", "z"]
@@ -19441,6 +25663,17 @@ Unresolved references mismatch:
 after transform: ["Observable", "from", "of"]
 rebuilt        : ["from", "of"]
 
+tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "Baz", "Foo", "getBarA", "getBazA"]
+rebuilt        : ScopeId(0): ["getBarA", "getBazA"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Unresolved references mismatch:
+after transform: ["Omit"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyPropertyDescriptor", "MyPropertyDescriptor2"]
@@ -19491,6 +25724,11 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable", "true"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/outModuleTripleSlashRefs.ts
+semantic error: Unresolved references mismatch:
+after transform: ["GlobalFoo"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overload2.ts
@@ -19890,6 +26128,14 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/parenthesisDoesNotBlockAliasSymbolCreation.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "A2", "InvalidKeys", "InvalidKeys2", "a", "a2", "a3", "a4"]
+rebuilt        : ScopeId(0): ["a", "a2", "a3", "a4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/parseArrowFunctionWithFunctionReturnType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -20235,6 +26481,332 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Kind", "result"]
+rebuilt        : ScopeId(0): ["result"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyAccessorDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateGetAccessorTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicGetAccessorTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateSetAccessorTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicSetAccessorTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPrivateModuleGetAccessorTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPrivateModuleSetAccessorTypes
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPrivateGetAccessorTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicGetAccessorTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPrivateSetAccessorTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicSetAccessorTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPrivateModuleGetAccessorTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPrivateModuleSetAccessorTypes
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(69)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(70)]
+Binding symbols mismatch:
+after transform: ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(46), SymbolId(51), SymbolId(56), SymbolId(61), SymbolId(62), SymbolId(65), SymbolId(66), SymbolId(104)]
+rebuilt        : ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(47), SymbolId(52), SymbolId(57), SymbolId(62), SymbolId(63), SymbolId(66), SymbolId(67)]
+Binding symbols mismatch:
+after transform: ScopeId(150): [SymbolId(70), SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(81), SymbolId(86), SymbolId(91), SymbolId(96), SymbolId(97), SymbolId(100), SymbolId(101), SymbolId(105)]
+rebuilt        : ScopeId(150): [SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(83), SymbolId(88), SymbolId(93), SymbolId(98), SymbolId(99), SymbolId(102), SymbolId(103)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47)]
+rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(35): [ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103)]
+rebuilt        : SymbolId(36): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37)]
+Symbol flags mismatch:
+after transform: SymbolId(36): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(37): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(36): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107)]
+rebuilt        : SymbolId(37): [ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
+Symbol flags mismatch:
+after transform: SymbolId(37): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(38): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(37): []
+rebuilt        : SymbolId(38): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(38): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(39): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(38): []
+rebuilt        : SymbolId(39): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(41): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(42): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(41): []
+rebuilt        : SymbolId(42): [ReferenceId(43)]
+Symbol flags mismatch:
+after transform: SymbolId(46): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(47): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(46): []
+rebuilt        : SymbolId(47): [ReferenceId(45)]
+Symbol flags mismatch:
+after transform: SymbolId(61): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(62): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(61): []
+rebuilt        : SymbolId(62): [ReferenceId(49)]
+Symbol flags mismatch:
+after transform: SymbolId(62): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(63): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(62): []
+rebuilt        : SymbolId(63): [ReferenceId(51)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(70): [ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163)]
+rebuilt        : SymbolId(72): [ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73)]
+Symbol flags mismatch:
+after transform: SymbolId(71): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(73): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(71): [ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167)]
+rebuilt        : SymbolId(73): [ReferenceId(57), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77)]
+Symbol flags mismatch:
+after transform: SymbolId(72): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(74): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(72): []
+rebuilt        : SymbolId(74): [ReferenceId(63)]
+Symbol flags mismatch:
+after transform: SymbolId(73): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(75): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(73): []
+rebuilt        : SymbolId(75): [ReferenceId(69)]
+Symbol flags mismatch:
+after transform: SymbolId(76): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(78): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(76): []
+rebuilt        : SymbolId(78): [ReferenceId(79)]
+Symbol flags mismatch:
+after transform: SymbolId(81): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(83): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(81): []
+rebuilt        : SymbolId(83): [ReferenceId(81)]
+Symbol flags mismatch:
+after transform: SymbolId(96): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(98): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(96): []
+rebuilt        : SymbolId(98): [ReferenceId(85)]
+Symbol flags mismatch:
+after transform: SymbolId(97): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(99): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(97): []
+rebuilt        : SymbolId(99): [ReferenceId(87)]
+Reference symbol mismatch:
+after transform: ReferenceId(50): Some("privateModule")
+rebuilt        : ReferenceId(16): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(51): Some("privateModule")
+rebuilt        : ReferenceId(17): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(56): Some("privateModule")
+rebuilt        : ReferenceId(18): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(57): Some("privateModule")
+rebuilt        : ReferenceId(19): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(110): Some("privateModule")
+rebuilt        : ReferenceId(46): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(111): Some("privateModule")
+rebuilt        : ReferenceId(47): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(116): Some("privateModule")
+rebuilt        : ReferenceId(52): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(117): Some("privateModule")
+rebuilt        : ReferenceId(53): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(170): Some("privateModule")
+rebuilt        : ReferenceId(82): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(171): Some("privateModule")
+rebuilt        : ReferenceId(83): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(176): Some("privateModule")
+rebuilt        : ReferenceId(88): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(177): Some("privateModule")
+rebuilt        : ReferenceId(89): Some("privateModule")
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameAccessorDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["GlobalWidgets"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["GlobalWidgets"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter.ts
+semantic error: Missing SymbolId: Query
+Missing SymbolId: _Query
+Missing ReferenceId: _Query
+Missing ReferenceId: fromDoWhile
+Missing ReferenceId: Query
+Missing ReferenceId: Query
+Bindings mismatch:
+after transform: ScopeId(0): ["Iterator", "Query", "x"]
+rebuilt        : ScopeId(0): ["Query", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(4), SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "doWhile"]
+rebuilt        : ScopeId(2): ["doWhile"]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter2.ts
+semantic error: Missing SymbolId: Q
+Missing SymbolId: _Q
+Missing ReferenceId: _Q
+Missing ReferenceId: foo
+Missing ReferenceId: Q
+Missing ReferenceId: Q
+Missing SymbolId: _Q2
+Missing ReferenceId: Q
+Missing ReferenceId: Q
+Bindings mismatch:
+after transform: ScopeId(0): ["Iterator", "Q", "x"]
+rebuilt        : ScopeId(0): ["Q", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "x"]
+rebuilt        : ScopeId(2): ["x"]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(3): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckCallbackOfInterfaceMethodWithTypeParameter.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface1.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface | NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 74, end: 107 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 59, end: 62 }, Span { start: 74, end: 107 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface2.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T1"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["T2"]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfFunction.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
 tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -20281,18 +26853,12 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(33), ScopeId(35),
 Bindings mismatch:
 after transform: ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public", "m1_i_private", "m1_i_public"]
 rebuilt        : ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 Bindings mismatch:
 after transform: ScopeId(19): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public", "m2_i_private", "m2_i_public"]
 rebuilt        : ScopeId(17): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public"]
-Scope flags mismatch:
-after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(17): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
 rebuilt        : ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
@@ -20380,6 +26946,93 @@ rebuilt        : SymbolId(31): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(33): []
 rebuilt        : SymbolId(31): [ReferenceId(45)]
+
+tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassImplementingPublicInterfaceInModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassImplementingPrivateInterfaceInModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassImplementingFromPrivateModuleInterface
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassImplementingPrivateAndPublicInterface
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassImplementingPublicInterfaceInModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassImplementingPrivateInterfaceInModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassImplementingFromPrivateModuleInterface
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Bindings mismatch:
+after transform: ScopeId(0): ["privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterface", "privateInterface", "privateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterface", "publicClassImplementingPublicInterface", "publicInterface", "publicModule"]
+rebuilt        : ScopeId(0): ["privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterface", "privateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterface", "publicClassImplementingPublicInterface", "publicModule"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_publicModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "privateInterfaceInPublicModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateAndPublicInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule", "publicInterfaceInPublicModule"]
+rebuilt        : ScopeId(1): ["_publicModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateAndPublicInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+Bindings mismatch:
+after transform: ScopeId(11): ["_privateModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "privateInterfaceInPrivateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule", "publicInterfaceInPrivateModule"]
+rebuilt        : ScopeId(9): ["_privateModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule"]
+Scope children mismatch:
+after transform: ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
+rebuilt        : ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(5): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(8): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(13): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(13): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(14): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(16): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): []
+rebuilt        : SymbolId(16): [ReferenceId(15)]
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
 semantic error: Missing SymbolId: m1
@@ -20491,6 +27144,488 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
 rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
+tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["GlobalWidgets"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["GlobalWidgets"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Bindings mismatch:
+after transform: ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes", "publicModule"]
+rebuilt        : ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicModule"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(33), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(50), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(59), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(130)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(35), ScopeId(36), ScopeId(40), ScopeId(41), ScopeId(82)]
+Bindings mismatch:
+after transform: ScopeId(65): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
+rebuilt        : ScopeId(41): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
+Scope children mismatch:
+after transform: ScopeId(65): [ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(71), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(86), ScopeId(92), ScopeId(98), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(115), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(124), ScopeId(128), ScopeId(129)]
+rebuilt        : ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(50), ScopeId(56), ScopeId(62), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(76), ScopeId(77), ScopeId(81)]
+Bindings mismatch:
+after transform: ScopeId(130): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
+rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
+Scope children mismatch:
+after transform: ScopeId(130): [ScopeId(131), ScopeId(132), ScopeId(133), ScopeId(136), ScopeId(139), ScopeId(142), ScopeId(145), ScopeId(151), ScopeId(157), ScopeId(163), ScopeId(169), ScopeId(170), ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(177), ScopeId(180), ScopeId(184), ScopeId(185), ScopeId(186), ScopeId(189), ScopeId(193), ScopeId(194)]
+rebuilt        : ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(91), ScopeId(97), ScopeId(103), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(113), ScopeId(117), ScopeId(118), ScopeId(122)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(71): [ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134)]
+rebuilt        : SymbolId(60): []
+Symbol flags mismatch:
+after transform: SymbolId(72): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(61): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(72): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151)]
+rebuilt        : SymbolId(61): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(77): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(62): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(77): []
+rebuilt        : SymbolId(62): [ReferenceId(17)]
+Symbol flags mismatch:
+after transform: SymbolId(85): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(70): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(85): []
+rebuilt        : SymbolId(70): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(109): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(94): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(109): []
+rebuilt        : SymbolId(94): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(111): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(96): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(111): []
+rebuilt        : SymbolId(96): [ReferenceId(29)]
+Symbol flags mismatch:
+after transform: SymbolId(113): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(98): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(115): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(100): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(122): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(102): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(122): []
+rebuilt        : SymbolId(102): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(128): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(108): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(128): []
+rebuilt        : SymbolId(108): [ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(138): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(116): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(142): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214)]
+rebuilt        : SymbolId(120): []
+Symbol flags mismatch:
+after transform: SymbolId(143): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(121): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(143): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231)]
+rebuilt        : SymbolId(121): [ReferenceId(41)]
+Symbol flags mismatch:
+after transform: SymbolId(148): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(122): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(148): []
+rebuilt        : SymbolId(122): [ReferenceId(45)]
+Symbol flags mismatch:
+after transform: SymbolId(156): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(130): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(156): []
+rebuilt        : SymbolId(130): [ReferenceId(49)]
+Symbol flags mismatch:
+after transform: SymbolId(180): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(154): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(180): []
+rebuilt        : SymbolId(154): [ReferenceId(55)]
+Symbol flags mismatch:
+after transform: SymbolId(182): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(156): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(182): []
+rebuilt        : SymbolId(156): [ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(184): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(158): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(186): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(160): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(193): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(162): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(193): []
+rebuilt        : SymbolId(162): [ReferenceId(61)]
+Symbol flags mismatch:
+after transform: SymbolId(199): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(168): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(199): []
+rebuilt        : SymbolId(168): [ReferenceId(63)]
+Symbol flags mismatch:
+after transform: SymbolId(209): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(176): SymbolFlags(FunctionScopedVariable)
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes1
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes1
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes1
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateParmeterTypes1
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPublicParmeterTypes1
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes1
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Bindings mismatch:
+after transform: ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes", "publicModule"]
+rebuilt        : ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicModule"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(24), ScopeId(33), ScopeId(42), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(66), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(82), ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(170)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(12), ScopeId(21), ScopeId(30), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(122)]
+Bindings mismatch:
+after transform: ScopeId(85): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
+rebuilt        : ScopeId(61): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1"]
+Scope children mismatch:
+after transform: ScopeId(85): [ScopeId(86), ScopeId(87), ScopeId(88), ScopeId(91), ScopeId(94), ScopeId(97), ScopeId(100), ScopeId(109), ScopeId(118), ScopeId(127), ScopeId(136), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147), ScopeId(148), ScopeId(151), ScopeId(156), ScopeId(157), ScopeId(158), ScopeId(159), ScopeId(162), ScopeId(167), ScopeId(168), ScopeId(169)]
+rebuilt        : ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(73), ScopeId(82), ScopeId(91), ScopeId(100), ScopeId(101), ScopeId(102), ScopeId(103), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(113), ScopeId(114), ScopeId(115), ScopeId(120), ScopeId(121)]
+Bindings mismatch:
+after transform: ScopeId(170): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
+rebuilt        : ScopeId(122): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1"]
+Scope children mismatch:
+after transform: ScopeId(170): [ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(176), ScopeId(179), ScopeId(182), ScopeId(185), ScopeId(194), ScopeId(203), ScopeId(212), ScopeId(221), ScopeId(222), ScopeId(223), ScopeId(224), ScopeId(225), ScopeId(226), ScopeId(227), ScopeId(228), ScopeId(229), ScopeId(230), ScopeId(231), ScopeId(232), ScopeId(233), ScopeId(236), ScopeId(241), ScopeId(242), ScopeId(243), ScopeId(244), ScopeId(247), ScopeId(252), ScopeId(253), ScopeId(254)]
+rebuilt        : ScopeId(122): [ScopeId(123), ScopeId(124), ScopeId(125), ScopeId(134), ScopeId(143), ScopeId(152), ScopeId(161), ScopeId(162), ScopeId(163), ScopeId(164), ScopeId(165), ScopeId(166), ScopeId(167), ScopeId(168), ScopeId(169), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(181), ScopeId(182)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(16), ReferenceId(18)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59)]
+rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): [ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(98), ReferenceId(99), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(140)]
+rebuilt        : SymbolId(22): [ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(58)]
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(23): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(28): [ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(141)]
+rebuilt        : SymbolId(23): [ReferenceId(27), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(55), ReferenceId(59)]
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(24): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): []
+rebuilt        : SymbolId(24): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(34): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(25): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(34): []
+rebuilt        : SymbolId(25): [ReferenceId(39)]
+Symbol flags mismatch:
+after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(37): []
+rebuilt        : SymbolId(28): [ReferenceId(49)]
+Symbol flags mismatch:
+after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(38): []
+rebuilt        : SymbolId(29): [ReferenceId(51)]
+Symbol flags mismatch:
+after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(31): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(41): []
+rebuilt        : SymbolId(32): [ReferenceId(54)]
+Symbol flags mismatch:
+after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(42): []
+rebuilt        : SymbolId(33): [ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(43): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(44): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(46): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(36): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(46): []
+rebuilt        : SymbolId(36): [ReferenceId(63)]
+Symbol flags mismatch:
+after transform: SymbolId(47): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(47): []
+rebuilt        : SymbolId(37): [ReferenceId(65)]
+Symbol flags mismatch:
+after transform: SymbolId(48): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(48): []
+rebuilt        : SymbolId(38): [ReferenceId(68)]
+Symbol flags mismatch:
+after transform: SymbolId(51): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(40): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(52): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(41): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(54): [ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(212), ReferenceId(214), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222)]
+rebuilt        : SymbolId(44): [ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(100), ReferenceId(106)]
+Symbol flags mismatch:
+after transform: SymbolId(55): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(45): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(55): [ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208), ReferenceId(209), ReferenceId(210), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(223)]
+rebuilt        : SymbolId(45): [ReferenceId(75), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(103), ReferenceId(107)]
+Symbol flags mismatch:
+after transform: SymbolId(60): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(46): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(60): []
+rebuilt        : SymbolId(46): [ReferenceId(81)]
+Symbol flags mismatch:
+after transform: SymbolId(61): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(47): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(61): []
+rebuilt        : SymbolId(47): [ReferenceId(87)]
+Symbol flags mismatch:
+after transform: SymbolId(64): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(50): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(64): []
+rebuilt        : SymbolId(50): [ReferenceId(97)]
+Symbol flags mismatch:
+after transform: SymbolId(65): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(51): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(65): []
+rebuilt        : SymbolId(51): [ReferenceId(99)]
+Symbol flags mismatch:
+after transform: SymbolId(66): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(67): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(68): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(54): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(68): []
+rebuilt        : SymbolId(54): [ReferenceId(102)]
+Symbol flags mismatch:
+after transform: SymbolId(69): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(55): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(69): []
+rebuilt        : SymbolId(55): [ReferenceId(105)]
+Symbol flags mismatch:
+after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(56): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(71): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(57): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(73): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(58): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(73): []
+rebuilt        : SymbolId(58): [ReferenceId(111)]
+Symbol flags mismatch:
+after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(59): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(74): []
+rebuilt        : SymbolId(59): [ReferenceId(113)]
+Symbol flags mismatch:
+after transform: SymbolId(75): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(60): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(75): []
+rebuilt        : SymbolId(60): [ReferenceId(116)]
+Symbol flags mismatch:
+after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(62): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(63): SymbolFlags(FunctionScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(66): Some("privateModule")
+rebuilt        : ReferenceId(20): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(67): Some("privateModule")
+rebuilt        : ReferenceId(21): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(69): Some("privateModule")
+rebuilt        : ReferenceId(22): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(77): Some("privateModule")
+rebuilt        : ReferenceId(23): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(78): Some("privateModule")
+rebuilt        : ReferenceId(24): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(80): Some("privateModule")
+rebuilt        : ReferenceId(25): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(148): Some("privateModule")
+rebuilt        : ReferenceId(60): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(149): Some("privateModule")
+rebuilt        : ReferenceId(61): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(151): Some("privateModule")
+rebuilt        : ReferenceId(66): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(159): Some("privateModule")
+rebuilt        : ReferenceId(69): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(160): Some("privateModule")
+rebuilt        : ReferenceId(70): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(162): Some("privateModule")
+rebuilt        : ReferenceId(71): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(230): Some("privateModule")
+rebuilt        : ReferenceId(108): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(231): Some("privateModule")
+rebuilt        : ReferenceId(109): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(233): Some("privateModule")
+rebuilt        : ReferenceId(114): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(241): Some("privateModule")
+rebuilt        : ReferenceId(117): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(242): Some("privateModule")
+rebuilt        : ReferenceId(118): Some("privateModule")
+Reference symbol mismatch:
+after transform: ReferenceId(244): Some("privateModule")
+rebuilt        : ReferenceId(119): Some("privateModule")
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -20514,15 +27649,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(28), SymbolId(
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(38)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(23): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(21), SymbolId(39)]
 rebuilt        : ScopeId(23): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(23)]
-Scope flags mismatch:
-after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(23): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -20692,9 +27821,6 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(80), SymbolId(
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(128)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
@@ -20704,9 +27830,6 @@ rebuilt        : ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23
 Binding symbols mismatch:
 after transform: ScopeId(57): [SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(54), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(74), SymbolId(76), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(83), SymbolId(84), SymbolId(85), SymbolId(129)]
 rebuilt        : ScopeId(53): [SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(50), SymbolId(56), SymbolId(58), SymbolId(60), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(79)]
-Scope flags mismatch:
-after transform: ScopeId(57): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(53): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76)]
 rebuilt        : ScopeId(57): [ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70)]
@@ -20747,37 +27870,55 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(23): []
 rebuilt        : SymbolId(20): [ReferenceId(23)]
 Symbol flags mismatch:
-after transform: SymbolId(29): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(27): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(24): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(29): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(29): []
 rebuilt        : SymbolId(26): [ReferenceId(25)]
 Symbol flags mismatch:
-after transform: SymbolId(33): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(31): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(33): []
 rebuilt        : SymbolId(30): [ReferenceId(27)]
 Symbol flags mismatch:
-after transform: SymbolId(36): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(35): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(36): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(36): []
 rebuilt        : SymbolId(33): [ReferenceId(31)]
 Symbol flags mismatch:
-after transform: SymbolId(38): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(38): []
 rebuilt        : SymbolId(35): [ReferenceId(35)]
 Symbol flags mismatch:
-after transform: SymbolId(40): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(36): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(40): []
 rebuilt        : SymbolId(37): [ReferenceId(39)]
 Symbol flags mismatch:
-after transform: SymbolId(42): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(39): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(42): []
@@ -20810,37 +27951,55 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(66): []
 rebuilt        : SymbolId(60): [ReferenceId(69)]
 Symbol flags mismatch:
-after transform: SymbolId(72): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(64): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(72): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(66): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(72): []
 rebuilt        : SymbolId(66): [ReferenceId(71)]
 Symbol flags mismatch:
-after transform: SymbolId(76): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(68): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(76): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(70): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(76): []
 rebuilt        : SymbolId(70): [ReferenceId(73)]
 Symbol flags mismatch:
-after transform: SymbolId(79): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(72): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(73): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(79): []
 rebuilt        : SymbolId(73): [ReferenceId(77)]
 Symbol flags mismatch:
-after transform: SymbolId(81): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(80): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(74): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(81): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(75): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(81): []
 rebuilt        : SymbolId(75): [ReferenceId(81)]
 Symbol flags mismatch:
-after transform: SymbolId(83): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(82): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(76): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(83): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(77): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(83): []
 rebuilt        : SymbolId(77): [ReferenceId(85)]
 Symbol flags mismatch:
-after transform: SymbolId(85): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(84): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(78): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(85): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(79): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(85): []
@@ -20889,6 +28048,22 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(13): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
 rebuilt        : SymbolId(14): [ReferenceId(14), ReferenceId(15)]
 
+tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
 tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -20932,6 +28107,36 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
+tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
 tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -20954,18 +28159,12 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(11)]
 Bindings mismatch:
 after transform: ScopeId(1): ["C1_public", "C2_private", "C3_public", "C4_private", "_m"]
 rebuilt        : ScopeId(1): ["C1_public", "C2_private", "_m"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(14)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(23): ["C1_public", "C2_private", "C3_public", "C4_private", "_m2"]
 rebuilt        : ScopeId(5): ["C1_public", "C2_private", "_m2"]
-Scope flags mismatch:
-after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(23): [ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(36)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(8)]
@@ -20993,6 +28192,89 @@ rebuilt        : SymbolId(8): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(11): [ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(87), ReferenceId(89), ReferenceId(91), ReferenceId(93), ReferenceId(95), ReferenceId(97), ReferenceId(99), ReferenceId(101), ReferenceId(103), ReferenceId(105), ReferenceId(107)]
 rebuilt        : SymbolId(9): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["privateInterface", "privateInterfaceImplementingFromPrivateModuleInterface", "privateInterfaceImplementingPrivateInterfaceInModule", "privateInterfaceImplementingPublicInterface", "privateModule", "publicInterface", "publicInterfaceImplementingFromPrivateModuleInterface", "publicInterfaceImplementingPrivateInterface", "publicInterfaceImplementingPublicInterface", "publicModule"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithoutExport.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
 semantic error: Bindings mismatch:
@@ -21098,6 +28380,504 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(1): []
 
+tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPublicTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithWithPrivateModuleTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicFunctionWithPrivateMopduleTypeParameters
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClass
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPrivateTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPrivateTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPublicTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicFunctionWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Bindings mismatch:
+after transform: ScopeId(0): ["privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivatModuleTypeParameters", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivatModuleTypeParameters", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends", "publicModule"]
+rebuilt        : ScopeId(0): ["privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicModule"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(20), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(45), ScopeId(50), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(60), ScopeId(63), ScopeId(64), ScopeId(67), ScopeId(70), ScopeId(71), ScopeId(142)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(8), ScopeId(13), ScopeId(18), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(32), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(46), ScopeId(47), ScopeId(94)]
+Bindings mismatch:
+after transform: ScopeId(16): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(17): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(18): ["T"]
+rebuilt        : ScopeId(6): []
+Bindings mismatch:
+after transform: ScopeId(19): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(21): ["T"]
+rebuilt        : ScopeId(9): []
+Bindings mismatch:
+after transform: ScopeId(22): ["T"]
+rebuilt        : ScopeId(10): []
+Bindings mismatch:
+after transform: ScopeId(23): ["T"]
+rebuilt        : ScopeId(11): []
+Bindings mismatch:
+after transform: ScopeId(24): ["T"]
+rebuilt        : ScopeId(12): []
+Bindings mismatch:
+after transform: ScopeId(26): ["T"]
+rebuilt        : ScopeId(14): []
+Bindings mismatch:
+after transform: ScopeId(27): ["T"]
+rebuilt        : ScopeId(15): []
+Bindings mismatch:
+after transform: ScopeId(28): ["T"]
+rebuilt        : ScopeId(16): []
+Bindings mismatch:
+after transform: ScopeId(29): ["T"]
+rebuilt        : ScopeId(17): []
+Bindings mismatch:
+after transform: ScopeId(31): ["T"]
+rebuilt        : ScopeId(19): []
+Bindings mismatch:
+after transform: ScopeId(32): ["T"]
+rebuilt        : ScopeId(20): []
+Bindings mismatch:
+after transform: ScopeId(33): ["T"]
+rebuilt        : ScopeId(21): []
+Bindings mismatch:
+after transform: ScopeId(34): ["T"]
+rebuilt        : ScopeId(22): []
+Bindings mismatch:
+after transform: ScopeId(35): ["T"]
+rebuilt        : ScopeId(23): []
+Bindings mismatch:
+after transform: ScopeId(36): ["T"]
+rebuilt        : ScopeId(24): []
+Bindings mismatch:
+after transform: ScopeId(37): ["T"]
+rebuilt        : ScopeId(25): []
+Bindings mismatch:
+after transform: ScopeId(38): ["T"]
+rebuilt        : ScopeId(26): []
+Bindings mismatch:
+after transform: ScopeId(46): ["T"]
+rebuilt        : ScopeId(28): []
+Bindings mismatch:
+after transform: ScopeId(47): ["T"]
+rebuilt        : ScopeId(29): []
+Bindings mismatch:
+after transform: ScopeId(48): ["T"]
+rebuilt        : ScopeId(30): []
+Bindings mismatch:
+after transform: ScopeId(49): ["T"]
+rebuilt        : ScopeId(31): []
+Bindings mismatch:
+after transform: ScopeId(51): ["T"]
+rebuilt        : ScopeId(33): []
+Bindings mismatch:
+after transform: ScopeId(52): ["T"]
+rebuilt        : ScopeId(34): []
+Bindings mismatch:
+after transform: ScopeId(53): ["T"]
+rebuilt        : ScopeId(35): []
+Bindings mismatch:
+after transform: ScopeId(54): ["T"]
+rebuilt        : ScopeId(36): []
+Bindings mismatch:
+after transform: ScopeId(55): ["T"]
+rebuilt        : ScopeId(37): []
+Bindings mismatch:
+after transform: ScopeId(56): ["T"]
+rebuilt        : ScopeId(38): []
+Bindings mismatch:
+after transform: ScopeId(61): ["T"]
+rebuilt        : ScopeId(40): []
+Bindings mismatch:
+after transform: ScopeId(62): ["T"]
+rebuilt        : ScopeId(41): []
+Bindings mismatch:
+after transform: ScopeId(63): ["T"]
+rebuilt        : ScopeId(42): []
+Bindings mismatch:
+after transform: ScopeId(68): ["T"]
+rebuilt        : ScopeId(44): []
+Bindings mismatch:
+after transform: ScopeId(69): ["T"]
+rebuilt        : ScopeId(45): []
+Bindings mismatch:
+after transform: ScopeId(70): ["T"]
+rebuilt        : ScopeId(46): []
+Bindings mismatch:
+after transform: ScopeId(71): ["_publicModule", "privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivatModuleTypeParameters", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivatModuleTypeParameters", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
+rebuilt        : ScopeId(47): ["_publicModule", "privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends"]
+Scope children mismatch:
+after transform: ScopeId(71): [ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(83), ScopeId(86), ScopeId(91), ScopeId(96), ScopeId(101), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(113), ScopeId(116), ScopeId(121), ScopeId(126), ScopeId(127), ScopeId(128), ScopeId(131), ScopeId(134), ScopeId(135), ScopeId(138), ScopeId(141)]
+rebuilt        : ScopeId(47): [ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(55), ScopeId(60), ScopeId(65), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(79), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(89), ScopeId(90), ScopeId(93)]
+Bindings mismatch:
+after transform: ScopeId(87): ["T"]
+rebuilt        : ScopeId(51): []
+Bindings mismatch:
+after transform: ScopeId(88): ["T"]
+rebuilt        : ScopeId(52): []
+Bindings mismatch:
+after transform: ScopeId(89): ["T"]
+rebuilt        : ScopeId(53): []
+Bindings mismatch:
+after transform: ScopeId(90): ["T"]
+rebuilt        : ScopeId(54): []
+Bindings mismatch:
+after transform: ScopeId(92): ["T"]
+rebuilt        : ScopeId(56): []
+Bindings mismatch:
+after transform: ScopeId(93): ["T"]
+rebuilt        : ScopeId(57): []
+Bindings mismatch:
+after transform: ScopeId(94): ["T"]
+rebuilt        : ScopeId(58): []
+Bindings mismatch:
+after transform: ScopeId(95): ["T"]
+rebuilt        : ScopeId(59): []
+Bindings mismatch:
+after transform: ScopeId(97): ["T"]
+rebuilt        : ScopeId(61): []
+Bindings mismatch:
+after transform: ScopeId(98): ["T"]
+rebuilt        : ScopeId(62): []
+Bindings mismatch:
+after transform: ScopeId(99): ["T"]
+rebuilt        : ScopeId(63): []
+Bindings mismatch:
+after transform: ScopeId(100): ["T"]
+rebuilt        : ScopeId(64): []
+Bindings mismatch:
+after transform: ScopeId(102): ["T"]
+rebuilt        : ScopeId(66): []
+Bindings mismatch:
+after transform: ScopeId(103): ["T"]
+rebuilt        : ScopeId(67): []
+Bindings mismatch:
+after transform: ScopeId(104): ["T"]
+rebuilt        : ScopeId(68): []
+Bindings mismatch:
+after transform: ScopeId(105): ["T"]
+rebuilt        : ScopeId(69): []
+Bindings mismatch:
+after transform: ScopeId(106): ["T"]
+rebuilt        : ScopeId(70): []
+Bindings mismatch:
+after transform: ScopeId(107): ["T"]
+rebuilt        : ScopeId(71): []
+Bindings mismatch:
+after transform: ScopeId(108): ["T"]
+rebuilt        : ScopeId(72): []
+Bindings mismatch:
+after transform: ScopeId(109): ["T"]
+rebuilt        : ScopeId(73): []
+Bindings mismatch:
+after transform: ScopeId(117): ["T"]
+rebuilt        : ScopeId(75): []
+Bindings mismatch:
+after transform: ScopeId(118): ["T"]
+rebuilt        : ScopeId(76): []
+Bindings mismatch:
+after transform: ScopeId(119): ["T"]
+rebuilt        : ScopeId(77): []
+Bindings mismatch:
+after transform: ScopeId(120): ["T"]
+rebuilt        : ScopeId(78): []
+Bindings mismatch:
+after transform: ScopeId(122): ["T"]
+rebuilt        : ScopeId(80): []
+Bindings mismatch:
+after transform: ScopeId(123): ["T"]
+rebuilt        : ScopeId(81): []
+Bindings mismatch:
+after transform: ScopeId(124): ["T"]
+rebuilt        : ScopeId(82): []
+Bindings mismatch:
+after transform: ScopeId(125): ["T"]
+rebuilt        : ScopeId(83): []
+Bindings mismatch:
+after transform: ScopeId(126): ["T"]
+rebuilt        : ScopeId(84): []
+Bindings mismatch:
+after transform: ScopeId(127): ["T"]
+rebuilt        : ScopeId(85): []
+Bindings mismatch:
+after transform: ScopeId(132): ["T"]
+rebuilt        : ScopeId(87): []
+Bindings mismatch:
+after transform: ScopeId(133): ["T"]
+rebuilt        : ScopeId(88): []
+Bindings mismatch:
+after transform: ScopeId(134): ["T"]
+rebuilt        : ScopeId(89): []
+Bindings mismatch:
+after transform: ScopeId(139): ["T"]
+rebuilt        : ScopeId(91): []
+Bindings mismatch:
+after transform: ScopeId(140): ["T"]
+rebuilt        : ScopeId(92): []
+Bindings mismatch:
+after transform: ScopeId(141): ["T"]
+rebuilt        : ScopeId(93): []
+Bindings mismatch:
+after transform: ScopeId(142): ["_privateModule", "privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
+rebuilt        : ScopeId(94): ["_privateModule", "privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends"]
+Scope children mismatch:
+after transform: ScopeId(142): [ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(148), ScopeId(151), ScopeId(154), ScopeId(157), ScopeId(162), ScopeId(167), ScopeId(172), ScopeId(177), ScopeId(178), ScopeId(179), ScopeId(180), ScopeId(181), ScopeId(184), ScopeId(187), ScopeId(192), ScopeId(197), ScopeId(198)]
+rebuilt        : ScopeId(94): [ScopeId(95), ScopeId(96), ScopeId(97), ScopeId(102), ScopeId(107), ScopeId(112), ScopeId(117), ScopeId(118), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(126), ScopeId(131), ScopeId(132)]
+Bindings mismatch:
+after transform: ScopeId(158): ["T"]
+rebuilt        : ScopeId(98): []
+Bindings mismatch:
+after transform: ScopeId(159): ["T"]
+rebuilt        : ScopeId(99): []
+Bindings mismatch:
+after transform: ScopeId(160): ["T"]
+rebuilt        : ScopeId(100): []
+Bindings mismatch:
+after transform: ScopeId(161): ["T"]
+rebuilt        : ScopeId(101): []
+Bindings mismatch:
+after transform: ScopeId(163): ["T"]
+rebuilt        : ScopeId(103): []
+Bindings mismatch:
+after transform: ScopeId(164): ["T"]
+rebuilt        : ScopeId(104): []
+Bindings mismatch:
+after transform: ScopeId(165): ["T"]
+rebuilt        : ScopeId(105): []
+Bindings mismatch:
+after transform: ScopeId(166): ["T"]
+rebuilt        : ScopeId(106): []
+Bindings mismatch:
+after transform: ScopeId(168): ["T"]
+rebuilt        : ScopeId(108): []
+Bindings mismatch:
+after transform: ScopeId(169): ["T"]
+rebuilt        : ScopeId(109): []
+Bindings mismatch:
+after transform: ScopeId(170): ["T"]
+rebuilt        : ScopeId(110): []
+Bindings mismatch:
+after transform: ScopeId(171): ["T"]
+rebuilt        : ScopeId(111): []
+Bindings mismatch:
+after transform: ScopeId(173): ["T"]
+rebuilt        : ScopeId(113): []
+Bindings mismatch:
+after transform: ScopeId(174): ["T"]
+rebuilt        : ScopeId(114): []
+Bindings mismatch:
+after transform: ScopeId(175): ["T"]
+rebuilt        : ScopeId(115): []
+Bindings mismatch:
+after transform: ScopeId(176): ["T"]
+rebuilt        : ScopeId(116): []
+Bindings mismatch:
+after transform: ScopeId(177): ["T"]
+rebuilt        : ScopeId(117): []
+Bindings mismatch:
+after transform: ScopeId(178): ["T"]
+rebuilt        : ScopeId(118): []
+Bindings mismatch:
+after transform: ScopeId(179): ["T"]
+rebuilt        : ScopeId(119): []
+Bindings mismatch:
+after transform: ScopeId(180): ["T"]
+rebuilt        : ScopeId(120): []
+Bindings mismatch:
+after transform: ScopeId(188): ["T"]
+rebuilt        : ScopeId(122): []
+Bindings mismatch:
+after transform: ScopeId(189): ["T"]
+rebuilt        : ScopeId(123): []
+Bindings mismatch:
+after transform: ScopeId(190): ["T"]
+rebuilt        : ScopeId(124): []
+Bindings mismatch:
+after transform: ScopeId(191): ["T"]
+rebuilt        : ScopeId(125): []
+Bindings mismatch:
+after transform: ScopeId(193): ["T"]
+rebuilt        : ScopeId(127): []
+Bindings mismatch:
+after transform: ScopeId(194): ["T"]
+rebuilt        : ScopeId(128): []
+Bindings mismatch:
+after transform: ScopeId(195): ["T"]
+rebuilt        : ScopeId(129): []
+Bindings mismatch:
+after transform: ScopeId(196): ["T"]
+rebuilt        : ScopeId(130): []
+Bindings mismatch:
+after transform: ScopeId(197): ["T"]
+rebuilt        : ScopeId(131): []
+Bindings mismatch:
+after transform: ScopeId(198): ["T"]
+rebuilt        : ScopeId(132): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(42)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(87): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(110)]
+rebuilt        : SymbolId(20): []
+Symbol flags mismatch:
+after transform: SymbolId(88): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(21): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117)]
+rebuilt        : SymbolId(21): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(105): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(22): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(105): []
+rebuilt        : SymbolId(22): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(110): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(23): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(110): []
+rebuilt        : SymbolId(23): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(125): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(125): []
+rebuilt        : SymbolId(26): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(127): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(27): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(127): []
+rebuilt        : SymbolId(27): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(129): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(131): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(141): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(30): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(141): []
+rebuilt        : SymbolId(30): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(151): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(151): []
+rebuilt        : SymbolId(32): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(153): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(159): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(34): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(159): []
+rebuilt        : SymbolId(34): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(162): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(162): []
+rebuilt        : SymbolId(35): [ReferenceId(17)]
+Symbol flags mismatch:
+after transform: SymbolId(171): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(174): [ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163), ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(178)]
+rebuilt        : SymbolId(40): []
+Symbol flags mismatch:
+after transform: SymbolId(175): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(41): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(175): [ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(177), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185)]
+rebuilt        : SymbolId(41): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(192): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(42): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(192): []
+rebuilt        : SymbolId(42): [ReferenceId(23)]
+Symbol flags mismatch:
+after transform: SymbolId(197): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(43): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(197): []
+rebuilt        : SymbolId(43): [ReferenceId(25)]
+Symbol flags mismatch:
+after transform: SymbolId(212): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(46): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(212): []
+rebuilt        : SymbolId(46): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(214): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(47): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(214): []
+rebuilt        : SymbolId(47): [ReferenceId(29)]
+Symbol flags mismatch:
+after transform: SymbolId(216): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(48): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(218): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(49): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(228): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(50): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(228): []
+rebuilt        : SymbolId(50): [ReferenceId(31)]
+Symbol flags mismatch:
+after transform: SymbolId(238): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(238): []
+rebuilt        : SymbolId(52): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(240): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T"]
@@ -21123,6 +28903,178 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
 rebuilt        : SymbolId(1): []
+
+tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassInPublicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPrivateTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPublicTypeParameters
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassWithTypeParametersFromPrivateModule
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassInPrivateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPrivateTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPublicTypeParameters
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassWithPublicTypeParametersWithoutExtends
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(53)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(38)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(3): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(9): ["T"]
+rebuilt        : ScopeId(9): []
+Bindings mismatch:
+after transform: ScopeId(11): ["T"]
+rebuilt        : ScopeId(11): []
+Bindings mismatch:
+after transform: ScopeId(13): ["T"]
+rebuilt        : ScopeId(13): []
+Bindings mismatch:
+after transform: ScopeId(15): ["T"]
+rebuilt        : ScopeId(15): []
+Bindings mismatch:
+after transform: ScopeId(17): ["T"]
+rebuilt        : ScopeId(17): []
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(74)]
+rebuilt        : ScopeId(19): [SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(34), SymbolId(36)]
+Bindings mismatch:
+after transform: ScopeId(22): ["T"]
+rebuilt        : ScopeId(22): []
+Bindings mismatch:
+after transform: ScopeId(24): ["T"]
+rebuilt        : ScopeId(24): []
+Bindings mismatch:
+after transform: ScopeId(26): ["T"]
+rebuilt        : ScopeId(26): []
+Bindings mismatch:
+after transform: ScopeId(28): ["T"]
+rebuilt        : ScopeId(28): []
+Bindings mismatch:
+after transform: ScopeId(30): ["T"]
+rebuilt        : ScopeId(30): []
+Bindings mismatch:
+after transform: ScopeId(32): ["T"]
+rebuilt        : ScopeId(32): []
+Bindings mismatch:
+after transform: ScopeId(34): ["T"]
+rebuilt        : ScopeId(34): []
+Bindings mismatch:
+after transform: ScopeId(36): ["T"]
+rebuilt        : ScopeId(36): []
+Binding symbols mismatch:
+after transform: ScopeId(38): [SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(75)]
+rebuilt        : ScopeId(38): [SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(44), SymbolId(46), SymbolId(48), SymbolId(50), SymbolId(52)]
+Bindings mismatch:
+after transform: ScopeId(41): ["T"]
+rebuilt        : ScopeId(41): []
+Bindings mismatch:
+after transform: ScopeId(43): ["T"]
+rebuilt        : ScopeId(43): []
+Bindings mismatch:
+after transform: ScopeId(45): ["T"]
+rebuilt        : ScopeId(45): []
+Bindings mismatch:
+after transform: ScopeId(47): ["T"]
+rebuilt        : ScopeId(47): []
+Bindings mismatch:
+after transform: ScopeId(49): ["T"]
+rebuilt        : ScopeId(49): []
+Bindings mismatch:
+after transform: ScopeId(51): ["T"]
+rebuilt        : ScopeId(51): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): [ReferenceId(30), ReferenceId(38)]
+rebuilt        : SymbolId(20): []
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(21): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42)]
+rebuilt        : SymbolId(21): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(29): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(22): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): []
+rebuilt        : SymbolId(22): [ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(32): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(24): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(32): []
+rebuilt        : SymbolId(24): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(41): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(30): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(41): []
+rebuilt        : SymbolId(30): [ReferenceId(20)]
+Symbol flags mismatch:
+after transform: SymbolId(47): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(34): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(47): []
+rebuilt        : SymbolId(34): [ReferenceId(24)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(54): [ReferenceId(60), ReferenceId(68)]
+rebuilt        : SymbolId(40): []
+Symbol flags mismatch:
+after transform: SymbolId(55): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(41): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(55): [ReferenceId(64), ReferenceId(72)]
+rebuilt        : SymbolId(41): [ReferenceId(29)]
+Symbol flags mismatch:
+after transform: SymbolId(56): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(42): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(56): []
+rebuilt        : SymbolId(42): [ReferenceId(32)]
+Symbol flags mismatch:
+after transform: SymbolId(59): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(44): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(59): []
+rebuilt        : SymbolId(44): [ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(68): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(50): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(68): []
+rebuilt        : SymbolId(50): [ReferenceId(40)]
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.ts
 semantic error: Bindings mismatch:
@@ -21150,6 +29102,111 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
 rebuilt        : SymbolId(3): []
 
+tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
+semantic error: Missing SymbolId: publicModule
+Missing SymbolId: _publicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassInPublicModule
+Missing ReferenceId: _publicModule
+Missing ReferenceId: publicClassInPublicModuleT
+Missing ReferenceId: publicModule
+Missing ReferenceId: publicModule
+Missing SymbolId: privateModule
+Missing SymbolId: _privateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassInPrivateModule
+Missing ReferenceId: _privateModule
+Missing ReferenceId: publicClassInPrivateModuleT
+Missing ReferenceId: privateModule
+Missing ReferenceId: privateModule
+Bindings mismatch:
+after transform: ScopeId(0): ["privateClass", "privateClassT", "privateInterfaceWithPrivateModuleTypeParameterConstraints", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassT", "publicInterfaceWithPrivateModuleTypeParameterConstraints", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends", "publicModule"]
+rebuilt        : ScopeId(0): ["privateClass", "privateClassT", "privateModule", "publicClass", "publicClassT", "publicModule"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(12), ScopeId(19), ScopeId(26), ScopeId(33), ScopeId(36), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(82)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(10)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(3): []
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(41): ["_publicModule", "privateClassInPublicModule", "privateClassInPublicModuleT", "privateInterfaceWithPrivateModuleTypeParameterConstraints", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClassInPublicModule", "publicClassInPublicModuleT", "publicInterfaceWithPrivateModuleTypeParameterConstraints", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
+rebuilt        : ScopeId(5): ["_publicModule", "privateClassInPublicModule", "privateClassInPublicModuleT", "publicClassInPublicModule", "publicClassInPublicModuleT"]
+Scope children mismatch:
+after transform: ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(53), ScopeId(60), ScopeId(67), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(81)]
+rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+Bindings mismatch:
+after transform: ScopeId(44): ["T"]
+rebuilt        : ScopeId(8): []
+Bindings mismatch:
+after transform: ScopeId(45): ["T"]
+rebuilt        : ScopeId(9): []
+Bindings mismatch:
+after transform: ScopeId(82): ["_privateModule", "privateClassInPrivateModule", "privateClassInPrivateModuleT", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClassInPrivateModule", "publicClassInPrivateModuleT", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
+rebuilt        : ScopeId(10): ["_privateModule", "privateClassInPrivateModule", "privateClassInPrivateModuleT", "publicClassInPrivateModule", "publicClassInPrivateModuleT"]
+Scope children mismatch:
+after transform: ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(87), ScopeId(94), ScopeId(101), ScopeId(108), ScopeId(115), ScopeId(118)]
+rebuilt        : ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
+Bindings mismatch:
+after transform: ScopeId(85): ["T"]
+rebuilt        : ScopeId(13): []
+Bindings mismatch:
+after transform: ScopeId(86): ["T"]
+rebuilt        : ScopeId(14): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(32), ReferenceId(36), ReferenceId(45), ReferenceId(49)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(8), ReferenceId(12), ReferenceId(13), ReferenceId(21), ReferenceId(25), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(47), ReferenceId(51)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(7), ReferenceId(18), ReferenceId(20), ReferenceId(31), ReferenceId(33), ReferenceId(44), ReferenceId(46)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): [ReferenceId(62), ReferenceId(68), ReferenceId(72), ReferenceId(81), ReferenceId(85), ReferenceId(88), ReferenceId(94), ReferenceId(98), ReferenceId(107), ReferenceId(111)]
+rebuilt        : SymbolId(6): []
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): [ReferenceId(70), ReferenceId(74), ReferenceId(75), ReferenceId(83), ReferenceId(87), ReferenceId(96), ReferenceId(100), ReferenceId(101), ReferenceId(109), ReferenceId(113)]
+rebuilt        : SymbolId(7): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(25): [ReferenceId(67), ReferenceId(69), ReferenceId(80), ReferenceId(82), ReferenceId(93), ReferenceId(95), ReferenceId(106), ReferenceId(108)]
+rebuilt        : SymbolId(8): []
+Symbol flags mismatch:
+after transform: SymbolId(27): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120)]
+rebuilt        : SymbolId(9): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(46): [ReferenceId(124), ReferenceId(130), ReferenceId(134), ReferenceId(143), ReferenceId(147), ReferenceId(150), ReferenceId(156), ReferenceId(160), ReferenceId(169), ReferenceId(173)]
+rebuilt        : SymbolId(12): []
+Symbol flags mismatch:
+after transform: SymbolId(47): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(13): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(47): [ReferenceId(132), ReferenceId(136), ReferenceId(137), ReferenceId(145), ReferenceId(149), ReferenceId(158), ReferenceId(162), ReferenceId(163), ReferenceId(171), ReferenceId(175)]
+rebuilt        : SymbolId(13): [ReferenceId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(48): [ReferenceId(129), ReferenceId(131), ReferenceId(142), ReferenceId(144), ReferenceId(155), ReferenceId(157), ReferenceId(168), ReferenceId(170)]
+rebuilt        : SymbolId(14): []
+Symbol flags mismatch:
+after transform: SymbolId(50): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(15): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(50): [ReferenceId(127), ReferenceId(133), ReferenceId(135), ReferenceId(140), ReferenceId(146), ReferenceId(148), ReferenceId(153), ReferenceId(159), ReferenceId(161), ReferenceId(166), ReferenceId(172), ReferenceId(174), ReferenceId(178), ReferenceId(182)]
+rebuilt        : SymbolId(15): [ReferenceId(9)]
+Unresolved references mismatch:
+after transform: ["privateModule"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -21158,6 +29215,14 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -22428,6 +30493,17 @@ Unresolved reference IDs mismatch for "Float32Array":
 after transform: [ReferenceId(1), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
 rebuilt        : [ReferenceId(9)]
 
+tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "Foo", "f", "g", "z"]
+rebuilt        : ScopeId(0): ["C", "f", "g", "z"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(21), ScopeId(25)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(20), ScopeId(24)]
+Unresolved references mismatch:
+after transform: ["Object"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
@@ -22510,6 +30586,32 @@ rebuilt        : ["xyz"]
 Unresolved reference IDs mismatch for "xyz":
 after transform: [ReferenceId(1), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Base", "Base1", "C", "Derived1", "T", "p"]
+rebuilt        : ScopeId(0): ["Base1", "C", "Derived1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+Scope children mismatch:
+after transform: ScopeId(4): [ScopeId(5)]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(6)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(7)]
+rebuilt        : SymbolId(2): []
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("Base")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("p")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: ["undefined"]
+rebuilt        : ["Base", "p", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
 semantic error: Missing SymbolId: TypeScript2
@@ -22752,21 +30854,24 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(8)]
 rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
 Unresolved reference IDs mismatch for "C":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
 rebuilt        : [ReferenceId(5)]
@@ -23048,6 +31153,11 @@ Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 39, end: 45 }]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Test", "things"]
+rebuilt        : ScopeId(0): ["Test"]
+
 tasks/coverage/typescript/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Math", "RegExpExecArray", "RegExpMatchArray", "undefined"]
@@ -23137,7 +31247,27 @@ tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWitho
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
+tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -23218,6 +31348,14 @@ tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foobar"]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C1", "I1"]
+rebuilt        : ScopeId(0): ["C1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
 semantic error: Bindings mismatch:
@@ -23550,6 +31688,23 @@ Unresolved references mismatch:
 after transform: ["EventTarget", "Extract", "HTMLButtonElement", "Parameters", "bindAll"]
 rebuilt        : ["bindAll"]
 
+tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["NativeTypeValidator", "ObjValidator", "ObjectValidator", "SimpleStringValidator", "V", "Validator", "outputExample", "test", "validatorFunc"]
+rebuilt        : ScopeId(0): ["outputExample", "test", "validatorFunc"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("SimpleStringValidator")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("ObjValidator")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["ObjValidator", "SimpleStringValidator"]
+
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action", "ConfigureStoreOptions", "Reducer", "ReducersMapObject", "UnknownAction", "counterReducer1", "store2"]
@@ -23620,6 +31775,14 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["f", "g", "h"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
 semantic error: Missing SymbolId: X
 Missing SymbolId: _X
@@ -23672,6 +31835,14 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ModuleWithState", "MoreState", "State", "breaks"]
+rebuilt        : ScopeId(0): ["breaks"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase2.ts
 semantic error: Bindings mismatch:
@@ -25401,9 +33572,6 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -25603,6 +33771,20 @@ Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : ["Array", "foo1", "foo2"]
 
+tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Apple", "Orange", "test", "test2"]
+rebuilt        : ScopeId(0): ["test", "test2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "item"]
+rebuilt        : ScopeId(1): ["item"]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "item", "x"]
+rebuilt        : ScopeId(2): ["item", "x"]
+
 tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "thing"]
@@ -25769,6 +33951,20 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record", "undefined"]
 rebuilt        : ["undefined"]
+
+tasks/coverage/typescript/tests/cases/compiler/spreadParameterTupleType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "C"]
+rebuilt        : ScopeId(1): []
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(5): ["A", "B", "C", "D"]
+rebuilt        : ScopeId(3): []
+Scope children mismatch:
+after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(3): [ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -25951,6 +34147,32 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(6): ["T"]
+rebuilt        : ScopeId(6): []
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(8): ["T"]
+rebuilt        : ScopeId(8): []
+Bindings mismatch:
+after transform: ScopeId(9): ["T"]
+rebuilt        : ScopeId(9): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(1): []
+
 tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
@@ -25958,6 +34180,38 @@ rebuilt        : ScopeId(2): []
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(5): [ScopeId(6)]
+
+tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Func", "a", "b", "never", "t1", "t2", "t3", "t4", "t5", "t6", "x", "x1", "x10", "x11", "x2", "x3", "x4"]
+rebuilt        : ScopeId(0): ["t1", "t2", "t3", "t4", "t5", "t6", "x", "x1", "x10", "x11", "x2", "x3", "x4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(32): Some("never")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(36): Some("never")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(53): Some("a")
+rebuilt        : ReferenceId(22): None
+Reference symbol mismatch:
+after transform: ReferenceId(57): Some("b")
+rebuilt        : ReferenceId(25): None
+Reference symbol mismatch:
+after transform: ReferenceId(61): Some("never")
+rebuilt        : ReferenceId(28): None
+Reference symbol mismatch:
+after transform: ReferenceId(68): Some("a")
+rebuilt        : ReferenceId(31): None
+Reference symbol mismatch:
+after transform: ReferenceId(72): Some("b")
+rebuilt        : ReferenceId(34): None
+Unresolved references mismatch:
+after transform: ["Object", "ReadonlyArray", "acceptA", "acceptUnion", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx"]
+rebuilt        : ["a", "acceptA", "acceptUnion", "b", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx", "never"]
 
 tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
 semantic error: Bindings mismatch:
@@ -25993,6 +34247,17 @@ Unresolved references mismatch:
 after transform: ["Readonly"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T1", "T2"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["true"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
@@ -26000,6 +34265,9 @@ rebuilt        : ScopeId(1): []
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6)]
 rebuilt        : ScopeId(4): []
+
+tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 semantic error: Bindings mismatch:
@@ -26043,6 +34311,9 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
+
+tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 semantic error: Bindings mismatch:
@@ -26285,6 +34556,14 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Constructor", "ControllerClass"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Constructor", "ControllerClass"]
@@ -26303,6 +34582,14 @@ rebuilt        : SymbolId(0): Span { start: 35, end: 36 }
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["SymbolConstructor", "obj"]
+rebuilt        : ScopeId(0): ["obj"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment.ts
 semantic error: Bindings mismatch:
@@ -26345,9 +34632,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
 semantic error: Bindings mismatch:
@@ -26380,20 +34664,17 @@ Bindings mismatch:
 after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
 rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -26424,20 +34705,17 @@ Bindings mismatch:
 after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
 rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -26464,27 +34742,18 @@ Missing ReferenceId: E
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
 rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
+after transform: ScopeId(5): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
 rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): []
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -26537,33 +34806,24 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(13)]
 rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["E", "TopLevelEnum"]
 rebuilt        : ScopeId(4): ["TopLevelEnum"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Binding symbols mismatch:
 after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(11), SymbolId(14)]
 rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(7): [SymbolId(9), SymbolId(15)]
 rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(9): ["E", "NonTopLevelEnum"]
 rebuilt        : ScopeId(9): ["NonTopLevelEnum"]
 Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(0x0)
-rebuilt        : ScopeId(9): ScopeFlags(Function)
+after transform: ScopeId(9): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | Export)
@@ -26574,7 +34834,7 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(7): []
 rebuilt        : SymbolId(9): [ReferenceId(6)]
 Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): []
@@ -26597,15 +34857,12 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["AnEnum", "ONE", "TWO"]
 rebuilt        : ScopeId(2): ["AnEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
@@ -26615,6 +34872,20 @@ rebuilt        : ReferenceId(8): Some("ns")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("ns")
 rebuilt        : ReferenceId(10): Some("ns")
+
+tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Hash", "getHashLength", "getHashLength2"]
+rebuilt        : ScopeId(0): ["getHashLength", "getHashLength2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "hash"]
+rebuilt        : ScopeId(3): ["hash"]
+Unresolved references mismatch:
+after transform: ["Error", "true"]
+rebuilt        : ["Error"]
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
 semantic error: Scope children mismatch:
@@ -26646,6 +34917,14 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch:
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["GetChars", "GetCharsRec", "Reverse", "ReverseRec", "T10", "T11", "T20", "T30", "T31", "T40", "T41", "Trim", "TupleOf", "TupleOfRec"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/targetEs6DecoratorMetadataImportNotElided.ts
 semantic error: Bindings mismatch:
@@ -26824,7 +35103,9 @@ after transform: ReferenceId(0): Some("bar")
 rebuilt        : ReferenceId(4): Some("bar")
 
 tasks/coverage/typescript/tests/cases/compiler/thisInObjectJs.ts
-semantic error: Cannot use export statement outside a module
+semantic error: Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 semantic error: Symbol reference IDs mismatch:
@@ -26915,6 +35196,26 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Node", "Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
+rebuilt        : ScopeId(0): ["SyntaxKind"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78), ScopeId(79), ScopeId(80), ScopeId(81), ScopeId(82), ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(87), ScopeId(88), ScopeId(89), ScopeId(90), ScopeId(91), ScopeId(92), ScopeId(93), ScopeId(94), ScopeId(95), ScopeId(96), ScopeId(97), ScopeId(98), ScopeId(99), ScopeId(100), ScopeId(101), ScopeId(102)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
+rebuilt        : ScopeId(1): ["SyntaxKind"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99)]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -26974,8 +35275,8 @@ rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Foo", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Foo", "JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["Foo", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -26993,9 +35294,6 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 Symbol redeclarations mismatch:
 after transform: SymbolId(2): [Span { start: 243, end: 256 }]
 rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(5): [ReferenceId(2)]
 Unresolved references mismatch:
 after transform: ["Date", "React"]
 rebuilt        : ["React"]
@@ -27013,14 +35311,14 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
-after transform: ["Comp", "JSX", "parseInt", "require", "true", "undefined"]
-rebuilt        : ["Comp", "parseInt", "require", "undefined"]
+after transform: ["Comp", "JSX", "parseInt", "true", "undefined"]
+rebuilt        : ["Comp", "parseInt", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
 semantic error: Bindings mismatch:
@@ -27035,8 +35333,8 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Props", "PropsBase", "PropsWithConvert", "ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
-rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
+after transform: ScopeId(0): ["JSX", "Props", "PropsBase", "PropsWithConvert", "ShouldInferFromData", "_jsx", "_jsxFileName", "f1", "f2", "f3"]
+rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsx", "_jsxFileName", "f1", "f2", "f3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
@@ -27044,8 +35342,8 @@ Bindings mismatch:
 after transform: ScopeId(6): ["T", "props"]
 rebuilt        : ScopeId(1): ["props"]
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
+after transform: ["JSX"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
 semantic error: Bindings mismatch:
@@ -27084,14 +35382,14 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AnimalComponent", "AnimalInfo", "CatInfo", "DogInfo", "JSX", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
-rebuilt        : ScopeId(0): ["AnimalComponent", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
+after transform: ScopeId(0): ["AnimalComponent", "AnimalInfo", "CatInfo", "DogInfo", "JSX", "_jsx", "_jsxFileName", "component", "component2", "getProps", "props", "props2"]
+rebuilt        : ScopeId(0): ["AnimalComponent", "_jsx", "_jsxFileName", "component", "component2", "getProps", "props", "props2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
-after transform: ["JSX", "require", "undefined"]
-rebuilt        : ["require", "undefined"]
+after transform: ["JSX", "undefined"]
+rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 semantic error: Bindings mismatch:
@@ -27149,6 +35447,14 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "Pick", "Required", "set"]
 rebuilt        : ["set"]
+
+tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 semantic error: Bindings mismatch:
@@ -27303,6 +35609,10 @@ rebuilt        : ScopeId(1): ["a", "f", "x"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "a", "f", "x"]
 rebuilt        : ScopeId(2): ["a", "f", "x"]
+
+tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
 semantic error: Bindings mismatch:
@@ -27502,9 +35812,6 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -27528,11 +35835,8 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
@@ -27619,17 +35923,14 @@ tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["JSX", "T", "require"]
+after transform: ["JSX", "T"]
 rebuilt        : ["T", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(13)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
 semantic error: Scope children mismatch:
@@ -28030,6 +36331,94 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["$"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["$", "A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["$", "A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["$"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["$"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
+semantic error: Unresolved references mismatch:
+after transform: ["$"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["$", "A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
+semantic error: Unresolved references mismatch:
+after transform: ["$"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Lib"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["./main", "Cls"]
+rebuilt        : ScopeId(0): ["Cls"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Unresolved references mismatch:
+after transform: ["Lib", "undefined"]
+rebuilt        : ["undefined"]
+
 tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
 semantic error: Missing SymbolId: TopLevelModule1
 Missing SymbolId: _TopLevelModule
@@ -28093,63 +36482,39 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(50)]
 Bindings mismatch:
 after transform: ScopeId(1): ["ClassA", "InterfaceY", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
 rebuilt        : ScopeId(1): ["ClassA", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(16), ScopeId(29), ScopeId(31), ScopeId(33)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(14), ScopeId(22), ScopeId(24)]
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(31), SymbolId(53)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(33)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["ClassA", "ClassB", "InterfaceX", "NonExportedClassQ", "_SubSubModule"]
 rebuilt        : ScopeId(3): ["ClassA", "ClassB", "NonExportedClassQ", "_SubSubModule"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(16): ["InterfaceY", "SubSubModule2", "_SubModule2"]
 rebuilt        : ScopeId(14): ["SubSubModule2", "_SubModule2"]
-Scope flags mismatch:
-after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(14): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(16): [ScopeId(17), ScopeId(27)]
 rebuilt        : ScopeId(14): [ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(17): ["ClassA", "ClassB", "ClassC", "InterfaceY", "NonExportedInterfaceQ", "_SubSubModule2"]
 rebuilt        : ScopeId(15): ["ClassA", "ClassB", "ClassC", "_SubSubModule2"]
-Scope flags mismatch:
-after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(15): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(18), ScopeId(20)]
 Binding symbols mismatch:
 after transform: ScopeId(33): [SymbolId(48), SymbolId(57)]
 rebuilt        : ScopeId(24): [SymbolId(48), SymbolId(49)]
-Scope flags mismatch:
-after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(24): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(35): [SymbolId(50), SymbolId(58)]
 rebuilt        : ScopeId(26): [SymbolId(51), SymbolId(52)]
-Scope flags mismatch:
-after transform: ScopeId(35): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(26): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(36): [SymbolId(51), SymbolId(59)]
 rebuilt        : ScopeId(27): [SymbolId(53), SymbolId(54)]
-Scope flags mismatch:
-after transform: ScopeId(36): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(27): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(3): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(6): SymbolFlags(Class)
@@ -28380,6 +36745,11 @@ rebuilt        : ["Collection"]
 tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
 semantic error: Unresolved references mismatch:
 after transform: ["this"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/compiler/typeofUndefined.ts
+semantic error: Unresolved references mismatch:
+after transform: ["undefined"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
@@ -28790,6 +37160,14 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "D"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction1.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
@@ -28841,6 +37219,17 @@ Unresolved references mismatch:
 after transform: ["Promise", "Symbol"]
 rebuilt        : ["Symbol"]
 
+tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Op"]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("Op")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Op"]
+
 tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myUnusedFunction", "myVar"]
@@ -28879,6 +37268,10 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -28957,12 +37350,9 @@ rebuilt        : ScopeId(1): ["a"]
 Binding symbols mismatch:
 after transform: ScopeId(43): [SymbolId(30), SymbolId(31)]
 rebuilt        : ScopeId(43): [SymbolId(29), SymbolId(30)]
-Scope flags mismatch:
-after transform: ScopeId(43): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(43): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Reference symbol mismatch:
 after transform: ReferenceId(53): Some("N")
 rebuilt        : ReferenceId(53): Some("N")
@@ -29243,9 +37633,15 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/usedImportNotElidedInJs.ts
-semantic error: Cannot use import statement outside a module
-Cannot use import statement outside a module
-Cannot use export statement outside a module
+semantic error: Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 24, end: 30 }
+rebuilt        : SymbolId(1): Span { start: 103, end: 109 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 103, end: 109 }]
+rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -29297,6 +37693,13 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
 semantic error: Bindings mismatch:
@@ -29467,6 +37870,17 @@ Unresolved references mismatch:
 after transform: ["Pick", "Record"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "Map", "MapOrUndefined", "foo1"]
+rebuilt        : ScopeId(0): ["Foo", "foo1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Unresolved references mismatch:
+after transform: ["Exclude"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -29490,6 +37904,11 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(2): ["T", "val"]
+rebuilt        : ScopeId(2): ["val"]
 
 tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
 semantic error: Scope children mismatch:
@@ -29585,6 +38004,51 @@ rebuilt        : ScopeId(5): []
 Scope children mismatch:
 after transform: ScopeId(20): [ScopeId(21)]
 rebuilt        : ScopeId(6): []
+
+tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
+semantic error: Missing SymbolId: m1
+Missing SymbolId: _m
+Missing ReferenceId: _m
+Missing ReferenceId: foo
+Missing ReferenceId: m1
+Missing ReferenceId: m1
+Missing SymbolId: m3
+Missing SymbolId: _m2
+Missing ReferenceId: _m2
+Missing ReferenceId: foo
+Missing ReferenceId: m3
+Missing ReferenceId: m3
+Bindings mismatch:
+after transform: ScopeId(0): ["anotherVar", "arrayVar", "deckareVarWithType", "declareVar2", "declaredVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedDeclaredVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m2", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
+rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(18), SymbolId(29)]
+rebuilt        : ScopeId(3): [SymbolId(14), SymbolId(15)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(22), SymbolId(30)]
+rebuilt        : ScopeId(5): [SymbolId(17), SymbolId(18)]
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): []
+rebuilt        : SymbolId(15): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(22): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(22): []
+rebuilt        : SymbolId(18): [ReferenceId(8)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("m1")
+rebuilt        : ReferenceId(6): Some("m1")
+
+tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 semantic error: 'with' statements are not allowed
@@ -29685,6 +38149,14 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_declarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_duplicate.ts
 semantic error: Bindings mismatch:
@@ -30988,6 +39460,29 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "c5"]
+rebuilt        : ScopeId(0): ["C3", "C4", "c5"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 104, end: 106 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(1): SymbolFlags(Class)
+Symbol span mismatch:
+after transform: SymbolId(3): Span { start: 122, end: 124 }
+rebuilt        : SymbolId(1): Span { start: 136, end: 138 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(3): [Span { start: 136, end: 138 }]
+rebuilt        : SymbolId(1): []
+
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClass", "BaseInterface", "Child", "ChildNoBaseClass", "Grandchild", "child", "grandchild"]
@@ -31330,6 +39825,84 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
+Bindings mismatch:
+after transform: ScopeId(3): ["MixinClass", "TBaseClass", "baseClass"]
+rebuilt        : ScopeId(1): ["MixinClass", "baseClass"]
+Scope children mismatch:
+after transform: ScopeId(8): [ScopeId(9)]
+rebuilt        : ScopeId(6): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 10, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 55, end: 60 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(11)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(7)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 55, end: 60 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClassesReturnTypeInference.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AbstractBase", "DerivedFromAbstract2", "Mixin1", "Mixin2"]
+rebuilt        : ScopeId(0): ["AbstractBase", "DerivedFromAbstract2", "Mixin2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4)]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(5): ["MixinClass", "TBase", "baseClass"]
+rebuilt        : ScopeId(2): ["MixinClass", "baseClass"]
+
+tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Base", "Constructor", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "f1", "f2"]
+rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "f1", "f2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(17)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13)]
+Bindings mismatch:
+after transform: ScopeId(8): ["T", "superClass"]
+rebuilt        : ScopeId(5): ["superClass"]
+Bindings mismatch:
+after transform: ScopeId(12): ["C", "T", "superClass"]
+rebuilt        : ScopeId(8): ["C", "superClass"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction | Interface)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)
+Symbol span mismatch:
+after transform: SymbolId(9): Span { start: 247, end: 256 }
+rebuilt        : SymbolId(7): Span { start: 287, end: 296 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(8), ReferenceId(22)]
+rebuilt        : SymbolId(7): [ReferenceId(13)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(9): [Span { start: 287, end: 296 }]
+rebuilt        : SymbolId(7): []
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(FunctionScopedVariable | Interface)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(13): Span { start: 557, end: 563 }
+rebuilt        : SymbolId(10): Span { start: 596, end: 602 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(14), ReferenceId(19), ReferenceId(21)]
+rebuilt        : SymbolId(10): [ReferenceId(10), ReferenceId(12)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(13): [Span { start: 596, end: 602 }]
+rebuilt        : SymbolId(10): []
+
 tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Constructor", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "Timestamped", "f1", "f2"]
@@ -31349,6 +39922,89 @@ rebuilt        : ScopeId(16): ["Base"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
+
+tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C2", "C3", "Mixed1", "Mixed2", "Mixed3", "Mixed4", "Mixed5", "f1", "f2", "f3", "f4", "f5", "f6"]
+rebuilt        : ScopeId(0): ["C2", "C3", "f1", "f2", "f3", "f4", "f5", "f6"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("Mixed1")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("Mixed1")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("Mixed2")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("Mixed2")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("Mixed3")
+rebuilt        : ReferenceId(4): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("Mixed3")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(18): Some("Mixed4")
+rebuilt        : ReferenceId(6): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("Mixed4")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("Mixed5")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(21): Some("Mixed1")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(24): Some("Mixed1")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(25): Some("Mixed2")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(28): Some("Mixed2")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("Mixed3")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(33): Some("Mixed3")
+rebuilt        : ReferenceId(21): None
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("Mixed3")
+rebuilt        : ReferenceId(22): None
+Reference symbol mismatch:
+after transform: ReferenceId(35): Some("Mixed4")
+rebuilt        : ReferenceId(23): None
+Reference symbol mismatch:
+after transform: ReferenceId(39): Some("Mixed4")
+rebuilt        : ReferenceId(27): None
+Reference symbol mismatch:
+after transform: ReferenceId(40): Some("Mixed4")
+rebuilt        : ReferenceId(28): None
+Reference symbol mismatch:
+after transform: ReferenceId(41): Some("Mixed5")
+rebuilt        : ReferenceId(29): None
+Reference symbol mismatch:
+after transform: ReferenceId(44): Some("Mixed5")
+rebuilt        : ReferenceId(32): None
+Reference symbol mismatch:
+after transform: ReferenceId(45): Some("Mixed5")
+rebuilt        : ReferenceId(33): None
+Reference symbol mismatch:
+after transform: ReferenceId(46): Some("Mixed1")
+rebuilt        : ReferenceId(34): None
+Reference symbol mismatch:
+after transform: ReferenceId(47): Some("Mixed3")
+rebuilt        : ReferenceId(35): None
+Unresolved references mismatch:
+after transform: ["C1", "M1", "M2"]
+rebuilt        : ["Mixed1", "Mixed2", "Mixed3", "Mixed4", "Mixed5"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
 semantic error: Bindings mismatch:
@@ -31398,8 +40054,8 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(27)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Interface)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | Function | Interface)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
 Symbol span mismatch:
 after transform: SymbolId(8): Span { start: 462, end: 483 }
 rebuilt        : SymbolId(2): Span { start: 558, end: 579 }
@@ -31412,6 +40068,11 @@ rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["ReadonlyArray"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts
 semantic error: Scope children mismatch:
@@ -31435,6 +40096,11 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
 semantic error: Bindings mismatch:
@@ -31533,63 +40199,33 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Binding symbols mismatch:
 after transform: ScopeId(81): [SymbolId(42), SymbolId(71)]
 rebuilt        : ScopeId(81): [SymbolId(42), SymbolId(43)]
-Scope flags mismatch:
-after transform: ScopeId(81): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(81): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(84): [SymbolId(45), SymbolId(72)]
 rebuilt        : ScopeId(84): [SymbolId(46), SymbolId(47)]
-Scope flags mismatch:
-after transform: ScopeId(84): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(84): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(91): [SymbolId(48), SymbolId(73)]
 rebuilt        : ScopeId(91): [SymbolId(50), SymbolId(51)]
-Scope flags mismatch:
-after transform: ScopeId(91): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(91): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(94): [SymbolId(51), SymbolId(74)]
 rebuilt        : ScopeId(94): [SymbolId(54), SymbolId(55)]
-Scope flags mismatch:
-after transform: ScopeId(94): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(94): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(101): [SymbolId(54), SymbolId(75)]
 rebuilt        : ScopeId(101): [SymbolId(58), SymbolId(59)]
-Scope flags mismatch:
-after transform: ScopeId(101): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(101): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(104): [SymbolId(57), SymbolId(76)]
 rebuilt        : ScopeId(104): [SymbolId(62), SymbolId(63)]
-Scope flags mismatch:
-after transform: ScopeId(104): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(104): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(111): [SymbolId(60), SymbolId(77)]
 rebuilt        : ScopeId(111): [SymbolId(66), SymbolId(67)]
-Scope flags mismatch:
-after transform: ScopeId(111): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(111): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(114): [SymbolId(63), SymbolId(78)]
 rebuilt        : ScopeId(114): [SymbolId(70), SymbolId(71)]
-Scope flags mismatch:
-after transform: ScopeId(114): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(114): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(121): [SymbolId(66), SymbolId(79)]
 rebuilt        : ScopeId(121): [SymbolId(74), SymbolId(75)]
-Scope flags mismatch:
-after transform: ScopeId(121): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(121): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(124): [SymbolId(69), SymbolId(80)]
 rebuilt        : ScopeId(124): [SymbolId(78), SymbolId(79)]
-Scope flags mismatch:
-after transform: ScopeId(124): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(124): ScopeFlags(Function)
 Unresolved references mismatch:
 after transform: ["const"]
 rebuilt        : []
@@ -31603,6 +40239,9 @@ tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/s
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
+
+tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
+semantic error: Enum member must have initializer.
 
 tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
 semantic error: Bindings mismatch:
@@ -31634,9 +40273,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates2.ts
-semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
 semantic error: Scope children mismatch:
@@ -31993,6 +40629,122 @@ rebuilt        : ScopeId(6): [ScopeId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/classDoesNotDependOnPrivateMember.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: C
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C", "I", "_M"]
+rebuilt        : ScopeId(1): ["C", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["elem"]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["HTMLElement"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmitBundle.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["elem"]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["HTMLElement"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I", "f"]
+rebuilt        : ScopeId(0): ["f"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(1): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "obj"]
+rebuilt        : ScopeId(0): ["obj"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(1): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "obj"]
+rebuilt        : ScopeId(0): ["obj"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["FSWatcher", "f"]
+rebuilt        : ScopeId(0): ["f"]
+
+tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(2): ["C", "class_"]
+rebuilt        : ScopeId(2): ["class_"]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
 semantic error: Bindings mismatch:
@@ -32452,6 +41204,37 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
 
+tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["directory", "moduleFile", "p0", "p1", "p2", "returnDynamicLoad", "whatToLoad"]
+rebuilt        : ScopeId(0): ["p0", "p1", "p2", "returnDynamicLoad"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("directory")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("moduleFile")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("whatToLoad")
+rebuilt        : ReferenceId(4): None
+Unresolved references mismatch:
+after transform: ["getSpecifier"]
+rebuilt        : ["directory", "getSpecifier", "moduleFile", "whatToLoad"]
+
+tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Zero", "p0", "p1", "p2"]
+rebuilt        : ScopeId(0): ["p0", "p1", "p2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Promise", "getPath"]
+rebuilt        : ["getPath"]
+
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Promise"]
@@ -32702,25 +41485,251 @@ Symbol flags mismatch:
 after transform: SymbolId(31): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(19): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
+semantic error: Missing ReferenceId: E20
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "E01"]
+rebuilt        : ScopeId(1): ["E01"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "E02"]
+rebuilt        : ScopeId(2): ["E02"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "E03"]
+rebuilt        : ScopeId(3): ["E03"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["A", "B", "C", "E04"]
+rebuilt        : ScopeId(4): ["E04"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["A", "B", "C", "E05"]
+rebuilt        : ScopeId(5): ["E05"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["A", "B", "C", "E06"]
+rebuilt        : ScopeId(6): ["E06"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(0x0)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["A", "B", "C", "D", "E", "E07", "F"]
+rebuilt        : ScopeId(7): ["E07"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "B", "C", "D", "E", "E08"]
+rebuilt        : ScopeId(8): ["E08"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(0x0)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(10): ["A", "B", "C", "E11"]
+rebuilt        : ScopeId(10): ["E11"]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(0x0)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(11): ["A", "B", "C", "E12"]
+rebuilt        : ScopeId(11): ["E12"]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(0x0)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(12): ["A", "B", "C", "D", "E20"]
+rebuilt        : ScopeId(12): ["E20"]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(0x0)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(25): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(31): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(32): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(36): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(22): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(56): [ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84)]
+rebuilt        : SymbolId(23): [ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(81)]
+
+tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithStringEmitDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
+rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T1", "a", "b", "c"]
+rebuilt        : ScopeId(1): ["T1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T2", "a", "b"]
+rebuilt        : ScopeId(2): ["T2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["T3", "a", "b"]
+rebuilt        : ScopeId(3): ["T3"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T4", "a"]
+rebuilt        : ScopeId(4): ["T4"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["T5", "a"]
+rebuilt        : ScopeId(5): ["T5"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6", "T7"]
+rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T1", "a"]
+rebuilt        : ScopeId(1): ["T1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T2", "a", "b", "c"]
+rebuilt        : ScopeId(2): ["T2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["T3", "a"]
+rebuilt        : ScopeId(3): ["T3"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T4", "a", "b", "c", "d", "e"]
+rebuilt        : ScopeId(4): ["T4"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["T5", "a", "b", "c", "d"]
+rebuilt        : ScopeId(5): ["T5"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["T6", "a", "b"]
+rebuilt        : ScopeId(6): ["T6"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(0x0)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Animals", "Cat"]
 rebuilt        : ScopeId(1): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["Animals", "Dog"]
 rebuilt        : ScopeId(2): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["Animals", "CatDog"]
 rebuilt        : ScopeId(3): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -33209,6 +42218,41 @@ semantic error: Unresolved references mismatch:
 after transform: ["Intl", "const"]
 rebuilt        : ["Intl"]
 
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Unresolved reference IDs mismatch for "Symbol":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Symbol"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Symbol"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Symbol"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "i"]
@@ -33460,6 +42504,23 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["InteropObservable", "MyObservable", "from", "global", "observable"]
+rebuilt        : ScopeId(0): ["MyObservable", "from", "observable"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(9): ["T", "obs"]
+rebuilt        : ScopeId(5): ["obs"]
+Unresolved reference IDs mismatch for "Symbol":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(11)]
+rebuilt        : [ReferenceId(0), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 semantic error: Bindings mismatch:
@@ -34177,6 +43238,29 @@ Unresolved references mismatch:
 after transform: ["Array", "TemplateStringsArray", "f", "g"]
 rebuilt        : ["f", "g", "obj"]
 
+tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
+semantic error: Missing SymbolId: M
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: generator
+Missing ReferenceId: M
+Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -34629,9 +43713,6 @@ rebuilt        : ScopeId(0): ["Example"]
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(3): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
@@ -34740,6 +43821,80 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["dec"]
+
+tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "dec"]
+rebuilt        : ScopeId(0): ["C"]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("dec")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("dec")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("dec")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("dec")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("dec")
+rebuilt        : ReferenceId(4): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("dec")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("dec")
+rebuilt        : ReferenceId(6): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("dec")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(8): Some("dec")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("dec")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("dec")
+rebuilt        : ReferenceId(10): None
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("dec")
+rebuilt        : ReferenceId(11): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("dec")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("dec")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("dec")
+rebuilt        : ReferenceId(14): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("dec")
+rebuilt        : ReferenceId(15): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("dec")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("dec")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(18): Some("dec")
+rebuilt        : ReferenceId(18): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("dec")
+rebuilt        : ReferenceId(19): None
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("dec")
+rebuilt        : ReferenceId(20): None
+Reference symbol mismatch:
+after transform: ReferenceId(21): Some("dec")
+rebuilt        : ReferenceId(21): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["dec"]
@@ -35580,14 +44735,14 @@ Bindings mismatch:
 after transform: ScopeId(1): ["AdvancedList", "AppType", "Composite", "HeaderDetail", "HeaderMultiDetail", "ListOnly", "ModuleSettings", "Relationship", "Report", "Standard"]
 rebuilt        : ScopeId(1): ["AppType"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["AppStyle", "MiniApp", "PivotTable", "Standard", "Tree", "TreeEntity"]
 rebuilt        : ScopeId(2): ["AppStyle"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -37550,6 +46705,35 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
+tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ArrowElite", "ArrowGuard", "ArrowMedic", "Crate", "FollowerGuard", "GuardInterface", "LeadGuard", "MimicFollower", "MimicGuard", "MimicGuardInterface", "MimicLeader", "RoyalGuard", "Sundries", "Supplies", "a", "b", "crate", "guard", "holder2", "mimic"]
+rebuilt        : ScopeId(0): ["ArrowElite", "ArrowGuard", "ArrowMedic", "FollowerGuard", "LeadGuard", "MimicFollower", "MimicGuard", "MimicLeader", "RoyalGuard", "a", "b", "crate", "guard", "holder2", "mimic"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(39)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(30), ScopeId(32)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(62)]
+rebuilt        : SymbolId(1): [ReferenceId(0)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(7), ReferenceId(63)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(4)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(22), ReferenceId(23)]
+rebuilt        : SymbolId(7): [ReferenceId(17)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(24), ReferenceId(25)]
+rebuilt        : SymbolId(8): [ReferenceId(18)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): [ReferenceId(47), ReferenceId(48)]
+rebuilt        : SymbolId(12): [ReferenceId(34)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): [ReferenceId(49), ReferenceId(50)]
+rebuilt        : SymbolId(13): [ReferenceId(35)]
+
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Beast", "Legged", "Winged", "X", "Y", "Z", "beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
@@ -38419,8 +47603,13 @@ after transform: ["f"]
 rebuilt        : ["dec", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
-semantic error: Cannot use `await` as an identifier in an async context
-The keyword 'await' is reserved
+semantic error: Missing SymbolId: await
+Bindings mismatch:
+after transform: ScopeId(0): ["await", "foo"]
+rebuilt        : ScopeId(0): ["await"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -40116,11 +49305,52 @@ Unresolved references mismatch:
 after transform: ["mod1", "mod2", "pack1", "pack2"]
 rebuilt        : ["mod2", "pack2"]
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
-semantic error: Cannot use export statement outside a module
-Cannot use export statement outside a module
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassImplementsGenericsSerialization.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Encoder"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Uint8Array"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Point", "magnitude"]
+rebuilt        : ScopeId(0): ["magnitude"]
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportNamespacedType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["dot2", "dummy"]
+rebuilt        : ScopeId(0): ["dot2"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag16.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "I"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag18.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag19.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
@@ -40136,7 +49366,23 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag20.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
@@ -40175,9 +49421,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/inferThis.ts
-semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_qualifiedName.ts
 semantic error: Bindings mismatch:
@@ -40221,9 +49464,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
-semantic error: Cannot use export statement outside a module
-
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback"]
@@ -40237,8 +49477,37 @@ semantic error: Unresolved references mismatch:
 after transform: ["Function", "Promise"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag3.ts
-semantic error: Cannot use export statement outside a module
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "NS", "a", "b", "c"]
+rebuilt        : ScopeId(0): ["a", "b", "c"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Aleph", "Bet", "a"]
+rebuilt        : ScopeId(0): ["Bet", "a"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Aleph", "Bet", "a"]
+rebuilt        : ScopeId(0): ["Bet", "a"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Aleph", "Bet", "a"]
+rebuilt        : ScopeId(0): ["Bet", "a"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts
 semantic error: Bindings mismatch:
@@ -40258,167 +49527,128 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
-rebuilt        : ScopeId(0): ["Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
+after transform: ScopeId(0): ["Comp", "Prop", "React", "_jsx", "_jsxFileName", "k", "k1", "k2"]
+rebuilt        : ScopeId(0): ["Comp", "React", "_jsx", "_jsxFileName", "k", "k1", "k2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["JSX"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["Button", "JSX", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["Button", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["Button", "JSX", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["Button", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Button", "ButtonProp", "InnerButton", "InnerButtonProp", "React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Button", "InnerButton", "React", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Button", "ButtonProp", "InnerButton", "InnerButtonProp", "React", "_jsx", "_jsxFileName", "_jsxs"]
+rebuilt        : ScopeId(0): ["Button", "InnerButton", "React", "_jsx", "_jsxFileName", "_jsxs"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(8)]
+rebuilt        : SymbolId(4): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("React")
-rebuilt        : ReferenceId(12): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(17)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(11): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Props", "React", "Test", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["React", "Test", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Props", "React", "Test", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+rebuilt        : ScopeId(0): ["React", "Test", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["Foo", "JSX", "require", "true"]
+after transform: ["Foo", "JSX", "true"]
 rebuilt        : ["Foo", "require"]
-Unresolved reference IDs mismatch for "Foo":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(19)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["FetchUser", "IFetchUserProps", "IUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["FetchUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["FetchUser", "IFetchUserProps", "IUser", "React", "UserName0", "UserName1", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["FetchUser", "React", "UserName0", "UserName1", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["JSX"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
-rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["JSX"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(48)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
-rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["JSX"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(48)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(15)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "JSX", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
-rebuilt        : ScopeId(0): ["C", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
+after transform: ScopeId(0): ["C", "JSX", "_jsx", "_jsxFileName", "x", "y"]
+rebuilt        : ScopeId(0): ["C", "_jsx", "_jsxFileName", "x", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -40426,8 +49656,8 @@ Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["Component", "Readonly", "require"]
-rebuilt        : ["Component", "require"]
+after transform: ["Component", "Readonly"]
+rebuilt        : ["Component"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
 semantic error: Bindings mismatch:
@@ -40458,11 +49688,11 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJ
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 semantic error: Bindings mismatch:
@@ -40493,97 +49723,97 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Child", "Component", "Composite", "Composite2", "Namespace", "React", "_jsxFileName", "_reactJsxRuntime", "bar", "foo", "hasOwnProperty", "x", "y", "z"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["Child", "Component", "Composite", "Composite2", "Namespace", "React", "_jsx", "_jsxFileName", "_jsxs", "bar", "foo", "hasOwnProperty", "x", "y", "z"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_jsxs", "x"]
 Symbol span mismatch:
 after transform: SymbolId(9): Span { start: 231, end: 236 }
-rebuilt        : SymbolId(2): Span { start: 537, end: 538 }
+rebuilt        : SymbolId(3): Span { start: 537, end: 538 }
 Symbol redeclarations mismatch:
 after transform: SymbolId(9): [Span { start: 537, end: 538 }]
-rebuilt        : SymbolId(2): []
+rebuilt        : SymbolId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Component")
-rebuilt        : ReferenceId(11): None
+rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("foo")
-rebuilt        : ReferenceId(12): None
+rebuilt        : ReferenceId(11): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("bar")
-rebuilt        : ReferenceId(15): None
+rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("Composite")
-rebuilt        : ReferenceId(21): None
+rebuilt        : ReferenceId(20): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("Composite")
-rebuilt        : ReferenceId(24): None
+rebuilt        : ReferenceId(23): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("Composite2")
-rebuilt        : ReferenceId(26): None
+rebuilt        : ReferenceId(25): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Component")
-rebuilt        : ReferenceId(48): None
+rebuilt        : ReferenceId(47): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("Namespace")
-rebuilt        : ReferenceId(51): None
+rebuilt        : ReferenceId(50): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("Namespace")
-rebuilt        : ReferenceId(54): None
+rebuilt        : ReferenceId(53): None
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Component")
-rebuilt        : ReferenceId(57): None
+rebuilt        : ReferenceId(56): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("Component")
-rebuilt        : ReferenceId(61): None
+rebuilt        : ReferenceId(60): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("Component")
-rebuilt        : ReferenceId(66): None
+rebuilt        : ReferenceId(65): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("y")
-rebuilt        : ReferenceId(67): None
+rebuilt        : ReferenceId(66): None
 Reference symbol mismatch:
 after transform: ReferenceId(17): Some("Component")
-rebuilt        : ReferenceId(72): None
+rebuilt        : ReferenceId(71): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("Component")
-rebuilt        : ReferenceId(76): None
+rebuilt        : ReferenceId(75): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("Component")
-rebuilt        : ReferenceId(80): None
+rebuilt        : ReferenceId(79): None
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("Component")
-rebuilt        : ReferenceId(84): None
+rebuilt        : ReferenceId(83): None
 Reference symbol mismatch:
 after transform: ReferenceId(24): Some("y")
-rebuilt        : ReferenceId(85): None
+rebuilt        : ReferenceId(84): None
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("Component")
-rebuilt        : ReferenceId(88): None
+rebuilt        : ReferenceId(87): None
 Reference symbol mismatch:
 after transform: ReferenceId(26): Some("z")
-rebuilt        : ReferenceId(89): None
+rebuilt        : ReferenceId(88): None
 Reference symbol mismatch:
 after transform: ReferenceId(27): Some("z")
-rebuilt        : ReferenceId(90): None
+rebuilt        : ReferenceId(89): None
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("Child")
-rebuilt        : ReferenceId(92): None
+rebuilt        : ReferenceId(91): None
 Reference symbol mismatch:
 after transform: ReferenceId(30): Some("Component")
-rebuilt        : ReferenceId(96): None
+rebuilt        : ReferenceId(95): None
 Reference symbol mismatch:
 after transform: ReferenceId(31): Some("z")
-rebuilt        : ReferenceId(97): None
+rebuilt        : ReferenceId(96): None
 Reference symbol mismatch:
 after transform: ReferenceId(32): Some("z")
-rebuilt        : ReferenceId(98): None
+rebuilt        : ReferenceId(97): None
 Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["Child", "Component", "Composite", "Composite2", "Namespace", "bar", "foo", "require", "y", "z"]
+after transform: []
+rebuilt        : ["Child", "Component", "Composite", "Composite2", "Namespace", "bar", "foo", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["React", "_jsx", "_jsxFileName", "_jsxs"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_jsxs"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
 semantic error: Bindings mismatch:
@@ -40593,31 +49823,26 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution13.tsx
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Address", "AddressComp", "AmericanAddress", "CanadianAddress", "Properties", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
-rebuilt        : ScopeId(0): ["AddressComp", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
+after transform: ScopeId(0): ["Address", "AddressComp", "AmericanAddress", "CanadianAddress", "Properties", "React", "_jsx", "_jsxFileName", "a"]
+rebuilt        : ScopeId(0): ["AddressComp", "React", "_jsx", "_jsxFileName", "a"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -40643,57 +49868,46 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolu
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsx", "_jsxFileName", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsx", "_jsxFileName", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["require", "true"]
+after transform: ["true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["CustomTag", "JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["CustomTag", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["CustomTag", "JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["CustomTag", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "foo", "t"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "foo", "t"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "foo", "t"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -40706,8 +49920,8 @@ Missing ReferenceId: Name
 Missing ReferenceId: Dotted
 Missing ReferenceId: Dotted
 Bindings mismatch:
-after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
-rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
+after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsx", "_jsxFileName", "a", "b", "d", "e", "foundFirst"]
+rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsx", "_jsxFileName", "a", "b", "d", "e", "foundFirst"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
@@ -40722,23 +49936,23 @@ after transform: SymbolId(5): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(6): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(2)]
+rebuilt        : SymbolId(6): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("Dotted")
-rebuilt        : ReferenceId(13): Some("Dotted")
+rebuilt        : ReferenceId(12): Some("Dotted")
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
+after transform: ScopeId(0): ["JSX", "Obj1", "_jsx", "_jsxFileName", "obj1"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
+after transform: ScopeId(0): ["JSX", "Obj1", "_jsx", "_jsxFileName", "obj1"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
@@ -40761,32 +49975,32 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
-rebuilt        : ScopeId(0): ["SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
+after transform: ScopeId(0): ["JSX", "SomeClass", "_jsx", "_jsxFileName", "_jsxs", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
+rebuilt        : ScopeId(0): ["SomeClass", "_jsx", "_jsxFileName", "_jsxs", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -40860,8 +50074,8 @@ rebuilt        : ["Foo", "React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "React", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+rebuilt        : ScopeId(0): ["_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -40958,18 +50172,9 @@ rebuilt        : ScopeId(3): ["Component"]
 Bindings mismatch:
 after transform: ScopeId(5): ["Component", "T", "U"]
 rebuilt        : ScopeId(5): ["Component"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): [ReferenceId(18), ReferenceId(20)]
-rebuilt        : SymbolId(10): [ReferenceId(11)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(27)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
 semantic error: Missing SymbolId: React
@@ -40980,12 +50185,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Bindings mismatch:
 after transform: ScopeId(1): ["Component", "T"]
 rebuilt        : ScopeId(1): ["Component"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
 semantic error: Missing SymbolId: React
@@ -41001,13 +50203,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(4): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
 semantic error: Missing SymbolId: React
@@ -41023,13 +50225,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(4): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
 semantic error: Missing SymbolId: React
@@ -41045,13 +50247,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(4): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
 semantic error: Missing SymbolId: React
@@ -41067,13 +50269,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(4): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
 semantic error: Missing SymbolId: React
@@ -41091,11 +50293,8 @@ Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
 Unresolved references mismatch:
-after transform: ["Component", "JSX", "require"]
+after transform: ["Component", "JSX"]
 rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 semantic error: Missing SymbolId: React
@@ -41113,11 +50312,8 @@ Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
 Unresolved references mismatch:
-after transform: ["Component", "JSX", "require"]
+after transform: ["Component", "JSX"]
 rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 semantic error: Missing SymbolId: React
@@ -41130,18 +50326,15 @@ after transform: ScopeId(1): ["Ctor", "P"]
 rebuilt        : ScopeId(1): ["Ctor"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX", "require"]
+after transform: ["JSX"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -41162,27 +50355,24 @@ Namespace tags are not supported by default. React's JSX doesn't support namespa
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "JSX", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["A", "JSX", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "A":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -41206,27 +50396,27 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefau
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x"]
-rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x"]
+after transform: ScopeId(0): ["Prop", "React", "_jsx", "_jsxFileName", "x"]
+rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["MyComp"]
+rebuilt        : ["MyComp", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
-rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
+after transform: ScopeId(0): ["Prop", "React", "_jsx", "_jsxFileName", "x", "x1"]
+rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x", "x1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["MyComp"]
+rebuilt        : ["MyComp", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
@@ -41427,17 +50617,17 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "render"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitSpreadAttribute.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "__proto__", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "__proto__", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "_jsx", "_jsxFileName"]
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("__proto__")
-rebuilt        : ReferenceId(35): None
+rebuilt        : ReferenceId(34): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("__proto__")
-rebuilt        : ReferenceId(40): None
+rebuilt        : ReferenceId(39): None
 Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["__proto__", "require"]
+after transform: []
+rebuilt        : ["__proto__"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
 semantic error: Bindings mismatch:
@@ -41518,9 +50708,9 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(6)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
 semantic error: Missing SymbolId: React
@@ -41528,9 +50718,9 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(6)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
 semantic error: Missing SymbolId: React
@@ -41540,122 +50730,116 @@ after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
-rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsx", "_jsxFileName", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsx", "_jsxFileName", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["require", "true"]
+after transform: ["true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(31)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherComponentProps", "ChildComponent", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["AnotherComponentProps", "ChildComponent", "Component", "ComponentProps", "React", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherComponent", "AnotherComponentProps", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["AnotherComponent", "AnotherComponentProps", "Component", "ComponentProps", "React", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "PoisonedProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
+after transform: ScopeId(0): ["Poisoned", "PoisonedProp", "React", "_jsx", "_jsxFileName", "obj", "p", "y"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "obj", "p", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["React", "TextComponent", "TextProps", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
-rebuilt        : ScopeId(0): ["React", "TextComponent", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+after transform: ScopeId(0): ["React", "TextComponent", "TextProps", "_jsx", "_jsxFileName", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+rebuilt        : ScopeId(0): ["React", "TextComponent", "_jsx", "_jsxFileName", "textPropsFalse", "textPropsTrue", "y1", "y2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(1): Some("React")
 Unresolved references mismatch:
-after transform: ["require", "true"]
+after transform: ["true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(15)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
-rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsx", "_jsxFileName", "obj", "obj1", "obj3", "x", "x1"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsx", "_jsxFileName", "obj", "obj1", "obj3", "x", "x1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Opt", "OptionProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
-rebuilt        : ScopeId(0): ["Opt", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+after transform: ScopeId(0): ["Opt", "OptionProp", "React", "_jsx", "_jsxFileName", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+rebuilt        : ScopeId(0): ["Opt", "React", "_jsx", "_jsxFileName", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(24)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+rebuilt        : ReferenceId(1): Some("React")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 semantic error: Spread children are not supported in React.
@@ -41674,74 +50858,65 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["JSX", "OneThing", "require"]
+after transform: ["JSX", "OneThing"]
 rebuilt        : ["OneThing", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(40)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Context", "_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
-rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
+after transform: ScopeId(0): ["Context", "_jsx", "_jsxFileName", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
+rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing", "require"]
-rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing", "require"]
+after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing"]
+rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["ButtonProps", "ClickableProps", "HyphenProps", "LinkProps", "MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
-rebuilt        : ScopeId(0): ["MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+after transform: ScopeId(0): ["ButtonProps", "ClickableProps", "HyphenProps", "LinkProps", "MainButton", "React", "_jsx", "_jsxFileName", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+rebuilt        : ScopeId(0): ["MainButton", "React", "_jsx", "_jsxFileName", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(11): [ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42)]
-rebuilt        : SymbolId(6): [ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(25), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49)]
 Unresolved references mismatch:
-after transform: ["JSX", "console", "require"]
+after transform: ["JSX", "console"]
 rebuilt        : ["console", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(69)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["MyComponent", "MyComponentProp", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
-rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
+after transform: ScopeId(0): ["MyComponent", "MyComponentProp", "React", "_jsx", "_jsxFileName", "i", "i1"]
+rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsx", "_jsxFileName", "i", "i1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "attr"]
 rebuilt        : ScopeId(1): ["attr"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(9)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Baz", "InferParamProp", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
-rebuilt        : ScopeId(0): ["Baz", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
+after transform: ScopeId(0): ["Baz", "InferParamProp", "React", "_createElement", "_jsx", "_jsxFileName", "createLink", "createLink1", "i"]
+rebuilt        : ScopeId(0): ["Baz", "React", "_createElement", "_jsx", "_jsxFileName", "createLink", "createLink1", "i"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -41749,11 +50924,8 @@ Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "a0", "a1", "key1", "value"]
 rebuilt        : ScopeId(1): ["a0", "a1", "key1", "value"]
 Unresolved references mismatch:
-after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link", "require"]
+after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link"]
 rebuilt        : ["ComponentWithTwoAttributes", "InferParamComponent", "Link", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(34), ReferenceId(35)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
 semantic error: Missing SymbolId: React
@@ -41768,11 +50940,8 @@ Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
 rebuilt        : ScopeId(1): ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
 Unresolved references mismatch:
-after transform: ["JSX", "Link", "OverloadComponent", "require"]
+after transform: ["JSX", "Link", "OverloadComponent"]
 rebuilt        : ["Link", "OverloadComponent", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(48)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
 semantic error: Missing SymbolId: React
@@ -41790,30 +50959,24 @@ Bindings mismatch:
 after transform: ScopeId(5): ["T", "a1", "a2", "a3", "a4", "arg"]
 rebuilt        : ScopeId(2): ["a1", "a2", "a3", "a4", "arg"]
 Unresolved references mismatch:
-after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX", "require"]
+after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX"]
 rebuilt        : ["Component", "ComponentSpecific", "ComponentSpecific1", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(32)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "InterfaceProps", "React", "TypeProps", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Foo", "React", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["Foo", "InterfaceProps", "React", "TypeProps", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+rebuilt        : ScopeId(0): ["Foo", "React", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33)]
-rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47), ReferenceId(50), ReferenceId(53), ReferenceId(56), ReferenceId(59), ReferenceId(62)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(76)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -41867,6 +51030,14 @@ Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTypeOnlyImport1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Default", "Import", "ImportRelative", "Require", "RequireRelative", "_Default", "_Import", "_ImportRelative", "_Require", "_RequireRelative"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolvesWithoutExportsDiagnostic1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
@@ -41907,6 +51078,99 @@ tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackag
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAssignments.ts
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+`import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmit.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface", "a", "b"]
+rebuilt        : ScopeId(0): ["a", "b"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["ImportInterface", "RequireInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface", "a", "b"]
+rebuilt        : ScopeId(0): ["a", "b"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["ImportInterface", "RequireInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["RequireInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["ImportInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["RequireInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["ImportInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LocalInterface"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["ImportInterface", "RequireInterface"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
+semantic error: Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlFileWithinDeclarationFile.ts
 semantic error: Bindings mismatch:
@@ -41952,6 +51216,14 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): []
+Scope children mismatch:
+after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
+rebuilt        : ScopeId(2): [ScopeId(3)]
+
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
@@ -41977,8 +51249,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -41988,16 +51260,16 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum3.ts
 semantic error: Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -42585,9 +51857,6 @@ semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
-semantic error: Cannot use export statement outside a module
-
 tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "t"]
@@ -42605,6 +51874,9 @@ Please consider using `import lib from '...';` alongside Typescript's --allowSyn
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSRedeclare3.ts
 semantic error: Identifier `orbitol` has already been declared
+
+tasks/coverage/typescript/tests/cases/conformance/salsa/privateIdentifierExpando.ts
+semantic error: Private identifier '#bar' is not allowed outside class bodies
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
 semantic error: Bindings mismatch:
@@ -42627,16 +51899,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
-semantic error: Cannot use export statement outside a module
-
 tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["CodeGenTarget", "ES3", "ES5"]
 rebuilt        : ScopeId(1): ["CodeGenTarget"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -42767,6 +52036,20 @@ tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["R1", "R2", "r1", "r2"]
+rebuilt        : ScopeId(0): ["r1", "r2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3)]
+rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 semantic error: Bindings mismatch:
@@ -43260,6 +52543,40 @@ Unresolved references mismatch:
 after transform: ["AsyncIterable", "AsyncIterableIterator", "AsyncIterator", "Promise", "PromiseLike"]
 rebuilt        : ["Promise"]
 
+tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AlsoWeird", "BadNested", "Weird", "a", "b", "bar", "bar2"]
+rebuilt        : ScopeId(0): ["a", "b", "bar", "bar2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(12)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "obj"]
+rebuilt        : ScopeId(1): ["obj"]
+Bindings mismatch:
+after transform: ScopeId(9): ["T", "obj"]
+rebuilt        : ScopeId(2): ["obj"]
+Unresolved references mismatch:
+after transform: ["P", "foo", "foo2"]
+rebuilt        : ["foo", "foo2"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ExpectNumber", "IfEquals", "T", "X1", "X10", "X10_T1_T1", "X10_Y1", "X11", "X12", "X13", "X14", "X15", "X16", "X17", "X18", "X19", "X19_T1", "X19_T2", "X19_T3", "X1_T1", "X1_T2", "X1_T3", "X2", "X20", "X20_T1", "X21", "X21_T1", "X21_T2", "X21_T3", "X21_T4", "X21_T5", "X2_T1", "X2_T2", "X2_T3", "X3", "X3_T1", "X3_T2", "X3_T3", "X4", "X4_T1", "X4_T2", "X4_T3", "X5", "X5_T1", "X5_T2", "X5_T3", "X6", "X6_T1", "X6_T2", "X6_T3", "X7", "X7_T1", "X7_T2", "X7_T3", "X7_T4", "X8", "X8_T1", "X8_T2", "X8_T3", "X8_T4", "X9", "X9_T1", "X9_T2", "X9_T3", "X9_T4", "f1", "f2", "x1", "x2"]
+rebuilt        : ScopeId(0): ["f1", "f2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(61), ScopeId(63), ScopeId(64), ScopeId(67), ScopeId(69), ScopeId(71), ScopeId(73), ScopeId(77), ScopeId(80), ScopeId(84), ScopeId(87), ScopeId(89), ScopeId(90), ScopeId(91), ScopeId(92), ScopeId(95), ScopeId(96), ScopeId(98), ScopeId(99), ScopeId(100), ScopeId(101), ScopeId(102), ScopeId(103), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(111)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(118): Some("x1")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(122): Some("x2")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: ["Promise"]
+rebuilt        : ["x1", "x2"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "foo", "x", "y", "z"]
@@ -43383,6 +52700,33 @@ rebuilt        : ReferenceId(17): None
 Unresolved references mismatch:
 after transform: ["AsyncIterable", "Iterable", "Promise"]
 rebuilt        : ["asyncIterable", "iterable", "iterableOfPromise"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar2", "foo", "foo2", "shim", "x", "y"]
+rebuilt        : ScopeId(0): ["Bar2", "shim", "x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Unresolved references mismatch:
+after transform: ["Bar", "Baz"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGenericTypes.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocal.ts
+semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
 semantic error: Bindings mismatch:
@@ -43535,6 +52879,37 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
+tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["K", "T", "b", "k", "k1", "obj"]
+rebuilt        : ScopeId(1): ["b", "k", "k1", "obj"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "b", "k", "k1", "obj"]
+rebuilt        : ScopeId(6): ["b", "k", "k1", "obj"]
+Scope children mismatch:
+after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(11)]
+rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(9)]
+Bindings mismatch:
+after transform: ScopeId(13): ["K", "T", "b", "k", "k1", "obj"]
+rebuilt        : ScopeId(11): ["b", "k", "k1", "obj"]
+Scope children mismatch:
+after transform: ScopeId(13): [ScopeId(14), ScopeId(15), ScopeId(17)]
+rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(14)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Example1", "Example3", "Example4", "Example5", "Result1", "Result2", "Result3", "Result4", "Result5", "T01", "T02", "T03", "T04", "T05", "T06", "T07"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Record"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
@@ -43626,8 +53001,8 @@ Bindings mismatch:
 after transform: ScopeId(26): ["A", "B", "E"]
 rebuilt        : ScopeId(18): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(26): ScopeFlags(0x0)
-rebuilt        : ScopeId(18): ScopeFlags(Function)
+after transform: ScopeId(26): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(18): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(63): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -43743,6 +53118,17 @@ rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(34)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Container", "T0", "T1", "T10", "T11", "T2", "T20", "T21", "T3", "T4", "UnwrapContainers", "container1", "container2", "f1", "f2"]
+rebuilt        : ScopeId(0): ["container1", "container2", "f1", "f2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Unresolved references mismatch:
+after transform: ["Capitalize", "createContainer", "f"]
+rebuilt        : ["createContainer", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
 semantic error: Bindings mismatch:
@@ -44031,6 +53417,47 @@ Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Box", "Boxified", "Foo", "Func", "Spec", "assignBoxified", "box", "boxify", "f1", "f10", "f2", "f3", "f4", "f5", "f6", "foo", "g1", "g2", "getProps", "makeDictionary", "makeRecord", "myAny", "o", "o1", "o2", "unbox", "unboxify", "x0", "x1", "x2", "x3", "x4"]
+rebuilt        : ScopeId(0): ["assignBoxified", "box", "boxify", "f1", "f10", "f2", "f3", "f4", "f5", "f6", "foo", "g1", "g2", "getProps", "makeDictionary", "makeRecord", "myAny", "o", "o1", "o2", "unbox", "unboxify", "x0", "x1", "x2", "x3", "x4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25)]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "x"]
+rebuilt        : ScopeId(1): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "x"]
+rebuilt        : ScopeId(2): ["x"]
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "obj", "result"]
+rebuilt        : ScopeId(3): ["obj", "result"]
+Bindings mismatch:
+after transform: ScopeId(9): ["T", "obj", "result"]
+rebuilt        : ScopeId(6): ["obj", "result"]
+Bindings mismatch:
+after transform: ScopeId(12): ["T", "obj", "values"]
+rebuilt        : ScopeId(9): ["obj", "values"]
+Bindings mismatch:
+after transform: ScopeId(19): ["K", "T", "obj"]
+rebuilt        : ScopeId(16): ["obj"]
+Scope children mismatch:
+after transform: ScopeId(19): [ScopeId(20)]
+rebuilt        : ScopeId(16): []
+Bindings mismatch:
+after transform: ScopeId(22): ["T", "obj"]
+rebuilt        : ScopeId(18): ["obj"]
+Bindings mismatch:
+after transform: ScopeId(39): ["T", "object", "partial"]
+rebuilt        : ScopeId(24): ["object", "partial"]
+Bindings mismatch:
+after transform: ScopeId(45): ["K", "T", "list", "obj"]
+rebuilt        : ScopeId(25): ["list", "obj"]
+Unresolved references mismatch:
+after transform: ["Partial", "Pick", "applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
+rebuilt        : ["applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TargetProps", "f0", "f1", "f2", "f3", "f4", "modifier"]
@@ -44119,6 +53546,97 @@ rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(8)]
 Unresolved references mismatch:
 after transform: ["Extract"]
 rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Item", "T00", "T01", "T02", "T03", "T10", "T11", "T12", "T13", "T20", "T21", "T30", "T31", "T32", "T33", "T34", "T35", "T36", "T37", "T38", "T40", "T43", "T44", "T47", "x1", "x2", "x3", "x4"]
+rebuilt        : ScopeId(0): ["x1", "x2", "x3", "x4"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52), ScopeId(54)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Array", "Date", "Number", "f1", "f2", "f3", "f4"]
+rebuilt        : ["f1", "f2", "f3", "f4"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["DeepReadonly", "PartialShape", "Point", "Proxify", "Proxy", "ReadonlyShape", "Shape", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "verifyLibTypes"]
+rebuilt        : ScopeId(0): ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "verifyLibTypes"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(28), ScopeId(29)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9)]
+Bindings mismatch:
+after transform: ScopeId(1): ["K", "T", "U", "x1", "x2", "x3", "x4"]
+rebuilt        : ScopeId(1): ["x1", "x2", "x3", "x4"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): []
+Unresolved references mismatch:
+after transform: ["Partial", "Pick", "Readonly", "Record", "assign", "freeze", "mapObject", "pick", "proxify"]
+rebuilt        : ["assign", "freeze", "mapObject", "pick", "proxify"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bacon", "Box", "Boxified", "BoxifiedBacon", "f1", "f2", "f3"]
+rebuilt        : ScopeId(0): ["Box", "f1", "f2", "f3"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["P"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Box", "Boxified", "BoxifiedWithSentinel", "C", "Clone", "DeepReadonly", "DeepReadonlyFoo", "Foo", "M", "T00", "T01", "T02", "T03", "T04", "T05", "T10", "T11", "T12", "Z", "boxify", "f1", "x1", "z1"]
+rebuilt        : ScopeId(0): ["boxify", "f1", "x1", "z1"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(30)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "obj"]
+rebuilt        : ScopeId(1): ["obj"]
+Unresolved references mismatch:
+after transform: ["Partial", "Readonly"]
+rebuilt        : []
+
+tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "Awaitified", "B", "Box", "Boxified", "Constrained", "ElementType", "F", "Mapped", "R1", "R2", "ReadWrite", "T00", "T01", "T02", "T1", "T10", "T11", "T12", "T13", "T14", "T15", "T2", "T20", "T21", "T22", "T23", "T24", "T25", "T30", "T31", "T40", "T50", "T51", "T52", "T53", "T54", "Unconstrained", "__Awaited", "acceptMappedArray", "f1", "f2", "x10", "x11", "x12", "x20", "x21", "x22", "y10", "y11", "y12", "y20", "y21", "y22"]
+rebuilt        : ScopeId(0): ["acceptMappedArray", "f1", "f2", "y10", "y11", "y12", "y20", "y21", "y22"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Bindings mismatch:
+after transform: ScopeId(39): ["T", "a", "x", "y"]
+rebuilt        : ScopeId(2): ["a", "x", "y"]
+Bindings mismatch:
+after transform: ScopeId(49): ["T", "arr"]
+rebuilt        : ScopeId(3): ["arr"]
+Reference symbol mismatch:
+after transform: ReferenceId(56): Some("x10")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(59): Some("x11")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(63): Some("x12")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(68): Some("x20")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(70): Some("x21")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(72): Some("x22")
+rebuilt        : ReferenceId(11): None
+Unresolved references mismatch:
+after transform: ["Array", "Partial", "Promise", "PromiseLike", "Readonly", "ReadonlyArray", "Required", "acceptArray", "all", "mapArray", "nonpartial", "unboxify"]
+rebuilt        : ["acceptArray", "all", "mapArray", "nonpartial", "unboxify", "x10", "x11", "x12", "x20", "x21", "x22"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
 semantic error: Bindings mismatch:
@@ -44323,6 +53841,23 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "Base", "Derived", "Foo", "test1", "test2"]
+rebuilt        : ScopeId(0): ["Bar", "Base", "Derived", "test1", "test2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(10), ScopeId(11), ScopeId(13)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8)]
+Scope children mismatch:
+after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
+Scope children mismatch:
+after transform: ScopeId(11): [ScopeId(12)]
+rebuilt        : ScopeId(7): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(10)]
+rebuilt        : SymbolId(5): []
+
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comparator", "LinkedList", "Node", "a1", "a2", "list", "neverArray"]
@@ -44331,6 +53866,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
+tasks/coverage/typescript/tests/cases/conformance/types/never/neverType.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(13): ["T", "x"]
+rebuilt        : ScopeId(13): ["x"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10", "T11", "T12"]
@@ -44338,6 +53878,20 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["BarProps", "FooProps", "foo", "fooProps"]
+rebuilt        : ScopeId(0): ["fooProps"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("foo")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
 semantic error: Bindings mismatch:
@@ -44819,6 +54373,269 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(17): [ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(16): [ReferenceId(10)]
 
+tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["P1", "T", "T01", "T02", "T03", "T04", "T05", "T06", "T10", "T11", "T12", "f00", "f01", "f02", "f03", "f04", "f10", "f11", "f12", "f13", "f20", "ns", "sn", "t1", "t2", "t3", "t4"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("f10")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("f10")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("f10")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("f10")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("t1")
+rebuilt        : ReferenceId(4): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("t1")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("t1")
+rebuilt        : ReferenceId(6): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("t1")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(8): Some("f10")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("t1")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("f10")
+rebuilt        : ReferenceId(10): None
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("t2")
+rebuilt        : ReferenceId(11): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("f10")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("t3")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("f10")
+rebuilt        : ReferenceId(14): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("t4")
+rebuilt        : ReferenceId(15): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("f10")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("t4")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(18): Some("t3")
+rebuilt        : ReferenceId(18): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("f11")
+rebuilt        : ReferenceId(19): None
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("f11")
+rebuilt        : ReferenceId(20): None
+Reference symbol mismatch:
+after transform: ReferenceId(21): Some("f11")
+rebuilt        : ReferenceId(21): None
+Reference symbol mismatch:
+after transform: ReferenceId(22): Some("f11")
+rebuilt        : ReferenceId(22): None
+Reference symbol mismatch:
+after transform: ReferenceId(23): Some("t1")
+rebuilt        : ReferenceId(23): None
+Reference symbol mismatch:
+after transform: ReferenceId(24): Some("t1")
+rebuilt        : ReferenceId(24): None
+Reference symbol mismatch:
+after transform: ReferenceId(25): Some("t1")
+rebuilt        : ReferenceId(25): None
+Reference symbol mismatch:
+after transform: ReferenceId(26): Some("t1")
+rebuilt        : ReferenceId(26): None
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("f11")
+rebuilt        : ReferenceId(27): None
+Reference symbol mismatch:
+after transform: ReferenceId(28): Some("t1")
+rebuilt        : ReferenceId(28): None
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("f11")
+rebuilt        : ReferenceId(29): None
+Reference symbol mismatch:
+after transform: ReferenceId(30): Some("t2")
+rebuilt        : ReferenceId(30): None
+Reference symbol mismatch:
+after transform: ReferenceId(31): Some("f11")
+rebuilt        : ReferenceId(31): None
+Reference symbol mismatch:
+after transform: ReferenceId(32): Some("t3")
+rebuilt        : ReferenceId(32): None
+Reference symbol mismatch:
+after transform: ReferenceId(33): Some("f11")
+rebuilt        : ReferenceId(33): None
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("t4")
+rebuilt        : ReferenceId(34): None
+Reference symbol mismatch:
+after transform: ReferenceId(35): Some("f11")
+rebuilt        : ReferenceId(35): None
+Reference symbol mismatch:
+after transform: ReferenceId(36): Some("t4")
+rebuilt        : ReferenceId(36): None
+Reference symbol mismatch:
+after transform: ReferenceId(37): Some("t3")
+rebuilt        : ReferenceId(37): None
+Reference symbol mismatch:
+after transform: ReferenceId(38): Some("f12")
+rebuilt        : ReferenceId(38): None
+Reference symbol mismatch:
+after transform: ReferenceId(39): Some("f12")
+rebuilt        : ReferenceId(39): None
+Reference symbol mismatch:
+after transform: ReferenceId(40): Some("f12")
+rebuilt        : ReferenceId(40): None
+Reference symbol mismatch:
+after transform: ReferenceId(41): Some("f12")
+rebuilt        : ReferenceId(41): None
+Reference symbol mismatch:
+after transform: ReferenceId(42): Some("t1")
+rebuilt        : ReferenceId(42): None
+Reference symbol mismatch:
+after transform: ReferenceId(43): Some("t1")
+rebuilt        : ReferenceId(43): None
+Reference symbol mismatch:
+after transform: ReferenceId(44): Some("t1")
+rebuilt        : ReferenceId(44): None
+Reference symbol mismatch:
+after transform: ReferenceId(45): Some("t1")
+rebuilt        : ReferenceId(45): None
+Reference symbol mismatch:
+after transform: ReferenceId(46): Some("f12")
+rebuilt        : ReferenceId(46): None
+Reference symbol mismatch:
+after transform: ReferenceId(47): Some("t1")
+rebuilt        : ReferenceId(47): None
+Reference symbol mismatch:
+after transform: ReferenceId(48): Some("f12")
+rebuilt        : ReferenceId(48): None
+Reference symbol mismatch:
+after transform: ReferenceId(49): Some("t2")
+rebuilt        : ReferenceId(49): None
+Reference symbol mismatch:
+after transform: ReferenceId(50): Some("f12")
+rebuilt        : ReferenceId(50): None
+Reference symbol mismatch:
+after transform: ReferenceId(51): Some("t3")
+rebuilt        : ReferenceId(51): None
+Reference symbol mismatch:
+after transform: ReferenceId(52): Some("f12")
+rebuilt        : ReferenceId(52): None
+Reference symbol mismatch:
+after transform: ReferenceId(53): Some("t4")
+rebuilt        : ReferenceId(53): None
+Reference symbol mismatch:
+after transform: ReferenceId(54): Some("f12")
+rebuilt        : ReferenceId(54): None
+Reference symbol mismatch:
+after transform: ReferenceId(55): Some("t4")
+rebuilt        : ReferenceId(55): None
+Reference symbol mismatch:
+after transform: ReferenceId(56): Some("t3")
+rebuilt        : ReferenceId(56): None
+Reference symbol mismatch:
+after transform: ReferenceId(57): Some("f13")
+rebuilt        : ReferenceId(57): None
+Reference symbol mismatch:
+after transform: ReferenceId(58): Some("f13")
+rebuilt        : ReferenceId(58): None
+Reference symbol mismatch:
+after transform: ReferenceId(59): Some("f13")
+rebuilt        : ReferenceId(59): None
+Reference symbol mismatch:
+after transform: ReferenceId(60): Some("f13")
+rebuilt        : ReferenceId(60): None
+Reference symbol mismatch:
+after transform: ReferenceId(61): Some("t1")
+rebuilt        : ReferenceId(61): None
+Reference symbol mismatch:
+after transform: ReferenceId(62): Some("t1")
+rebuilt        : ReferenceId(62): None
+Reference symbol mismatch:
+after transform: ReferenceId(63): Some("t1")
+rebuilt        : ReferenceId(63): None
+Reference symbol mismatch:
+after transform: ReferenceId(64): Some("t1")
+rebuilt        : ReferenceId(64): None
+Reference symbol mismatch:
+after transform: ReferenceId(65): Some("f13")
+rebuilt        : ReferenceId(65): None
+Reference symbol mismatch:
+after transform: ReferenceId(66): Some("t1")
+rebuilt        : ReferenceId(66): None
+Reference symbol mismatch:
+after transform: ReferenceId(67): Some("f13")
+rebuilt        : ReferenceId(67): None
+Reference symbol mismatch:
+after transform: ReferenceId(68): Some("t2")
+rebuilt        : ReferenceId(68): None
+Reference symbol mismatch:
+after transform: ReferenceId(69): Some("f13")
+rebuilt        : ReferenceId(69): None
+Reference symbol mismatch:
+after transform: ReferenceId(70): Some("t3")
+rebuilt        : ReferenceId(70): None
+Reference symbol mismatch:
+after transform: ReferenceId(71): Some("f13")
+rebuilt        : ReferenceId(71): None
+Reference symbol mismatch:
+after transform: ReferenceId(72): Some("t4")
+rebuilt        : ReferenceId(72): None
+Reference symbol mismatch:
+after transform: ReferenceId(73): Some("f13")
+rebuilt        : ReferenceId(73): None
+Reference symbol mismatch:
+after transform: ReferenceId(74): Some("t4")
+rebuilt        : ReferenceId(74): None
+Reference symbol mismatch:
+after transform: ReferenceId(75): Some("t3")
+rebuilt        : ReferenceId(75): None
+Reference symbol mismatch:
+after transform: ReferenceId(78): Some("f20")
+rebuilt        : ReferenceId(76): None
+Reference symbol mismatch:
+after transform: ReferenceId(79): Some("t1")
+rebuilt        : ReferenceId(77): None
+Reference symbol mismatch:
+after transform: ReferenceId(80): Some("f20")
+rebuilt        : ReferenceId(78): None
+Reference symbol mismatch:
+after transform: ReferenceId(81): Some("t2")
+rebuilt        : ReferenceId(79): None
+Reference symbol mismatch:
+after transform: ReferenceId(82): Some("f20")
+rebuilt        : ReferenceId(80): None
+Reference symbol mismatch:
+after transform: ReferenceId(83): Some("t3")
+rebuilt        : ReferenceId(81): None
+Reference symbol mismatch:
+after transform: ReferenceId(84): Some("f20")
+rebuilt        : ReferenceId(82): None
+Reference symbol mismatch:
+after transform: ReferenceId(85): Some("t2")
+rebuilt        : ReferenceId(83): None
+Unresolved references mismatch:
+after transform: ["ConstructorParameters", "Function", "Parameters"]
+rebuilt        : ["f10", "f11", "f12", "f13", "f20", "t1", "t2", "t3", "t4"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
@@ -45105,6 +54922,198 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndParenthesizedExpressions01.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndTuples01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["RexOrRaptor", "a", "brave", "dinosaur", "hello", "im", "newish", "rawr", "world"]
+rebuilt        : ScopeId(0): ["a", "brave", "dinosaur", "hello", "im", "newish", "rawr", "world"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
+rebuilt        : ScopeId(0): ["hasKind", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
+rebuilt        : ScopeId(0): ["hasKind", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
+rebuilt        : ScopeId(0): ["hasKind", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "f"]
+rebuilt        : ScopeId(1): ["f"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "f"]
+rebuilt        : ScopeId(2): ["f"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "f"]
+rebuilt        : ScopeId(1): ["f"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
+rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
+rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(13), ReferenceId(16)]
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(13)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(15)]
+rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(12)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes04.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["T", "x", "y"]
+rebuilt        : ScopeId(0): ["x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability03.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability04.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability05.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads01.ts
+semantic error: Missing SymbolId: Consts1
+Missing SymbolId: _Consts
+Missing ReferenceId: Consts1
+Missing ReferenceId: Consts1
+Missing SymbolId: Consts2
+Missing SymbolId: _Consts2
+Missing ReferenceId: Consts2
+Missing ReferenceId: Consts2
+Bindings mismatch:
+after transform: ScopeId(0): ["Consts1", "Consts2", "PrimitiveName", "boolean", "booleanOrNumber", "getFalsyPrimitive", "number", "string", "stringOrBoolean", "stringOrBooleanOrNumber", "stringOrNumber"]
+rebuilt        : ScopeId(0): ["Consts1", "Consts2", "boolean", "booleanOrNumber", "getFalsyPrimitive", "number", "string", "stringOrBoolean", "stringOrBooleanOrNumber", "stringOrNumber"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(29)]
+rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(14): [SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(30)]
+rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
+semantic error: Missing SymbolId: Consts1
+Missing SymbolId: _Consts
+Missing ReferenceId: Consts1
+Missing ReferenceId: Consts1
+Missing SymbolId: Consts2
+Missing SymbolId: _Consts2
+Missing ReferenceId: Consts2
+Missing ReferenceId: Consts2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(7), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(12), ScopeId(13)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(28)]
+rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(29)]
+rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Base", "HelloOrWorld", "JustHello", "JustWorld", "f", "fResult1", "fResult2", "fResult3", "g", "gResult1", "gResult2", "gResult3", "hello", "helloOrWorld", "world"]
+rebuilt        : ScopeId(0): ["f", "fResult1", "fResult2", "fResult3", "g", "gResult1", "gResult2", "gResult3", "hello", "helloOrWorld", "world"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Kind", "kindIs", "x"]
+rebuilt        : ScopeId(0): ["kindIs", "x"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "x", "y"]
@@ -45150,6 +55159,14 @@ rebuilt        : ScopeId(7): ["x"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
 rebuilt        : SymbolId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInBasePropertyAndDerivedContainerOfBase01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "BoxOfFoo", "Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
 semantic error: Bindings mismatch:
@@ -45203,6 +55220,20 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
+tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Accessors", "Computed", "D", "Dictionary", "M", "ObjectDescriptor", "ObjectDescriptor2", "P", "Point", "PropDesc", "PropDescMap", "Vue", "VueOptions", "obj1", "p1", "p10", "p11", "p12", "p2", "p3", "p4", "vue", "x1", "x2"]
+rebuilt        : ScopeId(0): ["obj1", "p1", "p10", "p11", "p12", "p2", "p3", "p4", "vue", "x1", "x2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(31), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(41), ScopeId(42), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
+Reference symbol mismatch:
+after transform: ReferenceId(124): Some("Vue")
+rebuilt        : ReferenceId(49): None
+Unresolved references mismatch:
+after transform: ["Record", "ThisType", "defineProp", "defineProps", "f1", "f2", "makeObject", "makeObject2"]
+rebuilt        : ["Vue", "defineProp", "defineProps", "f1", "f2", "makeObject", "makeObject2"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "strings"]
@@ -45228,6 +55259,119 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptiona
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "R", "T", "fn", "obj"]
 rebuilt        : ScopeId(1): ["fn", "obj"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Func", "Iter", "RecursiveTupleA", "RecursiveTupleB", "RecusiveRest", "RecusiveRest2", "Segment", "SegmentAnnotated", "WithOptAndRest", "a", "argumentsOfG", "argumentsOfGAsFirstArgument", "b", "c", "d", "func", "q", "r", "readSegment", "useState", "val", "x", "y"]
+rebuilt        : ScopeId(0): ["argumentsOfG", "argumentsOfGAsFirstArgument", "func", "readSegment", "useState", "val"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "initial"]
+rebuilt        : ScopeId(1): ["initial"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): [ReferenceId(33)]
+rebuilt        : SymbolId(3): []
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("a")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("b")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("a")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("c")
+rebuilt        : ReferenceId(3): None
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("a")
+rebuilt        : ReferenceId(4): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("d")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(8): Some("b")
+rebuilt        : ReferenceId(6): None
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("a")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("b")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("c")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("b")
+rebuilt        : ReferenceId(10): None
+Reference symbol mismatch:
+after transform: ReferenceId(13): Some("d")
+rebuilt        : ReferenceId(11): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("c")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("a")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("c")
+rebuilt        : ReferenceId(14): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("b")
+rebuilt        : ReferenceId(15): None
+Reference symbol mismatch:
+after transform: ReferenceId(18): Some("c")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("d")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("d")
+rebuilt        : ReferenceId(18): None
+Reference symbol mismatch:
+after transform: ReferenceId(21): Some("a")
+rebuilt        : ReferenceId(19): None
+Reference symbol mismatch:
+after transform: ReferenceId(22): Some("d")
+rebuilt        : ReferenceId(20): None
+Reference symbol mismatch:
+after transform: ReferenceId(23): Some("b")
+rebuilt        : ReferenceId(21): None
+Reference symbol mismatch:
+after transform: ReferenceId(24): Some("d")
+rebuilt        : ReferenceId(22): None
+Reference symbol mismatch:
+after transform: ReferenceId(25): Some("c")
+rebuilt        : ReferenceId(23): None
+Reference symbol mismatch:
+after transform: ReferenceId(38): Some("q")
+rebuilt        : ReferenceId(24): None
+Reference symbol mismatch:
+after transform: ReferenceId(39): Some("r")
+rebuilt        : ReferenceId(25): None
+Reference symbol mismatch:
+after transform: ReferenceId(40): Some("r")
+rebuilt        : ReferenceId(26): None
+Reference symbol mismatch:
+after transform: ReferenceId(41): Some("q")
+rebuilt        : ReferenceId(27): None
+Reference symbol mismatch:
+after transform: ReferenceId(46): Some("x")
+rebuilt        : ReferenceId(28): None
+Reference symbol mismatch:
+after transform: ReferenceId(47): Some("y")
+rebuilt        : ReferenceId(29): None
+Reference symbol mismatch:
+after transform: ReferenceId(48): Some("y")
+rebuilt        : ReferenceId(30): None
+Reference symbol mismatch:
+after transform: ReferenceId(49): Some("x")
+rebuilt        : ReferenceId(31): None
+Unresolved references mismatch:
+after transform: ["Parameters", "f", "g", "getArgsForInjection"]
+rebuilt        : ["a", "b", "c", "d", "f", "g", "getArgsForInjection", "q", "r", "x", "y"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
 semantic error: Bindings mismatch:
@@ -45264,6 +55408,23 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["tuple"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples2.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "T10", "T11", "T12", "T13", "T20", "T21", "someDec"]
+rebuilt        : ScopeId(0): ["A"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("someDec")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("someDec")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: ["Array", "ReadonlyArray"]
+rebuilt        : ["someDec"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
 semantic error: Scope children mismatch:
@@ -45435,6 +55596,14 @@ rebuilt        : SymbolId(6): []
 Symbol flags mismatch:
 after transform: SymbolId(38): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Bar", "BoxOfFoo", "Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments.ts
 semantic error: Bindings mismatch:
@@ -45852,6 +56021,20 @@ rebuilt        : ScopeId(2): ["baz", "z"]
 Bindings mismatch:
 after transform: ScopeId(3): ["W", "a", "c", "d", "e"]
 rebuilt        : ScopeId(3): ["a", "c", "d", "e"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "a", "b", "c", "v"]
+rebuilt        : ScopeId(1): ["a", "b", "c", "v"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "a"]
+rebuilt        : ScopeId(2): ["a"]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "a", "b", "v"]
+rebuilt        : ScopeId(4): ["a", "b", "v"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "a"]
+rebuilt        : ScopeId(5): ["a"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -46353,6 +56536,39 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x", "y"]
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "foo1", "foo2"]
+rebuilt        : ScopeId(0): ["foo1", "foo2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/weakTypesAndLiterals01.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["LiteralsOrWeakTypes", "WeakTypes", "aOrB", "f", "g", "h", "i"]
+rebuilt        : ScopeId(0): ["f", "g", "h", "i"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("aOrB")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("aOrB")
+rebuilt        : ReferenceId(11): None
+Unresolved references mismatch:
+after transform: ["true"]
+rebuilt        : ["aOrB"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 semantic error: Bindings mismatch:
@@ -48824,6 +59040,32 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(16): [ReferenceId(26)]
 rebuilt        : SymbolId(14): []
 
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Box", "T", "arrayFilter", "arrayMap", "f00", "f01", "f02", "f03", "f10", "f11", "f12", "f13", "f20", "f21", "f22", "f23", "f30", "f31", "f40", "fn"]
+rebuilt        : ScopeId(0): ["arrayFilter", "arrayMap", "f00", "f01", "f02", "f03", "f10", "f11", "f12", "f13", "f20", "f21", "f22", "f23", "f30", "f31", "f40", "fn"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
+Bindings mismatch:
+after transform: ScopeId(18): ["T", "U", "f"]
+rebuilt        : ScopeId(7): ["f"]
+Bindings mismatch:
+after transform: ScopeId(20): ["T", "f"]
+rebuilt        : ScopeId(9): ["f"]
+Symbol flags mismatch:
+after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction | TypeAlias)
+rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)
+Symbol span mismatch:
+after transform: SymbolId(70): Span { start: 1594, end: 1596 }
+rebuilt        : SymbolId(32): Span { start: 1621, end: 1627 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(70): [ReferenceId(118)]
+rebuilt        : SymbolId(32): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(70): [Span { start: 1621, end: 1627 }]
+rebuilt        : SymbolId(32): []
+
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AssignAction", "Config", "LowInfer", "Meta", "PartialAssigner", "PropertyAssigner"]
@@ -48840,10 +59082,24 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["R", "S", "s", "x", "x1", "x2", "x3"]
+rebuilt        : ScopeId(0): ["x", "x1", "x2", "x3"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("s")
+rebuilt        : ReferenceId(6): None
+Unresolved references mismatch:
+after transform: ["Array", "f1", "f2", "f3"]
+rebuilt        : ["f1", "f2", "f3", "s"]
+
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "AnimatedViewProps", "Animations", "B", "C", "Component", "Foo", "Props", "StyleParam", "_jsxFileName", "_reactJsxRuntime"]
-rebuilt        : ScopeId(0): ["Component", "Foo", "_jsxFileName", "_reactJsxRuntime"]
+after transform: ScopeId(0): ["A", "AnimatedViewProps", "Animations", "B", "C", "Component", "Foo", "Props", "StyleParam", "_Fragment", "_jsx", "_jsxFileName"]
+rebuilt        : ScopeId(0): ["Component", "Foo", "_Fragment", "_jsx", "_jsxFileName"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
@@ -48854,8 +59110,8 @@ Bindings mismatch:
 after transform: ScopeId(17): ["T", "props"]
 rebuilt        : ScopeId(7): ["props"]
 Unresolved references mismatch:
-after transform: ["Partial", "Record", "require"]
-rebuilt        : ["require"]
+after transform: ["Partial", "Record"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 semantic error: Bindings mismatch:
@@ -48881,6 +59137,14 @@ rebuilt        : ["ConflictTarget", "Error"]
 Unresolved reference IDs mismatch for "ConflictTarget":
 after transform: [ReferenceId(22), ReferenceId(24), ReferenceId(33), ReferenceId(39)]
 rebuilt        : [ReferenceId(3)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["T", "x", "y"]
+rebuilt        : ScopeId(1): ["x", "y"]
+Unresolved references mismatch:
+after transform: ["NoInfer"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
 semantic error: Bindings mismatch:
@@ -49278,6 +59542,223 @@ rebuilt        : [ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(82), ReferenceId(164)]
 rebuilt        : [ReferenceId(60)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "C0", "C1", "Context", "I", "L", "N", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "c", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constType", "constTypeAndCall", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "i", "l", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o", "o2", "o4", "promiseForConstCall", "s", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
+rebuilt        : ScopeId(0): ["C", "C0", "C1", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constTypeAndCall", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o2", "o4", "promiseForConstCall", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(33), ScopeId(34), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(34), ReferenceId(83), ReferenceId(84)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(25), ReferenceId(26), ReferenceId(29), ReferenceId(61), ReferenceId(62)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): [ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(61), ReferenceId(63)]
+rebuilt        : SymbolId(32): [ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44)]
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("constType")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("constType")
+rebuilt        : ReferenceId(11): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("constType")
+rebuilt        : ReferenceId(15): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("constType")
+rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(55): Some("c")
+rebuilt        : ReferenceId(45): None
+Reference symbol mismatch:
+after transform: ReferenceId(56): Some("c")
+rebuilt        : ReferenceId(46): None
+Reference symbol mismatch:
+after transform: ReferenceId(58): Some("c")
+rebuilt        : ReferenceId(47): None
+Reference symbol mismatch:
+after transform: ReferenceId(60): Some("c")
+rebuilt        : ReferenceId(48): None
+Reference symbol mismatch:
+after transform: ReferenceId(62): Some("c")
+rebuilt        : ReferenceId(49): None
+Reference symbol mismatch:
+after transform: ReferenceId(64): Some("c")
+rebuilt        : ReferenceId(50): None
+Reference symbol mismatch:
+after transform: ReferenceId(66): Some("i")
+rebuilt        : ReferenceId(51): None
+Reference symbol mismatch:
+after transform: ReferenceId(68): Some("i")
+rebuilt        : ReferenceId(52): None
+Reference symbol mismatch:
+after transform: ReferenceId(70): Some("i")
+rebuilt        : ReferenceId(53): None
+Reference symbol mismatch:
+after transform: ReferenceId(72): Some("l")
+rebuilt        : ReferenceId(54): None
+Reference symbol mismatch:
+after transform: ReferenceId(73): Some("l")
+rebuilt        : ReferenceId(55): None
+Reference symbol mismatch:
+after transform: ReferenceId(75): Some("l")
+rebuilt        : ReferenceId(56): None
+Reference symbol mismatch:
+after transform: ReferenceId(77): Some("l")
+rebuilt        : ReferenceId(57): None
+Reference symbol mismatch:
+after transform: ReferenceId(79): Some("l")
+rebuilt        : ReferenceId(58): None
+Reference symbol mismatch:
+after transform: ReferenceId(81): Some("l")
+rebuilt        : ReferenceId(59): None
+Reference symbol mismatch:
+after transform: ReferenceId(92): Some("s")
+rebuilt        : ReferenceId(64): None
+Reference symbol mismatch:
+after transform: ReferenceId(97): Some("s")
+rebuilt        : ReferenceId(69): None
+Reference symbol mismatch:
+after transform: ReferenceId(100): Some("s")
+rebuilt        : ReferenceId(72): None
+Reference symbol mismatch:
+after transform: ReferenceId(103): Some("s")
+rebuilt        : ReferenceId(75): None
+Reference symbol mismatch:
+after transform: ReferenceId(104): Some("s")
+rebuilt        : ReferenceId(76): None
+Reference symbol mismatch:
+after transform: ReferenceId(105): Some("s")
+rebuilt        : ReferenceId(77): None
+Reference symbol mismatch:
+after transform: ReferenceId(106): Some("s")
+rebuilt        : ReferenceId(78): None
+Reference symbol mismatch:
+after transform: ReferenceId(107): Some("s")
+rebuilt        : ReferenceId(79): None
+Reference symbol mismatch:
+after transform: ReferenceId(109): Some("s")
+rebuilt        : ReferenceId(81): None
+Reference symbol mismatch:
+after transform: ReferenceId(112): Some("s")
+rebuilt        : ReferenceId(84): None
+Reference symbol mismatch:
+after transform: ReferenceId(115): Some("s")
+rebuilt        : ReferenceId(87): None
+Reference symbol mismatch:
+after transform: ReferenceId(118): Some("s")
+rebuilt        : ReferenceId(90): None
+Reference symbol mismatch:
+after transform: ReferenceId(121): Some("s")
+rebuilt        : ReferenceId(93): None
+Reference symbol mismatch:
+after transform: ReferenceId(122): Some("s")
+rebuilt        : ReferenceId(94): None
+Reference symbol mismatch:
+after transform: ReferenceId(123): Some("s")
+rebuilt        : ReferenceId(95): None
+Reference symbol mismatch:
+after transform: ReferenceId(124): Some("s")
+rebuilt        : ReferenceId(96): None
+Reference symbol mismatch:
+after transform: ReferenceId(125): Some("s")
+rebuilt        : ReferenceId(97): None
+Reference symbol mismatch:
+after transform: ReferenceId(127): Some("o")
+rebuilt        : ReferenceId(99): None
+Reference symbol mismatch:
+after transform: ReferenceId(128): Some("s")
+rebuilt        : ReferenceId(100): None
+Reference symbol mismatch:
+after transform: ReferenceId(129): Some("o")
+rebuilt        : ReferenceId(101): None
+Reference symbol mismatch:
+after transform: ReferenceId(131): Some("o")
+rebuilt        : ReferenceId(103): None
+Reference symbol mismatch:
+after transform: ReferenceId(135): Some("s")
+rebuilt        : ReferenceId(106): None
+Reference symbol mismatch:
+after transform: ReferenceId(143): Some("s")
+rebuilt        : ReferenceId(112): None
+Reference symbol mismatch:
+after transform: ReferenceId(148): Some("s")
+rebuilt        : ReferenceId(117): None
+Reference symbol mismatch:
+after transform: ReferenceId(152): Some("s")
+rebuilt        : ReferenceId(121): None
+Reference symbol mismatch:
+after transform: ReferenceId(157): Some("s")
+rebuilt        : ReferenceId(126): None
+Reference symbol mismatch:
+after transform: ReferenceId(159): Some("s")
+rebuilt        : ReferenceId(128): None
+Reference symbol mismatch:
+after transform: ReferenceId(161): Some("s")
+rebuilt        : ReferenceId(130): None
+Reference symbol mismatch:
+after transform: ReferenceId(173): Some("s")
+rebuilt        : ReferenceId(132): None
+Reference symbol mismatch:
+after transform: ReferenceId(174): Some("s")
+rebuilt        : ReferenceId(133): None
+Reference symbol mismatch:
+after transform: ReferenceId(175): Some("s")
+rebuilt        : ReferenceId(134): None
+Reference symbol mismatch:
+after transform: ReferenceId(176): Some("s")
+rebuilt        : ReferenceId(135): None
+Reference symbol mismatch:
+after transform: ReferenceId(177): Some("s")
+rebuilt        : ReferenceId(136): None
+Unresolved references mismatch:
+after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "N", "Promise", "Symbol", "f", "g"]
+rebuilt        : ["Math", "N", "Promise", "Symbol", "c", "constType", "f", "g", "i", "l", "o", "s"]
+Unresolved reference IDs mismatch for "N":
+after transform: [ReferenceId(86), ReferenceId(90), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(99), ReferenceId(101), ReferenceId(102), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(130), ReferenceId(132), ReferenceId(137), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(145), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(154), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
+rebuilt        : [ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId(71), ReferenceId(73), ReferenceId(74), ReferenceId(82), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(88), ReferenceId(89), ReferenceId(91), ReferenceId(92), ReferenceId(102), ReferenceId(104), ReferenceId(108), ReferenceId(110), ReferenceId(114), ReferenceId(116), ReferenceId(118), ReferenceId(119), ReferenceId(123), ReferenceId(125), ReferenceId(127), ReferenceId(129), ReferenceId(131)]
+Unresolved reference IDs mismatch for "Promise":
+after transform: [ReferenceId(82), ReferenceId(164)]
+rebuilt        : [ReferenceId(60)]
+
+tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["ClassWithPrivateNamedAccessors", "ClassWithPrivateNamedMethods", "ClassWithPrivateNamedProperties", "I", "InterfaceWithPrivateNamedMethods", "InterfaceWithPrivateNamedProperties", "TypeLiteralWithPrivateNamedMethods", "TypeLiteralWithPrivateNamedProperties", "classExpression", "funcInferredReturnType", "obj", "s"]
+rebuilt        : ScopeId(0): ["ClassWithPrivateNamedAccessors", "ClassWithPrivateNamedMethods", "ClassWithPrivateNamedProperties", "classExpression", "funcInferredReturnType", "obj"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(19)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(11)]
+Scope children mismatch:
+after transform: ScopeId(7): [ScopeId(8)]
+rebuilt        : ScopeId(6): []
+Reference symbol mismatch:
+after transform: ReferenceId(18): Some("s")
+rebuilt        : ReferenceId(5): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("s")
+rebuilt        : ReferenceId(6): None
+Reference symbol mismatch:
+after transform: ReferenceId(20): Some("s")
+rebuilt        : ReferenceId(7): None
+Reference symbol mismatch:
+after transform: ReferenceId(21): Some("s")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(22): Some("s")
+rebuilt        : ReferenceId(9): None
+Reference symbol mismatch:
+after transform: ReferenceId(24): Some("s")
+rebuilt        : ReferenceId(11): None
+Reference symbol mismatch:
+after transform: ReferenceId(25): Some("s")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("s")
+rebuilt        : ReferenceId(14): None
+Unresolved references mismatch:
+after transform: ["undefined"]
+rebuilt        : ["s", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: a709f989
 
 semantic_typescript Summary:
 AST Parsed     : 6479/6479 (100.00%)
-Positive Passed: 2671/6479 (41.23%)
+Positive Passed: 3259/6479 (50.30%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -139,14 +139,6 @@ Unresolved references mismatch:
 after transform: ["Date", "undefined"]
 rebuilt        : ["console", "fs", "process", "undefined"]
 
-tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I", "T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -209,42 +201,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["N", "R", "X", "_M"]
-rebuilt        : ScopeId(1): ["N", "_M"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-
 tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExtendedMapper", "ExtendedMapper1", "ExtendedMapper2", "a", "a1", "a2", "a3", "b", "b1", "b2", "b3", "check", "check1", "check2", "check3", "test", "test1", "test2", "test3"]
@@ -296,14 +252,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Color"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
 semantic error: Missing SymbolId: D
 Missing SymbolId: _D
@@ -337,20 +285,6 @@ tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.t
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "E", "non identifier"]
-rebuilt        : ScopeId(2): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
 semantic error: Bindings mismatch:
@@ -491,17 +425,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(5)]
 rebuilt        : SymbolId(1): []
 
-tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Configurable", "Constructor"]
-rebuilt        : ScopeId(0): ["Configurable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "base"]
-rebuilt        : ScopeId(1): ["base"]
-
 tasks/coverage/typescript/tests/cases/compiler/amdModuleConstEnumUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "CharCode"]
@@ -517,17 +440,6 @@ tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Constructor", "Timestamped", "wrapClass"]
-rebuilt        : ScopeId(0): ["Timestamped", "wrapClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(5): ["Base", "TBase"]
-rebuilt        : ScopeId(4): ["Base"]
 
 tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
 semantic error: Missing SymbolId: M
@@ -721,13 +633,10 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "arr", "depth"]
 rebuilt        : ScopeId(1): ["arr", "depth"]
 
-tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInferenceDeclarations.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "arr", "depth"]
-rebuilt        : ScopeId(1): ["arr", "depth"]
-
 tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
-semantic error: Expected `(` but found `await`
+semantic error: Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 
 tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
 semantic error: Bindings mismatch:
@@ -1531,6 +1440,9 @@ rebuilt        : ScopeId(13): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(28), ReferenceId(32), ReferenceId(33), ReferenceId(36), ReferenceId(38), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
 rebuilt        : SymbolId(1): [ReferenceId(24), ReferenceId(28), ReferenceId(31)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): [ReferenceId(30), ReferenceId(31)]
+rebuilt        : SymbolId(25): [ReferenceId(25)]
 
 tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 semantic error: Bindings mismatch:
@@ -1574,11 +1486,6 @@ tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(17), ScopeId(33), ScopeId(45), ScopeId(51)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(32), ScopeId(44), ScopeId(50)]
-
-tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Broken", "TypeB"]
-rebuilt        : ScopeId(0): ["Broken"]
 
 tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 semantic error: Bindings mismatch:
@@ -1761,14 +1668,6 @@ Unresolved references mismatch:
 after transform: ["this"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/circularInstantiationExpression.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "foo":
-after transform: [ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
-
 tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
@@ -1776,11 +1675,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Capitalize", "foo2"]
 rebuilt        : ["foo2"]
-
-tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Db", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
 semantic error: Missing SymbolId: _maker
@@ -2046,23 +1940,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "Class", "Fields", "OutputFrom", "Pretty", "Schema", "Self", "Type"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): [ReferenceId(18)]
-rebuilt        : SymbolId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("Class")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["JSON", "string"]
-rebuilt        : ["Class", "JSON", "string"]
-
 tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
@@ -2102,88 +1979,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(3)]
 
-tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: b
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Missing SymbolId: m2
-Missing SymbolId: _m2
-Missing SymbolId: m3
-Missing SymbolId: _m3
-Missing ReferenceId: _m3
-Missing ReferenceId: c
-Missing ReferenceId: _m3
-Missing ReferenceId: ib2
-Missing ReferenceId: m3
-Missing ReferenceId: m3
-Missing ReferenceId: _m2
-Missing ReferenceId: _m2
-Missing ReferenceId: m2
-Missing ReferenceId: m2
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(17), SymbolId(18), SymbolId(22), SymbolId(26)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(9), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(19)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(14), ScopeId(15), ScopeId(19), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(31), ScopeId(35)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(22)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Bindings mismatch:
-after transform: ScopeId(15): ["_m", "b", "d", "ib"]
-rebuilt        : ScopeId(11): ["_m", "b", "d"]
-Scope flags mismatch:
-after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(11): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(14), SymbolId(31)]
-rebuilt        : ScopeId(14): [SymbolId(10), SymbolId(11)]
-Scope flags mismatch:
-after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(14): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(15), SymbolId(16), SymbolId(32)]
-rebuilt        : ScopeId(15): [SymbolId(12), SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(15): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(31): [ScopeId(32), ScopeId(33), ScopeId(34)]
-rebuilt        : ScopeId(20): [ScopeId(21)]
-Scope children mismatch:
-after transform: ScopeId(35): [ScopeId(36), ScopeId(37), ScopeId(38)]
-rebuilt        : ScopeId(22): [ScopeId(23)]
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(7): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(15): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(13): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(13): [ReferenceId(8)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(14): [ReferenceId(10)]
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("m1")
-rebuilt        : ReferenceId(17): Some("m1")
-Unresolved references mismatch:
-after transform: ["m1"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
 semantic error: Missing SymbolId: M
 Missing SymbolId: _M
@@ -2198,6 +1993,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(9)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
@@ -2375,32 +2173,6 @@ rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "Action", "B", "a", "actionA", "actionB", "b", "call", "printFn"]
-rebuilt        : ScopeId(0): ["actionA", "actionB", "call", "printFn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(6): ["TName", "TPayload", "action", "fn"]
-rebuilt        : ScopeId(1): ["action", "fn"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(11): [ReferenceId(24), ReferenceId(29)]
-rebuilt        : SymbolId(0): [ReferenceId(11)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): [ReferenceId(25), ReferenceId(32)]
-rebuilt        : SymbolId(1): [ReferenceId(14)]
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("a")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("b")
-rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["console", "fab", "foo"]
-rebuilt        : ["a", "b", "console", "fab", "foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
 semantic error: Bindings mismatch:
@@ -2810,6 +2582,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
@@ -3292,8 +3067,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Color", "b", "g", "r"]
 rebuilt        : ScopeId(1): ["Color"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -3319,375 +3094,13 @@ Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
 
-tasks/coverage/typescript/tests/cases/compiler/commentsCommentParsing.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsDottedModuleName.ts
-semantic error: Missing SymbolId: outerModule
-Missing SymbolId: _outerModule
-Missing SymbolId: InnerModule
-Missing SymbolId: _InnerModule
-Missing ReferenceId: _InnerModule
-Missing ReferenceId: b
-Missing ReferenceId: InnerModule
-Missing ReferenceId: InnerModule
-Missing ReferenceId: _outerModule
-Missing ReferenceId: _outerModule
-Missing ReferenceId: outerModule
-Missing ReferenceId: outerModule
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsEnums.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Colors", "Cornflower", "FancyPink"]
-rebuilt        : ScopeId(1): ["Colors"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules2.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/commentsExternalModules3.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/commentsFormatting.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: c2
-Missing ReferenceId: _m
-Missing ReferenceId: c3
-Missing ReferenceId: _m
-Missing ReferenceId: c4
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(5): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsInheritance.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["c1", "c1_i", "c2", "c2_i", "c3", "c3_i", "c4", "c4_i", "i1", "i1_i", "i2", "i2_i", "i3", "i3_i"]
-rebuilt        : ScopeId(0): ["c1", "c1_i", "c2", "c2_i", "c3", "c3_i", "c4", "c4_i", "i1_i", "i2_i", "i3_i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(11), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(33)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(16), ScopeId(22)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsInterface.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["i1", "i1_i", "i2", "i2_i", "i2_i_fnfoo", "i2_i_fnfoo_r", "i2_i_foo", "i2_i_foo_r", "i2_i_i2_ii", "i2_i_i2_si", "i2_i_n", "i2_i_nc_fnfoo", "i2_i_nc_fnfoo_r", "i2_i_nc_foo", "i2_i_nc_foo_r", "i2_i_nc_x", "i2_i_r", "i2_i_x", "i3", "i3_i", "nc_i1", "nc_i1_i"]
-rebuilt        : ScopeId(0): ["i1_i", "i2_i", "i2_i_fnfoo", "i2_i_fnfoo_r", "i2_i_foo", "i2_i_foo_r", "i2_i_i2_ii", "i2_i_i2_si", "i2_i_n", "i2_i_nc_fnfoo", "i2_i_nc_fnfoo_r", "i2_i_nc_foo", "i2_i_nc_foo_r", "i2_i_nc_x", "i2_i_r", "i2_i_x", "i3_i", "nc_i1_i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsModules.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
-semantic error: Missing SymbolId: multiM
-Missing SymbolId: _multiM
-Missing ReferenceId: _multiM
-Missing ReferenceId: b
-Missing ReferenceId: multiM
-Missing ReferenceId: multiM
-Missing SymbolId: _multiM2
-Missing ReferenceId: _multiM2
-Missing ReferenceId: c
-Missing ReferenceId: _multiM2
-Missing ReferenceId: e
-Missing ReferenceId: multiM
-Missing ReferenceId: multiM
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(5): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("multiM")
-rebuilt        : ReferenceId(10): Some("multiM")
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("multiM")
-rebuilt        : ReferenceId(11): Some("multiM")
-
-tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleSingleFile.ts
-semantic error: Missing SymbolId: multiM
-Missing SymbolId: _multiM
-Missing ReferenceId: _multiM
-Missing ReferenceId: b
-Missing ReferenceId: _multiM
-Missing ReferenceId: d
-Missing ReferenceId: multiM
-Missing ReferenceId: multiM
-Missing SymbolId: _multiM2
-Missing ReferenceId: _multiM2
-Missing ReferenceId: c
-Missing ReferenceId: _multiM2
-Missing ReferenceId: e
-Missing ReferenceId: multiM
-Missing ReferenceId: multiM
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(5): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(6): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(9)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("multiM")
-rebuilt        : ReferenceId(12): Some("multiM")
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("multiM")
-rebuilt        : ReferenceId(13): Some("multiM")
-
 tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Component", "JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["Component", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["Component", "JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Component", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["c", "c1", "c1_i_1", "c1_i_2", "c2", "c2_i_1", "c2_i_2", "c3", "c3_i_1", "c3_i_2", "c4", "c4_i_1", "c4_i_2", "c5", "c5_i_1", "c5_i_2", "c_i", "f1", "f2", "f3", "f4", "i1", "i1_i", "i2", "i2_i", "i3", "i3_i", "i4"]
-rebuilt        : ScopeId(0): ["c", "c1", "c1_i_1", "c1_i_2", "c2", "c2_i_1", "c2_i_2", "c3", "c3_i_1", "c3_i_2", "c4", "c4_i_1", "c4_i_2", "c5", "c5_i_1", "c5_i_2", "c_i", "f1", "f2", "f3", "f4", "i1_i", "i2_i", "i3_i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(27), ScopeId(30), ScopeId(33), ScopeId(36), ScopeId(52), ScopeId(56), ScopeId(60), ScopeId(64), ScopeId(68)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19)]
-Scope children mismatch:
-after transform: ScopeId(36): [ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-Scope children mismatch:
-after transform: ScopeId(52): [ScopeId(53), ScopeId(54), ScopeId(55)]
-rebuilt        : ScopeId(11): [ScopeId(12)]
-Scope children mismatch:
-after transform: ScopeId(56): [ScopeId(57), ScopeId(58), ScopeId(59)]
-rebuilt        : ScopeId(13): [ScopeId(14)]
-Scope children mismatch:
-after transform: ScopeId(60): [ScopeId(61), ScopeId(62), ScopeId(63)]
-rebuilt        : ScopeId(15): [ScopeId(16)]
-Scope children mismatch:
-after transform: ScopeId(64): [ScopeId(65), ScopeId(66), ScopeId(67)]
-rebuilt        : ScopeId(17): [ScopeId(18)]
-Scope children mismatch:
-after transform: ScopeId(68): [ScopeId(69), ScopeId(70), ScopeId(71)]
-rebuilt        : ScopeId(19): [ScopeId(20)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["U", "a"]
-rebuilt        : ScopeId(2): ["a"]
-Bindings mismatch:
-after transform: ScopeId(3): ["U", "a"]
-rebuilt        : ScopeId(3): ["a"]
-Bindings mismatch:
-after transform: ScopeId(4): ["U", "a"]
-rebuilt        : ScopeId(4): ["a"]
-Bindings mismatch:
-after transform: ScopeId(5): ["U", "a"]
-rebuilt        : ScopeId(5): ["a"]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "a", "b"]
-rebuilt        : ScopeId(6): ["a", "b"]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: b
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Bindings mismatch:
-after transform: ScopeId(0): ["c", "color", "foo", "fooVar", "i", "i1", "i1_i", "m1", "myVariable", "shade", "x"]
-rebuilt        : ScopeId(0): ["c", "color", "foo", "fooVar", "i", "i1_i", "m1", "myVariable", "shade"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(10), ScopeId(13), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(8), ScopeId(11)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Bindings mismatch:
-after transform: ScopeId(13): ["_m", "b", "m2"]
-rebuilt        : ScopeId(8): ["_m", "b"]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(13): [ScopeId(14), ScopeId(16)]
-rebuilt        : ScopeId(8): [ScopeId(9)]
-Bindings mismatch:
-after transform: ScopeId(17): ["blue", "color", "green", "red"]
-rebuilt        : ScopeId(11): ["color"]
-Scope flags mismatch:
-after transform: ScopeId(17): ScopeFlags(0x0)
-rebuilt        : ScopeId(11): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(11): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(11): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(17): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(16)]
-rebuilt        : SymbolId(13): [ReferenceId(17), ReferenceId(18)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: b
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Bindings mismatch:
-after transform: ScopeId(0): ["c", "foo", "fooVar", "i", "i1", "i1_i", "m1", "myVariable", "x"]
-rebuilt        : ScopeId(0): ["c", "foo", "fooVar", "i", "i1_i", "m1", "myVariable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(10), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(8)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Bindings mismatch:
-after transform: ScopeId(13): ["_m", "b", "m2"]
-rebuilt        : ScopeId(8): ["_m", "b"]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(13): [ScopeId(14), ScopeId(16)]
-rebuilt        : ScopeId(8): [ScopeId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(11): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(11): [ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -3715,8 +3128,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["AutomationMode", "LOCATION", "NONE", "SYSTEM", "TIME"]
 rebuilt        : ScopeId(1): ["AutomationMode"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -3819,54 +3232,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(14): [ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31)]
 rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(27), ReferenceId(28)]
 
-tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeWidening.ts
-semantic error: Missing ReferenceId: E
-Missing ReferenceId: E
-Missing ReferenceId: E
-Missing ReferenceId: E
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "E", "E2", "MyDeclaredEnum", "MyEnum", "c1", "c2", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
-rebuilt        : ScopeId(0): ["C", "E", "MyEnum", "c1", "c2", "f1", "f2", "f3", "f4", "v1", "v2", "val1", "val2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "D", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(9): ["A", "B", "C", "MyEnum"]
-rebuilt        : ScopeId(7): ["MyEnum"]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(35), ReferenceId(37), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(46), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(78)]
-rebuilt        : SymbolId(0): [ReferenceId(13), ReferenceId(14), ReferenceId(18), ReferenceId(23), ReferenceId(24), ReferenceId(31), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(61): [ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77)]
-rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
-Symbol flags mismatch:
-after transform: SymbolId(51): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(42): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch:
-after transform: ReferenceId(49): Some("E2")
-rebuilt        : ReferenceId(48): None
-Reference symbol mismatch:
-after transform: ReferenceId(66): Some("MyDeclaredEnum")
-rebuilt        : ReferenceId(69): None
-Reference symbol mismatch:
-after transform: ReferenceId(68): Some("MyDeclaredEnum")
-rebuilt        : ReferenceId(71): None
-Unresolved references mismatch:
-after transform: ["computed", "const"]
-rebuilt        : ["E2", "MyDeclaredEnum"]
-
 tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
 semantic error: Missing SymbolId: NS
 Missing SymbolId: _NS
@@ -3888,14 +3253,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("NS")
 rebuilt        : ReferenceId(2): Some("NS")
-
-tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["O"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 semantic error: Bindings mismatch:
@@ -4021,14 +3378,6 @@ Unresolved references mismatch:
 after transform: ["Field"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSONSchema4"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExcludeWithDefault", "ExtractWithDefault", "TemplatedConditional", "fn1", "fn10", "fn11", "fn12", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8", "fn9", "x", "z", "zee"]
@@ -4112,55 +3461,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/constDeclarations2.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "E2"]
-rebuilt        : ScopeId(2): ["E2"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
 tasks/coverage/typescript/tests/cases/compiler/constEnumExternalModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -4172,15 +3472,18 @@ Missing ReferenceId: foo
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
@@ -4198,12 +3501,15 @@ Missing ReferenceId: foo
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -4225,17 +3531,20 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "foo"]
 rebuilt        : ScopeId(1): ["foo"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
 rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -4263,15 +3572,21 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -4287,12 +3602,15 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -4926,14 +4244,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
 
-tasks/coverage/typescript/tests/cases/compiler/constructorTypeWithTypeParameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T", "X", "Y", "anotherVar"]
-rebuilt        : ScopeId(0): ["anotherVar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(11)]
@@ -5362,14 +4672,14 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsx", "_jsxFileName", "a", "y"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "a", "y"]
+after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsxFileName", "_reactJsxRuntime", "a", "y"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "a", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(21), ScopeId(22)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Unresolved references mismatch:
-after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "undefined"]
-rebuilt        : ["App4", "app", "app2", "app3", "foo", "undefined"]
+after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "require", "undefined"]
+rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
 semantic error: Bindings mismatch:
@@ -5430,14 +4740,6 @@ Unresolved references mismatch:
 after transform: ["AsyncGenerator", "Generator", "Promise"]
 rebuilt        : ["Promise"]
 
-tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Box", "Observable", "bb1", "bb2", "bn1", "bn2", "x"]
-rebuilt        : ScopeId(0): ["bb1", "bb2", "bn1", "bn2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ADT", "invoke", "kind"]
@@ -5453,8 +4755,8 @@ rebuilt        : ScopeId(1): ["arg"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Elements", "Props", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["Elements", "Props", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
@@ -5536,26 +4838,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Record", "test"]
 rebuilt        : ["test"]
-
-tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "Action", "B", "ab", "x"]
-rebuilt        : ScopeId(0): ["A", "B", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(10), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(6)]
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("ab")
-rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Symbol", "f"]
-rebuilt        : ["Symbol", "ab", "f"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
 semantic error: Bindings mismatch:
@@ -5804,8 +5086,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "One", "Two"]
 rebuilt        : ScopeId(1): ["Choice"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -5864,83 +5146,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
 rebuilt        : [ReferenceId(0), ReferenceId(9)]
-
-tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "ACaller", "ALL_BARS", "ArgMap", "B", "BAR_LOOKUP", "BCaller", "BarLookup", "Baz", "Config", "DataEntry", "Ev", "FieldMap", "Foo", "Foo1", "FormField", "Func", "Funcs", "HandlerMap", "KeyOfOriginal", "Keys", "LetterCaller", "LetterMap", "MappedFromOriginal", "MyObj", "NestedKeyOfOriginalFor", "Original", "RecordMap", "RenderFunc", "RenderFuncMap", "SameKeys", "SelectFieldData", "TextFieldData", "TypeMap", "UnionRecord", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "process", "processEvents", "processRecord", "r1", "r2", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent", "xx"]
-rebuilt        : ScopeId(0): ["ALL_BARS", "BAR_LOOKUP", "call", "clickEvent", "createEventListener", "data", "f1", "f2", "f3", "f4", "ff1", "foo", "func", "getConfigOrDefault", "getStringAndNumberFromOriginalAndMapped", "getValueConcrete", "handlers", "process", "processEvents", "processRecord", "ref", "renderField", "renderFuncs", "renderSelectField", "renderTextField", "scrollEvent"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(27), ScopeId(28), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(37), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(70), ScopeId(71), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(79), ScopeId(80), ScopeId(81), ScopeId(82), ScopeId(83), ScopeId(84)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35)]
-Bindings mismatch:
-after transform: ScopeId(4): ["K", "rec"]
-rebuilt        : ScopeId(1): ["rec"]
-Bindings mismatch:
-after transform: ScopeId(15): ["K", "field", "renderFn"]
-rebuilt        : ScopeId(5): ["field", "renderFn"]
-Bindings mismatch:
-after transform: ScopeId(24): ["K", "data"]
-rebuilt        : ScopeId(8): ["data"]
-Bindings mismatch:
-after transform: ScopeId(30): ["K", "caller", "letter"]
-rebuilt        : ScopeId(11): ["caller", "letter"]
-Bindings mismatch:
-after transform: ScopeId(37): ["K", "events"]
-rebuilt        : ScopeId(12): ["events"]
-Bindings mismatch:
-after transform: ScopeId(41): ["K", "callback", "name", "once"]
-rebuilt        : ScopeId(16): ["callback", "name", "once"]
-Bindings mismatch:
-after transform: ScopeId(46): ["ArgMap", "Keys", "apply", "funs", "x1", "x2"]
-rebuilt        : ScopeId(21): ["apply", "funs", "x1", "x2"]
-Scope children mismatch:
-after transform: ScopeId(46): [ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
-rebuilt        : ScopeId(21): [ScopeId(22), ScopeId(23), ScopeId(24)]
-Bindings mismatch:
-after transform: ScopeId(52): ["K", "args", "fn", "funKey"]
-rebuilt        : ScopeId(24): ["args", "fn", "funKey"]
-Bindings mismatch:
-after transform: ScopeId(57): ["K", "arg", "funcs", "key"]
-rebuilt        : ScopeId(25): ["arg", "funcs", "key"]
-Bindings mismatch:
-after transform: ScopeId(58): ["K", "arg", "func", "funcs", "key"]
-rebuilt        : ScopeId(26): ["arg", "func", "funcs", "key"]
-Bindings mismatch:
-after transform: ScopeId(59): ["K", "arg", "func", "funcs", "key"]
-rebuilt        : ScopeId(27): ["arg", "func", "funcs", "key"]
-Bindings mismatch:
-after transform: ScopeId(60): ["K", "x", "y"]
-rebuilt        : ScopeId(28): ["x", "y"]
-Bindings mismatch:
-after transform: ScopeId(62): ["K", "k", "myObj", "myObj2"]
-rebuilt        : ScopeId(29): ["k", "myObj", "myObj2"]
-Bindings mismatch:
-after transform: ScopeId(66): ["T", "f", "prop"]
-rebuilt        : ScopeId(32): ["f", "prop"]
-Bindings mismatch:
-after transform: ScopeId(80): ["K", "N", "key", "mappedFromOriginal", "nestedKey", "original"]
-rebuilt        : ScopeId(33): ["key", "mappedFromOriginal", "nestedKey", "original"]
-Bindings mismatch:
-after transform: ScopeId(82): ["T", "assertedCheck", "defaultValue", "key", "userConfig", "userValue"]
-rebuilt        : ScopeId(34): ["assertedCheck", "defaultValue", "key", "userConfig", "userValue"]
-Bindings mismatch:
-after transform: ScopeId(84): ["K", "k", "o"]
-rebuilt        : ScopeId(35): ["k", "o"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(137): [ReferenceId(232)]
-rebuilt        : SymbolId(74): []
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("r1")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("r2")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(96): Some("xx")
-rebuilt        : ReferenceId(28): None
-Unresolved references mismatch:
-after transform: ["DocumentEventMap", "Partial", "ReadonlyArray", "Record", "Required", "bar", "console", "const", "document", "makeCompleteLookupMapping", "undefined"]
-rebuilt        : ["bar", "console", "document", "makeCompleteLookupMapping", "r1", "r2", "undefined", "xx"]
 
 tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
 semantic error: Missing SymbolId: M
@@ -6067,14 +5272,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(10)]
 rebuilt        : SymbolId(6): []
 
-tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["MainModule", "SubModule"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
@@ -6089,3012 +5286,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(3): [ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["test"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["SubModule"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileCallSignatures.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ICallSignature", "ICallSignatureWithOverloads", "ICallSignatureWithOwnTypeParametes", "ICallSignatureWithParameters", "ICallSignatureWithRestParameters", "ICallSignatureWithTypeParameters"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileConstructSignatures.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IConstructSignature", "IConstructSignatureWithOverloads", "IConstructSignatureWithOwnTypeParametes", "IConstructSignatureWithParameters", "IConstructSignatureWithRestParameters", "IConstructSignatureWithTypeParameters"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileConstructors.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(7): [ScopeId(8)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e"]
-rebuilt        : ScopeId(1): ["e"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "c", "e1"]
-rebuilt        : ScopeId(1): ["e1"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["a", "b", "c", "e2"]
-rebuilt        : ScopeId(2): ["e2"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["a", "b", "c", "e3"]
-rebuilt        : ScopeId(3): ["e3"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "c", "d", "e", "e4"]
-rebuilt        : ScopeId(4): ["e4"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["Friday", "Saturday", "Sunday", "Weekend days", "e5"]
-rebuilt        : ScopeId(5): ["e5"]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "D", "I", "J"]
-rebuilt        : ScopeId(0): ["A", "B", "D"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithPrivateOverloadedFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "I", "X"]
-rebuilt        : ScopeId(0): ["C", "X"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["x"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-Bindings mismatch:
-after transform: ScopeId(11): ["T", "a"]
-rebuilt        : ScopeId(8): ["a"]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Base", "Baz", "Derived", "IBar", "IFoo"]
-rebuilt        : ScopeId(0): ["Base", "Baz", "Derived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(3): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(7)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(0), ReferenceId(6), ReferenceId(8)]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
-semantic error: Missing SymbolId: C
-Missing SymbolId: _C
-Missing ReferenceId: _C
-Missing ReferenceId: A
-Missing ReferenceId: _C
-Missing ReferenceId: B
-Missing ReferenceId: _C
-Missing ReferenceId: F
-Missing ReferenceId: _C
-Missing ReferenceId: F2
-Missing ReferenceId: _C
-Missing ReferenceId: F3
-Missing ReferenceId: _C
-Missing ReferenceId: F4
-Missing ReferenceId: _C
-Missing ReferenceId: F5
-Missing ReferenceId: _C
-Missing ReferenceId: F6
-Missing ReferenceId: _C
-Missing ReferenceId: D
-Missing ReferenceId: C
-Missing ReferenceId: C
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "x"]
-rebuilt        : ScopeId(0): ["C", "a", "b", "c", "d", "e", "f", "g", "h", "j", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(10), SymbolId(13), SymbolId(16), SymbolId(18), SymbolId(21), SymbolId(36)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(15)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "x"]
-rebuilt        : ScopeId(4): ["x"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "x"]
-rebuilt        : ScopeId(5): ["x"]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "x"]
-rebuilt        : ScopeId(6): ["x"]
-Bindings mismatch:
-after transform: ScopeId(7): ["T", "x"]
-rebuilt        : ScopeId(7): ["x"]
-Bindings mismatch:
-after transform: ScopeId(8): ["T"]
-rebuilt        : ScopeId(8): []
-Bindings mismatch:
-after transform: ScopeId(9): ["T", "x"]
-rebuilt        : ScopeId(9): ["x"]
-Bindings mismatch:
-after transform: ScopeId(10): ["T"]
-rebuilt        : ScopeId(10): []
-Bindings mismatch:
-after transform: ScopeId(12): ["T"]
-rebuilt        : ScopeId(12): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(16)]
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10), ReferenceId(17)]
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(8): [ReferenceId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(10): [ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(12): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(13): [ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(21): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(15): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(21): []
-rebuilt        : SymbolId(15): [ReferenceId(18)]
-Reference symbol mismatch:
-after transform: ReferenceId(23): Some("C")
-rebuilt        : ReferenceId(21): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("C")
-rebuilt        : ReferenceId(22): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(25): Some("C")
-rebuilt        : ReferenceId(23): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(26): Some("C")
-rebuilt        : ReferenceId(24): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(27): Some("C")
-rebuilt        : ReferenceId(25): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(28): Some("C")
-rebuilt        : ReferenceId(26): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(34): Some("C")
-rebuilt        : ReferenceId(27): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(37): Some("C")
-rebuilt        : ReferenceId(28): Some("C")
-Reference symbol mismatch:
-after transform: ReferenceId(41): Some("C")
-rebuilt        : ReferenceId(29): Some("C")
-Unresolved references mismatch:
-after transform: ["Array", "C"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
-semantic error: Missing SymbolId: templa
-Missing SymbolId: _templa2
-Missing SymbolId: dom
-Missing SymbolId: _dom2
-Missing SymbolId: mvc
-Missing SymbolId: _mvc2
-Missing ReferenceId: _mvc2
-Missing ReferenceId: AbstractElementController
-Missing ReferenceId: mvc
-Missing ReferenceId: mvc
-Missing ReferenceId: _dom2
-Missing ReferenceId: _dom2
-Missing ReferenceId: dom
-Missing ReferenceId: dom
-Missing ReferenceId: _templa2
-Missing ReferenceId: _templa2
-Missing ReferenceId: templa
-Missing ReferenceId: templa
-Missing SymbolId: _templa3
-Missing SymbolId: dom
-Missing SymbolId: _dom3
-Missing SymbolId: mvc
-Missing SymbolId: _mvc3
-Missing SymbolId: composite
-Missing SymbolId: _composite
-Missing ReferenceId: _composite
-Missing ReferenceId: AbstractCompositeElementController
-Missing ReferenceId: composite
-Missing ReferenceId: composite
-Missing ReferenceId: _mvc3
-Missing ReferenceId: _mvc3
-Missing ReferenceId: mvc
-Missing ReferenceId: mvc
-Missing ReferenceId: _dom3
-Missing ReferenceId: _dom3
-Missing ReferenceId: dom
-Missing ReferenceId: dom
-Missing ReferenceId: _templa3
-Missing ReferenceId: _templa3
-Missing ReferenceId: templa
-Missing ReferenceId: templa
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(15), ScopeId(19), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(16), SymbolId(28)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(17), SymbolId(29)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(18), SymbolId(30)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(21): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(22): ["ModelType"]
-rebuilt        : ScopeId(4): []
-Binding symbols mismatch:
-after transform: ScopeId(24): [SymbolId(20), SymbolId(31)]
-rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(21), SymbolId(32)]
-rebuilt        : ScopeId(7): [SymbolId(9), SymbolId(10)]
-Scope flags mismatch:
-after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(22), SymbolId(33)]
-rebuilt        : ScopeId(8): [SymbolId(11), SymbolId(12)]
-Scope flags mismatch:
-after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(27): [SymbolId(23), SymbolId(34)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(27): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(9): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(28): ["ModelType"]
-rebuilt        : ScopeId(10): []
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(6): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(6): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(23): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(23): []
-rebuilt        : SymbolId(14): [ReferenceId(15)]
-Reference symbol mismatch:
-after transform: ReferenceId(11): None
-rebuilt        : ReferenceId(0): Some("templa")
-Reference symbol mismatch:
-after transform: ReferenceId(16): None
-rebuilt        : ReferenceId(13): Some("templa")
-Unresolved references mismatch:
-after transform: ["IElementController", "mvc", "templa"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing SymbolId: c
-Missing SymbolId: _c
-Missing ReferenceId: _c
-Missing ReferenceId: c
-Missing ReferenceId: c
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: m
-Missing ReferenceId: m
-Missing SymbolId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("m")
-rebuilt        : ReferenceId(8): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("a")
-rebuilt        : ReferenceId(9): Some("a")
-
-tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["List", "mod1", "moo"]
-rebuilt        : ScopeId(0): ["List"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileIndexSignatures.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IBothIndexSignature", "IIndexSignatureWithTypeParameter", "INumberIndexSignature", "IStringIndexSignature"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileInternalAliases.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileMethods.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I1", "c1"]
-rebuilt        : ScopeId(0): ["c1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("m1")
-rebuilt        : ReferenceId(4): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("m1")
-rebuilt        : ReferenceId(5): Some("m1")
-
-tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
-semantic error: Missing SymbolId: A
-Missing SymbolId: _A2
-Missing SymbolId: B
-Missing SymbolId: _B
-Missing SymbolId: C
-Missing SymbolId: _C2
-Missing ReferenceId: _C2
-Missing ReferenceId: W
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _B
-Missing ReferenceId: _B
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A2
-Missing ReferenceId: _A2
-Missing ReferenceId: A
-Missing ReferenceId: A
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(6): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileOptionalInterfaceMethod.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IContext", "c1"]
-rebuilt        : ScopeId(0): ["c1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileRestParametersOfFunctionAndFunctionType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationArrayType.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: g
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(17)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("m")
-rebuilt        : ReferenceId(8): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("m")
-rebuilt        : ReferenceId(9): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("m")
-rebuilt        : ReferenceId(12): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("m")
-rebuilt        : ReferenceId(13): Some("m")
-Unresolved references mismatch:
-after transform: ["m"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationStringLiteral.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTupleType.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: g
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(8)]
-rebuilt        : SymbolId(5): [ReferenceId(9)]
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("m")
-rebuilt        : ReferenceId(7): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("m")
-rebuilt        : ReferenceId(10): Some("m")
-Unresolved references mismatch:
-after transform: ["m"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeAlias.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["m"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeQuery.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: g
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("m")
-rebuilt        : ReferenceId(8): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("m")
-rebuilt        : ReferenceId(9): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("m")
-rebuilt        : ReferenceId(12): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("m")
-rebuilt        : ReferenceId(13): Some("m")
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeReference.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: g
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("m")
-rebuilt        : ReferenceId(8): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("m")
-rebuilt        : ReferenceId(9): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("m")
-rebuilt        : ReferenceId(12): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("m")
-rebuilt        : ReferenceId(13): Some("m")
-Unresolved references mismatch:
-after transform: ["m"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: g
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
-rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(13)]
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("m")
-rebuilt        : ReferenceId(7): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("m")
-rebuilt        : ReferenceId(9): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("m")
-rebuilt        : ReferenceId(11): Some("m")
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("m")
-rebuilt        : ReferenceId(14): Some("m")
-Unresolved references mismatch:
-after transform: ["m"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: public1
-Missing SymbolId: m2
-Missing SymbolId: _m2
-Missing ReferenceId: _m2
-Missing ReferenceId: public2
-Missing ReferenceId: m2
-Missing ReferenceId: m2
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(16)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(6): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(13)]
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("m2")
-rebuilt        : ReferenceId(10): Some("m2")
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("m2")
-rebuilt        : ReferenceId(11): Some("m2")
-Unresolved references mismatch:
-after transform: ["m2"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorParameterOfFunction.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: public1
-Missing ReferenceId: _m
-Missing ReferenceId: foo3
-Missing ReferenceId: _m
-Missing ReferenceId: foo4
-Missing ReferenceId: _m
-Missing ReferenceId: foo13
-Missing ReferenceId: _m
-Missing ReferenceId: foo14
-Missing SymbolId: m2
-Missing SymbolId: _m2
-Missing ReferenceId: _m2
-Missing ReferenceId: public2
-Missing ReferenceId: m2
-Missing ReferenceId: m2
-Missing ReferenceId: _m
-Missing ReferenceId: foo113
-Missing ReferenceId: _m
-Missing ReferenceId: foo114
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(20), SymbolId(30)]
-rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22)]
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(12): ScopeFlags(Function)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(10): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(16): [ReferenceId(10)]
-Symbol flags mismatch:
-after transform: SymbolId(17): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(17): []
-rebuilt        : SymbolId(18): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(20): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(22): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(22): [ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(25): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(27): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(25): []
-rebuilt        : SymbolId(27): [ReferenceId(20)]
-Symbol flags mismatch:
-after transform: SymbolId(27): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(27): []
-rebuilt        : SymbolId(29): [ReferenceId(23)]
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("m2")
-rebuilt        : ReferenceId(18): Some("m2")
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("m2")
-rebuilt        : ReferenceId(21): Some("m2")
-Unresolved references mismatch:
-after transform: ["m2"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.ts
-semantic error: Missing SymbolId: m
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: public1
-Missing ReferenceId: _m
-Missing ReferenceId: foo3
-Missing ReferenceId: _m
-Missing ReferenceId: foo4
-Missing ReferenceId: _m
-Missing ReferenceId: foo13
-Missing ReferenceId: _m
-Missing ReferenceId: foo14
-Missing SymbolId: m2
-Missing SymbolId: _m2
-Missing ReferenceId: _m2
-Missing ReferenceId: public2
-Missing ReferenceId: m2
-Missing ReferenceId: m2
-Missing ReferenceId: _m
-Missing ReferenceId: foo113
-Missing ReferenceId: _m
-Missing ReferenceId: foo114
-Missing ReferenceId: m
-Missing ReferenceId: m
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(12), SymbolId(18)]
-rebuilt        : ScopeId(12): [SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(12): ScopeFlags(Function)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(11): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(14): [ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(17): [ReferenceId(20)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(18): [ReferenceId(23)]
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("m2")
-rebuilt        : ReferenceId(18): Some("m2")
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("m2")
-rebuilt        : ReferenceId(21): Some("m2")
-Unresolved references mismatch:
-after transform: ["m2"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeAlias.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeLiteral.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorVariableDeclaration.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeofClass.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["days", "friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
-rebuilt        : ScopeId(1): ["days"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(18)]
-rebuilt        : SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(17)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeofFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(6)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(8), ReferenceId(9), ReferenceId(10)]
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: c
-Missing ReferenceId: _m
-Missing ReferenceId: e
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["e", "holiday", "weekday", "weekend"]
-rebuilt        : ScopeId(3): ["e"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(10)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("m1")
-rebuilt        : ReferenceId(13): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("m1")
-rebuilt        : ReferenceId(14): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("m1")
-rebuilt        : ReferenceId(15): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("m1")
-rebuilt        : ReferenceId(16): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("m1")
-rebuilt        : ReferenceId(17): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("m1")
-rebuilt        : ReferenceId(18): Some("m1")
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("m1")
-rebuilt        : ReferenceId(19): Some("m1")
-Unresolved references mismatch:
-after transform: ["m1"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileTypeofModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
-semantic error: Missing SymbolId: X
-Missing SymbolId: _X
-Missing SymbolId: Y
-Missing SymbolId: _Y
-Missing SymbolId: base
-Missing SymbolId: _base
-Missing ReferenceId: _base
-Missing ReferenceId: W
-Missing ReferenceId: base
-Missing ReferenceId: base
-Missing ReferenceId: _Y
-Missing ReferenceId: _Y
-Missing ReferenceId: Y
-Missing ReferenceId: Y
-Missing ReferenceId: _X
-Missing ReferenceId: _X
-Missing ReferenceId: X
-Missing ReferenceId: X
-Missing SymbolId: _X2
-Missing SymbolId: Y
-Missing SymbolId: _Y2
-Missing SymbolId: base
-Missing SymbolId: _base2
-Missing SymbolId: Z
-Missing SymbolId: _Z
-Missing ReferenceId: _Z
-Missing ReferenceId: W
-Missing ReferenceId: Z
-Missing ReferenceId: Z
-Missing ReferenceId: _base2
-Missing ReferenceId: _base2
-Missing ReferenceId: base
-Missing ReferenceId: base
-Missing ReferenceId: _Y2
-Missing ReferenceId: _Y2
-Missing ReferenceId: Y
-Missing ReferenceId: Y
-Missing ReferenceId: _X2
-Missing ReferenceId: _X2
-Missing ReferenceId: X
-Missing ReferenceId: X
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "X"]
-rebuilt        : ScopeId(0): ["X"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(13)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(7), SymbolId(15)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(8), SymbolId(16)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(9), SymbolId(17)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
-Scope flags mismatch:
-after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(10), SymbolId(18)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(11), SymbolId(19)]
-rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(13): ["TValue"]
-rebuilt        : ScopeId(9): []
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(6): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(11): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(14): [ReferenceId(15)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("X")
-rebuilt        : ReferenceId(13): Some("X")
-
-tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
-semantic error: Missing SymbolId: A
-Missing SymbolId: _A
-Missing SymbolId: B
-Missing SymbolId: _B
-Missing ReferenceId: _B
-Missing ReferenceId: EventManager
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A
-Missing ReferenceId: _A
-Missing ReferenceId: A
-Missing ReferenceId: A
-Missing SymbolId: _A2
-Missing SymbolId: B
-Missing SymbolId: _B2
-Missing SymbolId: C
-Missing SymbolId: _C
-Missing ReferenceId: _C
-Missing ReferenceId: ContextMenu
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _B2
-Missing ReferenceId: _B2
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A2
-Missing ReferenceId: _A2
-Missing ReferenceId: A
-Missing ReferenceId: A
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(6), SymbolId(11)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(7), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
-Scope flags mismatch:
-after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(10): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
-
-tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
-semantic error: Missing SymbolId: X
-Missing SymbolId: _X2
-Missing SymbolId: A
-Missing SymbolId: _A2
-Missing SymbolId: B
-Missing SymbolId: _B
-Missing SymbolId: C
-Missing SymbolId: _C2
-Missing ReferenceId: _C2
-Missing ReferenceId: W
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _B
-Missing ReferenceId: _B
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A2
-Missing ReferenceId: _A2
-Missing ReferenceId: A
-Missing ReferenceId: A
-Missing ReferenceId: _X2
-Missing ReferenceId: _X2
-Missing ReferenceId: X
-Missing ReferenceId: X
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(12)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(13)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "W", "_C2"]
-rebuilt        : ScopeId(4): ["W", "_C2"]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
-semantic error: Missing SymbolId: X
-Missing SymbolId: _X2
-Missing SymbolId: A
-Missing SymbolId: _A2
-Missing SymbolId: B
-Missing SymbolId: _B
-Missing SymbolId: C
-Missing SymbolId: _C2
-Missing ReferenceId: _C2
-Missing ReferenceId: W
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _B
-Missing ReferenceId: _B
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A2
-Missing ReferenceId: _A2
-Missing ReferenceId: A
-Missing ReferenceId: A
-Missing ReferenceId: _X2
-Missing ReferenceId: _X2
-Missing ReferenceId: X
-Missing ReferenceId: X
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
-semantic error: Missing SymbolId: X
-Missing SymbolId: _X2
-Missing SymbolId: A
-Missing SymbolId: _A2
-Missing SymbolId: B
-Missing SymbolId: _B
-Missing SymbolId: C
-Missing SymbolId: _C2
-Missing ReferenceId: _C2
-Missing ReferenceId: W
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _B
-Missing ReferenceId: _B
-Missing ReferenceId: B
-Missing ReferenceId: B
-Missing ReferenceId: _A2
-Missing ReferenceId: _A2
-Missing ReferenceId: A
-Missing ReferenceId: A
-Missing ReferenceId: _X2
-Missing ReferenceId: _X2
-Missing ReferenceId: X
-Missing ReferenceId: X
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: E
-Missing ReferenceId: _M
-Missing ReferenceId: D
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["C", "D", "E", "I1", "I2", "_M"]
-rebuilt        : ScopeId(1): ["C", "D", "E", "_M"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/declInput.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Class | Interface)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 10, end: 13 }
-rebuilt        : SymbolId(0): Span { start: 26, end: 29 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 26, end: 29 }]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "bar2"]
-rebuilt        : ScopeId(0): ["bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: E
-Missing ReferenceId: _M
-Missing ReferenceId: D
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["C", "D", "E", "I1", "I2", "_M"]
-rebuilt        : ScopeId(1): ["C", "D", "E", "_M"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ThingB"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["FlatpickrFn", "fp"]
-rebuilt        : ScopeId(0): ["fp"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I", "O", "fn"]
-rebuilt        : ScopeId(0): ["fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["Omit"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["BoundedInteger", "Brand", "toBoundedInteger"]
-rebuilt        : ScopeId(0): ["toBoundedInteger"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(4): ["LowerBound", "UpperBound", "bounds"]
-rebuilt        : ScopeId(1): ["bounds"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ConvertLocaleConfig", "GetLocalesOptions", "LocaleConfig", "LocaleData", "getLocales"]
-rebuilt        : ScopeId(0): ["getLocales"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "app", "defaultLocalesConfig", "name", "userLocalesConfig"]
-rebuilt        : ScopeId(1): ["app", "defaultLocalesConfig", "name", "userLocalesConfig"]
-Unresolved references mismatch:
-after transform: ["Partial", "Record"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Named", "duplicateIndetifiers", "duplicateIndetifiers2", "duplicateIndetifiers3", "notReferenced", "shadowedVariable", "value"]
-rebuilt        : ScopeId(0): ["duplicateIndetifiers", "duplicateIndetifiers2", "duplicateIndetifiers3", "notReferenced", "shadowedVariable", "value"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): [ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(11): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundlePreservesHasNoDefaultLibDirective.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Result", "T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "P", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
-rebuilt        : ScopeId(0): ["C", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "P", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
-rebuilt        : ScopeId(0): ["C", "fn", "fnWithPartialAnnotationOnDefaultparam", "fnWithRequiredDefaultParam", "vConst", "vLet"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitCastReusesTypeNode5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "R", "vLiteral", "vNumberLiteral", "vStringLiteral"]
-rebuilt        : ScopeId(0): ["C", "vLiteral", "vNumberLiteral", "vStringLiteral"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberNameConflict.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(2)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(3)]
-rebuilt        : SymbolId(6): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberNameConflict2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Hello", "World"]
-rebuilt        : ScopeId(1): ["Hello"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["Hello1", "World1"]
-rebuilt        : ScopeId(2): ["Hello1"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol", "const"]
-rebuilt        : ["Symbol"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AnyConstructor", "AnyFunction", "Base", "Mixin", "MixinHelperFunc", "XmlElement2"]
-rebuilt        : ScopeId(0): ["Base", "Mixin", "XmlElement2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): [ReferenceId(11), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ExportedClass1", "ExportedClass2", "ExportedClass3", "ExportedClass4", "PrivateInterface"]
-rebuilt        : ScopeId(0): ["ExportedClass1", "ExportedClass2", "ExportedClass3", "ExportedClass4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ExportedClass1", "ExportedClass2", "PrivateInterface"]
-rebuilt        : ScopeId(0): ["ExportedClass1", "ExportedClass2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Context", "Key"]
-rebuilt        : ScopeId(0): ["Key"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["EnumExample", "TEST"]
-rebuilt        : ScopeId(1): ["EnumExample"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyName1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IData", "c"]
-rebuilt        : ScopeId(0): ["c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Enum", "Type"]
-rebuilt        : ScopeId(0): ["Enum"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Enum"]
-rebuilt        : ScopeId(1): ["Enum"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringArrayPattern3.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern2.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringOptionalBindingParametersInOverloads.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestructuringPrivacyError.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Collection", "Field", "subFun"]
-rebuilt        : ScopeId(1): ["subFun"]
-Unresolved references mismatch:
-after transform: ["FlatArray"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Promise", "add"]
-rebuilt        : ["add"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
-semantic error: Missing SymbolId: Translation
-Missing SymbolId: _Translation
-Missing ReferenceId: _Translation
-Missing ReferenceId: Translation
-Missing ReferenceId: Translation
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(1): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol span mismatch:
-after transform: SymbolId(1): Span { start: 129, end: 147 }
-rebuilt        : SymbolId(2): Span { start: 198, end: 216 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(1): [Span { start: 198, end: 216 }]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["In", "InexactOptionals", "Out", "baddts", "foo"]
-rebuilt        : ScopeId(0): ["baddts", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(9): ["A"]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(4): ["a", "b", "p"]
-rebuilt        : ScopeId(2): ["a", "b"]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction | Interface)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 17, end: 22 }
-rebuilt        : SymbolId(0): Span { start: 171, end: 176 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 171, end: 176 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction | Interface)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction)
-Symbol span mismatch:
-after transform: SymbolId(1): Span { start: 93, end: 97 }
-rebuilt        : SymbolId(3): Span { start: 237, end: 241 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(9)]
-rebuilt        : SymbolId(3): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(1): [Span { start: 237, end: 241 }]
-rebuilt        : SymbolId(3): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Rank", "Suit"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Component", "getComp"]
-rebuilt        : ScopeId(0): ["getComp"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignment.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Buzz", "bar", "foo"]
-rebuilt        : ScopeId(0): ["bar", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Buzz", "bar", "foo"]
-rebuilt        : ScopeId(0): ["bar", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "U"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "c"]
-rebuilt        : ScopeId(2): ["c"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ExportedClass", "ExportedInterface", "LocalClass", "LocalInterface", "MyClass", "MyClass2", "MyClass3", "MyClass4", "getExportedClass", "getLocalClass"]
-rebuilt        : ScopeId(0): ["ExportedClass", "LocalClass", "MyClass", "MyClass2", "MyClass3", "MyClass4", "getExportedClass", "getLocalClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "U"]
-rebuilt        : ScopeId(2): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "c"]
-rebuilt        : ScopeId(3): ["c"]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "c"]
-rebuilt        : ScopeId(4): ["c"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
-semantic error: Missing SymbolId: Test
-Missing SymbolId: _Test
-Missing ReferenceId: _Test
-Missing ReferenceId: SomeClass
-Missing ReferenceId: _Test
-Missing ReferenceId: Derived
-Missing ReferenceId: _Test
-Missing ReferenceId: getClass
-Missing ReferenceId: Test
-Missing ReferenceId: Test
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["Derived", "IFace", "SomeClass", "_Test", "getClass"]
-rebuilt        : ScopeId(1): ["Derived", "SomeClass", "_Test", "getClass"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(4): []
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(1)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(7)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitFBoundedTypeParams.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["a", "b", "result", "value"]
-rebuilt        : ScopeId(1): ["result", "value"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Tany", "X", "Y", "f1", "f2", "f3", "f4", "prop11", "prop12", "prop2", "prop3", "prop4"]
-rebuilt        : ScopeId(0): ["X", "Y", "f1", "f2", "f3", "f4", "prop11", "prop12", "prop2", "prop3", "prop4"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(4): ["Tany"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["Tany"]
-rebuilt        : ScopeId(5): []
-Bindings mismatch:
-after transform: ScopeId(6): ["A", "B"]
-rebuilt        : ScopeId(6): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(11): [ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(19)]
-rebuilt        : SymbolId(7): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefaultExportClassExtendingExpression01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "Greeter", "GreeterConstructor", "getGreeterBase"]
-rebuilt        : ScopeId(0): ["A", "getGreeterBase"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_whatever", "a", "getA"]
-rebuilt        : ScopeId(0): ["a", "getA"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_whatever", "a", "getA"]
-rebuilt        : ScopeId(0): ["a", "getA"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./parent", "ParentThing", "child1"]
-rebuilt        : ScopeId(0): ["child1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Named", "createNamed"]
-rebuilt        : ScopeId(0): ["createNamed"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "AsClassProperty", "AsFunctionType", "AsObjectProperty", "a1", "a2", "a3", "a4", "a4Return", "a4oReturn", "aObj", "b1", "b2", "b3", "b4", "b4Return", "b4oReturn", "bObj", "c1", "c2", "c3", "c4", "c4Return", "c4oReturn", "cObj", "d1", "d2", "d3", "d4", "d4Return", "explicitlyTypedFunction", "explicitlyTypedVariable", "fromParameter"]
-rebuilt        : ScopeId(0): ["A", "AsClassProperty", "a1", "a2", "a3", "a4", "aObj", "b1", "b2", "b3", "b4", "bObj", "c1", "c2", "c3", "c4", "cObj", "d1", "d2", "d3", "d4", "explicitlyTypedFunction", "explicitlyTypedVariable", "fromParameter"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(37), ScopeId(40), ScopeId(43), ScopeId(44), ScopeId(49), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(37), ScopeId(42), ScopeId(44), ScopeId(45), ScopeId(46)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(28)]
-rebuilt        : SymbolId(8): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): [ReferenceId(31)]
-rebuilt        : SymbolId(10): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(27): [ReferenceId(52)]
-rebuilt        : SymbolId(25): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(29): [ReferenceId(55)]
-rebuilt        : SymbolId(27): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(46): [ReferenceId(76)]
-rebuilt        : SymbolId(42): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(48): [ReferenceId(79)]
-rebuilt        : SymbolId(44): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(68): [ReferenceId(101)]
-rebuilt        : SymbolId(62): []
-Unresolved references mismatch:
-after transform: ["ReturnType", "globalThis"]
-rebuilt        : ["globalThis"]
-Unresolved reference IDs mismatch for "globalThis":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(24), ReferenceId(25), ReferenceId(32), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(40), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(47), ReferenceId(49), ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(64), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(90), ReferenceId(91), ReferenceId(94), ReferenceId(95), ReferenceId(102), ReferenceId(104), ReferenceId(105), ReferenceId(108), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122)]
-rebuilt        : [ReferenceId(4), ReferenceId(9), ReferenceId(14), ReferenceId(19), ReferenceId(24), ReferenceId(29), ReferenceId(37), ReferenceId(43)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
-semantic error: Unresolved references mismatch:
-after transform: ["NS"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Covariant", "DataFirst", "DataLast", "Invariant", "Kind", "SK", "SemiApplicative", "SemiProduct", "TypeClass", "TypeLambda", "Types", "URI", "dual", "zipRight", "zipWith"]
-rebuilt        : ScopeId(0): ["SK", "zipRight", "zipWith"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-Bindings mismatch:
-after transform: ScopeId(13): ["A", "B", "_", "b"]
-rebuilt        : ScopeId(1): ["_", "b"]
-Bindings mismatch:
-after transform: ScopeId(14): ["A", "B", "C", "E1", "E2", "F", "O1", "O2", "R1", "R2"]
-rebuilt        : ScopeId(2): ["F"]
-Bindings mismatch:
-after transform: ScopeId(15): ["A", "B", "C", "E1", "E2", "O1", "O2", "R1", "R2", "f", "self", "that"]
-rebuilt        : ScopeId(3): ["f", "self", "that"]
-Bindings mismatch:
-after transform: ScopeId(17): ["B", "E1", "E2", "F", "O1", "O2", "R1", "R2", "_"]
-rebuilt        : ScopeId(5): ["F"]
-Bindings mismatch:
-after transform: ScopeId(18): ["B", "E1", "E2", "O1", "O2", "R1", "R2", "_", "self", "that"]
-rebuilt        : ScopeId(6): ["self", "that"]
-Symbol flags mismatch:
-after transform: SymbolId(55): SymbolFlags(FunctionScopedVariable | TypeParameter)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(55): Span { start: 2588, end: 2589 }
-rebuilt        : SymbolId(4): Span { start: 2610, end: 2631 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(55): [ReferenceId(159), ReferenceId(161), ReferenceId(170), ReferenceId(176), ReferenceId(185), ReferenceId(191), ReferenceId(200), ReferenceId(210), ReferenceId(216), ReferenceId(225), ReferenceId(233), ReferenceId(234)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(3)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(55): [Span { start: 2610, end: 2631 }]
-rebuilt        : SymbolId(4): []
-Symbol flags mismatch:
-after transform: SymbolId(80): SymbolFlags(FunctionScopedVariable | TypeParameter)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(80): Span { start: 3332, end: 3333 }
-rebuilt        : SymbolId(11): Span { start: 3354, end: 3375 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(80): [ReferenceId(242), ReferenceId(244), ReferenceId(250), ReferenceId(256), ReferenceId(265), ReferenceId(271), ReferenceId(277), ReferenceId(287), ReferenceId(293), ReferenceId(299), ReferenceId(308)]
-rebuilt        : SymbolId(11): [ReferenceId(11)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(80): [Span { start: 3354, end: 3375 }]
-rebuilt        : SymbolId(11): []
-Reference symbol mismatch:
-after transform: ReferenceId(208): Some("dual")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(285): Some("dual")
-rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["Array", "IArguments", "Iterable", "Parameters", "Types"]
-rebuilt        : ["dual"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitIndexTypeArray.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "keys"]
-rebuilt        : ScopeId(1): ["keys"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredDefaultExportType2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["A", "Foo", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias8.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "returnSomeGlobalValue", "x"]
-rebuilt        : ScopeId(0): ["returnSomeGlobalValue", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias9.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "returnSomeGlobalValue", "x"]
-rebuilt        : ScopeId(0): ["returnSomeGlobalValue", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Obj", "obj"]
-rebuilt        : ScopeId(1): ["obj"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Obj", "obj"]
-rebuilt        : ScopeId(2): ["obj"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitKeywordDestructuring.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["P", "f1", "f2", "f3", "f4", "f5"]
-rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassDeclarationMixin.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Constructor", "Filter", "FilteredThing", "Mixed", "Unmixed", "mixin"]
-rebuilt        : ScopeId(0): ["Filter", "FilteredThing", "Mixed", "Unmixed", "mixin"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-Bindings mismatch:
-after transform: ScopeId(3): ["B", "Base", "PrivateMixed"]
-rebuilt        : ScopeId(1): ["Base", "PrivateMixed"]
-Bindings mismatch:
-after transform: ScopeId(6): ["C", "FilterMixin", "ctor"]
-rebuilt        : ScopeId(4): ["FilterMixin", "ctor"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8)]
-rebuilt        : ScopeId(5): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassHasRequiredDeclare.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
-rebuilt        : SymbolId(1): SymbolFlags(Export | Class)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 25, end: 26 }
-rebuilt        : SymbolId(1): Span { start: 78, end: 79 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 78, end: 79 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
-rebuilt        : SymbolId(2): SymbolFlags(Export | Class)
-Symbol span mismatch:
-after transform: SymbolId(3): Span { start: 128, end: 129 }
-rebuilt        : SymbolId(2): Span { start: 149, end: 150 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(3): [Span { start: 149, end: 150 }]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AllArg", "Fns", "Map", "fn"]
-rebuilt        : ScopeId(0): ["fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "sliceIndex"]
-rebuilt        : ScopeId(1): ["sliceIndex"]
-Unresolved references mismatch:
-after transform: ["Parameters", "Record"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "arg"]
-rebuilt        : ScopeId(1): ["arg"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitMergedAliasWithConst.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Color", "Colors"]
-rebuilt        : ScopeId(0): ["Color"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 100, end: 105 }]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["func"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitMonorepoBaseUrl.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PluginConfig"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts3.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithAlias.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
-semantic error: Missing SymbolId: Bar
-Missing SymbolId: _Bar
-Missing ReferenceId: _Bar
-Missing ReferenceId: biz
-Missing ReferenceId: Bar
-Missing ReferenceId: Bar
-Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Foo"]
-rebuilt        : ScopeId(0): ["Bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Members", "Part1", "Part2"]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(5)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedGenerics.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "g", "p"]
-rebuilt        : ScopeId(1): ["g", "p"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "x", "y"]
-rebuilt        : ScopeId(2): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNoNonRequiredParens.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Test", "TestType", "bar"]
-rebuilt        : ScopeId(0): ["Test", "bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "C", "Test"]
-rebuilt        : ScopeId(1): ["Test"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitNonExportedBindingPattern.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AliasType", "AliasType2", "AliasType3", "c", "foo", "getFoo", "getNested", "renamed"]
-rebuilt        : ScopeId(0): ["c", "foo", "getFoo", "getNested", "renamed"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(5)]
-rebuilt        : SymbolId(4): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 71, end: 83 }]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMethod.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitOverloadedPrivateInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "U", "fn"]
-rebuilt        : ScopeId(4): ["fn"]
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["N", "PrivateSpecialString", "SpecialString", "o"]
-rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2)]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Scalar", "scalar"]
-rebuilt        : ScopeId(0): ["scalar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Scalar", "scalar"]
-rebuilt        : ScopeId(0): ["scalar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Evt"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreservesHasNoDefaultLibDirective.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Array", "Boolean", "Foo", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
-rebuilt        : ScopeId(0): ["Foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["CtorT", "ctor"]
-rebuilt        : ScopeId(1): ["ctor"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "func", "result", "rfunc"]
-rebuilt        : ScopeId(2): ["a", "b", "c", "d", "e", "func", "result", "rfunc"]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "f"]
-rebuilt        : ScopeId(4): ["f"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "func", "result", "rfunc"]
-rebuilt        : ScopeId(5): ["a", "b", "c", "d", "e", "func", "result", "rfunc"]
-Bindings mismatch:
-after transform: ScopeId(7): ["T", "f"]
-rebuilt        : ScopeId(7): ["f"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(11)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29)]
-rebuilt        : SymbolId(9): [ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(32): [ReferenceId(57), ReferenceId(58)]
-rebuilt        : SymbolId(20): [ReferenceId(20)]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Q", "T", "create", "fun", "fun2"]
-rebuilt        : ScopeId(0): ["create", "fun", "fun2"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Power", "power"]
-rebuilt        : ScopeId(0): ["power"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Num", "PowerOf", "num", "powerOf"]
-rebuilt        : ScopeId(1): ["num", "powerOf"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["FooOptions", "foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "a", "o1", "o2", "o3", "o4", "u"]
-rebuilt        : ScopeId(0): ["a", "o1", "o2", "o3", "o4", "u"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["E", "i"]
-rebuilt        : ScopeId(1): ["i"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "foo", "global", "someMethod"]
-rebuilt        : ScopeId(0): ["Foo", "foo", "someMethod"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["CustomSelect1", "CustomSelect2", "Props"]
-rebuilt        : ScopeId(0): ["CustomSelect1", "CustomSelect2"]
-Bindings mismatch:
-after transform: ScopeId(1): ["Option", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Bindings mismatch:
-after transform: ScopeId(2): ["Option", "x"]
-rebuilt        : ScopeId(2): ["x"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "f"]
-rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Client", "UpdatedClient", "createClient"]
-rebuilt        : ScopeId(0): ["createClient"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(3): ["D", "clientDef"]
-rebuilt        : ScopeId(1): ["clientDef"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitSpreadStringlyKeyedEnum.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["0-17", "18-22", "23-27", "28-34", "35-44", "45-59", "60-150", "AgeGroups"]
-rebuilt        : ScopeId(1): ["AgeGroups"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "ITest", "TestEnum"]
-rebuilt        : ScopeId(0): ["A", "TestEnum"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(1): ["Test1", "Test2", "TestEnum"]
-rebuilt        : ScopeId(1): ["TestEnum"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitSymlinkPaths.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["NotificationRequest", "NotificationResponse", "getNotification"]
-rebuilt        : ScopeId(0): ["getNotification"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithCompositeOption.ts
 semantic error: Bindings mismatch:
@@ -9104,182 +5299,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X", "fn"]
-rebuilt        : ScopeId(0): ["fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTransitiveImportOfHtmlDeclarationItem.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTripleSlashReferenceAmbientModule.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Url"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTupleRestSignatureLeadingVariadic.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["TFirstArgs", "TLastArg", "args"]
-rebuilt        : ScopeId(1): ["args"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Foo", "y"]
-rebuilt        : ScopeId(0): ["y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Baa", "Bar", "Baz", "y"]
-rebuilt        : ScopeId(0): ["y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "bar"]
-rebuilt        : ScopeId(0): ["bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters6.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "SubFoo", "foo"]
-rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameInOuterScope.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "a", "a2", "a3", "a4", "b", "b2"]
-rebuilt        : ScopeId(0): ["A", "a", "a2", "a3", "a4", "b", "b2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "x"]
-rebuilt        : ScopeId(2): ["x"]
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "x"]
-rebuilt        : ScopeId(3): ["x"]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "x"]
-rebuilt        : ScopeId(4): ["x"]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "x"]
-rebuilt        : ScopeId(5): ["x"]
-Bindings mismatch:
-after transform: ScopeId(7): ["B", "x"]
-rebuilt        : ScopeId(6): ["x"]
-Bindings mismatch:
-after transform: ScopeId(8): ["B", "x"]
-rebuilt        : ScopeId(7): ["x"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameReusedInOverloads.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Base", "Derived", "Derived2", "Foo"]
-rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(10)]
-rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "inner", "x"]
-rebuilt        : ScopeId(1): ["inner", "x"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "y"]
-rebuilt        : ScopeId(2): ["y"]
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitUnnessesaryTypeReferenceNotAdded.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IEntry", "baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
-rebuilt        : ScopeId(0): ["baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Unresolved references mismatch:
-after transform: ["Promise", "console", "const", "fetch"]
-rebuilt        : ["console", "fetch"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IEntry", "baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
-rebuilt        : ScopeId(0): ["baseUrl", "entryKeys", "testApi", "useEntries", "useQuery"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Unresolved references mismatch:
-after transform: ["Promise", "console", "const", "fetch"]
-rebuilt        : ["console", "fetch"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "goodDeclaration", "shouldBeElided", "shouldReuseLocalName"]
-rebuilt        : ScopeId(0): ["bar", "goodDeclaration"]
-
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithComposite.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
@@ -9287,111 +5306,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Experiment", "Name", "createExperiment"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("createExperiment")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["createExperiment"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Experiment", "Name", "createExperiment"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("createExperiment")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["createExperiment"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["MutableRefObject", "useCsvParser", "useRef"]
-rebuilt        : ScopeId(0): ["useCsvParser", "useRef"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "current"]
-rebuilt        : ScopeId(1): ["current"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error2", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error2", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
-semantic error: Missing SymbolId: foo
-Missing SymbolId: _foo
-Missing ReferenceId: _foo
-Missing ReferenceId: foo
-Missing ReferenceId: foo
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/declarationMaps.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 7, end: 9 }
-rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 230, end: 323 }]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["m2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
 semantic error: Bindings mismatch:
@@ -9409,75 +5323,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/declarationNoDanglingGenerics.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(3): ["TKind", "kind"]
-rebuilt        : ScopeId(3): ["kind"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationQuotedMembers.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["example", "mapped"]
-rebuilt        : ScopeId(0): ["example"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("mapped")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["mapped"]
-
-tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["DOMNode"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Node"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Hash", "StringHash", "StringHash2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Foo"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Key", "Value", "p1", "p2", "p3", "testRecFun", "updateIfChanged"]
-rebuilt        : ScopeId(0): ["p1", "p2", "p3", "testRecFun", "updateIfChanged"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "reduce", "t"]
-rebuilt        : ScopeId(1): ["reduce", "t"]
-Bindings mismatch:
-after transform: ScopeId(4): ["U", "set", "u", "update"]
-rebuilt        : ScopeId(2): ["set", "u", "update"]
-Bindings mismatch:
-after transform: ScopeId(6): ["K", "key"]
-rebuilt        : ScopeId(4): ["key"]
-Bindings mismatch:
-after transform: ScopeId(10): ["T", "parent"]
-rebuilt        : ScopeId(8): ["parent"]
-Bindings mismatch:
-after transform: ScopeId(11): ["U", "child"]
-rebuilt        : ScopeId(9): ["child"]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(16), ReferenceId(34), ReferenceId(51), ReferenceId(54)]
-rebuilt        : [ReferenceId(0), ReferenceId(6), ReferenceId(11)]
-
 tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
 semantic error: Missing SymbolId: ab
 Bindings mismatch:
@@ -9490,14 +5335,6 @@ Reference symbol mismatch:
 after transform: ReferenceId(1): Some("ab")
 rebuilt        : ReferenceId(1): Some("ab")
 
-tasks/coverage/typescript/tests/cases/compiler/declareDottedModuleName.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M", "T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["express"]
@@ -9507,46 +5344,6 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "RegExp", "express"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 7, end: 9 }
-rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 230, end: 323 }]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["m2"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 7, end: 9 }
-rebuilt        : SymbolId(1): Span { start: 238, end: 331 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 238, end: 331 }]
-rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["m2"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
@@ -9736,31 +5533,6 @@ Unresolved references mismatch:
 after transform: ["Function", "PropertyDescriptor"]
 rebuilt        : ["console"]
 
-tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConditionalTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "T0", "T1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(102), ScopeId(103)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["BufferPool", "Enum", "TypeMap"]
-rebuilt        : ScopeId(0): ["BufferPool"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(4): ["E", "M"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(5): ["K", "_", "array"]
-rebuilt        : ScopeId(2): ["_", "array"]
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Extract", "Record"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "R", "S", "T", "X", "_S", "a1", "a2", "b"]
@@ -9771,50 +5543,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial", "true"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["MyComponent", "Props", "Things", "make"]
-rebuilt        : ScopeId(0): ["MyComponent", "make"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(2): ["CTor", "P", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
-semantic error: Missing SymbolId: Something
-Missing SymbolId: _Something
-Missing ReferenceId: _Something
-Missing ReferenceId: Something
-Missing ReferenceId: Something
-Bindings mismatch:
-after transform: ScopeId(0): ["MyComponent", "Props", "Something", "Things", "make", "me"]
-rebuilt        : ScopeId(0): ["MyComponent", "Something", "make", "me"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(2): ["CTor", "P", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(1): []
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(11), SymbolId(12), SymbolId(13)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 semantic error: Scope children mismatch:
@@ -9872,20 +5600,6 @@ Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 23, end: 26 }]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["OptionalNullableString", "allowsNull", "cond", "f", "foo1", "foo2", "foo3", "foo4", "g", "removeNothing", "removeUndefinedButNotFalse", "total"]
-rebuilt        : ScopeId(0): ["allowsNull", "f", "foo1", "foo2", "foo3", "foo4", "g", "removeNothing", "removeUndefinedButNotFalse", "total"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10)]
-Reference symbol mismatch:
-after transform: ReferenceId(36): Some("cond")
-rebuilt        : ReferenceId(35): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["cond", "undefined"]
-
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "And", "AndBit", "Bit", "Equals", "Extends", "FilterByStringValue", "FilteredRes1", "FilteredValuesMatchNever", "IsLiteral", "IsNumberLiteral", "Not", "Or", "T0", "T1", "T2", "T3", "T4", "T5", "T6", "TestBit", "TestBitRes", "Values"]
@@ -9906,31 +5620,6 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), Sc
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["First", "ObjectHasKey", "StringContains", "T1", "T2", "f2", "f3"]
-rebuilt        : ScopeId(0): ["f2", "f3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(9): ["A", "a"]
-rebuilt        : ScopeId(1): ["a"]
-Unresolved references mismatch:
-after transform: ["Extract", "f1"]
-rebuilt        : ["f1"]
-
-tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "D", "DeepError", "DeepOK", "E", "Juxtapose", "ObjectHasKey", "StringContains"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Extract"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayWithinTuple.ts
@@ -10108,17 +5797,6 @@ Unresolved references mismatch:
 after transform: ["Promise", "get"]
 rebuilt        : ["get"]
 
-tasks/coverage/typescript/tests/cases/compiler/destructureOptionalParameter.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["QueryMetadata", "QueryMetadataFactory", "Type", "f2"]
-rebuilt        : ScopeId(0): ["f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["ParameterDecorator"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "bar", "key", "lorem", "obj"]
@@ -10215,14 +5893,14 @@ Bindings mismatch:
 after transform: ScopeId(21): ["Num", "Str", "Types"]
 rebuilt        : ScopeId(17): ["Types"]
 Scope flags mismatch:
-after transform: ScopeId(21): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(17): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(21): ScopeFlags(0x0)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(44): ["BarEnum", "bar1", "bar2"]
 rebuilt        : ScopeId(28): ["BarEnum"]
 Scope flags mismatch:
-after transform: ScopeId(44): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(28): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(44): ScopeFlags(0x0)
+rebuilt        : ScopeId(28): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(20): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
@@ -10387,29 +6065,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Error", "GraphQLError", "ReadonlyArray", "getVariableValues"]
 rebuilt        : ["getVariableValues"]
-
-tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["IData", "IListItemData", "ListItem", "ListItemVariant", "Menu", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["ListItem", "ListItemVariant", "Menu", "_jsx", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(2): ["MenuItemVariant", "data", "listItemVariant"]
-rebuilt        : ScopeId(1): ["data", "listItemVariant"]
-Bindings mismatch:
-after transform: ScopeId(4): ["Avatar", "ListItemVariant", "OneLine"]
-rebuilt        : ScopeId(2): ["ListItemVariant"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(12), ReferenceId(21)]
-rebuilt        : SymbolId(5): [ReferenceId(1), ReferenceId(11)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
 semantic error: Bindings mismatch:
@@ -10617,14 +6272,23 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(7)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): []
@@ -10951,26 +6615,6 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 
-tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T0", "T3", "c0", "c1", "s0"]
-rebuilt        : ScopeId(0): ["c0", "c1", "s0"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5), ReferenceId(9)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(6), ReferenceId(10)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(7), ReferenceId(11)]
-rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Symbol", "T1", "T2"]
-rebuilt        : ["Symbol"]
-
 tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 semantic error: 'with' statements are not allowed
 
@@ -10979,23 +6623,6 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Constructor", "FooItem", "Test", "WithTags", "circularReference", "simpleExample", "test"]
-rebuilt        : ScopeId(0): ["FooItem", "Test", "WithTags", "circularReference", "simpleExample", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(13)]
-Bindings mismatch:
-after transform: ScopeId(10): ["Base", "T"]
-rebuilt        : ScopeId(9): ["Base"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(8), ReferenceId(12)]
-rebuilt        : SymbolId(5): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_object.ts
 semantic error: Bindings mismatch:
@@ -11197,11 +6824,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
-tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "i"]
-rebuilt        : ScopeId(0): ["Foo"]
-
 tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
@@ -11241,25 +6863,6 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-tasks/coverage/typescript/tests/cases/compiler/enumDecl1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["mAmbient"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/enumDeclarationEmitInitializerHasImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "Value1", "Value2"]
-rebuilt        : ScopeId(1): ["Enum"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
 tasks/coverage/typescript/tests/cases/compiler/enumFromExternalModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Mode", "Open"]
@@ -11289,17 +6892,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/enumKeysQuotedAsObjectPropertiesInDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["LEFT_BUTTON", "MIDDLE_BUTTON", "MouseButton", "NO_BUTTON", "RIGHT_BUTTON", "XBUTTON1_BUTTON", "XBUTTON2_BUTTON"]
-rebuilt        : ScopeId(1): ["MouseButton"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
 semantic error: Bindings mismatch:
@@ -11369,20 +6961,20 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "MyEnum"]
 rebuilt        : ScopeId(1): ["MyEnum"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "B", "C", "MyStringEnum"]
 rebuilt        : ScopeId(2): ["MyStringEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "C", "MyStringEnumWithEmpty"]
 rebuilt        : ScopeId(3): ["MyStringEnumWithEmpty"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -13335,44 +8927,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultClassDeclaration4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultFunctionDeclaration3.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/es5ExportDefaultFunctionDeclaration4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["func"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/es5ExportEqualsDts.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 82, end: 83 }]
-rebuilt        : SymbolId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "ChildClassWithoutConstructor", "GetSetMonster", "IFoo", "ImplementsInterface", "OverloadedMonster", "PrototypeMonster", "SplatMonster", "Statics", "SuperChild", "SuperParent", "Visibility", "ccwc", "foo", "m1", "m2", "m3", "m4", "m5", "m6", "stat", "x", "y"]
@@ -13428,12 +8982,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(5): [ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(21)]
 
-tasks/coverage/typescript/tests/cases/compiler/es6ExportAll.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/es6ExportAllInEs5.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
 tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
@@ -13444,141 +8992,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseInEs5.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifier.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithoutModuleSpecifierInEs5.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingAmd.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingDts.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "defaultBinding2", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "defaultBinding1", "defaultBinding2", "defaultBinding3", "defaultBinding4", "defaultBinding5", "defaultBinding6", "m", "x", "x1", "y", "z"]
-rebuilt        : ScopeId(0): ["a", "b", "m", "x", "x1", "y", "z"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["defaultBinding", "nameSpaceBinding", "x"]
-rebuilt        : ScopeId(0): ["defaultBinding", "x"]
-
 tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nameSpaceBinding", "nameSpaceBinding2", "x"]
-rebuilt        : ScopeId(0): ["nameSpaceBinding", "x"]
-
 tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportNoNamedExports.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "xxxx1", "xxxx2", "xxxx3", "xxxx4", "xxxx5", "xxxx6", "xxxx7", "xxxx8", "xxxx9", "y", "z", "z1", "z111", "z2", "z3"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInEs5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInExportAssignment.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: c
-Missing ReferenceId: a
-Missing ReferenceId: a
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "C2", "I", "I2"]
-rebuilt        : ScopeId(0): ["C", "C2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseNonInstantiatedModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["i"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 semantic error: Missing SymbolId: m1
@@ -13599,9 +9020,15 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)
 Binding symbols mismatch:
 after transform: ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(26): [SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(26): [SymbolId(7), SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(26): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(3): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
@@ -13639,9 +9066,15 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(20)]
 rebuilt        : ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(21)]
 rebuilt        : ScopeId(2): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -13681,44 +9114,50 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -13767,44 +9206,50 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -13853,44 +9298,50 @@ Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["e2", "x", "y", "z"]
 rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
 rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["e4", "x", "y", "z"]
 rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
 rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["e6", "x", "y", "z"]
 rebuilt        : ScopeId(8): ["e6"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -13938,27 +9389,27 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(4)]
 rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(8)]
 rebuilt        : SymbolId(8): [ReferenceId(11), ReferenceId(14)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("m1")
 rebuilt        : ReferenceId(16): Some("m1")
@@ -14090,47 +9541,6 @@ Unresolved references mismatch:
 after transform: ["Symbol", "const", "true"]
 rebuilt        : ["Symbol"]
 
-tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(11), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | Ambient)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 44, end: 47 }]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["TestNull", "TestNull2", "TestUndefined", "testNull", "testNull2", "testUndefined"]
-rebuilt        : ScopeId(0): ["testNull", "testNull2", "testUndefined"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["TestSymb", "symb", "test"]
-rebuilt        : ScopeId(0): ["symb", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["TestSymb", "symb"]
-rebuilt        : ScopeId(0): ["symb"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -14189,17 +9599,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -14227,17 +9626,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Constructor", "MyBaseClass"]
-rebuilt        : ScopeId(0): ["MyBaseClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
 semantic error: Missing SymbolId: A
 Missing SymbolId: _A
@@ -14251,8 +9639,11 @@ Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -14431,128 +9822,8 @@ tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
 tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
-semantic error: Missing SymbolId: MsPortalFx
-Missing SymbolId: _MsPortalFx
-Missing SymbolId: ViewModels
-Missing SymbolId: _ViewModels
-Missing SymbolId: Dialogs
-Missing SymbolId: _Dialogs
-Missing ReferenceId: _Dialogs
-Missing ReferenceId: DialogResult
-Missing ReferenceId: _Dialogs
-Missing ReferenceId: someExportedFunction
-Missing ReferenceId: _Dialogs
-Missing ReferenceId: MessageBoxButtons
-Missing ReferenceId: Dialogs
-Missing ReferenceId: Dialogs
-Missing ReferenceId: _ViewModels
-Missing ReferenceId: _ViewModels
-Missing ReferenceId: ViewModels
-Missing ReferenceId: ViewModels
-Missing ReferenceId: _MsPortalFx
-Missing ReferenceId: _MsPortalFx
-Missing ReferenceId: MsPortalFx
-Missing ReferenceId: MsPortalFx
-Missing SymbolId: _MsPortalFx2
-Missing SymbolId: ViewModels
-Missing SymbolId: _ViewModels2
-Missing ReferenceId: _ViewModels2
-Missing ReferenceId: SomeUsagesOfTheseConsts
-Missing ReferenceId: ViewModels
-Missing ReferenceId: ViewModels
-Missing ReferenceId: _MsPortalFx2
-Missing ReferenceId: _MsPortalFx2
-Missing ReferenceId: MsPortalFx
-Missing ReferenceId: MsPortalFx
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(27)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(28)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["DialogResult", "DialogResultCallback", "MessageBoxButtons", "_Dialogs", "someExportedFunction"]
-rebuilt        : ScopeId(3): ["DialogResult", "MessageBoxButtons", "_Dialogs", "someExportedFunction"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-Bindings mismatch:
-after transform: ScopeId(4): ["Abort", "Cancel", "DialogResult", "Ignore", "No", "Ok", "Retry", "Yes"]
-rebuilt        : ScopeId(4): ["DialogResult"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(7): ["AbortRetryIgnore", "MessageBoxButtons", "OK", "OKCancel", "RetryCancel", "YesNo", "YesNoCancel"]
-rebuilt        : ScopeId(6): ["MessageBoxButtons"]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(20), SymbolId(30)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(9): ["Callback", "DialogButtons", "ReExportedEnum", "SomeUsagesOfTheseConsts", "_ViewModels2"]
-rebuilt        : ScopeId(8): ["SomeUsagesOfTheseConsts", "_ViewModels2"]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | ConstEnum)
-rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(16)]
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(8): [ReferenceId(18)]
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(Export | ConstEnum)
-rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(9): [ReferenceId(33)]
-Symbol flags mismatch:
-after transform: SymbolId(24): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(24): []
-rebuilt        : SymbolId(14): [ReferenceId(51)]
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("ReExportedEnum")
-rebuilt        : ReferenceId(44): None
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("DialogButtons")
-rebuilt        : ReferenceId(47): None
-Unresolved references mismatch:
-after transform: ["Dialogs", "MsPortalFx", "console"]
-rebuilt        : ["DialogButtons", "ReExportedEnum", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -14569,21 +9840,6 @@ Unresolved references mismatch:
 after transform: ["A", "B"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -14595,8 +9851,8 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function | TypeAlias)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
 Symbol span mismatch:
 after transform: SymbolId(0): Span { start: 12, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 73, end: 76 }
@@ -14909,86 +10165,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-semantic error: Missing ReferenceId: Infinity
-Missing ReferenceId: Infinity
-Missing SymbolId: X
-Missing SymbolId: _X
-Missing ReferenceId: _X
-Missing ReferenceId: f
-Missing ReferenceId: X
-Missing ReferenceId: X
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "_X", "f"]
-rebuilt        : ScopeId(2): ["_X", "f"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(4): [ReferenceId(9)]
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("X")
-rebuilt        : ReferenceId(12): Some("X")
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : ["Error", "Infinity"]
-
-tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-semantic error: Missing ReferenceId: Infinity
-Missing ReferenceId: Infinity
-Missing SymbolId: X
-Missing SymbolId: _X
-Missing ReferenceId: _X
-Missing ReferenceId: f
-Missing ReferenceId: X
-Missing ReferenceId: X
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(6)]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "B", "Foo"]
-rebuilt        : ScopeId(1): ["Foo"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "_X", "f"]
-rebuilt        : ScopeId(2): ["_X", "f"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(4): [ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(5)]
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("X")
-rebuilt        : ReferenceId(12): Some("X")
-
 tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
@@ -15256,38 +10432,6 @@ tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
-semantic error: Missing SymbolId: m2
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: foo
-Missing ReferenceId: m2
-Missing ReferenceId: m2
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(38), SymbolId(45)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(33), SymbolId(34), SymbolId(36), SymbolId(41)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(39), SymbolId(46)]
-rebuilt        : ScopeId(12): [SymbolId(37), SymbolId(38)]
-Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(12): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(39): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(39): []
-rebuilt        : SymbolId(38): [ReferenceId(15)]
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("m2")
-rebuilt        : ReferenceId(18): Some("m2")
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
 semantic error: Unresolved references mismatch:
@@ -15753,11 +10897,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/genericArray0.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["U", "ys"]
-rebuilt        : ScopeId(1): ["ys"]
-
 tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -15936,38 +11075,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["First", "Second", "SubFirst", "SubFirstMore", "hasAFoo", "thing"]
 rebuilt        : ScopeId(1): ["hasAFoo", "thing"]
 
-tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
-semantic error: Missing SymbolId: bar
-Missing SymbolId: _bar
-Missing ReferenceId: _bar
-Missing ReferenceId: Foo
-Missing ReferenceId: bar
-Missing ReferenceId: bar
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): ["bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 semantic error: Missing SymbolId: Portal
 Missing SymbolId: _Portal
@@ -16141,44 +11248,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(19): [ReferenceId(4), ReferenceId(7)]
 rebuilt        : SymbolId(19): [ReferenceId(2), ReferenceId(74)]
 
-tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/genericClasses1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "Foo", "v1", "w", "y", "z"]
-rebuilt        : ScopeId(0): ["C", "v1", "w", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-
 tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A"]
@@ -16192,46 +11261,6 @@ rebuilt        : ScopeId(4): ["f", "retval", "x", "y"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(16), ReferenceId(19), ReferenceId(25), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
-
-tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
-semantic error: Missing SymbolId: Foo
-Missing SymbolId: _Foo
-Missing ReferenceId: _Foo
-Missing ReferenceId: B
-Missing ReferenceId: _Foo
-Missing ReferenceId: A
-Missing ReferenceId: Foo
-Missing ReferenceId: Foo
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("Foo")
-rebuilt        : ReferenceId(6): Some("Foo")
-Unresolved references mismatch:
-after transform: ["Foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 semantic error: Bindings mismatch:
@@ -16263,17 +11292,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 semantic error: Missing SymbolId: EndGate
@@ -16464,21 +11482,6 @@ rebuilt        : ScopeId(2): ["test"]
 Unresolved references mismatch:
 after transform: ["String"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/genericFunctions0.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "x"]
-rebuilt        : ScopeId(1): ["x"]
-
-tasks/coverage/typescript/tests/cases/compiler/genericFunctions1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "x"]
-rebuilt        : ScopeId(1): ["x"]
-
-tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 semantic error: Bindings mismatch:
@@ -17109,58 +12112,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3)]
 rebuilt        : SymbolId(3): []
 
-tasks/coverage/typescript/tests/cases/compiler/generics0.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["G", "v2", "z"]
-rebuilt        : ScopeId(0): ["v2", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "G", "v1", "v2", "v4"]
-rebuilt        : ScopeId(0): ["v1", "v2", "v4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/generics2NoError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "G", "v1", "v2", "v4"]
-rebuilt        : ScopeId(0): ["v1", "v2", "v4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/generics3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "X", "Y", "a", "b"]
-rebuilt        : ScopeId(0): ["C", "a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "X", "Y", "a", "b"]
-rebuilt        : ScopeId(0): ["C", "a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["K", "M", "N", "R", "S", "T", "U", "combine", "foo"]
@@ -17300,15 +12251,6 @@ rebuilt        : ScopeId(0): ["a", "b", "foo", "obj"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit3.ts
-semantic error: Missing SymbolId: mod
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("mod")
-rebuilt        : ReferenceId(1): Some("mod")
 
 tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
 semantic error: Bindings mismatch:
@@ -17452,26 +12394,6 @@ Unresolved references mismatch:
 after transform: ["Extract", "Omit", "RequestInit"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Equals", "f1"]
-rebuilt        : ScopeId(0): ["f1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(8): ["T1", "T2"]
-rebuilt        : ScopeId(2): []
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(15)]
-rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["State", "true"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Sequence"]
@@ -17576,60 +12498,12 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
-semantic error: Missing SymbolId: My
-Missing SymbolId: _My
-Missing SymbolId: Internal
-Missing SymbolId: _Internal
-Missing ReferenceId: _Internal
-Missing ReferenceId: getThing
-Missing ReferenceId: _Internal
-Missing ReferenceId: WhichThing
-Missing ReferenceId: Internal
-Missing ReferenceId: Internal
-Missing ReferenceId: _My
-Missing ReferenceId: _My
-Missing ReferenceId: My
-Missing ReferenceId: My
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "WhichThing"]
-rebuilt        : ScopeId(4): ["WhichThing"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | ConstEnum)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(10)]
-
 tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 semantic error: Bindings mismatch:
@@ -17641,10 +12515,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
 semantic error: Bindings mismatch:
@@ -17772,20 +12642,6 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["MakeItWork", "fail1", "fail2", "fn", "works1", "works2"]
-rebuilt        : ScopeId(0): ["fail1", "fail2", "fn", "works1", "works2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "x"]
-rebuilt        : ScopeId(2): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -18276,11 +13132,6 @@ Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 
-tasks/coverage/typescript/tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["KeysWithoutStringIndex", "RemoveIdxSgn", "test"]
@@ -18576,40 +13427,6 @@ Bindings mismatch:
 after transform: ScopeId(1): ["T", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
 
-tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "x1", "x2", "y1", "y2"]
-rebuilt        : ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "y1", "y2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("x1")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("x2")
-rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Partial", "Required", "test"]
-rebuilt        : ["test", "x1", "x2"]
-
-tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "x1", "x2", "y1", "y2"]
-rebuilt        : ScopeId(0): ["v1", "v2", "v3", "v4", "v5", "v6", "y1", "y2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("x1")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("x2")
-rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Partial", "Required", "test"]
-rebuilt        : ["test", "x1", "x2"]
-
 tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a2", "a3", "a4", "obj", "param2", "query", "x1", "x2", "x3", "x4"]
@@ -18759,37 +13576,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Args", "_"]
 rebuilt        : ScopeId(1): ["_"]
-
-tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Type", "Type2", "inferPipe", "inferPipe2", "out", "out2", "t", "t2"]
-rebuilt        : ScopeId(0): ["out", "out2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("t")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(34): Some("t2")
-rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["ReturnType", "parseInt"]
-rebuilt        : ["parseInt", "t", "t2"]
-
-tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ObjectTypeComposer", "User"]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("User")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("User")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["User"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
 semantic error: Bindings mismatch:
@@ -19142,20 +13928,6 @@ Unresolved references mismatch:
 after transform: ["Extract"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Obj", "processedInternally1", "processedInternally2", "test1", "test2", "wrappedTest1", "wrappedTest2"]
-rebuilt        : ScopeId(0): ["processedInternally1", "processedInternally2", "test1", "test2", "wrappedTest1", "wrappedTest2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(1): ["K", "T", "k", "obj"]
-rebuilt        : ScopeId(1): ["k", "obj"]
-Bindings mismatch:
-after transform: ScopeId(2): ["K", "T", "k", "obj"]
-rebuilt        : ScopeId(2): ["k", "obj"]
-
 tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Name", "RelationFields", "ShouldA"]
@@ -19406,6 +14178,9 @@ rebuilt        : ScopeId(1): ["value", "values"]
 Bindings mismatch:
 after transform: ScopeId(25): ["ComponentClass", "CreateElementChildren", "InferFunctionTypes", "_N"]
 rebuilt        : ScopeId(8): ["InferFunctionTypes", "_N"]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(25): [ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37)]
 rebuilt        : ScopeId(8): [ScopeId(9), ScopeId(10), ScopeId(11)]
@@ -19467,14 +14242,6 @@ rebuilt        : ScopeId(0): ["c", "d"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X", "Y", "Z", "x1", "x2"]
-rebuilt        : ScopeId(0): ["x1", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
 semantic error: Missing SymbolId: A
@@ -19887,14 +14654,6 @@ Unresolved references mismatch:
 after transform: ["ReturnType"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mover", "MoverShaker", "Shaker"]
@@ -19918,387 +14677,6 @@ rebuilt        : ScopeId(0): ["v"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/interfaceWithOptionalProperty.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/interfacedecl.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a", "a0", "a1", "a2", "b", "c", "c1", "d", "instance2"]
-rebuilt        : ScopeId(0): ["c1", "instance2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasClass.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: x
-Missing SymbolId: _x
-Missing ReferenceId: _x
-Missing ReferenceId: c
-Missing ReferenceId: x
-Missing ReferenceId: x
-Missing SymbolId: xc
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("x")
-rebuilt        : ReferenceId(5): Some("x")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("xc")
-rebuilt        : ReferenceId(6): Some("xc")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: x
-Missing SymbolId: _x
-Missing ReferenceId: _x
-Missing ReferenceId: c
-Missing ReferenceId: x
-Missing ReferenceId: x
-Missing SymbolId: xc
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("x")
-rebuilt        : ReferenceId(5): Some("x")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("xc")
-rebuilt        : ReferenceId(6): Some("xc")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasEnum.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: weekend
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
-after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
-rebuilt        : ScopeId(2): ["weekend"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(8)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("a")
-rebuilt        : ReferenceId(11): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(12): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: weekend
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
-after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
-rebuilt        : ScopeId(2): ["weekend"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(8)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("a")
-rebuilt        : ReferenceId(11): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(12): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: foo
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("a")
-rebuilt        : ReferenceId(5): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(6): Some("b")
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("b")
-rebuilt        : ReferenceId(7): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: foo
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("a")
-rebuilt        : ReferenceId(5): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(6): Some("b")
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("b")
-rebuilt        : ReferenceId(7): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing SymbolId: b
-Missing SymbolId: _b
-Missing ReferenceId: _b
-Missing ReferenceId: c
-Missing ReferenceId: b
-Missing ReferenceId: b
-Missing ReferenceId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("a")
-rebuilt        : ReferenceId(8): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(9): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: a
-Missing SymbolId: _a
-Missing SymbolId: b
-Missing SymbolId: _b
-Missing ReferenceId: _b
-Missing ReferenceId: c
-Missing ReferenceId: b
-Missing ReferenceId: b
-Missing ReferenceId: _a
-Missing ReferenceId: _a
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("a")
-rebuilt        : ReferenceId(8): Some("a")
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("b")
-rebuilt        : ReferenceId(9): Some("b")
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: b
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "x"]
-rebuilt        : ScopeId(0): ["b", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: b
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "x"]
-rebuilt        : ScopeId(0): ["b", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: b
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "x"]
-rebuilt        : ScopeId(0): ["b", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: b
-Bindings mismatch:
-after transform: ScopeId(0): ["a", "b", "x"]
-rebuilt        : ScopeId(0): ["b", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -20619,219 +14997,6 @@ Unresolved references mismatch:
 after transform: ["Windows"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
-semantic error: Missing SymbolId: schema
-Missing SymbolId: _schema
-Missing ReferenceId: _schema
-Missing ReferenceId: createValidator1
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema2
-Missing ReferenceId: _schema2
-Missing ReferenceId: createValidator2
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema3
-Missing ReferenceId: _schema3
-Missing ReferenceId: createValidator3
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema4
-Missing ReferenceId: _schema4
-Missing ReferenceId: createValidator4
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema5
-Missing ReferenceId: _schema5
-Missing ReferenceId: createValidator5
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema6
-Missing ReferenceId: _schema6
-Missing ReferenceId: createValidator6
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema7
-Missing ReferenceId: _schema7
-Missing ReferenceId: createValidator7
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema8
-Missing ReferenceId: _schema8
-Missing ReferenceId: createValidator8
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Missing SymbolId: _schema9
-Missing ReferenceId: _schema9
-Missing ReferenceId: T
-Missing ReferenceId: schema
-Missing ReferenceId: schema
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(29)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "schema"]
-rebuilt        : ScopeId(2): ["schema"]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(30)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "schema"]
-rebuilt        : ScopeId(4): ["schema"]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(31)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(6): []
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(10), SymbolId(32)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10)]
-rebuilt        : ScopeId(8): []
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(13), SymbolId(33)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(9): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(12): [ScopeId(13)]
-rebuilt        : ScopeId(10): []
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(16), SymbolId(34)]
-rebuilt        : ScopeId(11): [SymbolId(16), SymbolId(17)]
-Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(11): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(15): ["T", "schema"]
-rebuilt        : ScopeId(12): ["schema"]
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(19), SymbolId(35)]
-rebuilt        : ScopeId(13): [SymbolId(19), SymbolId(20)]
-Scope flags mismatch:
-after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(13): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(17): ["T", "schema"]
-rebuilt        : ScopeId(14): ["schema"]
-Binding symbols mismatch:
-after transform: ScopeId(18): [SymbolId(22), SymbolId(36)]
-rebuilt        : ScopeId(15): [SymbolId(22), SymbolId(23)]
-Scope flags mismatch:
-after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(15): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(19): ["T", "schema"]
-rebuilt        : ScopeId(16): ["schema"]
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(25), SymbolId(37)]
-rebuilt        : ScopeId(17): [SymbolId(25), SymbolId(26)]
-Scope flags mismatch:
-after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(17): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(22): ["T"]
-rebuilt        : ScopeId(19): []
-Bindings mismatch:
-after transform: ScopeId(23): ["T", "v"]
-rebuilt        : ScopeId(20): ["v"]
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(12)]
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(11): [ReferenceId(17)]
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(14): [ReferenceId(22)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(17): [ReferenceId(27)]
-Symbol flags mismatch:
-after transform: SymbolId(19): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(19): []
-rebuilt        : SymbolId(20): [ReferenceId(32)]
-Symbol flags mismatch:
-after transform: SymbolId(22): SymbolFlags(FunctionScopedVariable | Export)
-rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(22): []
-rebuilt        : SymbolId(23): [ReferenceId(37)]
-Symbol flags mismatch:
-after transform: SymbolId(25): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(26): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(25): []
-rebuilt        : SymbolId(26): [ReferenceId(42)]
-Unresolved references mismatch:
-after transform: ["Array", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsStrictBuiltinIteratorReturn.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "x1", "x10", "x11", "x12", "x13", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
-rebuilt        : ScopeId(0): ["a1", "a10", "a11", "a12", "a13", "a14", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-Unresolved references mismatch:
-after transform: ["BuiltinIteratorReturn", "Iterable", "IterableIterator"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E2"]
@@ -20878,8 +15043,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["E", "X"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -20977,10 +15142,14 @@ Unresolved references mismatch:
 after transform: ["shouldBeIdentity"]
 rebuilt        : ["p1", "shouldBeIdentity"]
 
+tasks/coverage/typescript/tests/cases/compiler/jsFileClassSelfReferencedProperty.ts
+semantic error: Cannot use export statement outside a module
+
+tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationRestParamJsDocFunction.ts
+semantic error: Cannot use export statement outside a module
+
 tasks/coverage/typescript/tests/cases/compiler/jsFileESModuleWithEnumTag.ts
-semantic error: Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
+semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/compiler/jsdocAccessEnumType.ts
 semantic error: Bindings mismatch:
@@ -20993,6 +15162,9 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
+tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash.ts
+semantic error: Cannot use export statement outside a module
+
 tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "data", "fn"]
@@ -21003,8 +15175,8 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Component", "MyComponent", "RouteProps", "_jsx", "_jsxFileName", "global"]
-rebuilt        : ScopeId(0): ["MyComponent", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["Component", "MyComponent", "RouteProps", "_jsxFileName", "_reactJsxRuntime", "global"]
+rebuilt        : ScopeId(0): ["MyComponent", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(14), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
@@ -21012,8 +15184,8 @@ Bindings mismatch:
 after transform: ScopeId(15): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["Component", "Readonly"]
-rebuilt        : ["Component"]
+after transform: ["Component", "Readonly", "require"]
+rebuilt        : ["Component", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 semantic error: Bindings mismatch:
@@ -21025,6 +15197,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(2): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 semantic error: Bindings mismatch:
@@ -21048,16 +15223,19 @@ rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "NoticeList", "Props", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["NoticeList", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "NoticeList", "Props", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["NoticeList", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ElemClass", "JSX", "_jsx", "_jsxFileName", "elem"]
-rebuilt        : ScopeId(0): ["ElemClass", "_jsx", "_jsxFileName", "elem"]
+after transform: ScopeId(0): ["ElemClass", "JSX", "_jsxFileName", "_reactJsxRuntime", "elem"]
+rebuilt        : ScopeId(0): ["ElemClass", "_jsxFileName", "_reactJsxRuntime", "elem"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -21065,8 +15243,8 @@ Bindings mismatch:
 after transform: ScopeId(9): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
@@ -21087,8 +15265,8 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
 semantic error: Missing SymbolId: Element
@@ -21129,11 +15307,14 @@ rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Props", "React", "Wrapper", "_jsx", "_jsxFileName", "element"]
-rebuilt        : ScopeId(0): ["Wrapper", "_jsx", "_jsxFileName", "element"]
+after transform: ScopeId(0): ["Props", "React", "Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
+rebuilt        : ScopeId(0): ["Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(2): [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
 semantic error: Bindings mismatch:
@@ -21237,17 +15418,17 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_jsx", "_jsxFileName", "otherProps"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "otherProps"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("otherProps")
-rebuilt        : ReferenceId(3): None
+rebuilt        : ReferenceId(4): None
 Unresolved references mismatch:
-after transform: ["GenericComponent", "Omit", "omit"]
-rebuilt        : ["GenericComponent", "omit", "otherProps"]
+after transform: ["GenericComponent", "Omit", "omit", "require"]
+rebuilt        : ["GenericComponent", "omit", "otherProps", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
 semantic error: Bindings mismatch:
@@ -21291,14 +15472,19 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
+after transform: ["Record", "require"]
+rebuilt        : ["require"]
+
+tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
 semantic error: Bindings mismatch:
@@ -21361,30 +15547,30 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["_jsx", "_jsxFileName", "react", "tag"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "tag"]
+after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "react", "tag"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "tag"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
+after transform: ["Function", "require"]
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "Repro", "Select", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["Repro", "Select", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["React", "Repro", "Select", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Repro", "Select", "_jsxFileName", "_reactJsxRuntime"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(4)]
 Unresolved references mismatch:
-after transform: ["Parameters", "Partial"]
-rebuilt        : []
+after transform: ["Parameters", "Partial", "require"]
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -21526,9 +15712,6 @@ tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 semantic error: Missing SymbolId: A
@@ -21794,14 +15977,6 @@ Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(4), ReferenceId(6)]
 rebuilt        : [ReferenceId(4)]
 
-tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Point", "increment"]
-rebuilt        : ScopeId(0): ["increment"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Boxify", "Hmm", "MustBeArray", "T1", "T2", "T3", "T4", "T5", "X"]
@@ -21865,51 +16040,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-
-tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericIndexedAccess.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["P", "Test", "TypeHandlers", "Types", "TypesMap", "onSomeEvent", "typeHandlers"]
-rebuilt        : ScopeId(0): ["Test", "onSomeEvent", "typeHandlers"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "entry", "name"]
-rebuilt        : ScopeId(3): ["entry", "name"]
-Bindings mismatch:
-after transform: ScopeId(13): ["T", "p"]
-rebuilt        : ScopeId(7): ["p"]
-Unresolved references mismatch:
-after transform: ["console", "true"]
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["PrivateMapped"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "schema"]
-rebuilt        : ScopeId(1): ["schema"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "schema"]
-rebuilt        : ScopeId(2): ["schema"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(2): []
-Unresolved references mismatch:
-after transform: ["Record", "Required"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
 semantic error: Bindings mismatch:
@@ -22040,14 +16170,6 @@ rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
 after transform: ["Readonly", "TupleSchema", "ZodEnum"]
 rebuilt        : ["TupleSchema"]
-
-tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 semantic error: Bindings mismatch:
@@ -22190,15 +16312,27 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(5): [SymbolId(4), SymbolId(8)]
 rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
 rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(5): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(9): SymbolFlags(Class)
@@ -22626,19 +16760,6 @@ Reference flags mismatch:
 after transform: ReferenceId(12): ReferenceFlags(Write)
 rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
 
-tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["SubModule"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x"]
@@ -22953,30 +17074,6 @@ Unresolved references mismatch:
 after transform: ["D3"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./observable", "Observable"]
-rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./observable", "Observable"]
-rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./observable", "Observable"]
-rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
@@ -23017,14 +17114,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Observable", "observable"]
-rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./observable", "Observable"]
@@ -23041,46 +17130,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "global", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "global", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "global"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["global"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./f1", "A", "B"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
 semantic error: Missing SymbolId: I
 Missing SymbolId: C
@@ -23090,31 +17139,6 @@ rebuilt        : ScopeId(0): ["A", "C", "I"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports5.ts
-semantic error: Missing SymbolId: I
-Missing SymbolId: C
-Bindings mismatch:
-after transform: ScopeId(0): ["./f1", "A", "B", "C", "I", "N"]
-rebuilt        : ScopeId(0): ["A", "C", "I"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports6.ts
-semantic error: Missing SymbolId: I
-Missing SymbolId: C
-Bindings mismatch:
-after transform: ScopeId(0): ["./f1", "A", "B", "C", "I", "N"]
-rebuilt        : ScopeId(0): ["A", "C", "I"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Observable", "x"]
-rebuilt        : ScopeId(0): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule2.ts
 semantic error: Bindings mismatch:
@@ -23148,43 +17172,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsBundledOutput1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./m1", "Cls"]
-rebuilt        : ScopeId(0): ["Cls"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./a", "A", "B", "Cls"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./a", "A", "B"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./a", "A", "Cls"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "a", "b", "c"]
-rebuilt        : ScopeId(0): ["a", "b", "c"]
-
 tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
@@ -23193,14 +17180,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(7): ["A", "E1"]
 rebuilt        : ScopeId(7): ["E1"]
 Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(7): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(8): ["B", "E2"]
 rebuilt        : ScopeId(8): ["E2"]
 Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable | Export)
@@ -23210,14 +17197,6 @@ rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Account", "Account2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleIdentifiers.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -23408,17 +17387,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["outer"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["outer"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -24027,14 +17995,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(6): []
 rebuilt        : SymbolId(9): [ReferenceId(9)]
 
-tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -24087,12 +18047,6 @@ Unresolved references mismatch:
 after transform: ["ng"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
 tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ICallback", "f1", "f2", "load"]
@@ -24108,10 +18062,6 @@ rebuilt        : ScopeId(0): ["a", "b", "i", "i1", "i2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -24181,14 +18131,6 @@ rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(5)]
 rebuilt        : SymbolId(2): []
-
-tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
 semantic error: Missing SymbolId: M
@@ -24288,14 +18230,6 @@ rebuilt        : ReferenceId(8): Some("A")
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 semantic error: Bindings mismatch:
@@ -24676,53 +18610,6 @@ Unresolved references mismatch:
 after transform: ["Array", "takeArray"]
 rebuilt        : ["takeArray"]
 
-tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["EmptyString", "Falsy", "MyDiscriminatedUnion", "TEST_CASES", "Union", "assertRelationIsNullOrStringArray", "broken", "check1", "check2", "example1", "example2", "example3", "f1", "f1x", "f2", "fx1", "fx10", "fx2", "fx3", "fx4", "fx5", "isEmpty", "test", "test1", "test3", "v1", "v2", "working", "workingAgain"]
-rebuilt        : ScopeId(0): ["TEST_CASES", "assertRelationIsNullOrStringArray", "check1", "check2", "example1", "example2", "example3", "f1", "f1x", "f2", "fx1", "fx10", "fx2", "fx3", "fx4", "fx5", "isEmpty", "test", "test1", "test3", "v1", "v2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(21), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(38), ScopeId(41), ScopeId(46), ScopeId(49), ScopeId(54), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(80)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(12), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(23), ScopeId(26), ScopeId(31), ScopeId(34), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(57), ScopeId(60)]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "x"]
-rebuilt        : ScopeId(3): ["x"]
-Bindings mismatch:
-after transform: ScopeId(7): ["T", "x"]
-rebuilt        : ScopeId(5): ["x"]
-Bindings mismatch:
-after transform: ScopeId(17): ["T", "c", "obj"]
-rebuilt        : ScopeId(9): ["c", "obj"]
-Reference symbol mismatch:
-after transform: ReferenceId(117): Some("working")
-rebuilt        : ReferenceId(97): None
-Reference symbol mismatch:
-after transform: ReferenceId(118): Some("working")
-rebuilt        : ReferenceId(98): None
-Reference symbol mismatch:
-after transform: ReferenceId(119): Some("working")
-rebuilt        : ReferenceId(99): None
-Reference symbol mismatch:
-after transform: ReferenceId(121): Some("broken")
-rebuilt        : ReferenceId(101): None
-Reference symbol mismatch:
-after transform: ReferenceId(122): Some("broken")
-rebuilt        : ReferenceId(102): None
-Reference symbol mismatch:
-after transform: ReferenceId(123): Some("broken")
-rebuilt        : ReferenceId(103): None
-Reference symbol mismatch:
-after transform: ReferenceId(125): Some("workingAgain")
-rebuilt        : ReferenceId(105): None
-Reference symbol mismatch:
-after transform: ReferenceId(126): Some("workingAgain")
-rebuilt        : ReferenceId(106): None
-Reference symbol mismatch:
-after transform: ReferenceId(127): Some("workingAgain")
-rebuilt        : ReferenceId(107): None
-Unresolved references mismatch:
-after transform: ["Record", "X", "XS", "Y", "YS", "assert", "isA", "isEmptyArray", "isEmptyStrOrUndefined", "isEmptyString", "isFalsy", "isMaybeEmptyArray", "isMaybeEmptyString", "isMaybeZero", "isMyDiscriminatedUnion", "isXSorY", "isZero", "undefined"]
-rebuilt        : ["assert", "broken", "isA", "isEmptyArray", "isEmptyStrOrUndefined", "isEmptyString", "isFalsy", "isMaybeEmptyArray", "isMaybeEmptyString", "isMaybeZero", "isMyDiscriminatedUnion", "isXSorY", "isZero", "undefined", "working", "workingAgain"]
-
 tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BorkedType", "FixedType", "WorkingType", "borked", "fixed", "working"]
@@ -24905,8 +18792,8 @@ Bindings mismatch:
 after transform: ScopeId(14): ["DISPATCH", "GatewayOpcode", "HEARTBEAT", "HEARTBEAT_ACK", "HELLO", "IDENTIFY", "INVALID_SESSION", "PRESENCE_UPDATE", "RECONNECT", "REQUEST_GUILD_MEMBERS", "RESUME", "VOICE_STATE_UPDATE"]
 rebuilt        : ScopeId(5): ["GatewayOpcode"]
 Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(14): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(14): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | Export)
@@ -25011,17 +18898,6 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(2): ["T"]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IListenable", "ObservableValue", "notifyListeners"]
@@ -25060,14 +18936,6 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["decorator"]
-
-tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringInPrivateMethod.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Arg", "Bar"]
-rebuilt        : ScopeId(0): ["Bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctionExpressionAssignment.ts
 semantic error: Bindings mismatch:
@@ -25146,17 +19014,6 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(8)]
 rebuilt        : SymbolId(3): []
-
-tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["EnhancedPrisma", "PrismaClient", "TPrismaClientCtor", "enhancePrisma"]
-rebuilt        : ScopeId(0): ["EnhancedPrisma", "PrismaClient"]
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("enhancePrisma")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["enhancePrisma"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -25331,17 +19188,6 @@ Bindings mismatch:
 after transform: ScopeId(8): ["T", "U", "x", "z"]
 rebuilt        : ScopeId(3): ["x", "z"]
 
-tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "x", "y"]
-rebuilt        : ScopeId(1): ["x", "y"]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "x"]
-rebuilt        : ScopeId(3): ["x"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "obj"]
-rebuilt        : ScopeId(5): ["obj"]
-
 tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ordering", "Query", "QueryHandler", "StateNodesConfig", "StateSchema"]
@@ -25421,69 +19267,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
-
-tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
-semantic error: Missing ReferenceId: N1
-Missing ReferenceId: N1
-Missing ReferenceId: N2
-Missing ReferenceId: N2
-Bindings mismatch:
-after transform: ScopeId(0): ["Bins1", "Bins2", "E", "E1", "E2", "N1", "N2", "T1", "b1", "b2", "e", "e1", "e2", "x"]
-rebuilt        : ScopeId(0): ["E1", "N1", "N2", "b1", "b2", "e", "e1", "e2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(1): ["E1", "ONE", "THREE", "TWO"]
-rebuilt        : ScopeId(1): ["E1"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "B", "N1"]
-rebuilt        : ScopeId(2): ["N1"]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(9): ["C", "D", "N2"]
-rebuilt        : ScopeId(3): ["N2"]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(32)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): [ReferenceId(18), ReferenceId(38)]
-rebuilt        : SymbolId(6): [ReferenceId(23)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(31): [ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37)]
-rebuilt        : SymbolId(7): [ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22)]
-Symbol flags mismatch:
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(19): [ReferenceId(19), ReferenceId(44)]
-rebuilt        : SymbolId(8): [ReferenceId(31)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(32): [ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43)]
-rebuilt        : SymbolId(9): [ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30)]
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("E2")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(22): Some("E")
-rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: ["val"]
-rebuilt        : ["E", "E2"]
 
 tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint3.ts
 semantic error: Symbol reference IDs mismatch:
@@ -25577,11 +19360,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/objectLiteralDeclarationGeneration1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Nums", "Strs", "TestNums", "TestStrs", "a", "an", "b", "bn", "m", "n", "um", "un", "ux", "uz", "x", "y", "z"]
@@ -25663,17 +19441,6 @@ Unresolved references mismatch:
 after transform: ["Observable", "from", "of"]
 rebuilt        : ["from", "of"]
 
-tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Baz", "Foo", "getBarA", "getBazA"]
-rebuilt        : ScopeId(0): ["getBarA", "getBazA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["Omit"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyPropertyDescriptor", "MyPropertyDescriptor2"]
@@ -25724,11 +19491,6 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable", "true"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/outModuleTripleSlashRefs.ts
-semantic error: Unresolved references mismatch:
-after transform: ["GlobalFoo"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overload2.ts
@@ -26128,14 +19890,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/parenthesisDoesNotBlockAliasSymbolCreation.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "A2", "InvalidKeys", "InvalidKeys2", "a", "a2", "a3", "a4"]
-rebuilt        : ScopeId(0): ["a", "a2", "a3", "a4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/parseArrowFunctionWithFunctionReturnType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -26481,332 +20235,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Kind", "result"]
-rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyAccessorDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateGetAccessorTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicGetAccessorTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateSetAccessorTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicSetAccessorTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPrivateModuleGetAccessorTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPrivateModuleSetAccessorTypes
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPrivateGetAccessorTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicGetAccessorTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPrivateSetAccessorTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicSetAccessorTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPrivateModuleGetAccessorTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPrivateModuleSetAccessorTypes
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(69)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(70)]
-Binding symbols mismatch:
-after transform: ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(46), SymbolId(51), SymbolId(56), SymbolId(61), SymbolId(62), SymbolId(65), SymbolId(66), SymbolId(104)]
-rebuilt        : ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(47), SymbolId(52), SymbolId(57), SymbolId(62), SymbolId(63), SymbolId(66), SymbolId(67)]
-Binding symbols mismatch:
-after transform: ScopeId(150): [SymbolId(70), SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(81), SymbolId(86), SymbolId(91), SymbolId(96), SymbolId(97), SymbolId(100), SymbolId(101), SymbolId(105)]
-rebuilt        : ScopeId(150): [SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(83), SymbolId(88), SymbolId(93), SymbolId(98), SymbolId(99), SymbolId(102), SymbolId(103)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47)]
-rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(35): [ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103)]
-rebuilt        : SymbolId(36): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37)]
-Symbol flags mismatch:
-after transform: SymbolId(36): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(37): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(36): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107)]
-rebuilt        : SymbolId(37): [ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
-Symbol flags mismatch:
-after transform: SymbolId(37): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(38): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(37): []
-rebuilt        : SymbolId(38): [ReferenceId(27)]
-Symbol flags mismatch:
-after transform: SymbolId(38): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(39): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(39): [ReferenceId(33)]
-Symbol flags mismatch:
-after transform: SymbolId(41): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(42): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(42): [ReferenceId(43)]
-Symbol flags mismatch:
-after transform: SymbolId(46): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(47): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(46): []
-rebuilt        : SymbolId(47): [ReferenceId(45)]
-Symbol flags mismatch:
-after transform: SymbolId(61): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(62): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(61): []
-rebuilt        : SymbolId(62): [ReferenceId(49)]
-Symbol flags mismatch:
-after transform: SymbolId(62): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(63): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(62): []
-rebuilt        : SymbolId(63): [ReferenceId(51)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(70): [ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163)]
-rebuilt        : SymbolId(72): [ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73)]
-Symbol flags mismatch:
-after transform: SymbolId(71): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(73): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(71): [ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167)]
-rebuilt        : SymbolId(73): [ReferenceId(57), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77)]
-Symbol flags mismatch:
-after transform: SymbolId(72): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(74): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(72): []
-rebuilt        : SymbolId(74): [ReferenceId(63)]
-Symbol flags mismatch:
-after transform: SymbolId(73): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(75): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(73): []
-rebuilt        : SymbolId(75): [ReferenceId(69)]
-Symbol flags mismatch:
-after transform: SymbolId(76): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(78): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(76): []
-rebuilt        : SymbolId(78): [ReferenceId(79)]
-Symbol flags mismatch:
-after transform: SymbolId(81): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(83): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(81): []
-rebuilt        : SymbolId(83): [ReferenceId(81)]
-Symbol flags mismatch:
-after transform: SymbolId(96): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(98): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(96): []
-rebuilt        : SymbolId(98): [ReferenceId(85)]
-Symbol flags mismatch:
-after transform: SymbolId(97): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(99): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(97): []
-rebuilt        : SymbolId(99): [ReferenceId(87)]
-Reference symbol mismatch:
-after transform: ReferenceId(50): Some("privateModule")
-rebuilt        : ReferenceId(16): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(51): Some("privateModule")
-rebuilt        : ReferenceId(17): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(56): Some("privateModule")
-rebuilt        : ReferenceId(18): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(57): Some("privateModule")
-rebuilt        : ReferenceId(19): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(110): Some("privateModule")
-rebuilt        : ReferenceId(46): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(111): Some("privateModule")
-rebuilt        : ReferenceId(47): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(116): Some("privateModule")
-rebuilt        : ReferenceId(52): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(117): Some("privateModule")
-rebuilt        : ReferenceId(53): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(170): Some("privateModule")
-rebuilt        : ReferenceId(82): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(171): Some("privateModule")
-rebuilt        : ReferenceId(83): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(176): Some("privateModule")
-rebuilt        : ReferenceId(88): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(177): Some("privateModule")
-rebuilt        : ReferenceId(89): Some("privateModule")
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameAccessorDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["GlobalWidgets"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["GlobalWidgets"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter.ts
-semantic error: Missing SymbolId: Query
-Missing SymbolId: _Query
-Missing ReferenceId: _Query
-Missing ReferenceId: fromDoWhile
-Missing ReferenceId: Query
-Missing ReferenceId: Query
-Bindings mismatch:
-after transform: ScopeId(0): ["Iterator", "Query", "x"]
-rebuilt        : ScopeId(0): ["Query", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(4), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "doWhile"]
-rebuilt        : ScopeId(2): ["doWhile"]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter2.ts
-semantic error: Missing SymbolId: Q
-Missing SymbolId: _Q
-Missing ReferenceId: _Q
-Missing ReferenceId: foo
-Missing ReferenceId: Q
-Missing ReferenceId: Q
-Missing SymbolId: _Q2
-Missing ReferenceId: Q
-Missing ReferenceId: Q
-Bindings mismatch:
-after transform: ScopeId(0): ["Iterator", "Q", "x"]
-rebuilt        : ScopeId(0): ["Q", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "x"]
-rebuilt        : ScopeId(2): ["x"]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(3): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckCallbackOfInterfaceMethodWithTypeParameter.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface | NameSpaceModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 7, end: 10 }
-rebuilt        : SymbolId(0): Span { start: 74, end: 107 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 59, end: 62 }, Span { start: 74, end: 107 }]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface2.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T1"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(3): ["T2"]
-rebuilt        : ScopeId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfFunction.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
 tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -26853,12 +20281,18 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(33), ScopeId(35),
 Bindings mismatch:
 after transform: ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public", "m1_i_private", "m1_i_public"]
 rebuilt        : ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 Bindings mismatch:
 after transform: ScopeId(19): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public", "m2_i_private", "m2_i_public"]
 rebuilt        : ScopeId(17): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public"]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
 rebuilt        : ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
@@ -26946,93 +20380,6 @@ rebuilt        : SymbolId(31): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(33): []
 rebuilt        : SymbolId(31): [ReferenceId(45)]
-
-tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassImplementingPublicInterfaceInModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassImplementingPrivateInterfaceInModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassImplementingFromPrivateModuleInterface
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassImplementingPrivateAndPublicInterface
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassImplementingPublicInterfaceInModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassImplementingPrivateInterfaceInModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassImplementingFromPrivateModuleInterface
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Bindings mismatch:
-after transform: ScopeId(0): ["privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterface", "privateInterface", "privateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterface", "publicClassImplementingPublicInterface", "publicInterface", "publicModule"]
-rebuilt        : ScopeId(0): ["privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterface", "privateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterface", "publicClassImplementingPublicInterface", "publicModule"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-Bindings mismatch:
-after transform: ScopeId(1): ["_publicModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "privateInterfaceInPublicModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateAndPublicInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule", "publicInterfaceInPublicModule"]
-rebuilt        : ScopeId(1): ["_publicModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateAndPublicInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
-after transform: ScopeId(11): ["_privateModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "privateInterfaceInPrivateModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule", "publicInterfaceInPrivateModule"]
-rebuilt        : ScopeId(9): ["_privateModule", "privateClassImplementingFromPrivateModuleInterface", "privateClassImplementingPrivateInterfaceInModule", "privateClassImplementingPublicInterfaceInModule", "publicClassImplementingFromPrivateModuleInterface", "publicClassImplementingPrivateInterfaceInModule", "publicClassImplementingPublicInterfaceInModule"]
-Scope children mismatch:
-after transform: ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
-rebuilt        : ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(5): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(5): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(7): [ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(8): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(8): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(15): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(13): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(13): [ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(14): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(16): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(16): [ReferenceId(15)]
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
 semantic error: Missing SymbolId: m1
@@ -27144,488 +20491,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
 rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
-tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["GlobalWidgets"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["GlobalWidgets"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Bindings mismatch:
-after transform: ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes", "publicModule"]
-rebuilt        : ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicModule"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(33), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(50), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(59), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(130)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(35), ScopeId(36), ScopeId(40), ScopeId(41), ScopeId(82)]
-Bindings mismatch:
-after transform: ScopeId(65): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
-rebuilt        : ScopeId(41): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
-Scope children mismatch:
-after transform: ScopeId(65): [ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(71), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(86), ScopeId(92), ScopeId(98), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(115), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(124), ScopeId(128), ScopeId(129)]
-rebuilt        : ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(50), ScopeId(56), ScopeId(62), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(76), ScopeId(77), ScopeId(81)]
-Bindings mismatch:
-after transform: ScopeId(130): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
-rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
-Scope children mismatch:
-after transform: ScopeId(130): [ScopeId(131), ScopeId(132), ScopeId(133), ScopeId(136), ScopeId(139), ScopeId(142), ScopeId(145), ScopeId(151), ScopeId(157), ScopeId(163), ScopeId(169), ScopeId(170), ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(177), ScopeId(180), ScopeId(184), ScopeId(185), ScopeId(186), ScopeId(189), ScopeId(193), ScopeId(194)]
-rebuilt        : ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(91), ScopeId(97), ScopeId(103), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(113), ScopeId(117), ScopeId(118), ScopeId(122)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(71): [ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134)]
-rebuilt        : SymbolId(60): []
-Symbol flags mismatch:
-after transform: SymbolId(72): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(61): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(72): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151)]
-rebuilt        : SymbolId(61): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(77): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(62): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(77): []
-rebuilt        : SymbolId(62): [ReferenceId(17)]
-Symbol flags mismatch:
-after transform: SymbolId(85): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(70): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(85): []
-rebuilt        : SymbolId(70): [ReferenceId(21)]
-Symbol flags mismatch:
-after transform: SymbolId(109): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(94): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(109): []
-rebuilt        : SymbolId(94): [ReferenceId(27)]
-Symbol flags mismatch:
-after transform: SymbolId(111): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(96): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(111): []
-rebuilt        : SymbolId(96): [ReferenceId(29)]
-Symbol flags mismatch:
-after transform: SymbolId(113): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(98): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(115): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(100): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(122): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(102): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(122): []
-rebuilt        : SymbolId(102): [ReferenceId(33)]
-Symbol flags mismatch:
-after transform: SymbolId(128): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(108): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(128): []
-rebuilt        : SymbolId(108): [ReferenceId(35)]
-Symbol flags mismatch:
-after transform: SymbolId(138): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(116): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(142): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214)]
-rebuilt        : SymbolId(120): []
-Symbol flags mismatch:
-after transform: SymbolId(143): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(121): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(143): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231)]
-rebuilt        : SymbolId(121): [ReferenceId(41)]
-Symbol flags mismatch:
-after transform: SymbolId(148): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(122): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(148): []
-rebuilt        : SymbolId(122): [ReferenceId(45)]
-Symbol flags mismatch:
-after transform: SymbolId(156): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(130): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(156): []
-rebuilt        : SymbolId(130): [ReferenceId(49)]
-Symbol flags mismatch:
-after transform: SymbolId(180): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(154): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(180): []
-rebuilt        : SymbolId(154): [ReferenceId(55)]
-Symbol flags mismatch:
-after transform: SymbolId(182): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(156): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(182): []
-rebuilt        : SymbolId(156): [ReferenceId(57)]
-Symbol flags mismatch:
-after transform: SymbolId(184): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(158): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(186): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(160): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(193): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(162): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(193): []
-rebuilt        : SymbolId(162): [ReferenceId(61)]
-Symbol flags mismatch:
-after transform: SymbolId(199): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(168): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(199): []
-rebuilt        : SymbolId(168): [ReferenceId(63)]
-Symbol flags mismatch:
-after transform: SymbolId(209): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(176): SymbolFlags(FunctionScopedVariable)
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes1
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes1
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes1
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPrivateParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateParmeterTypes1
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPublicParmeterTypes1
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPrivateModuleParameterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateModuleParameterTypes1
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Bindings mismatch:
-after transform: ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes", "publicModule"]
-rebuilt        : ScopeId(0): ["privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateModule", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicModule"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(24), ScopeId(33), ScopeId(42), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(66), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(82), ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(170)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(12), ScopeId(21), ScopeId(30), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(122)]
-Bindings mismatch:
-after transform: ScopeId(85): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
-rebuilt        : ScopeId(61): ["_publicModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1"]
-Scope children mismatch:
-after transform: ScopeId(85): [ScopeId(86), ScopeId(87), ScopeId(88), ScopeId(91), ScopeId(94), ScopeId(97), ScopeId(100), ScopeId(109), ScopeId(118), ScopeId(127), ScopeId(136), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147), ScopeId(148), ScopeId(151), ScopeId(156), ScopeId(157), ScopeId(158), ScopeId(159), ScopeId(162), ScopeId(167), ScopeId(168), ScopeId(169)]
-rebuilt        : ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(73), ScopeId(82), ScopeId(91), ScopeId(100), ScopeId(101), ScopeId(102), ScopeId(103), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(113), ScopeId(114), ScopeId(115), ScopeId(120), ScopeId(121)]
-Bindings mismatch:
-after transform: ScopeId(170): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "privateInterfaceWithPrivateModuleParameterTypes", "privateInterfaceWithPrivateParmeterTypes", "privateInterfaceWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1", "publicInterfaceWithPrivateModuleParameterTypes", "publicInterfaceWithPrivateParmeterTypes", "publicInterfaceWithPublicParmeterTypes"]
-rebuilt        : ScopeId(122): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateModuleParameterTypes1", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPrivateParmeterTypes1", "privateFunctionWithPublicParmeterTypes", "privateFunctionWithPublicParmeterTypes1", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateModuleParameterTypes1", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPrivateParmeterTypes1", "publicFunctionWithPublicParmeterTypes", "publicFunctionWithPublicParmeterTypes1"]
-Scope children mismatch:
-after transform: ScopeId(170): [ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(176), ScopeId(179), ScopeId(182), ScopeId(185), ScopeId(194), ScopeId(203), ScopeId(212), ScopeId(221), ScopeId(222), ScopeId(223), ScopeId(224), ScopeId(225), ScopeId(226), ScopeId(227), ScopeId(228), ScopeId(229), ScopeId(230), ScopeId(231), ScopeId(232), ScopeId(233), ScopeId(236), ScopeId(241), ScopeId(242), ScopeId(243), ScopeId(244), ScopeId(247), ScopeId(252), ScopeId(253), ScopeId(254)]
-rebuilt        : ScopeId(122): [ScopeId(123), ScopeId(124), ScopeId(125), ScopeId(134), ScopeId(143), ScopeId(152), ScopeId(161), ScopeId(162), ScopeId(163), ScopeId(164), ScopeId(165), ScopeId(166), ScopeId(167), ScopeId(168), ScopeId(169), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(181), ScopeId(182)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(16), ReferenceId(18)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59)]
-rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(27): [ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(98), ReferenceId(99), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(140)]
-rebuilt        : SymbolId(22): [ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(58)]
-Symbol flags mismatch:
-after transform: SymbolId(28): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(23): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(28): [ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(141)]
-rebuilt        : SymbolId(23): [ReferenceId(27), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(55), ReferenceId(59)]
-Symbol flags mismatch:
-after transform: SymbolId(33): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(24): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(24): [ReferenceId(33)]
-Symbol flags mismatch:
-after transform: SymbolId(34): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(25): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(34): []
-rebuilt        : SymbolId(25): [ReferenceId(39)]
-Symbol flags mismatch:
-after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(37): []
-rebuilt        : SymbolId(28): [ReferenceId(49)]
-Symbol flags mismatch:
-after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(29): [ReferenceId(51)]
-Symbol flags mismatch:
-after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(40): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(31): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(32): [ReferenceId(54)]
-Symbol flags mismatch:
-after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(42): []
-rebuilt        : SymbolId(33): [ReferenceId(57)]
-Symbol flags mismatch:
-after transform: SymbolId(43): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(44): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(46): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(36): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(46): []
-rebuilt        : SymbolId(36): [ReferenceId(63)]
-Symbol flags mismatch:
-after transform: SymbolId(47): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(47): []
-rebuilt        : SymbolId(37): [ReferenceId(65)]
-Symbol flags mismatch:
-after transform: SymbolId(48): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(48): []
-rebuilt        : SymbolId(38): [ReferenceId(68)]
-Symbol flags mismatch:
-after transform: SymbolId(51): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(40): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(52): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(41): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(54): [ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(212), ReferenceId(214), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222)]
-rebuilt        : SymbolId(44): [ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(100), ReferenceId(106)]
-Symbol flags mismatch:
-after transform: SymbolId(55): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(45): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(55): [ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208), ReferenceId(209), ReferenceId(210), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(223)]
-rebuilt        : SymbolId(45): [ReferenceId(75), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(103), ReferenceId(107)]
-Symbol flags mismatch:
-after transform: SymbolId(60): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(46): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(60): []
-rebuilt        : SymbolId(46): [ReferenceId(81)]
-Symbol flags mismatch:
-after transform: SymbolId(61): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(47): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(61): []
-rebuilt        : SymbolId(47): [ReferenceId(87)]
-Symbol flags mismatch:
-after transform: SymbolId(64): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(50): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(64): []
-rebuilt        : SymbolId(50): [ReferenceId(97)]
-Symbol flags mismatch:
-after transform: SymbolId(65): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(51): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(65): []
-rebuilt        : SymbolId(51): [ReferenceId(99)]
-Symbol flags mismatch:
-after transform: SymbolId(66): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(67): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(68): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(54): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(68): []
-rebuilt        : SymbolId(54): [ReferenceId(102)]
-Symbol flags mismatch:
-after transform: SymbolId(69): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(55): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(69): []
-rebuilt        : SymbolId(55): [ReferenceId(105)]
-Symbol flags mismatch:
-after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(56): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(71): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(57): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(73): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(58): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(73): []
-rebuilt        : SymbolId(58): [ReferenceId(111)]
-Symbol flags mismatch:
-after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(59): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(74): []
-rebuilt        : SymbolId(59): [ReferenceId(113)]
-Symbol flags mismatch:
-after transform: SymbolId(75): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(60): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(75): []
-rebuilt        : SymbolId(60): [ReferenceId(116)]
-Symbol flags mismatch:
-after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(62): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(63): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch:
-after transform: ReferenceId(66): Some("privateModule")
-rebuilt        : ReferenceId(20): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(67): Some("privateModule")
-rebuilt        : ReferenceId(21): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(69): Some("privateModule")
-rebuilt        : ReferenceId(22): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(77): Some("privateModule")
-rebuilt        : ReferenceId(23): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(78): Some("privateModule")
-rebuilt        : ReferenceId(24): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(80): Some("privateModule")
-rebuilt        : ReferenceId(25): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(148): Some("privateModule")
-rebuilt        : ReferenceId(60): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(149): Some("privateModule")
-rebuilt        : ReferenceId(61): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(151): Some("privateModule")
-rebuilt        : ReferenceId(66): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(159): Some("privateModule")
-rebuilt        : ReferenceId(69): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(160): Some("privateModule")
-rebuilt        : ReferenceId(70): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(162): Some("privateModule")
-rebuilt        : ReferenceId(71): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(230): Some("privateModule")
-rebuilt        : ReferenceId(108): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(231): Some("privateModule")
-rebuilt        : ReferenceId(109): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(233): Some("privateModule")
-rebuilt        : ReferenceId(114): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(241): Some("privateModule")
-rebuilt        : ReferenceId(117): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(242): Some("privateModule")
-rebuilt        : ReferenceId(118): Some("privateModule")
-Reference symbol mismatch:
-after transform: ReferenceId(244): Some("privateModule")
-rebuilt        : ReferenceId(119): Some("privateModule")
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -27649,9 +20514,15 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(28), SymbolId(
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(38)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(23): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(21), SymbolId(39)]
 rebuilt        : ScopeId(23): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(23)]
+Scope flags mismatch:
+after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(23): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -27821,6 +20692,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(80), SymbolId(
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(128)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
@@ -27830,6 +20704,9 @@ rebuilt        : ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23
 Binding symbols mismatch:
 after transform: ScopeId(57): [SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(54), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(74), SymbolId(76), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(83), SymbolId(84), SymbolId(85), SymbolId(129)]
 rebuilt        : ScopeId(53): [SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(50), SymbolId(56), SymbolId(58), SymbolId(60), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(79)]
+Scope flags mismatch:
+after transform: ScopeId(57): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(53): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76)]
 rebuilt        : ScopeId(57): [ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70)]
@@ -27870,55 +20747,37 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(23): []
 rebuilt        : SymbolId(20): [ReferenceId(23)]
 Symbol flags mismatch:
-after transform: SymbolId(27): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(24): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(29): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(29): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(29): []
 rebuilt        : SymbolId(26): [ReferenceId(25)]
 Symbol flags mismatch:
-after transform: SymbolId(31): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(33): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(33): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(33): []
 rebuilt        : SymbolId(30): [ReferenceId(27)]
 Symbol flags mismatch:
-after transform: SymbolId(35): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(36): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(36): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(36): []
 rebuilt        : SymbolId(33): [ReferenceId(31)]
 Symbol flags mismatch:
-after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(38): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(38): []
 rebuilt        : SymbolId(35): [ReferenceId(35)]
 Symbol flags mismatch:
-after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(36): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(40): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(40): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(40): []
 rebuilt        : SymbolId(37): [ReferenceId(39)]
 Symbol flags mismatch:
-after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(42): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(39): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(42): []
@@ -27951,55 +20810,37 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(66): []
 rebuilt        : SymbolId(60): [ReferenceId(69)]
 Symbol flags mismatch:
-after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(64): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(72): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(72): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(66): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(72): []
 rebuilt        : SymbolId(66): [ReferenceId(71)]
 Symbol flags mismatch:
-after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(68): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(76): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(76): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(70): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(76): []
 rebuilt        : SymbolId(70): [ReferenceId(73)]
 Symbol flags mismatch:
-after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(72): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(79): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(73): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(79): []
 rebuilt        : SymbolId(73): [ReferenceId(77)]
 Symbol flags mismatch:
-after transform: SymbolId(80): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(74): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(81): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(81): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(75): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(81): []
 rebuilt        : SymbolId(75): [ReferenceId(81)]
 Symbol flags mismatch:
-after transform: SymbolId(82): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(76): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(83): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(83): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(77): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(83): []
 rebuilt        : SymbolId(77): [ReferenceId(85)]
 Symbol flags mismatch:
-after transform: SymbolId(84): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(78): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(85): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(85): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(79): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(85): []
@@ -28048,22 +20889,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(13): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
 rebuilt        : SymbolId(14): [ReferenceId(14), ReferenceId(15)]
 
-tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
 tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -28107,36 +20932,6 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
-tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
 tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
 semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
@@ -28159,12 +20954,18 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(11)]
 Bindings mismatch:
 after transform: ScopeId(1): ["C1_public", "C2_private", "C3_public", "C4_private", "_m"]
 rebuilt        : ScopeId(1): ["C1_public", "C2_private", "_m"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(14)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(23): ["C1_public", "C2_private", "C3_public", "C4_private", "_m2"]
 rebuilt        : ScopeId(5): ["C1_public", "C2_private", "_m2"]
+Scope flags mismatch:
+after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(23): [ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(36)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(8)]
@@ -28192,89 +20993,6 @@ rebuilt        : SymbolId(8): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(11): [ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(87), ReferenceId(89), ReferenceId(91), ReferenceId(93), ReferenceId(95), ReferenceId(97), ReferenceId(99), ReferenceId(101), ReferenceId(103), ReferenceId(105), ReferenceId(107)]
 rebuilt        : SymbolId(9): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["privateInterface", "privateInterfaceImplementingFromPrivateModuleInterface", "privateInterfaceImplementingPrivateInterfaceInModule", "privateInterfaceImplementingPublicInterface", "privateModule", "publicInterface", "publicInterfaceImplementingFromPrivateModuleInterface", "publicInterfaceImplementingPrivateInterface", "publicInterfaceImplementingPublicInterface", "publicModule"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelInternalReferenceImportWithoutExport.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
 semantic error: Bindings mismatch:
@@ -28380,504 +21098,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(1): []
 
-tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPublicTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithWithPrivateModuleTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicFunctionWithPrivateMopduleTypeParameters
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClass
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPrivateTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPrivateTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPublicTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicFunctionWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Bindings mismatch:
-after transform: ScopeId(0): ["privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivatModuleTypeParameters", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivatModuleTypeParameters", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends", "publicModule"]
-rebuilt        : ScopeId(0): ["privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicModule"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(20), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(45), ScopeId(50), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(60), ScopeId(63), ScopeId(64), ScopeId(67), ScopeId(70), ScopeId(71), ScopeId(142)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(8), ScopeId(13), ScopeId(18), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(32), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(46), ScopeId(47), ScopeId(94)]
-Bindings mismatch:
-after transform: ScopeId(16): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(17): ["T"]
-rebuilt        : ScopeId(5): []
-Bindings mismatch:
-after transform: ScopeId(18): ["T"]
-rebuilt        : ScopeId(6): []
-Bindings mismatch:
-after transform: ScopeId(19): ["T"]
-rebuilt        : ScopeId(7): []
-Bindings mismatch:
-after transform: ScopeId(21): ["T"]
-rebuilt        : ScopeId(9): []
-Bindings mismatch:
-after transform: ScopeId(22): ["T"]
-rebuilt        : ScopeId(10): []
-Bindings mismatch:
-after transform: ScopeId(23): ["T"]
-rebuilt        : ScopeId(11): []
-Bindings mismatch:
-after transform: ScopeId(24): ["T"]
-rebuilt        : ScopeId(12): []
-Bindings mismatch:
-after transform: ScopeId(26): ["T"]
-rebuilt        : ScopeId(14): []
-Bindings mismatch:
-after transform: ScopeId(27): ["T"]
-rebuilt        : ScopeId(15): []
-Bindings mismatch:
-after transform: ScopeId(28): ["T"]
-rebuilt        : ScopeId(16): []
-Bindings mismatch:
-after transform: ScopeId(29): ["T"]
-rebuilt        : ScopeId(17): []
-Bindings mismatch:
-after transform: ScopeId(31): ["T"]
-rebuilt        : ScopeId(19): []
-Bindings mismatch:
-after transform: ScopeId(32): ["T"]
-rebuilt        : ScopeId(20): []
-Bindings mismatch:
-after transform: ScopeId(33): ["T"]
-rebuilt        : ScopeId(21): []
-Bindings mismatch:
-after transform: ScopeId(34): ["T"]
-rebuilt        : ScopeId(22): []
-Bindings mismatch:
-after transform: ScopeId(35): ["T"]
-rebuilt        : ScopeId(23): []
-Bindings mismatch:
-after transform: ScopeId(36): ["T"]
-rebuilt        : ScopeId(24): []
-Bindings mismatch:
-after transform: ScopeId(37): ["T"]
-rebuilt        : ScopeId(25): []
-Bindings mismatch:
-after transform: ScopeId(38): ["T"]
-rebuilt        : ScopeId(26): []
-Bindings mismatch:
-after transform: ScopeId(46): ["T"]
-rebuilt        : ScopeId(28): []
-Bindings mismatch:
-after transform: ScopeId(47): ["T"]
-rebuilt        : ScopeId(29): []
-Bindings mismatch:
-after transform: ScopeId(48): ["T"]
-rebuilt        : ScopeId(30): []
-Bindings mismatch:
-after transform: ScopeId(49): ["T"]
-rebuilt        : ScopeId(31): []
-Bindings mismatch:
-after transform: ScopeId(51): ["T"]
-rebuilt        : ScopeId(33): []
-Bindings mismatch:
-after transform: ScopeId(52): ["T"]
-rebuilt        : ScopeId(34): []
-Bindings mismatch:
-after transform: ScopeId(53): ["T"]
-rebuilt        : ScopeId(35): []
-Bindings mismatch:
-after transform: ScopeId(54): ["T"]
-rebuilt        : ScopeId(36): []
-Bindings mismatch:
-after transform: ScopeId(55): ["T"]
-rebuilt        : ScopeId(37): []
-Bindings mismatch:
-after transform: ScopeId(56): ["T"]
-rebuilt        : ScopeId(38): []
-Bindings mismatch:
-after transform: ScopeId(61): ["T"]
-rebuilt        : ScopeId(40): []
-Bindings mismatch:
-after transform: ScopeId(62): ["T"]
-rebuilt        : ScopeId(41): []
-Bindings mismatch:
-after transform: ScopeId(63): ["T"]
-rebuilt        : ScopeId(42): []
-Bindings mismatch:
-after transform: ScopeId(68): ["T"]
-rebuilt        : ScopeId(44): []
-Bindings mismatch:
-after transform: ScopeId(69): ["T"]
-rebuilt        : ScopeId(45): []
-Bindings mismatch:
-after transform: ScopeId(70): ["T"]
-rebuilt        : ScopeId(46): []
-Bindings mismatch:
-after transform: ScopeId(71): ["_publicModule", "privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivatModuleTypeParameters", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivatModuleTypeParameters", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
-rebuilt        : ScopeId(47): ["_publicModule", "privateClass", "privateClassWithWithPrivateModuleTypeParameters", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateMopduleTypeParameters", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateModuleTypeParameters", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateMopduleTypeParameters", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends"]
-Scope children mismatch:
-after transform: ScopeId(71): [ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(83), ScopeId(86), ScopeId(91), ScopeId(96), ScopeId(101), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(113), ScopeId(116), ScopeId(121), ScopeId(126), ScopeId(127), ScopeId(128), ScopeId(131), ScopeId(134), ScopeId(135), ScopeId(138), ScopeId(141)]
-rebuilt        : ScopeId(47): [ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(55), ScopeId(60), ScopeId(65), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(79), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(89), ScopeId(90), ScopeId(93)]
-Bindings mismatch:
-after transform: ScopeId(87): ["T"]
-rebuilt        : ScopeId(51): []
-Bindings mismatch:
-after transform: ScopeId(88): ["T"]
-rebuilt        : ScopeId(52): []
-Bindings mismatch:
-after transform: ScopeId(89): ["T"]
-rebuilt        : ScopeId(53): []
-Bindings mismatch:
-after transform: ScopeId(90): ["T"]
-rebuilt        : ScopeId(54): []
-Bindings mismatch:
-after transform: ScopeId(92): ["T"]
-rebuilt        : ScopeId(56): []
-Bindings mismatch:
-after transform: ScopeId(93): ["T"]
-rebuilt        : ScopeId(57): []
-Bindings mismatch:
-after transform: ScopeId(94): ["T"]
-rebuilt        : ScopeId(58): []
-Bindings mismatch:
-after transform: ScopeId(95): ["T"]
-rebuilt        : ScopeId(59): []
-Bindings mismatch:
-after transform: ScopeId(97): ["T"]
-rebuilt        : ScopeId(61): []
-Bindings mismatch:
-after transform: ScopeId(98): ["T"]
-rebuilt        : ScopeId(62): []
-Bindings mismatch:
-after transform: ScopeId(99): ["T"]
-rebuilt        : ScopeId(63): []
-Bindings mismatch:
-after transform: ScopeId(100): ["T"]
-rebuilt        : ScopeId(64): []
-Bindings mismatch:
-after transform: ScopeId(102): ["T"]
-rebuilt        : ScopeId(66): []
-Bindings mismatch:
-after transform: ScopeId(103): ["T"]
-rebuilt        : ScopeId(67): []
-Bindings mismatch:
-after transform: ScopeId(104): ["T"]
-rebuilt        : ScopeId(68): []
-Bindings mismatch:
-after transform: ScopeId(105): ["T"]
-rebuilt        : ScopeId(69): []
-Bindings mismatch:
-after transform: ScopeId(106): ["T"]
-rebuilt        : ScopeId(70): []
-Bindings mismatch:
-after transform: ScopeId(107): ["T"]
-rebuilt        : ScopeId(71): []
-Bindings mismatch:
-after transform: ScopeId(108): ["T"]
-rebuilt        : ScopeId(72): []
-Bindings mismatch:
-after transform: ScopeId(109): ["T"]
-rebuilt        : ScopeId(73): []
-Bindings mismatch:
-after transform: ScopeId(117): ["T"]
-rebuilt        : ScopeId(75): []
-Bindings mismatch:
-after transform: ScopeId(118): ["T"]
-rebuilt        : ScopeId(76): []
-Bindings mismatch:
-after transform: ScopeId(119): ["T"]
-rebuilt        : ScopeId(77): []
-Bindings mismatch:
-after transform: ScopeId(120): ["T"]
-rebuilt        : ScopeId(78): []
-Bindings mismatch:
-after transform: ScopeId(122): ["T"]
-rebuilt        : ScopeId(80): []
-Bindings mismatch:
-after transform: ScopeId(123): ["T"]
-rebuilt        : ScopeId(81): []
-Bindings mismatch:
-after transform: ScopeId(124): ["T"]
-rebuilt        : ScopeId(82): []
-Bindings mismatch:
-after transform: ScopeId(125): ["T"]
-rebuilt        : ScopeId(83): []
-Bindings mismatch:
-after transform: ScopeId(126): ["T"]
-rebuilt        : ScopeId(84): []
-Bindings mismatch:
-after transform: ScopeId(127): ["T"]
-rebuilt        : ScopeId(85): []
-Bindings mismatch:
-after transform: ScopeId(132): ["T"]
-rebuilt        : ScopeId(87): []
-Bindings mismatch:
-after transform: ScopeId(133): ["T"]
-rebuilt        : ScopeId(88): []
-Bindings mismatch:
-after transform: ScopeId(134): ["T"]
-rebuilt        : ScopeId(89): []
-Bindings mismatch:
-after transform: ScopeId(139): ["T"]
-rebuilt        : ScopeId(91): []
-Bindings mismatch:
-after transform: ScopeId(140): ["T"]
-rebuilt        : ScopeId(92): []
-Bindings mismatch:
-after transform: ScopeId(141): ["T"]
-rebuilt        : ScopeId(93): []
-Bindings mismatch:
-after transform: ScopeId(142): ["_privateModule", "privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
-rebuilt        : ScopeId(94): ["_privateModule", "privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends"]
-Scope children mismatch:
-after transform: ScopeId(142): [ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(148), ScopeId(151), ScopeId(154), ScopeId(157), ScopeId(162), ScopeId(167), ScopeId(172), ScopeId(177), ScopeId(178), ScopeId(179), ScopeId(180), ScopeId(181), ScopeId(184), ScopeId(187), ScopeId(192), ScopeId(197), ScopeId(198)]
-rebuilt        : ScopeId(94): [ScopeId(95), ScopeId(96), ScopeId(97), ScopeId(102), ScopeId(107), ScopeId(112), ScopeId(117), ScopeId(118), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(126), ScopeId(131), ScopeId(132)]
-Bindings mismatch:
-after transform: ScopeId(158): ["T"]
-rebuilt        : ScopeId(98): []
-Bindings mismatch:
-after transform: ScopeId(159): ["T"]
-rebuilt        : ScopeId(99): []
-Bindings mismatch:
-after transform: ScopeId(160): ["T"]
-rebuilt        : ScopeId(100): []
-Bindings mismatch:
-after transform: ScopeId(161): ["T"]
-rebuilt        : ScopeId(101): []
-Bindings mismatch:
-after transform: ScopeId(163): ["T"]
-rebuilt        : ScopeId(103): []
-Bindings mismatch:
-after transform: ScopeId(164): ["T"]
-rebuilt        : ScopeId(104): []
-Bindings mismatch:
-after transform: ScopeId(165): ["T"]
-rebuilt        : ScopeId(105): []
-Bindings mismatch:
-after transform: ScopeId(166): ["T"]
-rebuilt        : ScopeId(106): []
-Bindings mismatch:
-after transform: ScopeId(168): ["T"]
-rebuilt        : ScopeId(108): []
-Bindings mismatch:
-after transform: ScopeId(169): ["T"]
-rebuilt        : ScopeId(109): []
-Bindings mismatch:
-after transform: ScopeId(170): ["T"]
-rebuilt        : ScopeId(110): []
-Bindings mismatch:
-after transform: ScopeId(171): ["T"]
-rebuilt        : ScopeId(111): []
-Bindings mismatch:
-after transform: ScopeId(173): ["T"]
-rebuilt        : ScopeId(113): []
-Bindings mismatch:
-after transform: ScopeId(174): ["T"]
-rebuilt        : ScopeId(114): []
-Bindings mismatch:
-after transform: ScopeId(175): ["T"]
-rebuilt        : ScopeId(115): []
-Bindings mismatch:
-after transform: ScopeId(176): ["T"]
-rebuilt        : ScopeId(116): []
-Bindings mismatch:
-after transform: ScopeId(177): ["T"]
-rebuilt        : ScopeId(117): []
-Bindings mismatch:
-after transform: ScopeId(178): ["T"]
-rebuilt        : ScopeId(118): []
-Bindings mismatch:
-after transform: ScopeId(179): ["T"]
-rebuilt        : ScopeId(119): []
-Bindings mismatch:
-after transform: ScopeId(180): ["T"]
-rebuilt        : ScopeId(120): []
-Bindings mismatch:
-after transform: ScopeId(188): ["T"]
-rebuilt        : ScopeId(122): []
-Bindings mismatch:
-after transform: ScopeId(189): ["T"]
-rebuilt        : ScopeId(123): []
-Bindings mismatch:
-after transform: ScopeId(190): ["T"]
-rebuilt        : ScopeId(124): []
-Bindings mismatch:
-after transform: ScopeId(191): ["T"]
-rebuilt        : ScopeId(125): []
-Bindings mismatch:
-after transform: ScopeId(193): ["T"]
-rebuilt        : ScopeId(127): []
-Bindings mismatch:
-after transform: ScopeId(194): ["T"]
-rebuilt        : ScopeId(128): []
-Bindings mismatch:
-after transform: ScopeId(195): ["T"]
-rebuilt        : ScopeId(129): []
-Bindings mismatch:
-after transform: ScopeId(196): ["T"]
-rebuilt        : ScopeId(130): []
-Bindings mismatch:
-after transform: ScopeId(197): ["T"]
-rebuilt        : ScopeId(131): []
-Bindings mismatch:
-after transform: ScopeId(198): ["T"]
-rebuilt        : ScopeId(132): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(42)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(87): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(110)]
-rebuilt        : SymbolId(20): []
-Symbol flags mismatch:
-after transform: SymbolId(88): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(21): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117)]
-rebuilt        : SymbolId(21): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(105): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(22): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(105): []
-rebuilt        : SymbolId(22): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(110): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(23): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(110): []
-rebuilt        : SymbolId(23): [ReferenceId(5)]
-Symbol flags mismatch:
-after transform: SymbolId(125): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(125): []
-rebuilt        : SymbolId(26): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(127): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(27): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(127): []
-rebuilt        : SymbolId(27): [ReferenceId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(129): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(131): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(141): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(30): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(141): []
-rebuilt        : SymbolId(30): [ReferenceId(11)]
-Symbol flags mismatch:
-after transform: SymbolId(151): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(151): []
-rebuilt        : SymbolId(32): [ReferenceId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(153): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(159): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(34): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(159): []
-rebuilt        : SymbolId(34): [ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(162): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(162): []
-rebuilt        : SymbolId(35): [ReferenceId(17)]
-Symbol flags mismatch:
-after transform: SymbolId(171): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(174): [ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163), ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(178)]
-rebuilt        : SymbolId(40): []
-Symbol flags mismatch:
-after transform: SymbolId(175): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(41): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(175): [ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(177), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185)]
-rebuilt        : SymbolId(41): [ReferenceId(21)]
-Symbol flags mismatch:
-after transform: SymbolId(192): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(42): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(192): []
-rebuilt        : SymbolId(42): [ReferenceId(23)]
-Symbol flags mismatch:
-after transform: SymbolId(197): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(43): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(197): []
-rebuilt        : SymbolId(43): [ReferenceId(25)]
-Symbol flags mismatch:
-after transform: SymbolId(212): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(46): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(212): []
-rebuilt        : SymbolId(46): [ReferenceId(27)]
-Symbol flags mismatch:
-after transform: SymbolId(214): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(47): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(214): []
-rebuilt        : SymbolId(47): [ReferenceId(29)]
-Symbol flags mismatch:
-after transform: SymbolId(216): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(48): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(218): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(49): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(228): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(50): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(228): []
-rebuilt        : SymbolId(50): [ReferenceId(31)]
-Symbol flags mismatch:
-after transform: SymbolId(238): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(238): []
-rebuilt        : SymbolId(52): [ReferenceId(33)]
-Symbol flags mismatch:
-after transform: SymbolId(240): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T"]
@@ -28903,178 +21123,6 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
 rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassInPublicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPrivateTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPublicTypeParameters
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassWithTypeParametersFromPrivateModule
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassInPrivateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPrivateTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPublicTypeParameters
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassWithPublicTypeParametersWithoutExtends
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(53)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(38)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T"]
-rebuilt        : ScopeId(3): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Bindings mismatch:
-after transform: ScopeId(7): ["T"]
-rebuilt        : ScopeId(7): []
-Bindings mismatch:
-after transform: ScopeId(9): ["T"]
-rebuilt        : ScopeId(9): []
-Bindings mismatch:
-after transform: ScopeId(11): ["T"]
-rebuilt        : ScopeId(11): []
-Bindings mismatch:
-after transform: ScopeId(13): ["T"]
-rebuilt        : ScopeId(13): []
-Bindings mismatch:
-after transform: ScopeId(15): ["T"]
-rebuilt        : ScopeId(15): []
-Bindings mismatch:
-after transform: ScopeId(17): ["T"]
-rebuilt        : ScopeId(17): []
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(74)]
-rebuilt        : ScopeId(19): [SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(34), SymbolId(36)]
-Bindings mismatch:
-after transform: ScopeId(22): ["T"]
-rebuilt        : ScopeId(22): []
-Bindings mismatch:
-after transform: ScopeId(24): ["T"]
-rebuilt        : ScopeId(24): []
-Bindings mismatch:
-after transform: ScopeId(26): ["T"]
-rebuilt        : ScopeId(26): []
-Bindings mismatch:
-after transform: ScopeId(28): ["T"]
-rebuilt        : ScopeId(28): []
-Bindings mismatch:
-after transform: ScopeId(30): ["T"]
-rebuilt        : ScopeId(30): []
-Bindings mismatch:
-after transform: ScopeId(32): ["T"]
-rebuilt        : ScopeId(32): []
-Bindings mismatch:
-after transform: ScopeId(34): ["T"]
-rebuilt        : ScopeId(34): []
-Bindings mismatch:
-after transform: ScopeId(36): ["T"]
-rebuilt        : ScopeId(36): []
-Binding symbols mismatch:
-after transform: ScopeId(38): [SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(75)]
-rebuilt        : ScopeId(38): [SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(44), SymbolId(46), SymbolId(48), SymbolId(50), SymbolId(52)]
-Bindings mismatch:
-after transform: ScopeId(41): ["T"]
-rebuilt        : ScopeId(41): []
-Bindings mismatch:
-after transform: ScopeId(43): ["T"]
-rebuilt        : ScopeId(43): []
-Bindings mismatch:
-after transform: ScopeId(45): ["T"]
-rebuilt        : ScopeId(45): []
-Bindings mismatch:
-after transform: ScopeId(47): ["T"]
-rebuilt        : ScopeId(47): []
-Bindings mismatch:
-after transform: ScopeId(49): ["T"]
-rebuilt        : ScopeId(49): []
-Bindings mismatch:
-after transform: ScopeId(51): ["T"]
-rebuilt        : ScopeId(51): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(27): [ReferenceId(30), ReferenceId(38)]
-rebuilt        : SymbolId(20): []
-Symbol flags mismatch:
-after transform: SymbolId(28): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(21): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42)]
-rebuilt        : SymbolId(21): [ReferenceId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(29): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(22): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(29): []
-rebuilt        : SymbolId(22): [ReferenceId(12)]
-Symbol flags mismatch:
-after transform: SymbolId(32): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(24): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(32): []
-rebuilt        : SymbolId(24): [ReferenceId(15)]
-Symbol flags mismatch:
-after transform: SymbolId(41): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(30): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(30): [ReferenceId(20)]
-Symbol flags mismatch:
-after transform: SymbolId(47): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(34): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(47): []
-rebuilt        : SymbolId(34): [ReferenceId(24)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(54): [ReferenceId(60), ReferenceId(68)]
-rebuilt        : SymbolId(40): []
-Symbol flags mismatch:
-after transform: SymbolId(55): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(41): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(55): [ReferenceId(64), ReferenceId(72)]
-rebuilt        : SymbolId(41): [ReferenceId(29)]
-Symbol flags mismatch:
-after transform: SymbolId(56): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(42): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(56): []
-rebuilt        : SymbolId(42): [ReferenceId(32)]
-Symbol flags mismatch:
-after transform: SymbolId(59): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(44): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(59): []
-rebuilt        : SymbolId(44): [ReferenceId(35)]
-Symbol flags mismatch:
-after transform: SymbolId(68): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(50): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(68): []
-rebuilt        : SymbolId(50): [ReferenceId(40)]
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.ts
 semantic error: Bindings mismatch:
@@ -29102,111 +21150,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
 rebuilt        : SymbolId(3): []
 
-tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
-semantic error: Missing SymbolId: publicModule
-Missing SymbolId: _publicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassInPublicModule
-Missing ReferenceId: _publicModule
-Missing ReferenceId: publicClassInPublicModuleT
-Missing ReferenceId: publicModule
-Missing ReferenceId: publicModule
-Missing SymbolId: privateModule
-Missing SymbolId: _privateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassInPrivateModule
-Missing ReferenceId: _privateModule
-Missing ReferenceId: publicClassInPrivateModuleT
-Missing ReferenceId: privateModule
-Missing ReferenceId: privateModule
-Bindings mismatch:
-after transform: ScopeId(0): ["privateClass", "privateClassT", "privateInterfaceWithPrivateModuleTypeParameterConstraints", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "privateModule", "publicClass", "publicClassT", "publicInterfaceWithPrivateModuleTypeParameterConstraints", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends", "publicModule"]
-rebuilt        : ScopeId(0): ["privateClass", "privateClassT", "privateModule", "publicClass", "publicClassT", "publicModule"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(12), ScopeId(19), ScopeId(26), ScopeId(33), ScopeId(36), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(82)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(10)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T"]
-rebuilt        : ScopeId(3): []
-Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(41): ["_publicModule", "privateClassInPublicModule", "privateClassInPublicModuleT", "privateInterfaceWithPrivateModuleTypeParameterConstraints", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClassInPublicModule", "publicClassInPublicModuleT", "publicInterfaceWithPrivateModuleTypeParameterConstraints", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
-rebuilt        : ScopeId(5): ["_publicModule", "privateClassInPublicModule", "privateClassInPublicModuleT", "publicClassInPublicModule", "publicClassInPublicModuleT"]
-Scope children mismatch:
-after transform: ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(53), ScopeId(60), ScopeId(67), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(81)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Bindings mismatch:
-after transform: ScopeId(44): ["T"]
-rebuilt        : ScopeId(8): []
-Bindings mismatch:
-after transform: ScopeId(45): ["T"]
-rebuilt        : ScopeId(9): []
-Bindings mismatch:
-after transform: ScopeId(82): ["_privateModule", "privateClassInPrivateModule", "privateClassInPrivateModuleT", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClassInPrivateModule", "publicClassInPrivateModuleT", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
-rebuilt        : ScopeId(10): ["_privateModule", "privateClassInPrivateModule", "privateClassInPrivateModuleT", "publicClassInPrivateModule", "publicClassInPrivateModuleT"]
-Scope children mismatch:
-after transform: ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(87), ScopeId(94), ScopeId(101), ScopeId(108), ScopeId(115), ScopeId(118)]
-rebuilt        : ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-Bindings mismatch:
-after transform: ScopeId(85): ["T"]
-rebuilt        : ScopeId(13): []
-Bindings mismatch:
-after transform: ScopeId(86): ["T"]
-rebuilt        : ScopeId(14): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(32), ReferenceId(36), ReferenceId(45), ReferenceId(49)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(8), ReferenceId(12), ReferenceId(13), ReferenceId(21), ReferenceId(25), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(47), ReferenceId(51)]
-rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(7), ReferenceId(18), ReferenceId(20), ReferenceId(31), ReferenceId(33), ReferenceId(44), ReferenceId(46)]
-rebuilt        : SymbolId(2): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(23): [ReferenceId(62), ReferenceId(68), ReferenceId(72), ReferenceId(81), ReferenceId(85), ReferenceId(88), ReferenceId(94), ReferenceId(98), ReferenceId(107), ReferenceId(111)]
-rebuilt        : SymbolId(6): []
-Symbol flags mismatch:
-after transform: SymbolId(24): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(24): [ReferenceId(70), ReferenceId(74), ReferenceId(75), ReferenceId(83), ReferenceId(87), ReferenceId(96), ReferenceId(100), ReferenceId(101), ReferenceId(109), ReferenceId(113)]
-rebuilt        : SymbolId(7): [ReferenceId(1)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(25): [ReferenceId(67), ReferenceId(69), ReferenceId(80), ReferenceId(82), ReferenceId(93), ReferenceId(95), ReferenceId(106), ReferenceId(108)]
-rebuilt        : SymbolId(8): []
-Symbol flags mismatch:
-after transform: SymbolId(27): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(9): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(27): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120)]
-rebuilt        : SymbolId(9): [ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(46): [ReferenceId(124), ReferenceId(130), ReferenceId(134), ReferenceId(143), ReferenceId(147), ReferenceId(150), ReferenceId(156), ReferenceId(160), ReferenceId(169), ReferenceId(173)]
-rebuilt        : SymbolId(12): []
-Symbol flags mismatch:
-after transform: SymbolId(47): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(13): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(47): [ReferenceId(132), ReferenceId(136), ReferenceId(137), ReferenceId(145), ReferenceId(149), ReferenceId(158), ReferenceId(162), ReferenceId(163), ReferenceId(171), ReferenceId(175)]
-rebuilt        : SymbolId(13): [ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(48): [ReferenceId(129), ReferenceId(131), ReferenceId(142), ReferenceId(144), ReferenceId(155), ReferenceId(157), ReferenceId(168), ReferenceId(170)]
-rebuilt        : SymbolId(14): []
-Symbol flags mismatch:
-after transform: SymbolId(50): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(15): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(50): [ReferenceId(127), ReferenceId(133), ReferenceId(135), ReferenceId(140), ReferenceId(146), ReferenceId(148), ReferenceId(153), ReferenceId(159), ReferenceId(161), ReferenceId(166), ReferenceId(172), ReferenceId(174), ReferenceId(178), ReferenceId(182)]
-rebuilt        : SymbolId(15): [ReferenceId(9)]
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -29215,14 +21158,6 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -30493,17 +22428,6 @@ Unresolved reference IDs mismatch for "Float32Array":
 after transform: [ReferenceId(1), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
 rebuilt        : [ReferenceId(9)]
 
-tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "Foo", "f", "g", "z"]
-rebuilt        : ScopeId(0): ["C", "f", "g", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(21), ScopeId(25)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(20), ScopeId(24)]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
@@ -30586,32 +22510,6 @@ rebuilt        : ["xyz"]
 Unresolved reference IDs mismatch for "xyz":
 after transform: [ReferenceId(1), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Base", "Base1", "C", "Derived1", "T", "p"]
-rebuilt        : ScopeId(0): ["Base1", "C", "Derived1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(6)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(2): []
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("Base")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("p")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["Base", "p", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
 semantic error: Missing SymbolId: TypeScript2
@@ -30854,24 +22752,21 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(8)]
 rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
 Unresolved reference IDs mismatch for "C":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
 rebuilt        : [ReferenceId(5)]
@@ -31153,11 +23048,6 @@ Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 39, end: 45 }]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Test", "things"]
-rebuilt        : ScopeId(0): ["Test"]
-
 tasks/coverage/typescript/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Math", "RegExpExecArray", "RegExpMatchArray", "undefined"]
@@ -31247,27 +23137,7 @@ tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWitho
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -31348,14 +23218,6 @@ tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foobar"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C1", "I1"]
-rebuilt        : ScopeId(0): ["C1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
 semantic error: Bindings mismatch:
@@ -31688,23 +23550,6 @@ Unresolved references mismatch:
 after transform: ["EventTarget", "Extract", "HTMLButtonElement", "Parameters", "bindAll"]
 rebuilt        : ["bindAll"]
 
-tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["NativeTypeValidator", "ObjValidator", "ObjectValidator", "SimpleStringValidator", "V", "Validator", "outputExample", "test", "validatorFunc"]
-rebuilt        : ScopeId(0): ["outputExample", "test", "validatorFunc"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("SimpleStringValidator")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("ObjValidator")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["ObjValidator", "SimpleStringValidator"]
-
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action", "ConfigureStoreOptions", "Reducer", "ReducersMapObject", "UnknownAction", "counterReducer1", "store2"]
@@ -31775,14 +23620,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["f", "g", "h"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
 semantic error: Missing SymbolId: X
 Missing SymbolId: _X
@@ -31835,14 +23672,6 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ModuleWithState", "MoreState", "State", "breaks"]
-rebuilt        : ScopeId(0): ["breaks"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase2.ts
 semantic error: Bindings mismatch:
@@ -33572,6 +25401,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
@@ -33771,20 +25603,6 @@ Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : ["Array", "foo1", "foo2"]
 
-tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Apple", "Orange", "test", "test2"]
-rebuilt        : ScopeId(0): ["test", "test2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "item"]
-rebuilt        : ScopeId(1): ["item"]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "item", "x"]
-rebuilt        : ScopeId(2): ["item", "x"]
-
 tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "thing"]
@@ -33951,20 +25769,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record", "undefined"]
 rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/compiler/spreadParameterTupleType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["A", "C"]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -34147,32 +25951,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(4): ["T"]
-rebuilt        : ScopeId(4): []
-Bindings mismatch:
-after transform: ScopeId(5): ["T"]
-rebuilt        : ScopeId(5): []
-Bindings mismatch:
-after transform: ScopeId(6): ["T"]
-rebuilt        : ScopeId(6): []
-Bindings mismatch:
-after transform: ScopeId(7): ["T"]
-rebuilt        : ScopeId(7): []
-Bindings mismatch:
-after transform: ScopeId(8): ["T"]
-rebuilt        : ScopeId(8): []
-Bindings mismatch:
-after transform: ScopeId(9): ["T"]
-rebuilt        : ScopeId(9): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(1): []
-
 tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
@@ -34180,38 +25958,6 @@ rebuilt        : ScopeId(2): []
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(5): [ScopeId(6)]
-
-tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Func", "a", "b", "never", "t1", "t2", "t3", "t4", "t5", "t6", "x", "x1", "x10", "x11", "x2", "x3", "x4"]
-rebuilt        : ScopeId(0): ["t1", "t2", "t3", "t4", "t5", "t6", "x", "x1", "x10", "x11", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(32): Some("never")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(36): Some("never")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(53): Some("a")
-rebuilt        : ReferenceId(22): None
-Reference symbol mismatch:
-after transform: ReferenceId(57): Some("b")
-rebuilt        : ReferenceId(25): None
-Reference symbol mismatch:
-after transform: ReferenceId(61): Some("never")
-rebuilt        : ReferenceId(28): None
-Reference symbol mismatch:
-after transform: ReferenceId(68): Some("a")
-rebuilt        : ReferenceId(31): None
-Reference symbol mismatch:
-after transform: ReferenceId(72): Some("b")
-rebuilt        : ReferenceId(34): None
-Unresolved references mismatch:
-after transform: ["Object", "ReadonlyArray", "acceptA", "acceptUnion", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx"]
-rebuilt        : ["a", "acceptA", "acceptUnion", "b", "coAndContra", "coAndContraArray", "f1", "f2", "f3", "f4", "fo", "foo", "fs", "fx", "never"]
 
 tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
 semantic error: Bindings mismatch:
@@ -34247,17 +25993,6 @@ Unresolved references mismatch:
 after transform: ["Readonly"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T1", "T2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
@@ -34265,9 +26000,6 @@ rebuilt        : ScopeId(1): []
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6)]
 rebuilt        : ScopeId(4): []
-
-tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 semantic error: Bindings mismatch:
@@ -34311,9 +26043,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 semantic error: Bindings mismatch:
@@ -34556,14 +26285,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Constructor", "ControllerClass"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Constructor", "ControllerClass"]
@@ -34582,14 +26303,6 @@ rebuilt        : SymbolId(0): Span { start: 35, end: 36 }
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["SymbolConstructor", "obj"]
-rebuilt        : ScopeId(0): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment.ts
 semantic error: Bindings mismatch:
@@ -34632,6 +26345,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
 semantic error: Bindings mismatch:
@@ -34664,17 +26380,20 @@ Bindings mismatch:
 after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
 rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -34705,17 +26424,20 @@ Bindings mismatch:
 after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
 rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
 rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -34742,18 +26464,27 @@ Missing ReferenceId: E
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(1), SymbolId(6)]
 rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
 rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
 rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): []
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -34806,24 +26537,33 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5)
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(13)]
 rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["E", "TopLevelEnum"]
 rebuilt        : ScopeId(4): ["TopLevelEnum"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(11), SymbolId(14)]
 rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(7): [SymbolId(9), SymbolId(15)]
 rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(9): ["E", "NonTopLevelEnum"]
 rebuilt        : ScopeId(9): ["NonTopLevelEnum"]
 Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(9): ScopeFlags(0x0)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | Export)
@@ -34834,7 +26574,7 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(7): []
 rebuilt        : SymbolId(9): [ReferenceId(6)]
 Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): []
@@ -34857,12 +26597,15 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["AnEnum", "ONE", "TWO"]
 rebuilt        : ScopeId(2): ["AnEnum"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
@@ -34872,20 +26615,6 @@ rebuilt        : ReferenceId(8): Some("ns")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("ns")
 rebuilt        : ReferenceId(10): Some("ns")
-
-tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Hash", "getHashLength", "getHashLength2"]
-rebuilt        : ScopeId(0): ["getHashLength", "getHashLength2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "hash"]
-rebuilt        : ScopeId(3): ["hash"]
-Unresolved references mismatch:
-after transform: ["Error", "true"]
-rebuilt        : ["Error"]
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
 semantic error: Scope children mismatch:
@@ -34917,14 +26646,6 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch:
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["GetChars", "GetCharsRec", "Reverse", "ReverseRec", "T10", "T11", "T20", "T30", "T31", "T40", "T41", "Trim", "TupleOf", "TupleOfRec"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/targetEs6DecoratorMetadataImportNotElided.ts
 semantic error: Bindings mismatch:
@@ -35103,9 +26824,7 @@ after transform: ReferenceId(0): Some("bar")
 rebuilt        : ReferenceId(4): Some("bar")
 
 tasks/coverage/typescript/tests/cases/compiler/thisInObjectJs.ts
-semantic error: Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 semantic error: Symbol reference IDs mismatch:
@@ -35196,26 +26915,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Node", "Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
-rebuilt        : ScopeId(0): ["SyntaxKind"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78), ScopeId(79), ScopeId(80), ScopeId(81), ScopeId(82), ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(87), ScopeId(88), ScopeId(89), ScopeId(90), ScopeId(91), ScopeId(92), ScopeId(93), ScopeId(94), ScopeId(95), ScopeId(96), ScopeId(97), ScopeId(98), ScopeId(99), ScopeId(100), ScopeId(101), ScopeId(102)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(1): ["Node0", "Node1", "Node10", "Node11", "Node12", "Node13", "Node14", "Node15", "Node16", "Node17", "Node18", "Node19", "Node2", "Node20", "Node21", "Node22", "Node23", "Node24", "Node25", "Node26", "Node27", "Node28", "Node29", "Node3", "Node30", "Node31", "Node32", "Node33", "Node34", "Node35", "Node36", "Node37", "Node38", "Node39", "Node4", "Node40", "Node41", "Node42", "Node43", "Node44", "Node45", "Node46", "Node47", "Node48", "Node49", "Node5", "Node50", "Node51", "Node52", "Node53", "Node54", "Node55", "Node56", "Node57", "Node58", "Node59", "Node6", "Node60", "Node61", "Node62", "Node63", "Node64", "Node65", "Node66", "Node67", "Node68", "Node69", "Node7", "Node70", "Node71", "Node72", "Node73", "Node74", "Node75", "Node76", "Node77", "Node78", "Node79", "Node8", "Node80", "Node81", "Node82", "Node83", "Node84", "Node85", "Node86", "Node87", "Node88", "Node89", "Node9", "Node90", "Node91", "Node92", "Node93", "Node94", "Node95", "Node96", "Node97", "Node98", "Node99", "SyntaxKind"]
-rebuilt        : ScopeId(1): ["SyntaxKind"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99)]
-rebuilt        : SymbolId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -35275,8 +26974,8 @@ rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["Foo", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["Foo", "JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Foo", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -35294,6 +26993,9 @@ rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 Symbol redeclarations mismatch:
 after transform: SymbolId(2): [Span { start: 243, end: 256 }]
 rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(5): [ReferenceId(2)]
 Unresolved references mismatch:
 after transform: ["Date", "React"]
 rebuilt        : ["React"]
@@ -35311,14 +27013,14 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
-after transform: ["Comp", "JSX", "parseInt", "true", "undefined"]
-rebuilt        : ["Comp", "parseInt", "undefined"]
+after transform: ["Comp", "JSX", "parseInt", "require", "true", "undefined"]
+rebuilt        : ["Comp", "parseInt", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
 semantic error: Bindings mismatch:
@@ -35333,8 +27035,8 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Props", "PropsBase", "PropsWithConvert", "ShouldInferFromData", "_jsx", "_jsxFileName", "f1", "f2", "f3"]
-rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsx", "_jsxFileName", "f1", "f2", "f3"]
+after transform: ScopeId(0): ["JSX", "Props", "PropsBase", "PropsWithConvert", "ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
+rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
@@ -35342,8 +27044,8 @@ Bindings mismatch:
 after transform: ScopeId(6): ["T", "props"]
 rebuilt        : ScopeId(1): ["props"]
 Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
 semantic error: Bindings mismatch:
@@ -35382,14 +27084,14 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AnimalComponent", "AnimalInfo", "CatInfo", "DogInfo", "JSX", "_jsx", "_jsxFileName", "component", "component2", "getProps", "props", "props2"]
-rebuilt        : ScopeId(0): ["AnimalComponent", "_jsx", "_jsxFileName", "component", "component2", "getProps", "props", "props2"]
+after transform: ScopeId(0): ["AnimalComponent", "AnimalInfo", "CatInfo", "DogInfo", "JSX", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
+rebuilt        : ScopeId(0): ["AnimalComponent", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
+after transform: ["JSX", "require", "undefined"]
+rebuilt        : ["require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 semantic error: Bindings mismatch:
@@ -35447,14 +27149,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "Pick", "Required", "set"]
 rebuilt        : ["set"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 semantic error: Bindings mismatch:
@@ -35609,10 +27303,6 @@ rebuilt        : ScopeId(1): ["a", "f", "x"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "a", "f", "x"]
 rebuilt        : ScopeId(2): ["a", "f", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
 semantic error: Bindings mismatch:
@@ -35812,6 +27502,9 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -35835,8 +27528,11 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
@@ -35923,14 +27619,17 @@ tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["JSX", "T"]
+after transform: ["JSX", "T", "require"]
 rebuilt        : ["T", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(13)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
 semantic error: Scope children mismatch:
@@ -36331,94 +28030,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["$", "A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["$", "A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["$", "A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["$"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Lib"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["./main", "Cls"]
-rebuilt        : ScopeId(0): ["Cls"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["Lib", "undefined"]
-rebuilt        : ["undefined"]
-
 tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
 semantic error: Missing SymbolId: TopLevelModule1
 Missing SymbolId: _TopLevelModule
@@ -36482,39 +28093,63 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(50)]
 Bindings mismatch:
 after transform: ScopeId(1): ["ClassA", "InterfaceY", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
 rebuilt        : ScopeId(1): ["ClassA", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(16), ScopeId(29), ScopeId(31), ScopeId(33)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(14), ScopeId(22), ScopeId(24)]
 Binding symbols mismatch:
 after transform: ScopeId(2): [SymbolId(2), SymbolId(31), SymbolId(53)]
 rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(33)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["ClassA", "ClassB", "InterfaceX", "NonExportedClassQ", "_SubSubModule"]
 rebuilt        : ScopeId(3): ["ClassA", "ClassB", "NonExportedClassQ", "_SubSubModule"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(16): ["InterfaceY", "SubSubModule2", "_SubModule2"]
 rebuilt        : ScopeId(14): ["SubSubModule2", "_SubModule2"]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(16): [ScopeId(17), ScopeId(27)]
 rebuilt        : ScopeId(14): [ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(17): ["ClassA", "ClassB", "ClassC", "InterfaceY", "NonExportedInterfaceQ", "_SubSubModule2"]
 rebuilt        : ScopeId(15): ["ClassA", "ClassB", "ClassC", "_SubSubModule2"]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(18), ScopeId(20)]
 Binding symbols mismatch:
 after transform: ScopeId(33): [SymbolId(48), SymbolId(57)]
 rebuilt        : ScopeId(24): [SymbolId(48), SymbolId(49)]
+Scope flags mismatch:
+after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(24): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(35): [SymbolId(50), SymbolId(58)]
 rebuilt        : ScopeId(26): [SymbolId(51), SymbolId(52)]
+Scope flags mismatch:
+after transform: ScopeId(35): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(26): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(36): [SymbolId(51), SymbolId(59)]
 rebuilt        : ScopeId(27): [SymbolId(53), SymbolId(54)]
+Scope flags mismatch:
+after transform: ScopeId(36): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(27): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(3): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(6): SymbolFlags(Class)
@@ -36745,11 +28380,6 @@ rebuilt        : ["Collection"]
 tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
 semantic error: Unresolved references mismatch:
 after transform: ["this"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/typeofUndefined.ts
-semantic error: Unresolved references mismatch:
-after transform: ["undefined"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
@@ -37160,14 +28790,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "D"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction1.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
@@ -37219,17 +28841,6 @@ Unresolved references mismatch:
 after transform: ["Promise", "Symbol"]
 rebuilt        : ["Symbol"]
 
-tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Op"]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("Op")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Op"]
-
 tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myUnusedFunction", "myVar"]
@@ -37268,10 +28879,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -37350,9 +28957,12 @@ rebuilt        : ScopeId(1): ["a"]
 Binding symbols mismatch:
 after transform: ScopeId(43): [SymbolId(30), SymbolId(31)]
 rebuilt        : ScopeId(43): [SymbolId(29), SymbolId(30)]
+Scope flags mismatch:
+after transform: ScopeId(43): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(43): ScopeFlags(Function)
 Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(53): Some("N")
 rebuilt        : ReferenceId(53): Some("N")
@@ -37633,15 +29243,9 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/usedImportNotElidedInJs.ts
-semantic error: Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 24, end: 30 }
-rebuilt        : SymbolId(1): Span { start: 103, end: 109 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 103, end: 109 }]
-rebuilt        : SymbolId(1): []
+semantic error: Cannot use import statement outside a module
+Cannot use import statement outside a module
+Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -37693,13 +29297,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
 semantic error: Bindings mismatch:
@@ -37870,17 +29467,6 @@ Unresolved references mismatch:
 after transform: ["Pick", "Record"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "Map", "MapOrUndefined", "foo1"]
-rebuilt        : ScopeId(0): ["Foo", "foo1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -37904,11 +29490,6 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(2): ["T", "val"]
-rebuilt        : ScopeId(2): ["val"]
 
 tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
 semantic error: Scope children mismatch:
@@ -38004,51 +29585,6 @@ rebuilt        : ScopeId(5): []
 Scope children mismatch:
 after transform: ScopeId(20): [ScopeId(21)]
 rebuilt        : ScopeId(6): []
-
-tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
-semantic error: Missing SymbolId: m1
-Missing SymbolId: _m
-Missing ReferenceId: _m
-Missing ReferenceId: foo
-Missing ReferenceId: m1
-Missing ReferenceId: m1
-Missing SymbolId: m3
-Missing SymbolId: _m2
-Missing ReferenceId: _m2
-Missing ReferenceId: foo
-Missing ReferenceId: m3
-Missing ReferenceId: m3
-Bindings mismatch:
-after transform: ScopeId(0): ["anotherVar", "arrayVar", "deckareVarWithType", "declareVar2", "declaredVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedDeclaredVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m2", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
-rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(18), SymbolId(29)]
-rebuilt        : ScopeId(3): [SymbolId(14), SymbolId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(22), SymbolId(30)]
-rebuilt        : ScopeId(5): [SymbolId(17), SymbolId(18)]
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(15): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(22): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(22): []
-rebuilt        : SymbolId(18): [ReferenceId(8)]
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("m1")
-rebuilt        : ReferenceId(6): Some("m1")
-
-tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 semantic error: 'with' statements are not allowed
@@ -38149,14 +29685,6 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_declarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_duplicate.ts
 semantic error: Bindings mismatch:
@@ -39460,29 +30988,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "c5"]
-rebuilt        : ScopeId(0): ["C3", "C4", "c5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Class | Interface)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol redeclarations mismatch:
-after transform: SymbolId(2): [Span { start: 104, end: 106 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Class | Interface)
-rebuilt        : SymbolId(1): SymbolFlags(Class)
-Symbol span mismatch:
-after transform: SymbolId(3): Span { start: 122, end: 124 }
-rebuilt        : SymbolId(1): Span { start: 136, end: 138 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(3): [Span { start: 136, end: 138 }]
-rebuilt        : SymbolId(1): []
-
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClass", "BaseInterface", "Child", "ChildNoBaseClass", "Grandchild", "child", "grandchild"]
@@ -39825,84 +31330,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClasses.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
-after transform: ScopeId(3): ["MixinClass", "TBaseClass", "baseClass"]
-rebuilt        : ScopeId(1): ["MixinClass", "baseClass"]
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9)]
-rebuilt        : ScopeId(6): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 10, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 55, end: 60 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(11)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(7)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 55, end: 60 }]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/mixinAbstractClassesReturnTypeInference.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AbstractBase", "DerivedFromAbstract2", "Mixin1", "Mixin2"]
-rebuilt        : ScopeId(0): ["AbstractBase", "DerivedFromAbstract2", "Mixin2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(5): ["MixinClass", "TBase", "baseClass"]
-rebuilt        : ScopeId(2): ["MixinClass", "baseClass"]
-
-tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Base", "Constructor", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "f1", "f2"]
-rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13)]
-Bindings mismatch:
-after transform: ScopeId(8): ["T", "superClass"]
-rebuilt        : ScopeId(5): ["superClass"]
-Bindings mismatch:
-after transform: ScopeId(12): ["C", "T", "superClass"]
-rebuilt        : ScopeId(8): ["C", "superClass"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction | Interface)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)
-Symbol span mismatch:
-after transform: SymbolId(9): Span { start: 247, end: 256 }
-rebuilt        : SymbolId(7): Span { start: 287, end: 296 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): [ReferenceId(8), ReferenceId(22)]
-rebuilt        : SymbolId(7): [ReferenceId(13)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(9): [Span { start: 287, end: 296 }]
-rebuilt        : SymbolId(7): []
-Symbol flags mismatch:
-after transform: SymbolId(13): SymbolFlags(FunctionScopedVariable | Interface)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol span mismatch:
-after transform: SymbolId(13): Span { start: 557, end: 563 }
-rebuilt        : SymbolId(10): Span { start: 596, end: 602 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(13): [ReferenceId(14), ReferenceId(19), ReferenceId(21)]
-rebuilt        : SymbolId(10): [ReferenceId(10), ReferenceId(12)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(13): [Span { start: 596, end: 602 }]
-rebuilt        : SymbolId(10): []
-
 tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Constructor", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "Timestamped", "f1", "f2"]
@@ -39922,89 +31349,6 @@ rebuilt        : ScopeId(16): ["Base"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C2", "C3", "Mixed1", "Mixed2", "Mixed3", "Mixed4", "Mixed5", "f1", "f2", "f3", "f4", "f5", "f6"]
-rebuilt        : ScopeId(0): ["C2", "C3", "f1", "f2", "f3", "f4", "f5", "f6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9)]
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("Mixed1")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("Mixed1")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("Mixed2")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("Mixed2")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("Mixed3")
-rebuilt        : ReferenceId(4): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("Mixed3")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("Mixed4")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("Mixed4")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("Mixed5")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("Mixed1")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("Mixed1")
-rebuilt        : ReferenceId(12): None
-Reference symbol mismatch:
-after transform: ReferenceId(25): Some("Mixed2")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(28): Some("Mixed2")
-rebuilt        : ReferenceId(16): None
-Reference symbol mismatch:
-after transform: ReferenceId(29): Some("Mixed3")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(33): Some("Mixed3")
-rebuilt        : ReferenceId(21): None
-Reference symbol mismatch:
-after transform: ReferenceId(34): Some("Mixed3")
-rebuilt        : ReferenceId(22): None
-Reference symbol mismatch:
-after transform: ReferenceId(35): Some("Mixed4")
-rebuilt        : ReferenceId(23): None
-Reference symbol mismatch:
-after transform: ReferenceId(39): Some("Mixed4")
-rebuilt        : ReferenceId(27): None
-Reference symbol mismatch:
-after transform: ReferenceId(40): Some("Mixed4")
-rebuilt        : ReferenceId(28): None
-Reference symbol mismatch:
-after transform: ReferenceId(41): Some("Mixed5")
-rebuilt        : ReferenceId(29): None
-Reference symbol mismatch:
-after transform: ReferenceId(44): Some("Mixed5")
-rebuilt        : ReferenceId(32): None
-Reference symbol mismatch:
-after transform: ReferenceId(45): Some("Mixed5")
-rebuilt        : ReferenceId(33): None
-Reference symbol mismatch:
-after transform: ReferenceId(46): Some("Mixed1")
-rebuilt        : ReferenceId(34): None
-Reference symbol mismatch:
-after transform: ReferenceId(47): Some("Mixed3")
-rebuilt        : ReferenceId(35): None
-Unresolved references mismatch:
-after transform: ["C1", "M1", "M2"]
-rebuilt        : ["Mixed1", "Mixed2", "Mixed3", "Mixed4", "Mixed5"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
 semantic error: Bindings mismatch:
@@ -40054,8 +31398,8 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(27)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | Function | Interface)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Interface)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
 after transform: SymbolId(8): Span { start: 462, end: 483 }
 rebuilt        : SymbolId(2): Span { start: 558, end: 579 }
@@ -40068,11 +31412,6 @@ rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["ReadonlyArray"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts
 semantic error: Scope children mismatch:
@@ -40096,11 +31435,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
 semantic error: Bindings mismatch:
@@ -40199,33 +31533,63 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Binding symbols mismatch:
 after transform: ScopeId(81): [SymbolId(42), SymbolId(71)]
 rebuilt        : ScopeId(81): [SymbolId(42), SymbolId(43)]
+Scope flags mismatch:
+after transform: ScopeId(81): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(81): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(84): [SymbolId(45), SymbolId(72)]
 rebuilt        : ScopeId(84): [SymbolId(46), SymbolId(47)]
+Scope flags mismatch:
+after transform: ScopeId(84): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(84): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(91): [SymbolId(48), SymbolId(73)]
 rebuilt        : ScopeId(91): [SymbolId(50), SymbolId(51)]
+Scope flags mismatch:
+after transform: ScopeId(91): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(91): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(94): [SymbolId(51), SymbolId(74)]
 rebuilt        : ScopeId(94): [SymbolId(54), SymbolId(55)]
+Scope flags mismatch:
+after transform: ScopeId(94): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(94): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(101): [SymbolId(54), SymbolId(75)]
 rebuilt        : ScopeId(101): [SymbolId(58), SymbolId(59)]
+Scope flags mismatch:
+after transform: ScopeId(101): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(101): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(104): [SymbolId(57), SymbolId(76)]
 rebuilt        : ScopeId(104): [SymbolId(62), SymbolId(63)]
+Scope flags mismatch:
+after transform: ScopeId(104): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(104): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(111): [SymbolId(60), SymbolId(77)]
 rebuilt        : ScopeId(111): [SymbolId(66), SymbolId(67)]
+Scope flags mismatch:
+after transform: ScopeId(111): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(111): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(114): [SymbolId(63), SymbolId(78)]
 rebuilt        : ScopeId(114): [SymbolId(70), SymbolId(71)]
+Scope flags mismatch:
+after transform: ScopeId(114): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(114): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(121): [SymbolId(66), SymbolId(79)]
 rebuilt        : ScopeId(121): [SymbolId(74), SymbolId(75)]
+Scope flags mismatch:
+after transform: ScopeId(121): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(121): ScopeFlags(Function)
 Binding symbols mismatch:
 after transform: ScopeId(124): [SymbolId(69), SymbolId(80)]
 rebuilt        : ScopeId(124): [SymbolId(78), SymbolId(79)]
+Scope flags mismatch:
+after transform: ScopeId(124): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(124): ScopeFlags(Function)
 Unresolved references mismatch:
 after transform: ["const"]
 rebuilt        : []
@@ -40239,9 +31603,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/s
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
-
-tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
-semantic error: Enum member must have initializer.
 
 tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
 semantic error: Bindings mismatch:
@@ -40273,6 +31634,9 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates2.ts
+semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
 semantic error: Scope children mismatch:
@@ -40629,122 +31993,6 @@ rebuilt        : ScopeId(6): [ScopeId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/classDoesNotDependOnPrivateMember.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: C
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["C", "I", "_M"]
-rebuilt        : ScopeId(1): ["C", "_M"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["elem"]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmitBundle.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["elem"]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I", "f"]
-rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "obj"]
-rebuilt        : ScopeId(0): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "obj"]
-rebuilt        : ScopeId(0): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["FSWatcher", "f"]
-rebuilt        : ScopeId(0): ["f"]
-
-tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(2): ["C", "class_"]
-rebuilt        : ScopeId(2): ["class_"]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
 semantic error: Bindings mismatch:
@@ -41204,37 +32452,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
 
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["directory", "moduleFile", "p0", "p1", "p2", "returnDynamicLoad", "whatToLoad"]
-rebuilt        : ScopeId(0): ["p0", "p1", "p2", "returnDynamicLoad"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("directory")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("moduleFile")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("whatToLoad")
-rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["getSpecifier"]
-rebuilt        : ["directory", "getSpecifier", "moduleFile", "whatToLoad"]
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Zero", "p0", "p1", "p2"]
-rebuilt        : ScopeId(0): ["p0", "p1", "p2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Promise", "getPath"]
-rebuilt        : ["getPath"]
-
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Promise"]
@@ -41485,251 +32702,25 @@ Symbol flags mismatch:
 after transform: SymbolId(31): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(19): SymbolFlags(FunctionScopedVariable)
 
-tasks/coverage/typescript/tests/cases/conformance/enums/enumClassification.ts
-semantic error: Missing ReferenceId: E20
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E01"]
-rebuilt        : ScopeId(1): ["E01"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["A", "E02"]
-rebuilt        : ScopeId(2): ["E02"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "E03"]
-rebuilt        : ScopeId(3): ["E03"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["A", "B", "C", "E04"]
-rebuilt        : ScopeId(4): ["E04"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["A", "B", "C", "E05"]
-rebuilt        : ScopeId(5): ["E05"]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(6): ["A", "B", "C", "E06"]
-rebuilt        : ScopeId(6): ["E06"]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(0x0)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(7): ["A", "B", "C", "D", "E", "E07", "F"]
-rebuilt        : ScopeId(7): ["E07"]
-Scope flags mismatch:
-after transform: ScopeId(7): ScopeFlags(0x0)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(8): ["A", "B", "C", "D", "E", "E08"]
-rebuilt        : ScopeId(8): ["E08"]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(0x0)
-rebuilt        : ScopeId(8): ScopeFlags(Function)
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(0x0)
-rebuilt        : ScopeId(9): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(10): ["A", "B", "C", "E11"]
-rebuilt        : ScopeId(10): ["E11"]
-Scope flags mismatch:
-after transform: ScopeId(10): ScopeFlags(0x0)
-rebuilt        : ScopeId(10): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(11): ["A", "B", "C", "E12"]
-rebuilt        : ScopeId(11): ["E12"]
-Scope flags mismatch:
-after transform: ScopeId(11): ScopeFlags(0x0)
-rebuilt        : ScopeId(11): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(12): ["A", "B", "C", "D", "E20"]
-rebuilt        : ScopeId(12): ["E20"]
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(0x0)
-rebuilt        : ScopeId(12): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(25): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(31): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(32): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(36): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(40): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(22): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(56): [ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84)]
-rebuilt        : SymbolId(23): [ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(81)]
-
-tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithStringEmitDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
-rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T1", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["T1"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["T2", "a", "b"]
-rebuilt        : ScopeId(2): ["T2"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["T3", "a", "b"]
-rebuilt        : ScopeId(3): ["T3"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T4", "a"]
-rebuilt        : ScopeId(4): ["T4"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["T5", "a"]
-rebuilt        : ScopeId(5): ["T5"]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(10): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiteralsEmitDeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6", "T7"]
-rebuilt        : ScopeId(0): ["T1", "T2", "T3", "T4", "T5", "T6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-Bindings mismatch:
-after transform: ScopeId(1): ["T1", "a"]
-rebuilt        : ScopeId(1): ["T1"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["T2", "a", "b", "c"]
-rebuilt        : ScopeId(2): ["T2"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["T3", "a"]
-rebuilt        : ScopeId(3): ["T3"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["T4", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(4): ["T4"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["T5", "a", "b", "c", "d"]
-rebuilt        : ScopeId(5): ["T5"]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(0x0)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(6): ["T6", "a", "b"]
-rebuilt        : ScopeId(6): ["T6"]
-Scope flags mismatch:
-after transform: ScopeId(6): ScopeFlags(0x0)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(14): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(19): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-
 tasks/coverage/typescript/tests/cases/conformance/enums/enumExportMergingES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Animals", "Cat"]
 rebuilt        : ScopeId(1): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["Animals", "Dog"]
 rebuilt        : ScopeId(2): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["Animals", "CatDog"]
 rebuilt        : ScopeId(3): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -42218,41 +33209,6 @@ semantic error: Unresolved references mismatch:
 after transform: ["Intl", "const"]
 rebuilt        : ["Intl"]
 
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "i"]
@@ -42504,23 +33460,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["InteropObservable", "MyObservable", "from", "global", "observable"]
-rebuilt        : ScopeId(0): ["MyObservable", "from", "observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(9): ["T", "obs"]
-rebuilt        : ScopeId(5): ["obs"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(11)]
-rebuilt        : [ReferenceId(0), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 semantic error: Bindings mismatch:
@@ -43238,29 +34177,6 @@ Unresolved references mismatch:
 after transform: ["Array", "TemplateStringsArray", "f", "g"]
 rebuilt        : ["f", "g", "obj"]
 
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
-semantic error: Missing SymbolId: M
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: generator
-Missing ReferenceId: M
-Missing ReferenceId: M
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -43713,6 +34629,9 @@ rebuilt        : ScopeId(0): ["Example"]
 Binding symbols mismatch:
 after transform: ScopeId(3): [SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(3): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
@@ -43821,80 +34740,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "dec"]
-rebuilt        : ScopeId(0): ["C"]
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("dec")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("dec")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("dec")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("dec")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("dec")
-rebuilt        : ReferenceId(4): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("dec")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("dec")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("dec")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("dec")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("dec")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("dec")
-rebuilt        : ReferenceId(10): None
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("dec")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("dec")
-rebuilt        : ReferenceId(12): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("dec")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("dec")
-rebuilt        : ReferenceId(14): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("dec")
-rebuilt        : ReferenceId(15): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("dec")
-rebuilt        : ReferenceId(16): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("dec")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("dec")
-rebuilt        : ReferenceId(18): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("dec")
-rebuilt        : ReferenceId(19): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("dec")
-rebuilt        : ReferenceId(20): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("dec")
-rebuilt        : ReferenceId(21): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["dec"]
@@ -44735,14 +35580,14 @@ Bindings mismatch:
 after transform: ScopeId(1): ["AdvancedList", "AppType", "Composite", "HeaderDetail", "HeaderMultiDetail", "ListOnly", "ModuleSettings", "Relationship", "Report", "Standard"]
 rebuilt        : ScopeId(1): ["AppType"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["AppStyle", "MiniApp", "PivotTable", "Standard", "Tree", "TreeEntity"]
 rebuilt        : ScopeId(2): ["AppStyle"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -46705,35 +37550,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ArrowElite", "ArrowGuard", "ArrowMedic", "Crate", "FollowerGuard", "GuardInterface", "LeadGuard", "MimicFollower", "MimicGuard", "MimicGuardInterface", "MimicLeader", "RoyalGuard", "Sundries", "Supplies", "a", "b", "crate", "guard", "holder2", "mimic"]
-rebuilt        : ScopeId(0): ["ArrowElite", "ArrowGuard", "ArrowMedic", "FollowerGuard", "LeadGuard", "MimicFollower", "MimicGuard", "MimicLeader", "RoyalGuard", "a", "b", "crate", "guard", "holder2", "mimic"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(39)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(30), ScopeId(32)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(62)]
-rebuilt        : SymbolId(1): [ReferenceId(0)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(7), ReferenceId(63)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(4)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(7): [ReferenceId(17)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): [ReferenceId(24), ReferenceId(25)]
-rebuilt        : SymbolId(8): [ReferenceId(18)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(17): [ReferenceId(47), ReferenceId(48)]
-rebuilt        : SymbolId(12): [ReferenceId(34)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): [ReferenceId(49), ReferenceId(50)]
-rebuilt        : SymbolId(13): [ReferenceId(35)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Beast", "Legged", "Winged", "X", "Y", "Z", "beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
@@ -47603,13 +38419,8 @@ after transform: ["f"]
 rebuilt        : ["dec", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
-semantic error: Missing SymbolId: await
-Bindings mismatch:
-after transform: ScopeId(0): ["await", "foo"]
-rebuilt        : ScopeId(0): ["await"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+semantic error: Cannot use `await` as an identifier in an async context
+The keyword 'await' is reserved
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -49305,52 +40116,11 @@ Unresolved references mismatch:
 after transform: ["mod1", "mod2", "pack1", "pack2"]
 rebuilt        : ["mod2", "pack2"]
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassImplementsGenericsSerialization.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Encoder"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Uint8Array"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Point", "magnitude"]
-rebuilt        : ScopeId(0): ["magnitude"]
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportNamespacedType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dot2", "dummy"]
-rebuilt        : ScopeId(0): ["dot2"]
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
+semantic error: Cannot use export statement outside a module
+Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag16.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag18.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag19.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
@@ -49366,23 +40136,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag20.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
@@ -49421,6 +40175,9 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/inferThis.ts
+semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_qualifiedName.ts
 semantic error: Bindings mismatch:
@@ -49464,6 +40221,9 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
+semantic error: Cannot use export statement outside a module
+
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback"]
@@ -49477,37 +40237,8 @@ semantic error: Unresolved references mismatch:
 after transform: ["Function", "Promise"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "NS", "a", "b", "c"]
-rebuilt        : ScopeId(0): ["a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Aleph", "Bet", "a"]
-rebuilt        : ScopeId(0): ["Bet", "a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Aleph", "Bet", "a"]
-rebuilt        : ScopeId(0): ["Bet", "a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Aleph", "Bet", "a"]
-rebuilt        : ScopeId(0): ["Bet", "a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag3.ts
+semantic error: Cannot use export statement outside a module
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeParameterExtendsUnionConstraintDistributed.ts
 semantic error: Bindings mismatch:
@@ -49527,128 +40258,167 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Comp", "Prop", "React", "_jsx", "_jsxFileName", "k", "k1", "k2"]
-rebuilt        : ScopeId(0): ["Comp", "React", "_jsx", "_jsxFileName", "k", "k1", "k2"]
+after transform: ScopeId(0): ["Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
+rebuilt        : ScopeId(0): ["Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(18)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Button", "JSX", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["Button", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Button", "JSX", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["Button", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Button", "ButtonProp", "InnerButton", "InnerButtonProp", "React", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["Button", "InnerButton", "React", "_jsx", "_jsxFileName", "_jsxs"]
+after transform: ScopeId(0): ["Button", "ButtonProp", "InnerButton", "InnerButtonProp", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Button", "InnerButton", "React", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0)]
-rebuilt        : SymbolId(4): []
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(8)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("React")
-rebuilt        : ReferenceId(11): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(12): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(17)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Props", "React", "Test", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["React", "Test", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+after transform: ScopeId(0): ["Props", "React", "Test", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["React", "Test", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["Foo", "JSX", "true"]
+after transform: ["Foo", "JSX", "require", "true"]
 rebuilt        : ["Foo", "require"]
+Unresolved reference IDs mismatch for "Foo":
+after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(19)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["FetchUser", "IFetchUserProps", "IUser", "React", "UserName0", "UserName1", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["FetchUser", "React", "UserName0", "UserName1", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["FetchUser", "IFetchUserProps", "IUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["FetchUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(18)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
+rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(48)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
-rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsx", "_jsxFileName", "_jsxs", "k1", "k2", "k3", "k4"]
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
+rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(48)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(15)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "JSX", "_jsx", "_jsxFileName", "x", "y"]
-rebuilt        : ScopeId(0): ["C", "_jsx", "_jsxFileName", "x", "y"]
+after transform: ScopeId(0): ["C", "JSX", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
+rebuilt        : ScopeId(0): ["C", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -49656,8 +40426,8 @@ Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
-after transform: ["Component", "Readonly"]
-rebuilt        : ["Component"]
+after transform: ["Component", "Readonly", "require"]
+rebuilt        : ["Component", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
 semantic error: Bindings mismatch:
@@ -49688,11 +40458,11 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJ
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 semantic error: Bindings mismatch:
@@ -49723,97 +40493,97 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Child", "Component", "Composite", "Composite2", "Namespace", "React", "_jsx", "_jsxFileName", "_jsxs", "bar", "foo", "hasOwnProperty", "x", "y", "z"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_jsxs", "x"]
+after transform: ScopeId(0): ["Child", "Component", "Composite", "Composite2", "Namespace", "React", "_jsxFileName", "_reactJsxRuntime", "bar", "foo", "hasOwnProperty", "x", "y", "z"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
 Symbol span mismatch:
 after transform: SymbolId(9): Span { start: 231, end: 236 }
-rebuilt        : SymbolId(3): Span { start: 537, end: 538 }
+rebuilt        : SymbolId(2): Span { start: 537, end: 538 }
 Symbol redeclarations mismatch:
 after transform: SymbolId(9): [Span { start: 537, end: 538 }]
-rebuilt        : SymbolId(3): []
+rebuilt        : SymbolId(2): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Component")
-rebuilt        : ReferenceId(10): None
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("foo")
 rebuilt        : ReferenceId(11): None
 Reference symbol mismatch:
+after transform: ReferenceId(2): Some("foo")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
 after transform: ReferenceId(3): Some("bar")
-rebuilt        : ReferenceId(14): None
+rebuilt        : ReferenceId(15): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("Composite")
-rebuilt        : ReferenceId(20): None
+rebuilt        : ReferenceId(21): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("Composite")
-rebuilt        : ReferenceId(23): None
+rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("Composite2")
-rebuilt        : ReferenceId(25): None
+rebuilt        : ReferenceId(26): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Component")
-rebuilt        : ReferenceId(47): None
+rebuilt        : ReferenceId(48): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("Namespace")
-rebuilt        : ReferenceId(50): None
+rebuilt        : ReferenceId(51): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("Namespace")
-rebuilt        : ReferenceId(53): None
+rebuilt        : ReferenceId(54): None
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Component")
-rebuilt        : ReferenceId(56): None
+rebuilt        : ReferenceId(57): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("Component")
-rebuilt        : ReferenceId(60): None
+rebuilt        : ReferenceId(61): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("Component")
-rebuilt        : ReferenceId(65): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("y")
 rebuilt        : ReferenceId(66): None
 Reference symbol mismatch:
+after transform: ReferenceId(16): Some("y")
+rebuilt        : ReferenceId(67): None
+Reference symbol mismatch:
 after transform: ReferenceId(17): Some("Component")
-rebuilt        : ReferenceId(71): None
+rebuilt        : ReferenceId(72): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("Component")
-rebuilt        : ReferenceId(75): None
+rebuilt        : ReferenceId(76): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("Component")
-rebuilt        : ReferenceId(79): None
+rebuilt        : ReferenceId(80): None
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("Component")
-rebuilt        : ReferenceId(83): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("y")
 rebuilt        : ReferenceId(84): None
 Reference symbol mismatch:
-after transform: ReferenceId(25): Some("Component")
-rebuilt        : ReferenceId(87): None
+after transform: ReferenceId(24): Some("y")
+rebuilt        : ReferenceId(85): None
 Reference symbol mismatch:
-after transform: ReferenceId(26): Some("z")
+after transform: ReferenceId(25): Some("Component")
 rebuilt        : ReferenceId(88): None
 Reference symbol mismatch:
-after transform: ReferenceId(27): Some("z")
+after transform: ReferenceId(26): Some("z")
 rebuilt        : ReferenceId(89): None
 Reference symbol mismatch:
+after transform: ReferenceId(27): Some("z")
+rebuilt        : ReferenceId(90): None
+Reference symbol mismatch:
 after transform: ReferenceId(29): Some("Child")
-rebuilt        : ReferenceId(91): None
+rebuilt        : ReferenceId(92): None
 Reference symbol mismatch:
 after transform: ReferenceId(30): Some("Component")
-rebuilt        : ReferenceId(95): None
-Reference symbol mismatch:
-after transform: ReferenceId(31): Some("z")
 rebuilt        : ReferenceId(96): None
 Reference symbol mismatch:
-after transform: ReferenceId(32): Some("z")
+after transform: ReferenceId(31): Some("z")
 rebuilt        : ReferenceId(97): None
+Reference symbol mismatch:
+after transform: ReferenceId(32): Some("z")
+rebuilt        : ReferenceId(98): None
 Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Child", "Component", "Composite", "Composite2", "Namespace", "bar", "foo", "y", "z"]
+after transform: ["require"]
+rebuilt        : ["Child", "Component", "Composite", "Composite2", "Namespace", "bar", "foo", "require", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["React", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "_jsxs"]
+after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
 semantic error: Bindings mismatch:
@@ -49823,26 +40593,31 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution13.tsx
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Address", "AddressComp", "AmericanAddress", "CanadianAddress", "Properties", "React", "_jsx", "_jsxFileName", "a"]
-rebuilt        : ScopeId(0): ["AddressComp", "React", "_jsx", "_jsxFileName", "a"]
+after transform: ScopeId(0): ["Address", "AddressComp", "AmericanAddress", "CanadianAddress", "Properties", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
+rebuilt        : ScopeId(0): ["AddressComp", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -49868,46 +40643,57 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolu
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsx", "_jsxFileName", "p"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "p"]
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(7)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsx", "_jsxFileName", "p"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "p"]
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["true"]
+after transform: ["require", "true"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
+
+tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
+semantic error: Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["CustomTag", "JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["CustomTag", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["CustomTag", "JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["CustomTag", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "foo", "t"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "foo", "t"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "foo", "t"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -49920,8 +40706,8 @@ Missing ReferenceId: Name
 Missing ReferenceId: Dotted
 Missing ReferenceId: Dotted
 Bindings mismatch:
-after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsx", "_jsxFileName", "a", "b", "d", "e", "foundFirst"]
-rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsx", "_jsxFileName", "a", "b", "d", "e", "foundFirst"]
+after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
+rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
@@ -49936,23 +40722,23 @@ after transform: SymbolId(5): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(6): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
+rebuilt        : SymbolId(6): [ReferenceId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("Dotted")
-rebuilt        : ReferenceId(12): Some("Dotted")
+rebuilt        : ReferenceId(13): Some("Dotted")
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Obj1", "_jsx", "_jsxFileName", "obj1"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj1"]
+after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "Obj1", "_jsx", "_jsxFileName", "obj1"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj1"]
+after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
@@ -49975,32 +40761,32 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "SomeClass", "_jsx", "_jsxFileName", "_jsxs", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
-rebuilt        : ScopeId(0): ["SomeClass", "_jsx", "_jsxFileName", "_jsxs", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
+after transform: ScopeId(0): ["JSX", "SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
+rebuilt        : ScopeId(0): ["SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -50074,8 +40860,8 @@ rebuilt        : ["Foo", "React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "React", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -50172,9 +40958,18 @@ rebuilt        : ScopeId(3): ["Component"]
 Bindings mismatch:
 after transform: ScopeId(5): ["Component", "T", "U"]
 rebuilt        : ScopeId(5): ["Component"]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(11), ReferenceId(13)]
+rebuilt        : SymbolId(7): [ReferenceId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): [ReferenceId(18), ReferenceId(20)]
+rebuilt        : SymbolId(10): [ReferenceId(11)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(27)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
 semantic error: Missing SymbolId: React
@@ -50185,9 +40980,12 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Bindings mismatch:
 after transform: ScopeId(1): ["Component", "T"]
 rebuilt        : ScopeId(1): ["Component"]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
 semantic error: Missing SymbolId: React
@@ -50203,13 +41001,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(4): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
 semantic error: Missing SymbolId: React
@@ -50225,13 +41023,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(4): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
 semantic error: Missing SymbolId: React
@@ -50247,13 +41045,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(4): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
 semantic error: Missing SymbolId: React
@@ -50269,13 +41067,13 @@ after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(4): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
 semantic error: Missing SymbolId: React
@@ -50293,8 +41091,11 @@ Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
 Unresolved references mismatch:
-after transform: ["Component", "JSX"]
+after transform: ["Component", "JSX", "require"]
 rebuilt        : ["Component", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(12)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 semantic error: Missing SymbolId: React
@@ -50312,8 +41113,11 @@ Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
 Unresolved references mismatch:
-after transform: ["Component", "JSX"]
+after transform: ["Component", "JSX", "require"]
 rebuilt        : ["Component", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(12)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 semantic error: Missing SymbolId: React
@@ -50326,15 +41130,18 @@ after transform: ScopeId(1): ["Ctor", "P"]
 rebuilt        : ScopeId(1): ["Ctor"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -50355,24 +41162,27 @@ Namespace tags are not supported by default. React's JSX doesn't support namespa
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "JSX", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["A", "JSX", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
+Unresolved reference IDs mismatch for "A":
+after transform: [ReferenceId(0), ReferenceId(1)]
+rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["JSX", "_jsx", "_jsxFileName", "x"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "x"]
+after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -50396,27 +41206,27 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefau
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Prop", "React", "_jsx", "_jsxFileName", "x"]
-rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x"]
+after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["MyComp"]
-rebuilt        : ["MyComp", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(7)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Prop", "React", "_jsx", "_jsxFileName", "x", "x1"]
-rebuilt        : ScopeId(0): ["React", "_jsx", "_jsxFileName", "x", "x1"]
+after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["MyComp"]
-rebuilt        : ["MyComp", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
@@ -50617,17 +41427,17 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "render"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitSpreadAttribute.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "__proto__", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "__proto__", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["T1", "T10", "T11", "T12", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "_jsxFileName", "_reactJsxRuntime"]
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("__proto__")
-rebuilt        : ReferenceId(34): None
+rebuilt        : ReferenceId(35): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("__proto__")
-rebuilt        : ReferenceId(39): None
+rebuilt        : ReferenceId(40): None
 Unresolved references mismatch:
-after transform: []
-rebuilt        : ["__proto__"]
+after transform: ["require"]
+rebuilt        : ["__proto__", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
 semantic error: Bindings mismatch:
@@ -50708,9 +41518,9 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(6)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
 semantic error: Missing SymbolId: React
@@ -50718,9 +41528,9 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(6)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
 semantic error: Missing SymbolId: React
@@ -50730,116 +41540,122 @@ after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsx", "_jsxFileName", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
-rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsx", "_jsxFileName", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["true"]
+after transform: ["require", "true"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(31)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherComponentProps", "ChildComponent", "Component", "ComponentProps", "React", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["AnotherComponentProps", "ChildComponent", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(14)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["AnotherComponent", "AnotherComponentProps", "Component", "ComponentProps", "React", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["AnotherComponent", "AnotherComponentProps", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Poisoned", "PoisonedProp", "React", "_jsx", "_jsxFileName", "obj", "p", "y"]
-rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsx", "_jsxFileName", "obj", "p", "y"]
+after transform: ScopeId(0): ["Poisoned", "PoisonedProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(11)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["React", "TextComponent", "TextProps", "_jsx", "_jsxFileName", "textPropsFalse", "textPropsTrue", "y1", "y2"]
-rebuilt        : ScopeId(0): ["React", "TextComponent", "_jsx", "_jsxFileName", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+after transform: ScopeId(0): ["React", "TextComponent", "TextProps", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+rebuilt        : ScopeId(0): ["React", "TextComponent", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
 Unresolved references mismatch:
-after transform: ["true"]
+after transform: ["require", "true"]
 rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(15)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsx", "_jsxFileName", "obj", "obj1", "obj3", "x", "x1"]
-rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsx", "_jsxFileName", "obj", "obj1", "obj3", "x", "x1"]
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(14)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Opt", "OptionProp", "React", "_jsx", "_jsxFileName", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
-rebuilt        : ScopeId(0): ["Opt", "React", "_jsx", "_jsxFileName", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+after transform: ScopeId(0): ["Opt", "OptionProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+rebuilt        : ScopeId(0): ["Opt", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
-rebuilt        : ReferenceId(1): Some("React")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(24)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 semantic error: Spread children are not supported in React.
@@ -50858,65 +41674,74 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["JSX", "OneThing"]
+after transform: ["JSX", "OneThing", "require"]
 rebuilt        : ["OneThing", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(40)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Context", "_jsx", "_jsxFileName", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
-rebuilt        : ScopeId(0): ["_jsx", "_jsxFileName", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
+after transform: ScopeId(0): ["Context", "_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
+rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing"]
-rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing"]
+after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing", "require"]
+rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["ButtonProps", "ClickableProps", "HyphenProps", "LinkProps", "MainButton", "React", "_jsx", "_jsxFileName", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
-rebuilt        : ScopeId(0): ["MainButton", "React", "_jsx", "_jsxFileName", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+after transform: ScopeId(0): ["ButtonProps", "ClickableProps", "HyphenProps", "LinkProps", "MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+rebuilt        : ScopeId(0): ["MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42)]
+rebuilt        : SymbolId(6): [ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(25), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49)]
 Unresolved references mismatch:
-after transform: ["JSX", "console"]
+after transform: ["JSX", "console", "require"]
 rebuilt        : ["console", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(69)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["MyComponent", "MyComponentProp", "React", "_jsx", "_jsxFileName", "i", "i1"]
-rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsx", "_jsxFileName", "i", "i1"]
+after transform: ScopeId(0): ["MyComponent", "MyComponentProp", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
+rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "attr"]
 rebuilt        : ScopeId(1): ["attr"]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(9)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(16)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Baz", "InferParamProp", "React", "_createElement", "_jsx", "_jsxFileName", "createLink", "createLink1", "i"]
-rebuilt        : ScopeId(0): ["Baz", "React", "_createElement", "_jsx", "_jsxFileName", "createLink", "createLink1", "i"]
+after transform: ScopeId(0): ["Baz", "InferParamProp", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
+rebuilt        : ScopeId(0): ["Baz", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -50924,8 +41749,11 @@ Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "a0", "a1", "key1", "value"]
 rebuilt        : ScopeId(1): ["a0", "a1", "key1", "value"]
 Unresolved references mismatch:
-after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link"]
+after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link", "require"]
 rebuilt        : ["ComponentWithTwoAttributes", "InferParamComponent", "Link", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(34), ReferenceId(35)]
+rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
 semantic error: Missing SymbolId: React
@@ -50940,8 +41768,11 @@ Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
 rebuilt        : ScopeId(1): ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
 Unresolved references mismatch:
-after transform: ["JSX", "Link", "OverloadComponent"]
+after transform: ["JSX", "Link", "OverloadComponent", "require"]
 rebuilt        : ["Link", "OverloadComponent", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(48)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
 semantic error: Missing SymbolId: React
@@ -50959,24 +41790,30 @@ Bindings mismatch:
 after transform: ScopeId(5): ["T", "a1", "a2", "a3", "a4", "arg"]
 rebuilt        : ScopeId(2): ["a1", "a2", "a3", "a4", "arg"]
 Unresolved references mismatch:
-after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX"]
+after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX", "require"]
 rebuilt        : ["Component", "ComponentSpecific", "ComponentSpecific1", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(32)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 semantic error: Missing SymbolId: React
 Missing ReferenceId: require
 Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "InterfaceProps", "React", "TypeProps", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
-rebuilt        : ScopeId(0): ["Foo", "React", "_Fragment", "_jsx", "_jsxFileName", "_jsxs"]
+after transform: ScopeId(0): ["Foo", "InterfaceProps", "React", "TypeProps", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Foo", "React", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47), ReferenceId(50), ReferenceId(53), ReferenceId(56), ReferenceId(59), ReferenceId(62)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(76)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -51030,14 +41867,6 @@ Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeTypeOnlyImport1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Default", "Import", "ImportRelative", "Require", "RequireRelative", "_Default", "_Import", "_ImportRelative", "_Require", "_RequireRelative"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolvesWithoutExportsDiagnostic1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
@@ -51078,99 +41907,6 @@ tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackag
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAssignments.ts
-semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-`import lib = require(...);` is only supported when compiling modules to CommonJS.
-Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface", "a", "b"]
-rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ImportInterface", "RequireInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface", "a", "b"]
-rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ImportInterface", "RequireInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["RequireInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ImportInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["RequireInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ImportInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LocalInterface"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ImportInterface", "RequireInterface"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
-semantic error: Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlFileWithinDeclarationFile.ts
 semantic error: Bindings mismatch:
@@ -51216,14 +41952,6 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
@@ -51249,8 +41977,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -51260,16 +41988,16 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum3.ts
 semantic error: Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -51857,6 +42585,9 @@ semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
+tasks/coverage/typescript/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
+semantic error: Cannot use export statement outside a module
+
 tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "t"]
@@ -51874,9 +42605,6 @@ Please consider using `import lib from '...';` alongside Typescript's --allowSyn
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSRedeclare3.ts
 semantic error: Identifier `orbitol` has already been declared
-
-tasks/coverage/typescript/tests/cases/conformance/salsa/privateIdentifierExpando.ts
-semantic error: Private identifier '#bar' is not allowed outside class bodies
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
 semantic error: Bindings mismatch:
@@ -51899,13 +42627,16 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
+tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
+semantic error: Cannot use export statement outside a module
+
 tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["CodeGenTarget", "ES3", "ES5"]
 rebuilt        : ScopeId(1): ["CodeGenTarget"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
@@ -52036,20 +42767,6 @@ tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["R1", "R2", "r1", "r2"]
-rebuilt        : ScopeId(0): ["r1", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(1)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(3)]
-rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 semantic error: Bindings mismatch:
@@ -52543,40 +43260,6 @@ Unresolved references mismatch:
 after transform: ["AsyncIterable", "AsyncIterableIterator", "AsyncIterator", "Promise", "PromiseLike"]
 rebuilt        : ["Promise"]
 
-tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["AlsoWeird", "BadNested", "Weird", "a", "b", "bar", "bar2"]
-rebuilt        : ScopeId(0): ["a", "b", "bar", "bar2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(3): ["T", "obj"]
-rebuilt        : ScopeId(1): ["obj"]
-Bindings mismatch:
-after transform: ScopeId(9): ["T", "obj"]
-rebuilt        : ScopeId(2): ["obj"]
-Unresolved references mismatch:
-after transform: ["P", "foo", "foo2"]
-rebuilt        : ["foo", "foo2"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ExpectNumber", "IfEquals", "T", "X1", "X10", "X10_T1_T1", "X10_Y1", "X11", "X12", "X13", "X14", "X15", "X16", "X17", "X18", "X19", "X19_T1", "X19_T2", "X19_T3", "X1_T1", "X1_T2", "X1_T3", "X2", "X20", "X20_T1", "X21", "X21_T1", "X21_T2", "X21_T3", "X21_T4", "X21_T5", "X2_T1", "X2_T2", "X2_T3", "X3", "X3_T1", "X3_T2", "X3_T3", "X4", "X4_T1", "X4_T2", "X4_T3", "X5", "X5_T1", "X5_T2", "X5_T3", "X6", "X6_T1", "X6_T2", "X6_T3", "X7", "X7_T1", "X7_T2", "X7_T3", "X7_T4", "X8", "X8_T1", "X8_T2", "X8_T3", "X8_T4", "X9", "X9_T1", "X9_T2", "X9_T3", "X9_T4", "f1", "f2", "x1", "x2"]
-rebuilt        : ScopeId(0): ["f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(61), ScopeId(63), ScopeId(64), ScopeId(67), ScopeId(69), ScopeId(71), ScopeId(73), ScopeId(77), ScopeId(80), ScopeId(84), ScopeId(87), ScopeId(89), ScopeId(90), ScopeId(91), ScopeId(92), ScopeId(95), ScopeId(96), ScopeId(98), ScopeId(99), ScopeId(100), ScopeId(101), ScopeId(102), ScopeId(103), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(111)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Reference symbol mismatch:
-after transform: ReferenceId(118): Some("x1")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(122): Some("x2")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["x1", "x2"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "foo", "x", "y", "z"]
@@ -52700,33 +43383,6 @@ rebuilt        : ReferenceId(17): None
 Unresolved references mismatch:
 after transform: ["AsyncIterable", "Iterable", "Promise"]
 rebuilt        : ["asyncIterable", "iterable", "iterableOfPromise"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar2", "foo", "foo2", "shim", "x", "y"]
-rebuilt        : ScopeId(0): ["Bar2", "shim", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["Bar", "Baz"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeGenericTypes.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeLocal.ts
-semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
-Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
 semantic error: Bindings mismatch:
@@ -52879,37 +43535,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["K", "T", "b", "k", "k1", "obj"]
-rebuilt        : ScopeId(1): ["b", "k", "k1", "obj"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(7): ["T", "b", "k", "k1", "obj"]
-rebuilt        : ScopeId(6): ["b", "k", "k1", "obj"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(11)]
-rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(9)]
-Bindings mismatch:
-after transform: ScopeId(13): ["K", "T", "b", "k", "k1", "obj"]
-rebuilt        : ScopeId(11): ["b", "k", "k1", "obj"]
-Scope children mismatch:
-after transform: ScopeId(13): [ScopeId(14), ScopeId(15), ScopeId(17)]
-rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(14)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Example1", "Example3", "Example4", "Example5", "Result1", "Result2", "Result3", "Result4", "Result5", "T01", "T02", "T03", "T04", "T05", "T06", "T07"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
@@ -53001,8 +43626,8 @@ Bindings mismatch:
 after transform: ScopeId(26): ["A", "B", "E"]
 rebuilt        : ScopeId(18): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(26): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(18): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(26): ScopeFlags(0x0)
+rebuilt        : ScopeId(18): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(63): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable | ConstVariable)
@@ -53118,17 +43743,6 @@ rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(34)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Container", "T0", "T1", "T10", "T11", "T2", "T20", "T21", "T3", "T4", "UnwrapContainers", "container1", "container2", "f1", "f2"]
-rebuilt        : ScopeId(0): ["container1", "container2", "f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Unresolved references mismatch:
-after transform: ["Capitalize", "createContainer", "f"]
-rebuilt        : ["createContainer", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
 semantic error: Bindings mismatch:
@@ -53417,47 +44031,6 @@ Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Box", "Boxified", "Foo", "Func", "Spec", "assignBoxified", "box", "boxify", "f1", "f10", "f2", "f3", "f4", "f5", "f6", "foo", "g1", "g2", "getProps", "makeDictionary", "makeRecord", "myAny", "o", "o1", "o2", "unbox", "unboxify", "x0", "x1", "x2", "x3", "x4"]
-rebuilt        : ScopeId(0): ["assignBoxified", "box", "boxify", "f1", "f10", "f2", "f3", "f4", "f5", "f6", "foo", "g1", "g2", "getProps", "makeDictionary", "makeRecord", "myAny", "o", "o1", "o2", "unbox", "unboxify", "x0", "x1", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25)]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "x"]
-rebuilt        : ScopeId(1): ["x"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "x"]
-rebuilt        : ScopeId(2): ["x"]
-Bindings mismatch:
-after transform: ScopeId(6): ["T", "obj", "result"]
-rebuilt        : ScopeId(3): ["obj", "result"]
-Bindings mismatch:
-after transform: ScopeId(9): ["T", "obj", "result"]
-rebuilt        : ScopeId(6): ["obj", "result"]
-Bindings mismatch:
-after transform: ScopeId(12): ["T", "obj", "values"]
-rebuilt        : ScopeId(9): ["obj", "values"]
-Bindings mismatch:
-after transform: ScopeId(19): ["K", "T", "obj"]
-rebuilt        : ScopeId(16): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(19): [ScopeId(20)]
-rebuilt        : ScopeId(16): []
-Bindings mismatch:
-after transform: ScopeId(22): ["T", "obj"]
-rebuilt        : ScopeId(18): ["obj"]
-Bindings mismatch:
-after transform: ScopeId(39): ["T", "object", "partial"]
-rebuilt        : ScopeId(24): ["object", "partial"]
-Bindings mismatch:
-after transform: ScopeId(45): ["K", "T", "list", "obj"]
-rebuilt        : ScopeId(25): ["list", "obj"]
-Unresolved references mismatch:
-after transform: ["Partial", "Pick", "applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
-rebuilt        : ["applySpec", "clone", "f20", "f21", "f22", "f23", "f24", "validate", "validateAndClone"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TargetProps", "f0", "f1", "f2", "f3", "f4", "modifier"]
@@ -53546,97 +44119,6 @@ rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(8)]
 Unresolved references mismatch:
 after transform: ["Extract"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Item", "T00", "T01", "T02", "T03", "T10", "T11", "T12", "T13", "T20", "T21", "T30", "T31", "T32", "T33", "T34", "T35", "T36", "T37", "T38", "T40", "T43", "T44", "T47", "x1", "x2", "x3", "x4"]
-rebuilt        : ScopeId(0): ["x1", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52), ScopeId(54)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "Number", "f1", "f2", "f3", "f4"]
-rebuilt        : ["f1", "f2", "f3", "f4"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["DeepReadonly", "PartialShape", "Point", "Proxify", "Proxy", "ReadonlyShape", "Shape", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "verifyLibTypes"]
-rebuilt        : ScopeId(0): ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "verifyLibTypes"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9)]
-Bindings mismatch:
-after transform: ScopeId(1): ["K", "T", "U", "x1", "x2", "x3", "x4"]
-rebuilt        : ScopeId(1): ["x1", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["Partial", "Pick", "Readonly", "Record", "assign", "freeze", "mapObject", "pick", "proxify"]
-rebuilt        : ["assign", "freeze", "mapObject", "pick", "proxify"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bacon", "Box", "Boxified", "BoxifiedBacon", "f1", "f2", "f3"]
-rebuilt        : ScopeId(0): ["Box", "f1", "f2", "f3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Bindings mismatch:
-after transform: ScopeId(1): ["P"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Box", "Boxified", "BoxifiedWithSentinel", "C", "Clone", "DeepReadonly", "DeepReadonlyFoo", "Foo", "M", "T00", "T01", "T02", "T03", "T04", "T05", "T10", "T11", "T12", "Z", "boxify", "f1", "x1", "z1"]
-rebuilt        : ScopeId(0): ["boxify", "f1", "x1", "z1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(30)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "obj"]
-rebuilt        : ScopeId(1): ["obj"]
-Unresolved references mismatch:
-after transform: ["Partial", "Readonly"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "Awaitified", "B", "Box", "Boxified", "Constrained", "ElementType", "F", "Mapped", "R1", "R2", "ReadWrite", "T00", "T01", "T02", "T1", "T10", "T11", "T12", "T13", "T14", "T15", "T2", "T20", "T21", "T22", "T23", "T24", "T25", "T30", "T31", "T40", "T50", "T51", "T52", "T53", "T54", "Unconstrained", "__Awaited", "acceptMappedArray", "f1", "f2", "x10", "x11", "x12", "x20", "x21", "x22", "y10", "y11", "y12", "y20", "y21", "y22"]
-rebuilt        : ScopeId(0): ["acceptMappedArray", "f1", "f2", "y10", "y11", "y12", "y20", "y21", "y22"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
-after transform: ScopeId(39): ["T", "a", "x", "y"]
-rebuilt        : ScopeId(2): ["a", "x", "y"]
-Bindings mismatch:
-after transform: ScopeId(49): ["T", "arr"]
-rebuilt        : ScopeId(3): ["arr"]
-Reference symbol mismatch:
-after transform: ReferenceId(56): Some("x10")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(59): Some("x11")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(63): Some("x12")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(68): Some("x20")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(70): Some("x21")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(72): Some("x22")
-rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: ["Array", "Partial", "Promise", "PromiseLike", "Readonly", "ReadonlyArray", "Required", "acceptArray", "all", "mapArray", "nonpartial", "unboxify"]
-rebuilt        : ["acceptArray", "all", "mapArray", "nonpartial", "unboxify", "x10", "x11", "x12", "x20", "x21", "x22"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
 semantic error: Bindings mismatch:
@@ -53841,23 +44323,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Base", "Derived", "Foo", "test1", "test2"]
-rebuilt        : ScopeId(0): ["Bar", "Base", "Derived", "test1", "test2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(10), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8)]
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-Scope children mismatch:
-after transform: ScopeId(11): [ScopeId(12)]
-rebuilt        : ScopeId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(10)]
-rebuilt        : SymbolId(5): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comparator", "LinkedList", "Node", "a1", "a2", "list", "neverArray"]
@@ -53866,11 +44331,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/never/neverType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(13): ["T", "x"]
-rebuilt        : ScopeId(13): ["x"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10", "T11", "T12"]
@@ -53878,20 +44338,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["BarProps", "FooProps", "foo", "fooProps"]
-rebuilt        : ScopeId(0): ["fooProps"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("foo")
-rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
 semantic error: Bindings mismatch:
@@ -54373,269 +44819,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(17): [ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(16): [ReferenceId(10)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["P1", "T", "T01", "T02", "T03", "T04", "T05", "T06", "T10", "T11", "T12", "f00", "f01", "f02", "f03", "f04", "f10", "f11", "f12", "f13", "f20", "ns", "sn", "t1", "t2", "t3", "t4"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("f10")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("f10")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("f10")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("f10")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("t1")
-rebuilt        : ReferenceId(4): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("t1")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("t1")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("t1")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("f10")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("t1")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("f10")
-rebuilt        : ReferenceId(10): None
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("t2")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("f10")
-rebuilt        : ReferenceId(12): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("t3")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("f10")
-rebuilt        : ReferenceId(14): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("t4")
-rebuilt        : ReferenceId(15): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("f10")
-rebuilt        : ReferenceId(16): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("t4")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("t3")
-rebuilt        : ReferenceId(18): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("f11")
-rebuilt        : ReferenceId(19): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("f11")
-rebuilt        : ReferenceId(20): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("f11")
-rebuilt        : ReferenceId(21): None
-Reference symbol mismatch:
-after transform: ReferenceId(22): Some("f11")
-rebuilt        : ReferenceId(22): None
-Reference symbol mismatch:
-after transform: ReferenceId(23): Some("t1")
-rebuilt        : ReferenceId(23): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("t1")
-rebuilt        : ReferenceId(24): None
-Reference symbol mismatch:
-after transform: ReferenceId(25): Some("t1")
-rebuilt        : ReferenceId(25): None
-Reference symbol mismatch:
-after transform: ReferenceId(26): Some("t1")
-rebuilt        : ReferenceId(26): None
-Reference symbol mismatch:
-after transform: ReferenceId(27): Some("f11")
-rebuilt        : ReferenceId(27): None
-Reference symbol mismatch:
-after transform: ReferenceId(28): Some("t1")
-rebuilt        : ReferenceId(28): None
-Reference symbol mismatch:
-after transform: ReferenceId(29): Some("f11")
-rebuilt        : ReferenceId(29): None
-Reference symbol mismatch:
-after transform: ReferenceId(30): Some("t2")
-rebuilt        : ReferenceId(30): None
-Reference symbol mismatch:
-after transform: ReferenceId(31): Some("f11")
-rebuilt        : ReferenceId(31): None
-Reference symbol mismatch:
-after transform: ReferenceId(32): Some("t3")
-rebuilt        : ReferenceId(32): None
-Reference symbol mismatch:
-after transform: ReferenceId(33): Some("f11")
-rebuilt        : ReferenceId(33): None
-Reference symbol mismatch:
-after transform: ReferenceId(34): Some("t4")
-rebuilt        : ReferenceId(34): None
-Reference symbol mismatch:
-after transform: ReferenceId(35): Some("f11")
-rebuilt        : ReferenceId(35): None
-Reference symbol mismatch:
-after transform: ReferenceId(36): Some("t4")
-rebuilt        : ReferenceId(36): None
-Reference symbol mismatch:
-after transform: ReferenceId(37): Some("t3")
-rebuilt        : ReferenceId(37): None
-Reference symbol mismatch:
-after transform: ReferenceId(38): Some("f12")
-rebuilt        : ReferenceId(38): None
-Reference symbol mismatch:
-after transform: ReferenceId(39): Some("f12")
-rebuilt        : ReferenceId(39): None
-Reference symbol mismatch:
-after transform: ReferenceId(40): Some("f12")
-rebuilt        : ReferenceId(40): None
-Reference symbol mismatch:
-after transform: ReferenceId(41): Some("f12")
-rebuilt        : ReferenceId(41): None
-Reference symbol mismatch:
-after transform: ReferenceId(42): Some("t1")
-rebuilt        : ReferenceId(42): None
-Reference symbol mismatch:
-after transform: ReferenceId(43): Some("t1")
-rebuilt        : ReferenceId(43): None
-Reference symbol mismatch:
-after transform: ReferenceId(44): Some("t1")
-rebuilt        : ReferenceId(44): None
-Reference symbol mismatch:
-after transform: ReferenceId(45): Some("t1")
-rebuilt        : ReferenceId(45): None
-Reference symbol mismatch:
-after transform: ReferenceId(46): Some("f12")
-rebuilt        : ReferenceId(46): None
-Reference symbol mismatch:
-after transform: ReferenceId(47): Some("t1")
-rebuilt        : ReferenceId(47): None
-Reference symbol mismatch:
-after transform: ReferenceId(48): Some("f12")
-rebuilt        : ReferenceId(48): None
-Reference symbol mismatch:
-after transform: ReferenceId(49): Some("t2")
-rebuilt        : ReferenceId(49): None
-Reference symbol mismatch:
-after transform: ReferenceId(50): Some("f12")
-rebuilt        : ReferenceId(50): None
-Reference symbol mismatch:
-after transform: ReferenceId(51): Some("t3")
-rebuilt        : ReferenceId(51): None
-Reference symbol mismatch:
-after transform: ReferenceId(52): Some("f12")
-rebuilt        : ReferenceId(52): None
-Reference symbol mismatch:
-after transform: ReferenceId(53): Some("t4")
-rebuilt        : ReferenceId(53): None
-Reference symbol mismatch:
-after transform: ReferenceId(54): Some("f12")
-rebuilt        : ReferenceId(54): None
-Reference symbol mismatch:
-after transform: ReferenceId(55): Some("t4")
-rebuilt        : ReferenceId(55): None
-Reference symbol mismatch:
-after transform: ReferenceId(56): Some("t3")
-rebuilt        : ReferenceId(56): None
-Reference symbol mismatch:
-after transform: ReferenceId(57): Some("f13")
-rebuilt        : ReferenceId(57): None
-Reference symbol mismatch:
-after transform: ReferenceId(58): Some("f13")
-rebuilt        : ReferenceId(58): None
-Reference symbol mismatch:
-after transform: ReferenceId(59): Some("f13")
-rebuilt        : ReferenceId(59): None
-Reference symbol mismatch:
-after transform: ReferenceId(60): Some("f13")
-rebuilt        : ReferenceId(60): None
-Reference symbol mismatch:
-after transform: ReferenceId(61): Some("t1")
-rebuilt        : ReferenceId(61): None
-Reference symbol mismatch:
-after transform: ReferenceId(62): Some("t1")
-rebuilt        : ReferenceId(62): None
-Reference symbol mismatch:
-after transform: ReferenceId(63): Some("t1")
-rebuilt        : ReferenceId(63): None
-Reference symbol mismatch:
-after transform: ReferenceId(64): Some("t1")
-rebuilt        : ReferenceId(64): None
-Reference symbol mismatch:
-after transform: ReferenceId(65): Some("f13")
-rebuilt        : ReferenceId(65): None
-Reference symbol mismatch:
-after transform: ReferenceId(66): Some("t1")
-rebuilt        : ReferenceId(66): None
-Reference symbol mismatch:
-after transform: ReferenceId(67): Some("f13")
-rebuilt        : ReferenceId(67): None
-Reference symbol mismatch:
-after transform: ReferenceId(68): Some("t2")
-rebuilt        : ReferenceId(68): None
-Reference symbol mismatch:
-after transform: ReferenceId(69): Some("f13")
-rebuilt        : ReferenceId(69): None
-Reference symbol mismatch:
-after transform: ReferenceId(70): Some("t3")
-rebuilt        : ReferenceId(70): None
-Reference symbol mismatch:
-after transform: ReferenceId(71): Some("f13")
-rebuilt        : ReferenceId(71): None
-Reference symbol mismatch:
-after transform: ReferenceId(72): Some("t4")
-rebuilt        : ReferenceId(72): None
-Reference symbol mismatch:
-after transform: ReferenceId(73): Some("f13")
-rebuilt        : ReferenceId(73): None
-Reference symbol mismatch:
-after transform: ReferenceId(74): Some("t4")
-rebuilt        : ReferenceId(74): None
-Reference symbol mismatch:
-after transform: ReferenceId(75): Some("t3")
-rebuilt        : ReferenceId(75): None
-Reference symbol mismatch:
-after transform: ReferenceId(78): Some("f20")
-rebuilt        : ReferenceId(76): None
-Reference symbol mismatch:
-after transform: ReferenceId(79): Some("t1")
-rebuilt        : ReferenceId(77): None
-Reference symbol mismatch:
-after transform: ReferenceId(80): Some("f20")
-rebuilt        : ReferenceId(78): None
-Reference symbol mismatch:
-after transform: ReferenceId(81): Some("t2")
-rebuilt        : ReferenceId(79): None
-Reference symbol mismatch:
-after transform: ReferenceId(82): Some("f20")
-rebuilt        : ReferenceId(80): None
-Reference symbol mismatch:
-after transform: ReferenceId(83): Some("t3")
-rebuilt        : ReferenceId(81): None
-Reference symbol mismatch:
-after transform: ReferenceId(84): Some("f20")
-rebuilt        : ReferenceId(82): None
-Reference symbol mismatch:
-after transform: ReferenceId(85): Some("t2")
-rebuilt        : ReferenceId(83): None
-Unresolved references mismatch:
-after transform: ["ConstructorParameters", "Function", "Parameters"]
-rebuilt        : ["f10", "f11", "f12", "f13", "f20", "t1", "t2", "t3", "t4"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
@@ -54922,198 +45105,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndParenthesizedExpressions01.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndTuples01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["RexOrRaptor", "a", "brave", "dinosaur", "hello", "im", "newish", "rawr", "world"]
-rebuilt        : ScopeId(0): ["a", "brave", "dinosaur", "hello", "im", "newish", "rawr", "world"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
-rebuilt        : ScopeId(0): ["hasKind", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
-rebuilt        : ScopeId(0): ["hasKind", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Entity", "Kind", "hasKind", "x"]
-rebuilt        : ScopeId(0): ["hasKind", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "f"]
-rebuilt        : ScopeId(1): ["f"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "f"]
-rebuilt        : ScopeId(2): ["f"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "f"]
-rebuilt        : ScopeId(1): ["f"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(8), ReferenceId(12), ReferenceId(13)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(13), ReferenceId(16)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(13)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7), ReferenceId(11), ReferenceId(12)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes04.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["T", "x", "y"]
-rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability03.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability04.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability05.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads01.ts
-semantic error: Missing SymbolId: Consts1
-Missing SymbolId: _Consts
-Missing ReferenceId: Consts1
-Missing ReferenceId: Consts1
-Missing SymbolId: Consts2
-Missing SymbolId: _Consts2
-Missing ReferenceId: Consts2
-Missing ReferenceId: Consts2
-Bindings mismatch:
-after transform: ScopeId(0): ["Consts1", "Consts2", "PrimitiveName", "boolean", "booleanOrNumber", "getFalsyPrimitive", "number", "string", "stringOrBoolean", "stringOrBooleanOrNumber", "stringOrNumber"]
-rebuilt        : ScopeId(0): ["Consts1", "Consts2", "boolean", "booleanOrNumber", "getFalsyPrimitive", "number", "string", "stringOrBoolean", "stringOrBooleanOrNumber", "stringOrNumber"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(29)]
-rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(30)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
-Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
-semantic error: Missing SymbolId: Consts1
-Missing SymbolId: _Consts
-Missing ReferenceId: Consts1
-Missing ReferenceId: Consts1
-Missing SymbolId: Consts2
-Missing SymbolId: _Consts2
-Missing ReferenceId: Consts2
-Missing ReferenceId: Consts2
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(7), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(28)]
-rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(29)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Base", "HelloOrWorld", "JustHello", "JustWorld", "f", "fResult1", "fResult2", "fResult3", "g", "gResult1", "gResult2", "gResult3", "hello", "helloOrWorld", "world"]
-rebuilt        : ScopeId(0): ["f", "fResult1", "fResult2", "fResult3", "g", "gResult1", "gResult2", "gResult3", "hello", "helloOrWorld", "world"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Kind", "kindIs", "x"]
-rebuilt        : ScopeId(0): ["kindIs", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "x", "y"]
@@ -55159,14 +45150,6 @@ rebuilt        : ScopeId(7): ["x"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInBasePropertyAndDerivedContainerOfBase01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "BoxOfFoo", "Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
 semantic error: Bindings mismatch:
@@ -55220,20 +45203,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Accessors", "Computed", "D", "Dictionary", "M", "ObjectDescriptor", "ObjectDescriptor2", "P", "Point", "PropDesc", "PropDescMap", "Vue", "VueOptions", "obj1", "p1", "p10", "p11", "p12", "p2", "p3", "p4", "vue", "x1", "x2"]
-rebuilt        : ScopeId(0): ["obj1", "p1", "p10", "p11", "p12", "p2", "p3", "p4", "vue", "x1", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(31), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(41), ScopeId(42), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
-Reference symbol mismatch:
-after transform: ReferenceId(124): Some("Vue")
-rebuilt        : ReferenceId(49): None
-Unresolved references mismatch:
-after transform: ["Record", "ThisType", "defineProp", "defineProps", "f1", "f2", "makeObject", "makeObject2"]
-rebuilt        : ["Vue", "defineProp", "defineProps", "f1", "f2", "makeObject", "makeObject2"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "strings"]
@@ -55259,119 +45228,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptiona
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "R", "T", "fn", "obj"]
 rebuilt        : ScopeId(1): ["fn", "obj"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Func", "Iter", "RecursiveTupleA", "RecursiveTupleB", "RecusiveRest", "RecusiveRest2", "Segment", "SegmentAnnotated", "WithOptAndRest", "a", "argumentsOfG", "argumentsOfGAsFirstArgument", "b", "c", "d", "func", "q", "r", "readSegment", "useState", "val", "x", "y"]
-rebuilt        : ScopeId(0): ["argumentsOfG", "argumentsOfGAsFirstArgument", "func", "readSegment", "useState", "val"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "initial"]
-rebuilt        : ScopeId(1): ["initial"]
-Symbol reference IDs mismatch:
-after transform: SymbolId(14): [ReferenceId(33)]
-rebuilt        : SymbolId(3): []
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("a")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("b")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("a")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(5): Some("c")
-rebuilt        : ReferenceId(3): None
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("a")
-rebuilt        : ReferenceId(4): None
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("d")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("b")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("a")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("b")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("c")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("b")
-rebuilt        : ReferenceId(10): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("d")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("c")
-rebuilt        : ReferenceId(12): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("a")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("c")
-rebuilt        : ReferenceId(14): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("b")
-rebuilt        : ReferenceId(15): None
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("c")
-rebuilt        : ReferenceId(16): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("d")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("d")
-rebuilt        : ReferenceId(18): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("a")
-rebuilt        : ReferenceId(19): None
-Reference symbol mismatch:
-after transform: ReferenceId(22): Some("d")
-rebuilt        : ReferenceId(20): None
-Reference symbol mismatch:
-after transform: ReferenceId(23): Some("b")
-rebuilt        : ReferenceId(21): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("d")
-rebuilt        : ReferenceId(22): None
-Reference symbol mismatch:
-after transform: ReferenceId(25): Some("c")
-rebuilt        : ReferenceId(23): None
-Reference symbol mismatch:
-after transform: ReferenceId(38): Some("q")
-rebuilt        : ReferenceId(24): None
-Reference symbol mismatch:
-after transform: ReferenceId(39): Some("r")
-rebuilt        : ReferenceId(25): None
-Reference symbol mismatch:
-after transform: ReferenceId(40): Some("r")
-rebuilt        : ReferenceId(26): None
-Reference symbol mismatch:
-after transform: ReferenceId(41): Some("q")
-rebuilt        : ReferenceId(27): None
-Reference symbol mismatch:
-after transform: ReferenceId(46): Some("x")
-rebuilt        : ReferenceId(28): None
-Reference symbol mismatch:
-after transform: ReferenceId(47): Some("y")
-rebuilt        : ReferenceId(29): None
-Reference symbol mismatch:
-after transform: ReferenceId(48): Some("y")
-rebuilt        : ReferenceId(30): None
-Reference symbol mismatch:
-after transform: ReferenceId(49): Some("x")
-rebuilt        : ReferenceId(31): None
-Unresolved references mismatch:
-after transform: ["Parameters", "f", "g", "getArgsForInjection"]
-rebuilt        : ["a", "b", "c", "d", "f", "g", "getArgsForInjection", "q", "r", "x", "y"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
 semantic error: Bindings mismatch:
@@ -55408,23 +45264,6 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["tuple"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "T10", "T11", "T12", "T13", "T20", "T21", "someDec"]
-rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("someDec")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("someDec")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray"]
-rebuilt        : ["someDec"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
 semantic error: Scope children mismatch:
@@ -55596,14 +45435,6 @@ rebuilt        : SymbolId(6): []
 Symbol flags mismatch:
 after transform: SymbolId(38): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "BoxOfFoo", "Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments.ts
 semantic error: Bindings mismatch:
@@ -56021,20 +45852,6 @@ rebuilt        : ScopeId(2): ["baz", "z"]
 Bindings mismatch:
 after transform: ScopeId(3): ["W", "a", "c", "d", "e"]
 rebuilt        : ScopeId(3): ["a", "c", "d", "e"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "a", "b", "c", "v"]
-rebuilt        : ScopeId(1): ["a", "b", "c", "v"]
-Bindings mismatch:
-after transform: ScopeId(2): ["T", "a"]
-rebuilt        : ScopeId(2): ["a"]
-Bindings mismatch:
-after transform: ScopeId(4): ["T", "a", "b", "v"]
-rebuilt        : ScopeId(4): ["a", "b", "v"]
-Bindings mismatch:
-after transform: ScopeId(5): ["T", "a"]
-rebuilt        : ScopeId(5): ["a"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -56536,39 +46353,6 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x", "y"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "foo1", "foo2"]
-rebuilt        : ScopeId(0): ["foo1", "foo2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/weakTypesAndLiterals01.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["LiteralsOrWeakTypes", "WeakTypes", "aOrB", "f", "g", "h", "i"]
-rebuilt        : ScopeId(0): ["f", "g", "h", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10)]
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("aOrB")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("aOrB")
-rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["aOrB"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 semantic error: Bindings mismatch:
@@ -59040,32 +48824,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(16): [ReferenceId(26)]
 rebuilt        : SymbolId(14): []
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "Box", "T", "arrayFilter", "arrayMap", "f00", "f01", "f02", "f03", "f10", "f11", "f12", "f13", "f20", "f21", "f22", "f23", "f30", "f31", "f40", "fn"]
-rebuilt        : ScopeId(0): ["arrayFilter", "arrayMap", "f00", "f01", "f02", "f03", "f10", "f11", "f12", "f13", "f20", "f21", "f22", "f23", "f30", "f31", "f40", "fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-Bindings mismatch:
-after transform: ScopeId(18): ["T", "U", "f"]
-rebuilt        : ScopeId(7): ["f"]
-Bindings mismatch:
-after transform: ScopeId(20): ["T", "f"]
-rebuilt        : ScopeId(9): ["f"]
-Symbol flags mismatch:
-after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction | TypeAlias)
-rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)
-Symbol span mismatch:
-after transform: SymbolId(70): Span { start: 1594, end: 1596 }
-rebuilt        : SymbolId(32): Span { start: 1621, end: 1627 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(70): [ReferenceId(118)]
-rebuilt        : SymbolId(32): []
-Symbol redeclarations mismatch:
-after transform: SymbolId(70): [Span { start: 1621, end: 1627 }]
-rebuilt        : SymbolId(32): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AssignAction", "Config", "LowInfer", "Meta", "PartialAssigner", "PropertyAssigner"]
@@ -59082,24 +48840,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["R", "S", "s", "x", "x1", "x2", "x3"]
-rebuilt        : ScopeId(0): ["x", "x1", "x2", "x3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("s")
-rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: ["Array", "f1", "f2", "f3"]
-rebuilt        : ["f1", "f2", "f3", "s"]
-
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "AnimatedViewProps", "Animations", "B", "C", "Component", "Foo", "Props", "StyleParam", "_Fragment", "_jsx", "_jsxFileName"]
-rebuilt        : ScopeId(0): ["Component", "Foo", "_Fragment", "_jsx", "_jsxFileName"]
+after transform: ScopeId(0): ["A", "AnimatedViewProps", "Animations", "B", "C", "Component", "Foo", "Props", "StyleParam", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Component", "Foo", "_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
@@ -59110,8 +48854,8 @@ Bindings mismatch:
 after transform: ScopeId(17): ["T", "props"]
 rebuilt        : ScopeId(7): ["props"]
 Unresolved references mismatch:
-after transform: ["Partial", "Record"]
-rebuilt        : []
+after transform: ["Partial", "Record", "require"]
+rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 semantic error: Bindings mismatch:
@@ -59137,14 +48881,6 @@ rebuilt        : ["ConflictTarget", "Error"]
 Unresolved reference IDs mismatch for "ConflictTarget":
 after transform: [ReferenceId(22), ReferenceId(24), ReferenceId(33), ReferenceId(39)]
 rebuilt        : [ReferenceId(3)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): ["T", "x", "y"]
-rebuilt        : ScopeId(1): ["x", "y"]
-Unresolved references mismatch:
-after transform: ["NoInfer"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
 semantic error: Bindings mismatch:
@@ -59542,223 +49278,6 @@ rebuilt        : [ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(82), ReferenceId(164)]
 rebuilt        : [ReferenceId(60)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "C0", "C1", "Context", "I", "L", "N", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "c", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constType", "constTypeAndCall", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "i", "l", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o", "o2", "o4", "promiseForConstCall", "s", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
-rebuilt        : ScopeId(0): ["C", "C0", "C1", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constTypeAndCall", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o2", "o4", "promiseForConstCall", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(33), ScopeId(34), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(34), ReferenceId(83), ReferenceId(84)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(25), ReferenceId(26), ReferenceId(29), ReferenceId(61), ReferenceId(62)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(33): [ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(61), ReferenceId(63)]
-rebuilt        : SymbolId(32): [ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44)]
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("constType")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("constType")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("constType")
-rebuilt        : ReferenceId(15): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("constType")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
-after transform: ReferenceId(55): Some("c")
-rebuilt        : ReferenceId(45): None
-Reference symbol mismatch:
-after transform: ReferenceId(56): Some("c")
-rebuilt        : ReferenceId(46): None
-Reference symbol mismatch:
-after transform: ReferenceId(58): Some("c")
-rebuilt        : ReferenceId(47): None
-Reference symbol mismatch:
-after transform: ReferenceId(60): Some("c")
-rebuilt        : ReferenceId(48): None
-Reference symbol mismatch:
-after transform: ReferenceId(62): Some("c")
-rebuilt        : ReferenceId(49): None
-Reference symbol mismatch:
-after transform: ReferenceId(64): Some("c")
-rebuilt        : ReferenceId(50): None
-Reference symbol mismatch:
-after transform: ReferenceId(66): Some("i")
-rebuilt        : ReferenceId(51): None
-Reference symbol mismatch:
-after transform: ReferenceId(68): Some("i")
-rebuilt        : ReferenceId(52): None
-Reference symbol mismatch:
-after transform: ReferenceId(70): Some("i")
-rebuilt        : ReferenceId(53): None
-Reference symbol mismatch:
-after transform: ReferenceId(72): Some("l")
-rebuilt        : ReferenceId(54): None
-Reference symbol mismatch:
-after transform: ReferenceId(73): Some("l")
-rebuilt        : ReferenceId(55): None
-Reference symbol mismatch:
-after transform: ReferenceId(75): Some("l")
-rebuilt        : ReferenceId(56): None
-Reference symbol mismatch:
-after transform: ReferenceId(77): Some("l")
-rebuilt        : ReferenceId(57): None
-Reference symbol mismatch:
-after transform: ReferenceId(79): Some("l")
-rebuilt        : ReferenceId(58): None
-Reference symbol mismatch:
-after transform: ReferenceId(81): Some("l")
-rebuilt        : ReferenceId(59): None
-Reference symbol mismatch:
-after transform: ReferenceId(92): Some("s")
-rebuilt        : ReferenceId(64): None
-Reference symbol mismatch:
-after transform: ReferenceId(97): Some("s")
-rebuilt        : ReferenceId(69): None
-Reference symbol mismatch:
-after transform: ReferenceId(100): Some("s")
-rebuilt        : ReferenceId(72): None
-Reference symbol mismatch:
-after transform: ReferenceId(103): Some("s")
-rebuilt        : ReferenceId(75): None
-Reference symbol mismatch:
-after transform: ReferenceId(104): Some("s")
-rebuilt        : ReferenceId(76): None
-Reference symbol mismatch:
-after transform: ReferenceId(105): Some("s")
-rebuilt        : ReferenceId(77): None
-Reference symbol mismatch:
-after transform: ReferenceId(106): Some("s")
-rebuilt        : ReferenceId(78): None
-Reference symbol mismatch:
-after transform: ReferenceId(107): Some("s")
-rebuilt        : ReferenceId(79): None
-Reference symbol mismatch:
-after transform: ReferenceId(109): Some("s")
-rebuilt        : ReferenceId(81): None
-Reference symbol mismatch:
-after transform: ReferenceId(112): Some("s")
-rebuilt        : ReferenceId(84): None
-Reference symbol mismatch:
-after transform: ReferenceId(115): Some("s")
-rebuilt        : ReferenceId(87): None
-Reference symbol mismatch:
-after transform: ReferenceId(118): Some("s")
-rebuilt        : ReferenceId(90): None
-Reference symbol mismatch:
-after transform: ReferenceId(121): Some("s")
-rebuilt        : ReferenceId(93): None
-Reference symbol mismatch:
-after transform: ReferenceId(122): Some("s")
-rebuilt        : ReferenceId(94): None
-Reference symbol mismatch:
-after transform: ReferenceId(123): Some("s")
-rebuilt        : ReferenceId(95): None
-Reference symbol mismatch:
-after transform: ReferenceId(124): Some("s")
-rebuilt        : ReferenceId(96): None
-Reference symbol mismatch:
-after transform: ReferenceId(125): Some("s")
-rebuilt        : ReferenceId(97): None
-Reference symbol mismatch:
-after transform: ReferenceId(127): Some("o")
-rebuilt        : ReferenceId(99): None
-Reference symbol mismatch:
-after transform: ReferenceId(128): Some("s")
-rebuilt        : ReferenceId(100): None
-Reference symbol mismatch:
-after transform: ReferenceId(129): Some("o")
-rebuilt        : ReferenceId(101): None
-Reference symbol mismatch:
-after transform: ReferenceId(131): Some("o")
-rebuilt        : ReferenceId(103): None
-Reference symbol mismatch:
-after transform: ReferenceId(135): Some("s")
-rebuilt        : ReferenceId(106): None
-Reference symbol mismatch:
-after transform: ReferenceId(143): Some("s")
-rebuilt        : ReferenceId(112): None
-Reference symbol mismatch:
-after transform: ReferenceId(148): Some("s")
-rebuilt        : ReferenceId(117): None
-Reference symbol mismatch:
-after transform: ReferenceId(152): Some("s")
-rebuilt        : ReferenceId(121): None
-Reference symbol mismatch:
-after transform: ReferenceId(157): Some("s")
-rebuilt        : ReferenceId(126): None
-Reference symbol mismatch:
-after transform: ReferenceId(159): Some("s")
-rebuilt        : ReferenceId(128): None
-Reference symbol mismatch:
-after transform: ReferenceId(161): Some("s")
-rebuilt        : ReferenceId(130): None
-Reference symbol mismatch:
-after transform: ReferenceId(173): Some("s")
-rebuilt        : ReferenceId(132): None
-Reference symbol mismatch:
-after transform: ReferenceId(174): Some("s")
-rebuilt        : ReferenceId(133): None
-Reference symbol mismatch:
-after transform: ReferenceId(175): Some("s")
-rebuilt        : ReferenceId(134): None
-Reference symbol mismatch:
-after transform: ReferenceId(176): Some("s")
-rebuilt        : ReferenceId(135): None
-Reference symbol mismatch:
-after transform: ReferenceId(177): Some("s")
-rebuilt        : ReferenceId(136): None
-Unresolved references mismatch:
-after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "N", "Promise", "Symbol", "f", "g"]
-rebuilt        : ["Math", "N", "Promise", "Symbol", "c", "constType", "f", "g", "i", "l", "o", "s"]
-Unresolved reference IDs mismatch for "N":
-after transform: [ReferenceId(86), ReferenceId(90), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(99), ReferenceId(101), ReferenceId(102), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(130), ReferenceId(132), ReferenceId(137), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(145), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(154), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : [ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId(71), ReferenceId(73), ReferenceId(74), ReferenceId(82), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(88), ReferenceId(89), ReferenceId(91), ReferenceId(92), ReferenceId(102), ReferenceId(104), ReferenceId(108), ReferenceId(110), ReferenceId(114), ReferenceId(116), ReferenceId(118), ReferenceId(119), ReferenceId(123), ReferenceId(125), ReferenceId(127), ReferenceId(129), ReferenceId(131)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(82), ReferenceId(164)]
-rebuilt        : [ReferenceId(60)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ClassWithPrivateNamedAccessors", "ClassWithPrivateNamedMethods", "ClassWithPrivateNamedProperties", "I", "InterfaceWithPrivateNamedMethods", "InterfaceWithPrivateNamedProperties", "TypeLiteralWithPrivateNamedMethods", "TypeLiteralWithPrivateNamedProperties", "classExpression", "funcInferredReturnType", "obj", "s"]
-rebuilt        : ScopeId(0): ["ClassWithPrivateNamedAccessors", "ClassWithPrivateNamedMethods", "ClassWithPrivateNamedProperties", "classExpression", "funcInferredReturnType", "obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(11)]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8)]
-rebuilt        : ScopeId(6): []
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("s")
-rebuilt        : ReferenceId(5): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("s")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("s")
-rebuilt        : ReferenceId(7): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("s")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(22): Some("s")
-rebuilt        : ReferenceId(9): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("s")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(25): Some("s")
-rebuilt        : ReferenceId(12): None
-Reference symbol mismatch:
-after transform: ReferenceId(27): Some("s")
-rebuilt        : ReferenceId(14): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["s", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,7 +2,8 @@ commit: a709f989
 
 transformer_typescript Summary:
 AST Parsed     : 6479/6479 (100.00%)
-Positive Passed: 6476/6479 (99.95%)
+Positive Passed: 6475/6479 (99.94%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxResolveExternalModuleExportsTypes.ts
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,6 +2,7 @@ commit: a709f989
 
 transformer_typescript Summary:
 AST Parsed     : 6479/6479 (100.00%)
-Positive Passed: 6477/6479 (99.97%)
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
+Positive Passed: 6476/6479 (99.95%)
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxResolveExternalModuleExportsTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 329/1021
+Passed: 321/1024
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -10,15 +10,15 @@ Passed: 329/1021
 * babel-plugin-transform-react-jsx-source
 
 
-# babel-preset-env (109/585)
+# babel-preset-env (101/585)
 * .plugins-overlapping/chrome-49/input.js
-x Output mismatch
+
 
 * .plugins-overlapping/chrome-50/input.js
-x Output mismatch
+
 
 * .plugins-overlapping/chrome-54/input.js
-x Output mismatch
+
 
 * bugfixes/_esmodules/input.js
 Targets: The `esmodules` is not supported
@@ -27,1813 +27,2008 @@ Targets: The `esmodules` is not supported
 Targets: The `esmodules` is not supported
 
 * bugfixes/edge-default-params-chrome-40/input.js
-x Output mismatch
+
 
 * bugfixes/edge-default-params-edge-14/input.js
-x Output mismatch
+
 
 * bugfixes/edge-default-params-edge-15/input.js
-x Output mismatch
+
 
 * bugfixes/edge-default-params-edge-17/input.js
-x Output mismatch
+
 
 * bugfixes/edge-default-params-edge-17-no-bugfixes/input.js
-x Output mismatch
+
 
 * bugfixes/edge-function-name-edge-14/input.js
-x Output mismatch
+
 
 * bugfixes/edge-function-name-edge-14-no-bugfixes/input.js
-x Output mismatch
+
 
 * bugfixes/edge-function-name-edge-15/input.js
-x Output mismatch
+
 
 * bugfixes/safari-block-scoping-safari-10/input.js
-x Output mismatch
+
 
 * bugfixes/safari-block-scoping-safari-10-no-bugfixes/input.js
-x Output mismatch
+
 
 * bugfixes/safari-block-scoping-safari-9/input.js
-x Output mismatch
+
 
 * bugfixes/safari-class-fields-safari-13/input.mjs
-x Output mismatch
+
 
 * bugfixes/safari-class-fields-safari-15/input.mjs
-x Output mismatch
+
 
 * bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/input.js
-x Output mismatch
+
 
 * bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/input.js
-x Output mismatch
+
 
 * bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/input.js
-x Output mismatch
+
 
 * bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/class-in-computed-field-firefox-50/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/class-in-computed-field-firefox-90/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/static-class-fields-chrome-70/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/static-class-fields-chrome-90/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/static-class-fields-chrome-96/input.js
-x Output mismatch
+
 
 * bugfixes-always-enabled/static-class-fields-chrome-97/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/entry-all/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-chrome-48/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-chrome-49/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-chrome-66/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-chromeandroid/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-core-js-main/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-core-js-main-require/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-electron/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-ie-9/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-import/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-node/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-node-10.13/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-node-11/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-node-web/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/entry-require/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/entry-shippedProposals/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/exclude-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/exclude-include/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/exclude-regenerator/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/force-all-transforms/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/include-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-all/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs2-babel-7/usage-destructuring-assignment/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-destructuring-catch/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-destructuring-for-x/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-destructuring-params/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-destructuring-variable-declaration/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-evaluated-class-methods/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-evaluated-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-evaluated-not-confident/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-for-of/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-for-of-destructure-with/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-instance-methods-native-support/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-modules-transform/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-native-support/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-number-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-promise-all/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-promise-finally/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-promise-race/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-regenerator-used-async/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-regenerator-used-generator/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-remove-babel-polyfill-import/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-shippedProposals/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/usage-source-type-script/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/usage-source-type-script-query/input.js
-x Output mismatch
+
 
 * corejs2-babel-7/usage-symbol-iterator/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-symbol-iterator-in/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-timers/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-typed-array/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-typed-array-static/input.mjs
-x Output mismatch
+
 
 * corejs2-babel-7/usage-yield-star/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-all/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-all-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-chrome-48/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-chrome-49/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-chrome-66/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-chromeandroid/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-electron/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-es-proposals-stage/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-es-proposals-stage-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-features/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-features-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-missed/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-mixed/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-mixed-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-modules/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-modules-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-proposals/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-stable/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-stage/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-stage-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-web/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-entries-web-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-ie-9/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-import/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-node/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-node-10.13/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-node-11/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-node-web/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-normalization/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-require/input.js
-x Output mismatch
+
 
 * corejs3/entry-require-all/input.js
-x Output mismatch
+
 
 * corejs3/entry-require-es-chrome-71/input.js
-x Output mismatch
+
 
 * corejs3/entry-require-es-proposals/input.js
-x Output mismatch
+
 
 * corejs3/entry-specified-imports/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["fromEntries", "reflect"]
+  | rebuilt        : ScopeId(0): ["reflect"]
+
 
 * corejs3/entry-stable/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/entry-stable-samsung-8.2/input.mjs
-x Output mismatch
+
 
 * corejs3/exclude-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs3/exclude-include/input.mjs
-x Output mismatch
+
 
 * corejs3/force-all-transforms/input.mjs
-x Output mismatch
+
 
 * corejs3/include-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-all-proposals/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-all-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs3/usage-determanated-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-for-of-destructure-with/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-modules-transform/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-number-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-object-destructuring/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-object-destructuring-with-rest/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-promise-all/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-promise-finally/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-promise-race/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-regenerator-used-async-native-support/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-shippedProposals/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-source-type-script/input.js
-x Output mismatch
+
 
 * corejs3/usage-source-type-script-query/input.js
-x Output mismatch
+
 
 * corejs3/usage-static-methods/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-timers/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-typed-array/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-typed-array-edge-13/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-typed-array-static/input.mjs
-x Output mismatch
+
 
 * corejs3/usage-yield-star/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-all/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-all-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-chrome-48/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-chrome-49/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-chrome-66/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-chromeandroid/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-electron/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-es-proposals-stage/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-es-proposals-stage-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-features/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-features-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-missed/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-mixed/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-mixed-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-modules/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-modules-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-proposals/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-stable/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-stage/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-stage-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-web/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-entries-web-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-ie-9/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-import/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-node/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-node-10.13/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-node-11/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-node-web/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-normalization/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-require/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/entry-require-all/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/entry-require-es-chrome-71/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/entry-require-es-proposals/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/entry-specified-imports/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["fromEntries", "reflect"]
+  | rebuilt        : ScopeId(0): ["reflect"]
+
 
 * corejs3-babel-7/entry-stable/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/entry-stable-samsung-8.2/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/exclude/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/exclude-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/exclude-include/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/exclude-regenerator/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/force-all-transforms/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/include-built-ins/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-all/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-all-proposals/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-all-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs3-babel-7/usage-built-in-from-global-object/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-assignment/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-catch/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-for-x/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-iife/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-params/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-destructuring-variable-declaration/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-determanated-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-dynamic-import/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-evaluated-class-methods/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-evaluated-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-fetch/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-for-of/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-for-of-destructure-with/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-in/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-instance-methods/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-modules-transform/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-number-ie-11/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-object-destructuring/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-object-destructuring-with-rest/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-promise-all/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-promise-finally/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-promise-race/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-regenerator-used-async/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-regenerator-used-async-native-support/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-regenerator-used-generator/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-shippedProposals/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-source-type-script/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/usage-source-type-script-query/input.js
-x Output mismatch
+
 
 * corejs3-babel-7/usage-spread/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-static-methods/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-symbol-iterator/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-symbol-iterator-in/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-timers/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-typed-array/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-typed-array-edge-13/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-typed-array-static/input.mjs
-x Output mismatch
+
 
 * corejs3-babel-7/usage-yield-star/input.mjs
-x Output mismatch
+
 
 * debug/browserslist-env/input.mjs
-x Output mismatch
+
 
 * debug/browserslists-android-3/input.mjs
-x Output mismatch
+
 
 * debug/browserslists-defaults/input.mjs
-x Output mismatch
+
 
 * debug/browserslists-defaults-not-ie/input.mjs
-x Output mismatch
+
 
 * debug/browserslists-last-2-versions-not-ie/input.mjs
-x Output mismatch
+
 
 * debug/corejs-without-usebuiltins/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-all/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-all-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-android/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-babel-polyfill/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-electron/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-es/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-es-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-es-proposals/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-es-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-force-all-transforms/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-no-import/input.js
-x Output mismatch
+
 
 * debug/entry-corejs3-proposals/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-runtime-only/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-runtime-only-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-specific-entries/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-specific-entries-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-specific-targets/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-stable/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-stable-samsung-8.2/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-stage/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-stage-chrome-71/input.mjs
-x Output mismatch
+
+
+* debug/entry-corejs3-versions-decimals/input.mjs
+
+
+* debug/entry-corejs3-versions-strings/input.mjs
+
 
 * debug/entry-corejs3-versions-strings-minor-3.0/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-versions-strings-minor-3.1/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-web/input.mjs
-x Output mismatch
+
 
 * debug/entry-corejs3-web-chrome-71/input.mjs
-x Output mismatch
+
+
+* debug/entry-no-corejs/input.mjs
+
+
+* debug/entry-no-corejs-no-import/input.js
+
 
 * debug/plugins-only/input.mjs
-x Output mismatch
+
 
 * debug/shippedProposals-chrome-80/input.mjs
-x Output mismatch
+
 
 * debug/shippedProposals-chrome-84/input.mjs
-x Output mismatch
+
 
 * debug/top-level-targets/input.mjs
-x Output mismatch
+
 
 * debug/top-level-targets-shadowed/input.mjs
-x Output mismatch
+
 
 * debug/usage-corejs3-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-none-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-none-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-proposals-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-proposals-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-proposals-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-proposals-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-shippedProposals-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-shippedProposals-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-versions-strings-minor-3.0-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-versions-strings-minor-3.0-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-versions-strings-minor-3.1-1/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-versions-strings-minor-3.1-2/input.js
-x Output mismatch
+
 
 * debug/usage-corejs3-with-import/input.mjs
-x Output mismatch
+
+
+* debug/usage-no-corejs/input.js
+
+
+* debug/usage-no-corejs-none/input.js
+
 
 * debug-babel-7/browserslists-android-3/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/browserslists-defaults/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/browserslists-defaults-not-ie/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/browserslists-last-2-versions-not-ie/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/corejs-without-usebuiltins/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-android/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-electron/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-force-all-transforms/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-no-import/input.js
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-proposals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-shippedProposals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-shippedProposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-specific-targets/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-versions-decimals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs2-versions-strings/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-all/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-all-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-android/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-babel-polyfill/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-electron/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-es/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-es-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-es-proposals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-es-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-force-all-transforms/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-no-import/input.js
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-proposals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-proposals-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-runtime-only/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-runtime-only-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-specific-entries/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-specific-entries-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-specific-targets/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-stable/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-stable-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-stable-samsung-8.2/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-stage/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-stage-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-versions-decimals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-versions-strings/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-versions-strings-minor-3.0/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-versions-strings-minor-3.1/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-web/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-corejs3-web-chrome-71/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-no-corejs/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/entry-no-corejs-no-import/input.js
-x Output mismatch
+
 
 * debug-babel-7/entry-no-corejs-shippedProposals/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/plugins-only/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/shippedProposals-chrome-80/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/shippedProposals-chrome-84/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/top-level-targets/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/top-level-targets-shadowed/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-none-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-none-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-proposals-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-proposals-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-proposals-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-proposals-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-shippedProposals-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-shippedProposals-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs2-with-import/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-none-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-none-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-proposals-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-proposals-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-proposals-chrome-71-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-proposals-chrome-71-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-shippedProposals-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-shippedProposals-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-corejs3-with-import/input.mjs
-x Output mismatch
+
 
 * debug-babel-7/usage-no-corejs-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-no-corejs-2/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-no-corejs-none-1/input.js
-x Output mismatch
+
 
 * debug-babel-7/usage-no-corejs-none-2/input.js
-x Output mismatch
+
 
 * dynamic-import/auto-esm-unsupported-import-unsupported/input.mjs
-x Output mismatch
+
 
 * dynamic-import/modules-amd/input.js
-x Output mismatch
+
 
 * dynamic-import/modules-cjs/input.mjs
-x Output mismatch
+
 
 * dynamic-import/modules-systemjs/input.mjs
-x Output mismatch
+
 
 * dynamic-import/modules-umd/input.mjs
-x Output mismatch
+
 
 * dynamic-import-babel-7/auto-esm-unsupported-import-unsupported/input.mjs
-x Output mismatch
+
 
 * dynamic-import-babel-7/modules-amd/input.js
-x Output mismatch
+
 
 * dynamic-import-babel-7/modules-cjs/input.mjs
-x Output mismatch
+
 
 * dynamic-import-babel-7/modules-systemjs/input.mjs
-x Output mismatch
+
 
 * dynamic-import-babel-7/modules-umd/input.mjs
-x Output mismatch
+
 
 * export-namespace-from/auto-esm-not-supported/input.mjs
-x Output mismatch
+
 
 * export-namespace-from/auto-export-namespace-not-supported/input.mjs
-x Output mismatch
+
 
 * export-namespace-from/false-export-namespace-not-supported/input.mjs
-x Output mismatch
+
 
 * export-namespace-from/false-export-namespace-not-supported-caller-supported/input.mjs
-x Output mismatch
+
 
 * modules/auto-cjs/input.mjs
-x Output mismatch
+
 
 * modules/auto-unknown/input.mjs
-x Output mismatch
+
 
 * modules/modules-cjs/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["a"]
+  | rebuilt        : ScopeId(0): []
+
 
 * modules/modules-commonjs/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["a"]
+  | rebuilt        : ScopeId(0): []
+
 
 * modules/modules-false/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["a"]
+  | rebuilt        : ScopeId(0): []
+
 
 * modules/modules-systemjs/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["a"]
+  | rebuilt        : ScopeId(0): []
+
 
 * modules/modules-umd/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["a"]
+  | rebuilt        : ScopeId(0): []
+
 
 * plugins-integration/block-scoping-inside-generator/input.js
-x Output mismatch
+
 
 * plugins-integration/class-arrow-super-tagged-expr/input.js
-x Output mismatch
+
 
 * plugins-integration/class-features-node-12/input.js
-x Output mismatch
+
 
 * plugins-integration/for-of-array-block-scoping/input.js
-x Output mismatch
+
 
 * plugins-integration/for-of-array-block-scoping-2/input.js
-x Output mismatch
+
 
 * plugins-integration/issue-10662/input.mjs
-x Output mismatch
+
 
 * plugins-integration/issue-11278/input.mjs
-x Output mismatch
+
 
 * plugins-integration/issue-15012/input.js
-x Output mismatch
+
 
 * plugins-integration/issue-15170/input.js
-x Output mismatch
+
 
 * plugins-integration/issue-16155/input.mjs
-x Output mismatch
+
 
 * plugins-integration/issue-7527/input.mjs
-x Output mismatch
+
 
 * plugins-integration/issue-9935/input.js
-x Output mismatch
+
 
 * plugins-integration/regression-2892/input.mjs
-x Output mismatch
+
 
 * plugins-integration/regression-4855/input.js
-x Output mismatch
+
 
 * plugins-integration/spread-super-firefox-40/input.js
-x Output mismatch
+
 
 * preset-options/browserslist-config-ignore-config-with-false/input.mjs
-x Output mismatch
+
 
 * preset-options/browserslist-config-ignore-package-with-false/input.mjs
-x Output mismatch
+
 
 * preset-options/browserslist-defaults/input.mjs
-x Output mismatch
+
 
 * preset-options/browserslist-defaults-not-ie/input.mjs
 Targets: node `current` is not supported
 
 * preset-options/deno-1_0/input.mjs
-x Output mismatch
+
 
 * preset-options/destructuring-edge/input.js
-x Output mismatch
+
 
 * preset-options/duplicate-named-capturing-groups-regex-chrome-123/input.js
-x Output mismatch
+
 
 * preset-options/empty-options/input.mjs
-x Output mismatch
+
 
 * preset-options/esmodules-async-functions/input.mjs
 Targets: The `esmodules` is not supported
 
 * preset-options/include/input.mjs
-x Output mismatch
+
 
 * preset-options/include-scoped/input.mjs
-x Output mismatch
+
 
 * preset-options/ios-6/input.mjs
-x Output mismatch
+
 
 * preset-options/no-options/input.mjs
-x Output mismatch
+
+
+* preset-options/removed-loose/input.js
+
+
+* preset-options/removed-spec/input.js
+
 
 * preset-options/reserved-keys-ie8/input.mjs
-x Output mismatch
+
 
 * preset-options/reserved-names-ie8/input.mjs
-x Output mismatch
+
 
 * preset-options/rhino-1_7_13/input.mjs
-x Output mismatch
+
 
 * preset-options/safari-10_3-block-scoped/input.js
-x Output mismatch
+
 
 * preset-options/safari-tagged-template-literals/input.js
-x Output mismatch
+
 
 * preset-options/safari-tp/input.js
 failed to resolve query: failed to parse the rest of input: ...''
 
 * preset-options/unicode-property-regex-chrome-49/input.js
-x Output mismatch
+
 
 * preset-options/unicode-sets-regex-chrome-111/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/browserslist-config-ignore-config-with-false/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/browserslist-config-ignore-package-with-false/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/browserslist-defaults/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/browserslist-defaults-not-ie/input.mjs
 Targets: node `current` is not supported
 
 * preset-options-babel-7/deno-1_0/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/destructuring-edge/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/duplicate-named-capturing-groups-regex-chrome-120/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/empty-options/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/esmodules-async-functions/input.mjs
 Targets: The `esmodules` is not supported
 
 * preset-options-babel-7/include/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/include-scoped/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/ios-10/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/ios-10_3/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/ios-6/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/loose-typeof-symbol/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/loose-with-typeof-symbol-includes/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/no-options/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/reserved-keys-ie8/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/reserved-names-ie8/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/rhino-1_7_13/input.mjs
-x Output mismatch
+
 
 * preset-options-babel-7/safari-10_3-block-scoped/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/safari-tagged-template-literals/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/safari-tp/input.js
 failed to resolve query: failed to parse the rest of input: ...''
 
 * preset-options-babel-7/shippedProposals/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/spec/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/unicode-property-regex-chrome-49/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/unicode-sets-regex-chrome-111/input.js
-x Output mismatch
+
 
 * preset-options-babel-7/useBuiltIns-false/input.mjs
-x Output mismatch
+
 
 * sanity/block-scoping-for-of/input.js
-x Output mismatch
+
 
 * sanity/regex-dot-all/input.js
-x Output mismatch
+
 
 * sanity/transform-duplicate-keys/input.js
-x Output mismatch
+
 
 * shipped-proposals/import-assertions/input.mjs
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["packageJson"]
+  | rebuilt        : ScopeId(0): []
+
 
 * shipped-proposals/new-class-features-chrome-90/input.js
-x Output mismatch
+
 
 * shipped-proposals/new-class-features-firefox-70/input.js
-x Output mismatch
+
 
 
 # babel-plugin-transform-logical-assignment-operators (0/6)
 * logical-assignment/anonymous-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
-rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(6): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+
 
 * logical-assignment/arrow-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
-rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(6): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+
 
 * logical-assignment/general-semantics/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): [ReferenceId(117), ReferenceId(118), ReferenceId(121)]
-rebuilt        : SymbolId(8): [ReferenceId(87), ReferenceId(91)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(17): [ReferenceId(122), ReferenceId(123), ReferenceId(126)]
-rebuilt        : SymbolId(10): [ReferenceId(99), ReferenceId(103)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(19): [ReferenceId(127), ReferenceId(128), ReferenceId(131)]
-rebuilt        : SymbolId(12): [ReferenceId(111), ReferenceId(115)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(21): [ReferenceId(132), ReferenceId(133), ReferenceId(136)]
-rebuilt        : SymbolId(14): [ReferenceId(123), ReferenceId(127)]
-Reference flags mismatch:
-after transform: ReferenceId(98): ReferenceFlags(Write)
-rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(97): ReferenceFlags(Write)
-rebuilt        : ReferenceId(29): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(100): ReferenceFlags(Write)
-rebuilt        : ReferenceId(33): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(99): ReferenceFlags(Write)
-rebuilt        : ReferenceId(35): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(102): ReferenceFlags(Write)
-rebuilt        : ReferenceId(39): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(101): ReferenceFlags(Write)
-rebuilt        : ReferenceId(41): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(104): ReferenceFlags(Write)
-rebuilt        : ReferenceId(45): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(103): ReferenceFlags(Write)
-rebuilt        : ReferenceId(47): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(107): ReferenceFlags(Write)
-rebuilt        : ReferenceId(52): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(105): ReferenceFlags(Write)
-rebuilt        : ReferenceId(55): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(110): ReferenceFlags(Write)
-rebuilt        : ReferenceId(61): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(108): ReferenceFlags(Write)
-rebuilt        : ReferenceId(64): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(113): ReferenceFlags(Write)
-rebuilt        : ReferenceId(70): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(111): ReferenceFlags(Write)
-rebuilt        : ReferenceId(73): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(116): ReferenceFlags(Write)
-rebuilt        : ReferenceId(79): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(114): ReferenceFlags(Write)
-rebuilt        : ReferenceId(82): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(118): ReferenceFlags(Write)
-rebuilt        : ReferenceId(87): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(120): ReferenceFlags(Write)
-rebuilt        : ReferenceId(89): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(119): ReferenceFlags(Write)
-rebuilt        : ReferenceId(92): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(123): ReferenceFlags(Write)
-rebuilt        : ReferenceId(99): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(125): ReferenceFlags(Write)
-rebuilt        : ReferenceId(101): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(124): ReferenceFlags(Write)
-rebuilt        : ReferenceId(104): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(128): ReferenceFlags(Write)
-rebuilt        : ReferenceId(111): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(130): ReferenceFlags(Write)
-rebuilt        : ReferenceId(113): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(129): ReferenceFlags(Write)
-rebuilt        : ReferenceId(116): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(133): ReferenceFlags(Write)
-rebuilt        : ReferenceId(123): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(135): ReferenceFlags(Write)
-rebuilt        : ReferenceId(125): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(134): ReferenceFlags(Write)
-rebuilt        : ReferenceId(128): ReferenceFlags(Read)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(15): [ReferenceId(117), ReferenceId(118),
+  | ReferenceId(121)]
+  | rebuilt        : SymbolId(8): [ReferenceId(87), ReferenceId(91)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(122), ReferenceId(123),
+  | ReferenceId(126)]
+  | rebuilt        : SymbolId(10): [ReferenceId(99), ReferenceId(103)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(19): [ReferenceId(127), ReferenceId(128),
+  | ReferenceId(131)]
+  | rebuilt        : SymbolId(12): [ReferenceId(111), ReferenceId(115)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(21): [ReferenceId(132), ReferenceId(133),
+  | ReferenceId(136)]
+  | rebuilt        : SymbolId(14): [ReferenceId(123), ReferenceId(127)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(98): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(97): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(29): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(100): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(33): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(99): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(35): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(102): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(39): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(101): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(41): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(104): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(45): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(103): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(47): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(107): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(52): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(105): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(55): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(110): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(61): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(108): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(64): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(113): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(70): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(111): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(73): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(116): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(79): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(114): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(82): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(118): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(87): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(120): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(89): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(119): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(92): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(123): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(99): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(125): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(101): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(124): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(104): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(128): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(111): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(130): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(113): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(129): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(116): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(133): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(123): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(135): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(125): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(134): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(128): ReferenceFlags(Read)
+
 
 * logical-assignment/named-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
-rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(6): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+
 
 * logical-assignment/null-coalescing/input.js
-x Output mismatch
+  x Output mismatch
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(86), ReferenceId(87),
+  | ReferenceId(90)]
+  | rebuilt        : SymbolId(12): [ReferenceId(73), ReferenceId(79)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(20): [ReferenceId(94), ReferenceId(95),
+  | ReferenceId(98)]
+  | rebuilt        : SymbolId(14): [ReferenceId(88), ReferenceId(94)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(65): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(64): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(31): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(70): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(36): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(69): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(40): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(76): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(48): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(74): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(53): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(82): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(60): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(80): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(65): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(87): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(73): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(89): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(75): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(88): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(80): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(95): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(88): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(97): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(90): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(96): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(95): ReferenceFlags(Read)
+
 
 * logical-assignment/null-coalescing-without-other/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(11)]
-rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(8)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
-rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(5): ReferenceFlags(Write)
-rebuilt        : ReferenceId(4): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(10): ReferenceFlags(Write)
-rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(9): ReferenceFlags(Write)
-rebuilt        : ReferenceId(9): ReferenceFlags(Read)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(8)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+  | rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(3), ReferenceId(6)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(6): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(5): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(4): ReferenceFlags(Read)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(10): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(9): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(9): ReferenceFlags(Read)
+
 
 
 # babel-plugin-transform-nullish-coalescing-operator (5/12)
 * assumption-noDocumentAll/transform/input.js
-x Output mismatch
+
 
 * assumption-noDocumentAll/transform-in-default-destructuring/input.js
-x Output mismatch
+
 
 * assumption-noDocumentAll/transform-in-default-param/input.js
-x Output mismatch
+
 
 * assumption-noDocumentAll/transform-in-function/input.js
-x Output mismatch
+
 
 * assumption-noDocumentAll/transform-static-refs-in-default/input.js
-x Output mismatch
+
 
 * assumption-noDocumentAll/transform-static-refs-in-function/input.js
-x Output mismatch
+
 
 * nullish-coalescing/transform-loose/input.js
-x Output mismatch
+
 
 
 # babel-plugin-transform-object-rest-spread (5/59)
 * assumption-ignoreFunctionLength/parameters-object-rest-used-in-default/input.js
-x Output mismatch
+
 
 * assumption-objectRestNoSymbols/rest-assignment-expression/input.js
-x Output mismatch
+
 
 * assumption-objectRestNoSymbols/rest-computed/input.js
-x Output mismatch
+
 
 * assumption-objectRestNoSymbols/rest-nested/input.js
-x Output mismatch
+
 
 * assumption-objectRestNoSymbols/rest-var-declaration/input.js
-x Output mismatch
+
 
 * assumption-pureGetters/rest-remove-unused-excluded-keys/input.js
-x Output mismatch
+
 
 * assumption-pureGetters/spread-single-call/input.js
-x Output mismatch
+
 
 * assumption-setSpreadProperties/assignment/input.js
-x Output mismatch
+
 
 * assumption-setSpreadProperties/expression/input.js
-x Output mismatch
+
 
 * assumption-setSpreadProperties/targets-support-object-assign/input.js
-x Output mismatch
+
 
 * assumption-setSpreadProperties-with-useBuiltIns/assignment/input.js
-x Output mismatch
+
 
 * assumption-setSpreadProperties-with-useBuiltIns/expression/input.js
-x Output mismatch
+
 
 * object-rest/assignment-expression/input.js
-x Output mismatch
+
 
 * object-rest/catch-clause/input.js
-x Output mismatch
+
 
 * object-rest/duplicate-decl-bug/input.js
-x Output mismatch
+
 
 * object-rest/export/input.mjs
-x Output mismatch
+
 
 * object-rest/for-x/input.js
-x Output mismatch
+
 
 * object-rest/for-x-array-pattern/input.js
-x Output mismatch
+
 
 * object-rest/for-x-completion-record/input.js
-x Output mismatch
+
 
 * object-rest/impure-computed/input.js
-x Output mismatch
+
 
 * object-rest/nested/input.js
-x Output mismatch
+
 
 * object-rest/nested-2/input.js
-x Output mismatch
+
 
 * object-rest/nested-array/input.js
-x Output mismatch
+
 
 * object-rest/nested-array-2/input.js
-x Output mismatch
+
 
 * object-rest/nested-computed-key/input.js
-x Output mismatch
+
 
 * object-rest/nested-default-value/input.js
-x Output mismatch
+
 
 * object-rest/nested-literal-property/input.js
-x Output mismatch
+
 
 * object-rest/nested-order/input.js
-x Output mismatch
+
 
 * object-rest/non-string-computed/input.js
-x Output mismatch
+
 
 * object-rest/null-destructuring/input.js
-x Output mismatch
+
 
 * object-rest/object-ref-computed/input.js
-x Output mismatch
+
 
 * object-rest/parameters/input.js
-x Output mismatch
+
 
 * object-rest/parameters-object-rest-used-in-default/input.js
-x Output mismatch
+
 
 * object-rest/remove-unused-excluded-keys-loose/input.js
-x Output mismatch
+
 
 * object-rest/symbol/input.js
-x Output mismatch
+
 
 * object-rest/template-literal-allLiterals-true-no-hoisting/input.js
-x Output mismatch
+
 
 * object-rest/template-literal-property-allLiterals-false/input.js
-x Output mismatch
+
 
 * object-rest/template-literal-property-allLiterals-true/input.js
-x Output mismatch
+
 
 * object-rest/variable-destructuring/input.js
-x Output mismatch
+
 
 * object-rest/with-array-rest/input.js
-x Output mismatch
+
 
 * object-spread/expression/input.js
-x Output mismatch
+
 
 * object-spread/side-effect/input.js
-x Output mismatch
+
 
 * object-spread-loose/assignment/input.js
-x Output mismatch
+
 
 * object-spread-loose/expression/input.js
-x Output mismatch
+
 
 * object-spread-loose/parameters-object-rest-used-in-default/input.js
-x Output mismatch
+
 
 * object-spread-loose/side-effect/input.js
-x Output mismatch
+
 
 * object-spread-loose/variable-declaration/input.js
-x Output mismatch
+
 
 * object-spread-loose-builtins/expression/input.js
-x Output mismatch
+
 
 * object-spread-loose-builtins/side-effect/input.js
-x Output mismatch
+
 
 * regression/gh-4904/input.js
-x Output mismatch
+
 
 * regression/gh-5151/input.js
-x Output mismatch
+
 
 * regression/gh-7304/input.mjs
-x Output mismatch
+
 
 * regression/gh-7388/input.js
-x Output mismatch
+
 
 * regression/gh-8323/input.js
-x Output mismatch
+
 
 
 # babel-plugin-transform-exponentiation-operator (1/4)
 * exponentiation-operator/assignment/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-Reference flags mismatch:
-after transform: ReferenceId(2): ReferenceFlags(Write)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(1): ReferenceFlags(Write)
-rebuilt        : ReferenceId(2): ReferenceFlags(Read)
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(2): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(1): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(2): ReferenceFlags(Read)
+
 
 * regression/4349/input.js
-x Output mismatch
+
 
 * regression/4403/input.js
-Reference flags mismatch:
-after transform: ReferenceId(3): ReferenceFlags(Write)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+  x Reference flags mismatch:
+  | after transform: ReferenceId(3): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+
 
 
 # babel-plugin-transform-arrow-functions (1/6)
 * assumption-newableArrowFunctions-false/basic/input.js
-x Output mismatch
+
 
 * assumption-newableArrowFunctions-false/naming/input.js
-x Output mismatch
+
 
 * assumption-newableArrowFunctions-false/self-referential/input.js
-x Output mismatch
+
 
 * spec/newableArrowFunction-default/input.js
-x Output mismatch
+
 
 * spec/newableArrowFunction-vs-spec-false/input.js
-x Output mismatch
+
 
 
 # babel-preset-typescript (5/10)
@@ -1847,32 +2042,48 @@ x Output mismatch
 
 
 * node-extensions/import-in-cts/input.cts
-x Output mismatch
+
 
 * node-extensions/type-assertion-in-ts/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "x"]
+  | rebuilt        : ["x"]
+
 
 * node-extensions/type-param-arrow-in-ts/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["T"]
+  | rebuilt        : ScopeId(1): []
+
 
 * opts/optimizeConstEnums/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "x"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 
-# babel-plugin-transform-typescript (39/152)
+
+# babel-plugin-transform-typescript (41/154)
 * cast/as-expression/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "x"]
+  | rebuilt        : ["x"]
+
 
 * cast/type-assertion/input.ts
-Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "x"]
+  | rebuilt        : ["x"]
+
 
 * class/accessor-allowDeclareFields-false/input.ts
 TS(18010)
@@ -1899,340 +2110,673 @@ TS(18010)
 
 
 * class/head/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["T"]
-rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["D", "I"]
-rebuilt        : ["D"]
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["T"]
+  | rebuilt        : ScopeId(1): []
+
+  x Unresolved references mismatch:
+  | after transform: ["D", "I"]
+  | rebuilt        : ["D"]
+
 
 * class/methods/input.ts
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+  x Scope children mismatch:
+  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4),
+  | ScopeId(5)]
+  | rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+
 
 * class/private-method-override/input.ts
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
+  x Scope children mismatch:
+  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+  | rebuilt        : ScopeId(1): [ScopeId(2)]
+
 
 * declarations/const-enum/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["E"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
 
 * declarations/erased/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["E", "I", "M", "N", "T", "m", "x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["E", "I", "M", "N", "T", "m", "x"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+  | rebuilt        : ScopeId(0): []
+
 
 * declarations/export-declare-enum/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
 
 * declarations/nested-namespace/input.mjs
-Bindings mismatch:
-after transform: ScopeId(0): ["P"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["P"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
 
 * enum/boolean-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "E"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/const/input.ts
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/constant-folding/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h",
+  | "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/enum-merging-inner-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
-rebuilt        : ScopeId(1): ["Animals"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["Animals", "CatDog"]
-rebuilt        : ScopeId(2): ["Animals"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 41, end: 48 }]
-rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Cat", "Dog"]
-rebuilt        : []
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
+  | rebuilt        : ScopeId(1): ["Animals"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["Animals", "CatDog"]
+  | rebuilt        : ScopeId(2): ["Animals"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 41, end: 48 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Unresolved references mismatch:
+  | after transform: ["Cat", "Dog"]
+  | rebuilt        : []
+
 
 * enum/enum-merging-inner-references-shadow/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Animals", "Cat"]
-rebuilt        : ScopeId(1): ["Animals"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["Animals", "Dog"]
-rebuilt        : ScopeId(2): ["Animals"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["Animals", "CatDog"]
-rebuilt        : ScopeId(3): ["Animals"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol redeclarations mismatch:
-after transform: SymbolId(2): [Span { start: 65, end: 72 }, Span { start: 92, end: 99 }]
-rebuilt        : SymbolId(2): []
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Animals", "Cat"]
+  | rebuilt        : ScopeId(1): ["Animals"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["Animals", "Dog"]
+  | rebuilt        : ScopeId(2): ["Animals"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["Animals", "CatDog"]
+  | rebuilt        : ScopeId(3): ["Animals"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(3): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0)]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(1)]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(2): [Span { start: 65, end: 72 }, Span { start:
+  | 92, end: 99 }]
+  | rebuilt        : SymbolId(2): []
+
 
 * enum/export/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "E"]
-rebuilt        : ScopeId(2): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 40, end: 41 }]
-rebuilt        : SymbolId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "E"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["B", "E"]
+  | rebuilt        : ScopeId(2): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 40, end: 41 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * enum/inferred/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "x", "y"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["E", "x", "y"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/inner-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["E", "a", "b"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/mix-references/input.ts
-x Output mismatch
+  x Output mismatch
+  x Missing ReferenceId: Foo
+
+  x Missing ReferenceId: Bar
+
+  x Missing ReferenceId: Baz
+
+  x Missing ReferenceId: A
+
+  x Missing ReferenceId: A
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
+  | rebuilt        : ScopeId(1): ["Foo"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["Bar", "D", "E", "F", "G"]
+  | rebuilt        : ScopeId(2): ["Bar"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["Baz", "a", "b", "x"]
+  | rebuilt        : ScopeId(3): ["Baz"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(3): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["A", "a", "b", "c"]
+  | rebuilt        : ScopeId(4): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(7),
+  | ReferenceId(18)]
+  | rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(20)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(19): [ReferenceId(11), ReferenceId(12),
+  | ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16),
+  | ReferenceId(17)]
+  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(8)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(20): [ReferenceId(19), ReferenceId(20),
+  | ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24),
+  | ReferenceId(25), ReferenceId(26), ReferenceId(27)]
+  | rebuilt        : SymbolId(4): [ReferenceId(10), ReferenceId(11),
+  | ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15),
+  | ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(21)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(10): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(21): [ReferenceId(29), ReferenceId(30),
+  | ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34),
+  | ReferenceId(35)]
+  | rebuilt        : SymbolId(6): [ReferenceId(23), ReferenceId(24),
+  | ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28),
+  | ReferenceId(29), ReferenceId(30)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(14): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(22): [ReferenceId(37), ReferenceId(38),
+  | ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42),
+  | ReferenceId(43)]
+  | rebuilt        : SymbolId(8): [ReferenceId(32), ReferenceId(33),
+  | ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37),
+  | ReferenceId(38), ReferenceId(39), ReferenceId(40)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(9)]
+  | rebuilt        : SymbolId(9): []
+
 
 * enum/non-foldable-constant/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "a", "b"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["E", "a", "b"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/non-scoped/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["E", "x", "y"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["E", "z"]
-rebuilt        : ScopeId(2): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 40, end: 41 }]
-rebuilt        : SymbolId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["E", "x", "y"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["E", "z"]
+  | rebuilt        : ScopeId(2): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 40, end: 41 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * enum/outer-references/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
-rebuilt        : ScopeId(1): ["socketType"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE", "UV_WRITABLE", "constants"]
-rebuilt        : ScopeId(2): ["constants"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
+  | rebuilt        : ScopeId(1): ["socketType"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE",
+  | "UV_WRITABLE", "constants"]
+  | rebuilt        : ScopeId(2): ["constants"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(10)]
+  | rebuilt        : SymbolId(0): [ReferenceId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/reverse-mappings-syntactically-determinable/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "B", "C", "D", "E", "Foo"]
+  | rebuilt        : ScopeId(1): ["Foo"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+  | rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7),
+  | ReferenceId(10)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/scoped/input.ts
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
 
 * enum/string-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/string-value-template/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "E"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/string-values-computed/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "E"]
-rebuilt        : ScopeId(1): ["E"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "E"]
+  | rebuilt        : ScopeId(1): ["E"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * enum/ts5.0-const-foldable/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["First", "Second", "Third", "Values"]
+  | rebuilt        : ScopeId(1): ["Values"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["Invoices", "Parts", "Routes", "x", "y"]
+  | rebuilt        : ScopeId(2): ["Routes"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4)]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5),
+  | ReferenceId(16)]
+  | rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(11)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(6)]
+  | rebuilt        : SymbolId(5): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
 
 * exports/declare-namespace/input.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
-rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 83, end: 84 }]
-rebuilt        : SymbolId(0): []
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+  | rebuilt        : ScopeId(0): [ScopeId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
+  | | Ambient)
+  | rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 83, end: 84 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * exports/declare-shadowed/input.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["Signal", "Signal2"]
-rebuilt        : []
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+  x Unresolved references mismatch:
+  | after transform: ["Signal", "Signal2"]
+  | rebuilt        : []
+
 
 * exports/declared-types/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["AA", "AA2", "BB", "BB2", "Bar", "C2", "E",
+  | "I", "II2", "II3", "M", "N", "T", "foo", "m", "x"]
+  | rebuilt        : ScopeId(0): ["BB", "BB2", "C2", "foo"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9),
+  | ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14),
+  | ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4), ScopeId(5)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(12): ["BB", "K"]
+  | rebuilt        : ScopeId(2): ["BB"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(12): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(13): ["BB", "L"]
+  | rebuilt        : ScopeId(3): ["BB"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(13): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(16): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(10): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(10): [Span { start: 495, end: 497 }]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(15): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(0): Some("x")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(0): ReferenceFlags(Read)
+  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(2): Some("E")
+  | rebuilt        : ReferenceId(1): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(2): ReferenceFlags(Read)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Type)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(8): Some("x")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Read)
+  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Type)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(11): Some("E")
+  | rebuilt        : ReferenceId(3): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(11): ReferenceFlags(Read)
+  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Type)
+
+  x Unresolved references mismatch:
+  | after transform: ["Bar", "C", "M", "N", "f"]
+  | rebuilt        : ["Bar", "E", "x"]
+
 
 * exports/default-function/input.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+  | rebuilt        : ScopeId(0): [ScopeId(1)]
+
 
 * exports/export-const-enums/input.ts
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(1)]
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1)]
+
 
 * exports/export-import=/input.ts
-Missing SymbolId: JGraph
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+  x Missing SymbolId: JGraph
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+
 
 * exports/export-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
 
 * exports/export=/input.ts
   ! `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -2244,191 +2788,261 @@ rebuilt        : ScopeId(0): []
    `----
 
 
+* exports/export=-to-cjs/input.ts
+  ! `export = <value>;` is only supported when compiling modules to CommonJS.
+  | Please consider using `export default <value>;`, or add @babel/plugin-
+  | transform-modules-commonjs to your Babel config.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=-to-cjs/input.ts:1:1]
+ 1 | export = 0;
+   : ^^^^^^^^^^^
+   `----
+
+
 * exports/imported-types/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): ["C"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "C"]
+  | rebuilt        : ScopeId(0): ["C"]
+
 
 * exports/imported-types-only-remove-type-imports/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): ["C"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "C"]
+  | rebuilt        : ScopeId(0): ["C"]
+
 
 * exports/interface/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "I"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): []
+
 
 * exports/issue-9916-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
-rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
+  | rebuilt        : ScopeId(0): ["a"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): []
+
+  x Unresolved references mismatch:
+  | after transform: ["PromiseLike"]
+  | rebuilt        : []
+
 
 * exports/issue-9916-2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): []
+
+  x Unresolved references mismatch:
+  | after transform: ["PromiseLike"]
+  | rebuilt        : []
+
 
 * exports/issue-9916-3/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
-rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
+  | rebuilt        : ScopeId(0): ["a"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): []
+
+  x Unresolved references mismatch:
+  | after transform: ["PromiseLike"]
+  | rebuilt        : []
+
 
 * exports/type-only-export-specifier-1/input.ts
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0)]
+  | rebuilt        : SymbolId(0): []
+
 
 * function/overloads/input.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): [ScopeId(1)]
+
 
 * function/overloads-exports/input.mjs
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): [ScopeId(1)]
+
 
 * function/parameters/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["T", "x", "y"]
-rebuilt        : ScopeId(1): ["x", "y"]
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["T", "x", "y"]
+  | rebuilt        : ScopeId(1): ["x", "y"]
+
 
 * imports/elide-preact/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["FooBar", "Fragment", "h", "x"]
-rebuilt        : ScopeId(0): ["x"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["FooBar", "Fragment", "h", "x"]
+  | rebuilt        : ScopeId(0): ["x"]
+
 
 * imports/elide-preact-no-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Fragment", "h", "render"]
-rebuilt        : ScopeId(0): ["Fragment", "h"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Fragment", "h", "render"]
+  | rebuilt        : ScopeId(0): ["Fragment", "h"]
+
 
 * imports/elide-preact-no-2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Fragment", "render"]
-rebuilt        : ScopeId(0): ["Fragment"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Fragment", "render"]
+  | rebuilt        : ScopeId(0): ["Fragment"]
+
 
 * imports/elide-react/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["React", "x"]
-rebuilt        : ScopeId(0): ["x"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["React", "x"]
+  | rebuilt        : ScopeId(0): ["x"]
+
 
 * imports/elide-type-referenced-in-imports-equal-no/input.ts
-Missing SymbolId: foo
-Missing SymbolId: bar
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+  x Missing SymbolId: foo
+
+  x Missing SymbolId: bar
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
+  | SymbolId(3)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
+  | SymbolId(3)]
+
 
 * imports/elide-typeof/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "x"]
-rebuilt        : ScopeId(0): ["x"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "x"]
+  | rebuilt        : ScopeId(0): ["x"]
+
 
 * imports/elision/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "D", "Used", "Used2", "Used3", "x", "y", "z"]
-rebuilt        : ScopeId(0): ["Used", "Used2", "Used3", "x", "y", "z"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "C", "D", "Used", "Used2",
+  | "Used3", "x", "y", "z"]
+  | rebuilt        : ScopeId(0): ["Used", "Used2", "Used3", "x", "y", "z"]
+
 
 * imports/elision-export-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "T", "T1"]
-rebuilt        : ScopeId(0): ["A", "B"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "T", "T1"]
+  | rebuilt        : ScopeId(0): ["A", "B"]
+
 
 * imports/elision-locations/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G", "H", "Iface", "x", "y"]
-rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G",
+  | "H", "Iface", "x", "y"]
+  | rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): [ScopeId(1)]
+
 
 * imports/elision-qualifiedname/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "x"]
-rebuilt        : ScopeId(0): ["x"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "x"]
+  | rebuilt        : ScopeId(0): ["x"]
+
 
 * imports/elision-rename/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["B", "x"]
-rebuilt        : ScopeId(0): ["x"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["B", "x"]
+  | rebuilt        : ScopeId(0): ["x"]
+
 
 * imports/enum-id/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "Enum"]
-rebuilt        : ScopeId(0): ["Enum"]
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "Enum"]
-rebuilt        : ScopeId(1): ["Enum"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "Enum"]
+  | rebuilt        : ScopeId(0): ["Enum"]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "Enum"]
+  | rebuilt        : ScopeId(1): ["Enum"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * imports/enum-value/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Enum", "id"]
-rebuilt        : ScopeId(1): ["Enum"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Enum", "id"]
+  | rebuilt        : ScopeId(1): ["Enum"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
 
 * imports/import-removed-exceptions/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["H", "I", "I2", "J", "a", "b", "c2", "d", "d2", "e", "e4"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["H", "I", "I2", "J", "a", "b", "c2", "d",
+  | "d2", "e", "e4"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/import-type/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "T", "Types"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B", "T", "Types"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/import-type-func-with-duplicate-name/input.ts
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | TypeImport)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 13, end: 16 }
-rebuilt        : SymbolId(0): Span { start: 70, end: 73 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 70, end: 73 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function | TypeImport)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
-Symbol span mismatch:
-after transform: SymbolId(1): Span { start: 43, end: 47 }
-rebuilt        : SymbolId(1): Span { start: 87, end: 91 }
-Symbol redeclarations mismatch:
-after transform: SymbolId(1): [Span { start: 87, end: 91 }]
-rebuilt        : SymbolId(1): []
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function
+  | | TypeImport)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(0): Span { start: 13, end: 16 }
+  | rebuilt        : SymbolId(0): Span { start: 70, end: 73 }
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 70, end: 73 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function
+  | | TypeImport)
+  | rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(1): Span { start: 43, end: 47 }
+  | rebuilt        : SymbolId(1): Span { start: 87, end: 91 }
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(1): [Span { start: 87, end: 91 }]
+  | rebuilt        : SymbolId(1): []
+
 
 * imports/import-type-not-removed/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "B"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/import=-module/input.ts
   ! `import lib = require(...);` is only supported when compiling modules
@@ -2443,646 +3057,1073 @@ rebuilt        : ScopeId(0): []
    `----
 
 
+* imports/import=-module-to-cjs/input.ts
+  ! `import lib = require(...);` is only supported when compiling modules
+  | to CommonJS.
+  | Please consider using `import lib from '...';` alongside Typescript's
+  | --allowSyntheticDefaultImports option, or add @babel/plugin-transform-
+  | modules-commonjs to your Babel config.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-module-to-cjs/input.ts:1:1]
+ 1 | import lib = require("lib");
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 2 | lib();
+   `----
+
+
 * imports/only-remove-type-imports/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["H", "I", "I2", "J", "K1", "K2", "L1", "L2",
+  | "L3", "a", "b", "c2", "d", "d2", "e", "e4"]
+  | rebuilt        : ScopeId(0): ["K1", "K2", "L1", "L2", "L3", "a", "b",
+  | "c2", "d", "d2", "e", "e4"]
+
 
 * imports/property-signature/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "obj"]
-rebuilt        : ScopeId(0): ["obj"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "obj"]
+  | rebuilt        : ScopeId(0): ["obj"]
+
 
 * imports/type-only-export-specifier-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["bar", "baz", "foo"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["bar", "baz", "foo"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/type-only-export-specifier-2/input.ts
-x Output mismatch
+  x Output mismatch
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0)]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(Export | Import)
+  | rebuilt        : SymbolId(1): SymbolFlags(Import)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(1)]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | TypeImport)
+  | rebuilt        : SymbolId(2): SymbolFlags(TypeImport)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(2)]
+  | rebuilt        : SymbolId(2): []
+
 
 * imports/type-only-import-specifier-1/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): ["Foo1"]
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Foo1", "Foo2"]
+  | rebuilt        : ScopeId(0): ["Foo1"]
+
 
 * imports/type-only-import-specifier-2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Foo1", "Foo2"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/type-only-import-specifier-3/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo1", "Foo2"]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Foo1", "Foo2"]
+  | rebuilt        : ScopeId(0): []
+
 
 * imports/type-only-import-specifier-4/input.ts
-x Output mismatch
+
 
 * lvalues/TSTypeParameterInstantiation/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["M"]
-rebuilt        : ScopeId(1): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(1)]
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["M"]
+  | rebuilt        : ScopeId(1): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2),
+  | ReferenceId(3)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
+  | rebuilt        : SymbolId(1): [ReferenceId(1)]
+
 
 * namespace/alias/input.ts
-Missing SymbolId: b
-Missing SymbolId: AliasModule
-Bindings mismatch:
-after transform: ScopeId(0): ["AliasModule", "LongNameModule", "b", "babel", "bar", "baz", "node", "some", "str"]
-rebuilt        : ScopeId(0): ["AliasModule", "b", "babel", "bar", "baz", "node", "some", "str"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(3): Some("AliasModule")
-rebuilt        : ReferenceId(2): Some("AliasModule")
-Reference symbol mismatch:
-after transform: ReferenceId(4): Some("AliasModule")
-rebuilt        : ReferenceId(3): Some("AliasModule")
-Unresolved reference IDs mismatch for "LongNameModule":
-after transform: [ReferenceId(1), ReferenceId(5)]
-rebuilt        : [ReferenceId(1)]
+  x Missing SymbolId: b
 
-* namespace/ambient-module-nested/input.ts
-Ambient modules cannot be nested in other modules or namespaces.
+  x Missing SymbolId: AliasModule
 
-* namespace/ambient-module-nested-exported/input.ts
-Ambient modules cannot be nested in other modules or namespaces.
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["AliasModule", "LongNameModule", "b",
+  | "babel", "bar", "baz", "node", "some", "str"]
+  | rebuilt        : ScopeId(0): ["AliasModule", "b", "babel", "bar", "baz",
+  | "node", "some", "str"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(3): Some("AliasModule")
+  | rebuilt        : ReferenceId(2): Some("AliasModule")
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(4): Some("AliasModule")
+  | rebuilt        : ReferenceId(3): Some("AliasModule")
+
+  x Unresolved reference IDs mismatch for "LongNameModule":
+  | after transform: [ReferenceId(1), ReferenceId(5)]
+  | rebuilt        : [ReferenceId(1)]
+
 
 * namespace/clobber-class/input.ts
-Missing SymbolId: _A
-Missing ReferenceId: _A
-Missing ReferenceId: A
-Missing ReferenceId: A
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 22, end: 23 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+  x Missing SymbolId: _A
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: A
+
+  x Missing ReferenceId: A
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): []
+  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 * namespace/clobber-enum/input.ts
-Missing SymbolId: _A
-Missing ReferenceId: _A
-Missing ReferenceId: A
-Missing ReferenceId: A
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "C"]
-rebuilt        : ScopeId(1): ["A"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(6)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 30, end: 31 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
+  x Missing SymbolId: _A
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: A
+
+  x Missing ReferenceId: A
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "C"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
+  | rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule
+  | | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(3)]
+  | rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5),
+  | ReferenceId(6)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 30, end: 31 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 * namespace/clobber-export/input.ts
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 35, end: 36 }]
-rebuilt        : SymbolId(0): []
+  x Missing SymbolId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
+  | | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 35, end: 36 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * namespace/contentious-names/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing SymbolId: N
-Missing SymbolId: _N2
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing SymbolId: constructor
-Missing SymbolId: _constructor
-Missing ReferenceId: constructor
-Missing ReferenceId: constructor
-Missing SymbolId: length
-Missing SymbolId: _length
-Missing ReferenceId: length
-Missing ReferenceId: length
-Missing SymbolId: concat
-Missing SymbolId: _concat
-Missing ReferenceId: concat
-Missing ReferenceId: concat
-Missing SymbolId: copyWithin
-Missing SymbolId: _copyWithin
-Missing ReferenceId: copyWithin
-Missing ReferenceId: copyWithin
-Missing SymbolId: fill
-Missing SymbolId: _fill
-Missing ReferenceId: fill
-Missing ReferenceId: fill
-Missing SymbolId: find
-Missing SymbolId: _find
-Missing ReferenceId: find
-Missing ReferenceId: find
-Missing SymbolId: findIndex
-Missing SymbolId: _findIndex
-Missing ReferenceId: findIndex
-Missing ReferenceId: findIndex
-Missing SymbolId: lastIndexOf
-Missing SymbolId: _lastIndexOf
-Missing ReferenceId: lastIndexOf
-Missing ReferenceId: lastIndexOf
-Missing SymbolId: pop
-Missing SymbolId: _pop
-Missing ReferenceId: pop
-Missing ReferenceId: pop
-Missing SymbolId: push
-Missing SymbolId: _push
-Missing ReferenceId: push
-Missing ReferenceId: push
-Missing SymbolId: reverse
-Missing SymbolId: _reverse
-Missing ReferenceId: reverse
-Missing ReferenceId: reverse
-Missing SymbolId: shift
-Missing SymbolId: _shift
-Missing ReferenceId: shift
-Missing ReferenceId: shift
-Missing SymbolId: unshift
-Missing SymbolId: _unshift
-Missing ReferenceId: unshift
-Missing ReferenceId: unshift
-Missing SymbolId: slice
-Missing SymbolId: _slice
-Missing ReferenceId: slice
-Missing ReferenceId: slice
-Missing SymbolId: sort
-Missing SymbolId: _sort
-Missing ReferenceId: sort
-Missing ReferenceId: sort
-Missing SymbolId: splice
-Missing SymbolId: _splice
-Missing ReferenceId: splice
-Missing ReferenceId: splice
-Missing SymbolId: includes
-Missing SymbolId: _includes
-Missing ReferenceId: includes
-Missing ReferenceId: includes
-Missing SymbolId: indexOf
-Missing SymbolId: _indexOf
-Missing ReferenceId: indexOf
-Missing ReferenceId: indexOf
-Missing SymbolId: join
-Missing SymbolId: _join
-Missing ReferenceId: join
-Missing ReferenceId: join
-Missing SymbolId: keys
-Missing SymbolId: _keys
-Missing ReferenceId: keys
-Missing ReferenceId: keys
-Missing SymbolId: entries
-Missing SymbolId: _entries
-Missing ReferenceId: entries
-Missing ReferenceId: entries
-Missing SymbolId: values
-Missing SymbolId: _values
-Missing ReferenceId: values
-Missing ReferenceId: values
-Missing SymbolId: forEach
-Missing SymbolId: _forEach
-Missing ReferenceId: forEach
-Missing ReferenceId: forEach
-Missing SymbolId: filter
-Missing SymbolId: _filter
-Missing ReferenceId: filter
-Missing ReferenceId: filter
-Missing SymbolId: map
-Missing SymbolId: _map
-Missing ReferenceId: map
-Missing ReferenceId: map
-Missing SymbolId: every
-Missing SymbolId: _every
-Missing ReferenceId: every
-Missing ReferenceId: every
-Missing SymbolId: some
-Missing SymbolId: _some
-Missing ReferenceId: some
-Missing ReferenceId: some
-Missing SymbolId: reduce
-Missing SymbolId: _reduce
-Missing ReferenceId: reduce
-Missing ReferenceId: reduce
-Missing SymbolId: reduceRight
-Missing SymbolId: _reduceRight
-Missing ReferenceId: reduceRight
-Missing ReferenceId: reduceRight
-Missing SymbolId: toLocaleString
-Missing SymbolId: _toLocaleString
-Missing ReferenceId: toLocaleString
-Missing ReferenceId: toLocaleString
-Missing SymbolId: toString
-Missing SymbolId: _toString
-Missing ReferenceId: toString
-Missing ReferenceId: toString
-Missing SymbolId: flat
-Missing SymbolId: _flat
-Missing ReferenceId: flat
-Missing ReferenceId: flat
-Missing SymbolId: flatMap
-Missing SymbolId: _flatMap
-Missing ReferenceId: flatMap
-Missing ReferenceId: flatMap
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45), SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55), SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65), SymbolId(67), SymbolId(69)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80), SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95), SymbolId(98), SymbolId(101)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
-rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
-rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
-rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
-rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
-rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
-rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
-rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
-rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
-rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
-rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
-rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
-rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
-rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
-Binding symbols mismatch:
-after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
-rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
-rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
-rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
-rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
-Binding symbols mismatch:
-after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
-rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
-Binding symbols mismatch:
-after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
-rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
-Binding symbols mismatch:
-after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
-rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
-rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
-rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
-Binding symbols mismatch:
-after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
-rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
-Binding symbols mismatch:
-after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
-rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
-Binding symbols mismatch:
-after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
-rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
-Binding symbols mismatch:
-after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
-rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
-Binding symbols mismatch:
-after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
-rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
-Binding symbols mismatch:
-after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
-rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
-Binding symbols mismatch:
-after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
-rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
-Binding symbols mismatch:
-after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
-rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
-Binding symbols mismatch:
-after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
-rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N
+
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N2
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Missing SymbolId: constructor
+
+  x Missing SymbolId: _constructor
+
+  x Missing ReferenceId: constructor
+
+  x Missing ReferenceId: constructor
+
+  x Missing SymbolId: length
+
+  x Missing SymbolId: _length
+
+  x Missing ReferenceId: length
+
+  x Missing ReferenceId: length
+
+  x Missing SymbolId: concat
+
+  x Missing SymbolId: _concat
+
+  x Missing ReferenceId: concat
+
+  x Missing ReferenceId: concat
+
+  x Missing SymbolId: copyWithin
+
+  x Missing SymbolId: _copyWithin
+
+  x Missing ReferenceId: copyWithin
+
+  x Missing ReferenceId: copyWithin
+
+  x Missing SymbolId: fill
+
+  x Missing SymbolId: _fill
+
+  x Missing ReferenceId: fill
+
+  x Missing ReferenceId: fill
+
+  x Missing SymbolId: find
+
+  x Missing SymbolId: _find
+
+  x Missing ReferenceId: find
+
+  x Missing ReferenceId: find
+
+  x Missing SymbolId: findIndex
+
+  x Missing SymbolId: _findIndex
+
+  x Missing ReferenceId: findIndex
+
+  x Missing ReferenceId: findIndex
+
+  x Missing SymbolId: lastIndexOf
+
+  x Missing SymbolId: _lastIndexOf
+
+  x Missing ReferenceId: lastIndexOf
+
+  x Missing ReferenceId: lastIndexOf
+
+  x Missing SymbolId: pop
+
+  x Missing SymbolId: _pop
+
+  x Missing ReferenceId: pop
+
+  x Missing ReferenceId: pop
+
+  x Missing SymbolId: push
+
+  x Missing SymbolId: _push
+
+  x Missing ReferenceId: push
+
+  x Missing ReferenceId: push
+
+  x Missing SymbolId: reverse
+
+  x Missing SymbolId: _reverse
+
+  x Missing ReferenceId: reverse
+
+  x Missing ReferenceId: reverse
+
+  x Missing SymbolId: shift
+
+  x Missing SymbolId: _shift
+
+  x Missing ReferenceId: shift
+
+  x Missing ReferenceId: shift
+
+  x Missing SymbolId: unshift
+
+  x Missing SymbolId: _unshift
+
+  x Missing ReferenceId: unshift
+
+  x Missing ReferenceId: unshift
+
+  x Missing SymbolId: slice
+
+  x Missing SymbolId: _slice
+
+  x Missing ReferenceId: slice
+
+  x Missing ReferenceId: slice
+
+  x Missing SymbolId: sort
+
+  x Missing SymbolId: _sort
+
+  x Missing ReferenceId: sort
+
+  x Missing ReferenceId: sort
+
+  x Missing SymbolId: splice
+
+  x Missing SymbolId: _splice
+
+  x Missing ReferenceId: splice
+
+  x Missing ReferenceId: splice
+
+  x Missing SymbolId: includes
+
+  x Missing SymbolId: _includes
+
+  x Missing ReferenceId: includes
+
+  x Missing ReferenceId: includes
+
+  x Missing SymbolId: indexOf
+
+  x Missing SymbolId: _indexOf
+
+  x Missing ReferenceId: indexOf
+
+  x Missing ReferenceId: indexOf
+
+  x Missing SymbolId: join
+
+  x Missing SymbolId: _join
+
+  x Missing ReferenceId: join
+
+  x Missing ReferenceId: join
+
+  x Missing SymbolId: keys
+
+  x Missing SymbolId: _keys
+
+  x Missing ReferenceId: keys
+
+  x Missing ReferenceId: keys
+
+  x Missing SymbolId: entries
+
+  x Missing SymbolId: _entries
+
+  x Missing ReferenceId: entries
+
+  x Missing ReferenceId: entries
+
+  x Missing SymbolId: values
+
+  x Missing SymbolId: _values
+
+  x Missing ReferenceId: values
+
+  x Missing ReferenceId: values
+
+  x Missing SymbolId: forEach
+
+  x Missing SymbolId: _forEach
+
+  x Missing ReferenceId: forEach
+
+  x Missing ReferenceId: forEach
+
+  x Missing SymbolId: filter
+
+  x Missing SymbolId: _filter
+
+  x Missing ReferenceId: filter
+
+  x Missing ReferenceId: filter
+
+  x Missing SymbolId: map
+
+  x Missing SymbolId: _map
+
+  x Missing ReferenceId: map
+
+  x Missing ReferenceId: map
+
+  x Missing SymbolId: every
+
+  x Missing SymbolId: _every
+
+  x Missing ReferenceId: every
+
+  x Missing ReferenceId: every
+
+  x Missing SymbolId: some
+
+  x Missing SymbolId: _some
+
+  x Missing ReferenceId: some
+
+  x Missing ReferenceId: some
+
+  x Missing SymbolId: reduce
+
+  x Missing SymbolId: _reduce
+
+  x Missing ReferenceId: reduce
+
+  x Missing ReferenceId: reduce
+
+  x Missing SymbolId: reduceRight
+
+  x Missing SymbolId: _reduceRight
+
+  x Missing ReferenceId: reduceRight
+
+  x Missing ReferenceId: reduceRight
+
+  x Missing SymbolId: toLocaleString
+
+  x Missing SymbolId: _toLocaleString
+
+  x Missing ReferenceId: toLocaleString
+
+  x Missing ReferenceId: toLocaleString
+
+  x Missing SymbolId: toString
+
+  x Missing SymbolId: _toString
+
+  x Missing ReferenceId: toString
+
+  x Missing ReferenceId: toString
+
+  x Missing SymbolId: flat
+
+  x Missing SymbolId: _flat
+
+  x Missing ReferenceId: flat
+
+  x Missing ReferenceId: flat
+
+  x Missing SymbolId: flatMap
+
+  x Missing SymbolId: _flatMap
+
+  x Missing ReferenceId: flatMap
+
+  x Missing ReferenceId: flatMap
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5),
+  | SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15),
+  | SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25),
+  | SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35),
+  | SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45),
+  | SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55),
+  | SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65),
+  | SymbolId(67), SymbolId(69)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5),
+  | SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20),
+  | SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35),
+  | SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50),
+  | SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65),
+  | SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80),
+  | SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95),
+  | SymbolId(98), SymbolId(101)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
+  | rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
+  | rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
+  | rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
+  | rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
+  | rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
+  | rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
+  | rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
+  | rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
+  | rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
+  | rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
+  | rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
+  | rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
+  | rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
+  | rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
+  | rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
+  | rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
+  | rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
+  | rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
+  | rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
+  | rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
+  | rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
+  | rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
+  | rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
+  | rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
+  | rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
+  | rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
+  | rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
+  | rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
+  | rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
+  | rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
+  | rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
+  | rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
+
 
 * namespace/declare/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["B", "_N", "e", "v"]
-rebuilt        : ScopeId(1): ["_N"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): []
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["B", "_N", "e", "v"]
+  | rebuilt        : ScopeId(1): ["_N"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4),
+  | ScopeId(5)]
+  | rebuilt        : ScopeId(1): []
+
 
 * namespace/declare-global-nested-namespace/input.ts
-Missing SymbolId: X
-Missing SymbolId: _X
-Missing ReferenceId: X
-Missing ReferenceId: X
-Bindings mismatch:
-after transform: ScopeId(0): ["X", "global", "i18n"]
-rebuilt        : ScopeId(0): ["X", "i18n"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+  x Missing SymbolId: X
+
+  x Missing SymbolId: _X
+
+  x Missing ReferenceId: X
+
+  x Missing ReferenceId: X
+
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["X", "global", "i18n"]
+  | rebuilt        : ScopeId(0): ["X", "i18n"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
 
 * namespace/empty-removed/input.ts
-Missing SymbolId: a
-Missing SymbolId: _a
-Missing SymbolId: c
-Missing SymbolId: _c
-Missing ReferenceId: c
-Missing ReferenceId: c
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: WithTypes
-Missing SymbolId: _WithTypes
-Missing SymbolId: d
-Missing SymbolId: _d2
-Missing ReferenceId: d
-Missing ReferenceId: d
-Missing ReferenceId: WithTypes
-Missing ReferenceId: WithTypes
-Missing SymbolId: WithValues
-Missing SymbolId: _WithValues
-Missing SymbolId: a
-Missing SymbolId: _a3
-Missing ReferenceId: a
-Missing ReferenceId: a
-Missing SymbolId: b
-Missing SymbolId: _b3
-Missing ReferenceId: b
-Missing ReferenceId: b
-Missing SymbolId: c
-Missing SymbolId: _c3
-Missing ReferenceId: c
-Missing ReferenceId: c
-Missing SymbolId: d
-Missing SymbolId: _d3
-Missing ReferenceId: d
-Missing ReferenceId: d
-Missing SymbolId: e
-Missing SymbolId: _e2
-Missing ReferenceId: e
-Missing ReferenceId: e
-Missing ReferenceId: WithValues
-Missing ReferenceId: WithValues
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
-Bindings mismatch:
-after transform: ScopeId(1): ["_a", "b", "c", "d"]
-rebuilt        : ScopeId(1): ["_a", "c"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Bindings mismatch:
-after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
-rebuilt        : ScopeId(3): ["_WithTypes", "d"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(33)]
-rebuilt        : ScopeId(4): [SymbolId(8)]
-Scope children mismatch:
-after transform: ScopeId(12): [ScopeId(13)]
-rebuilt        : ScopeId(4): []
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(34)]
-rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14), SymbolId(18), SymbolId(21), SymbolId(24)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
-rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
-rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
-Scope flags mismatch:
-after transform: ScopeId(18): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
-rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
-rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
-Binding symbols mismatch:
-after transform: ScopeId(22): [SymbolId(39)]
-rebuilt        : ScopeId(13): [SymbolId(25)]
-Symbol flags mismatch:
-after transform: SymbolId(18): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+  x Missing SymbolId: a
+
+  x Missing SymbolId: _a
+
+  x Missing SymbolId: c
+
+  x Missing SymbolId: _c
+
+  x Missing ReferenceId: c
+
+  x Missing ReferenceId: c
+
+  x Missing ReferenceId: a
+
+  x Missing ReferenceId: a
+
+  x Missing SymbolId: WithTypes
+
+  x Missing SymbolId: _WithTypes
+
+  x Missing SymbolId: d
+
+  x Missing SymbolId: _d2
+
+  x Missing ReferenceId: d
+
+  x Missing ReferenceId: d
+
+  x Missing ReferenceId: WithTypes
+
+  x Missing ReferenceId: WithTypes
+
+  x Missing SymbolId: WithValues
+
+  x Missing SymbolId: _WithValues
+
+  x Missing SymbolId: a
+
+  x Missing SymbolId: _a3
+
+  x Missing ReferenceId: a
+
+  x Missing ReferenceId: a
+
+  x Missing SymbolId: b
+
+  x Missing SymbolId: _b3
+
+  x Missing ReferenceId: b
+
+  x Missing ReferenceId: b
+
+  x Missing SymbolId: c
+
+  x Missing SymbolId: _c3
+
+  x Missing ReferenceId: c
+
+  x Missing ReferenceId: c
+
+  x Missing SymbolId: d
+
+  x Missing SymbolId: _d3
+
+  x Missing ReferenceId: d
+
+  x Missing ReferenceId: d
+
+  x Missing SymbolId: e
+
+  x Missing SymbolId: _e2
+
+  x Missing ReferenceId: e
+
+  x Missing ReferenceId: e
+
+  x Missing ReferenceId: WithValues
+
+  x Missing ReferenceId: WithValues
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["_a", "b", "c", "d"]
+  | rebuilt        : ScopeId(1): ["_a", "c"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+  | rebuilt        : ScopeId(1): [ScopeId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
+  | rebuilt        : ScopeId(3): ["_WithTypes", "d"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(6): [ScopeId(7), ScopeId(9), ScopeId(11),
+  | ScopeId(12)]
+  | rebuilt        : ScopeId(3): [ScopeId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(33)]
+  | rebuilt        : ScopeId(4): [SymbolId(8)]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(12): [ScopeId(13)]
+  | rebuilt        : ScopeId(4): []
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19),
+  | SymbolId(21), SymbolId(23), SymbolId(34)]
+  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14),
+  | SymbolId(18), SymbolId(21), SymbolId(24)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
+  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
+  | rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(18): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
+  | rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
+  | rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(22): [SymbolId(39)]
+  | rebuilt        : ScopeId(13): [SymbolId(25)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(18): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
+  | rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+
 
 * namespace/export/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
 
 * namespace/export-type-only/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Platform"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Platform"]
-rebuilt        : []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Platform"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
+  x Unresolved references mismatch:
+  | after transform: ["Platform"]
+  | rebuilt        : []
+
 
 * namespace/module-nested/input.ts
-Missing SymbolId: src
-Missing SymbolId: _src
-Missing SymbolId: ns1
-Missing SymbolId: _ns
-Missing ReferenceId: _ns
-Missing ReferenceId: foo
-Missing ReferenceId: ns1
-Missing ReferenceId: ns1
-Missing ReferenceId: _src
-Missing ReferenceId: _src
-Missing SymbolId: ns2
-Missing SymbolId: _ns2
-Missing ReferenceId: _ns2
-Missing ReferenceId: foo
-Missing ReferenceId: ns2
-Missing ReferenceId: ns2
-Missing ReferenceId: _src
-Missing ReferenceId: _src
-Missing ReferenceId: src
-Missing ReferenceId: src
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
+  x Missing SymbolId: src
+
+  x Missing SymbolId: _src
+
+  x Missing SymbolId: ns1
+
+  x Missing SymbolId: _ns
+
+  x Missing ReferenceId: _ns
+
+  x Missing ReferenceId: foo
+
+  x Missing ReferenceId: ns1
+
+  x Missing ReferenceId: ns1
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: _src
+
+  x Missing SymbolId: ns2
+
+  x Missing SymbolId: _ns2
+
+  x Missing ReferenceId: _ns2
+
+  x Missing ReferenceId: foo
+
+  x Missing ReferenceId: ns2
+
+  x Missing ReferenceId: ns2
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: src
+
+  x Missing ReferenceId: src
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(7): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(7)]
+
 
 * namespace/module-nested-export/input.ts
-Missing SymbolId: src
-Missing SymbolId: _src
-Missing SymbolId: ns1
-Missing SymbolId: _ns
-Missing ReferenceId: _ns
-Missing ReferenceId: foo
-Missing ReferenceId: ns1
-Missing ReferenceId: ns1
-Missing ReferenceId: _src
-Missing ReferenceId: _src
-Missing SymbolId: ns2
-Missing SymbolId: _ns2
-Missing ReferenceId: _ns2
-Missing ReferenceId: foo
-Missing ReferenceId: ns2
-Missing ReferenceId: ns2
-Missing ReferenceId: _src
-Missing ReferenceId: _src
-Missing ReferenceId: src
-Missing ReferenceId: src
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(7): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
+  x Missing SymbolId: src
+
+  x Missing SymbolId: _src
+
+  x Missing SymbolId: ns1
+
+  x Missing SymbolId: _ns
+
+  x Missing ReferenceId: _ns
+
+  x Missing ReferenceId: foo
+
+  x Missing ReferenceId: ns1
+
+  x Missing ReferenceId: ns1
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: _src
+
+  x Missing SymbolId: ns2
+
+  x Missing SymbolId: _ns2
+
+  x Missing ReferenceId: _ns2
+
+  x Missing ReferenceId: foo
+
+  x Missing ReferenceId: ns2
+
+  x Missing ReferenceId: ns2
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: _src
+
+  x Missing ReferenceId: src
+
+  x Missing ReferenceId: src
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(7): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(7)]
+
 
 * namespace/multiple/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing SymbolId: _N2
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Missing SymbolId: _N2
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
 
 * namespace/mutable-fail/input.ts
   ! Namespaces exporting non-const are not supported by Babel. Change to const
@@ -3106,387 +4147,822 @@ rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 
 
 * namespace/nested/input.ts
-Missing SymbolId: _A
-Missing SymbolId: C
-Missing SymbolId: _C
-Missing ReferenceId: _C
-Missing ReferenceId: G
-Missing ReferenceId: _C
-Missing ReferenceId: C
-Missing ReferenceId: C
-Missing ReferenceId: _A
-Missing ReferenceId: _A
-Missing SymbolId: _M
-Missing ReferenceId: _M
-Missing ReferenceId: M
-Missing ReferenceId: M
-Missing ReferenceId: _A
-Missing ReferenceId: D
-Missing SymbolId: _D
-Missing ReferenceId: _D
-Missing ReferenceId: H
-Missing ReferenceId: D
-Missing ReferenceId: D
-Missing ReferenceId: _A
-Missing ReferenceId: _A
-Missing SymbolId: _F
-Missing ReferenceId: F
-Missing ReferenceId: F
-Missing SymbolId: G
-Missing SymbolId: _G
-Missing ReferenceId: G
-Missing ReferenceId: G
-Missing ReferenceId: A
-Missing ReferenceId: A
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6), SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
-rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
-rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
-Bindings mismatch:
-after transform: ScopeId(9): ["H", "I", "J", "K"]
-rebuilt        : ScopeId(9): ["H"]
-Scope flags mismatch:
-after transform: ScopeId(9): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
-rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
-rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
-Bindings mismatch:
-after transform: ScopeId(13): ["L", "M"]
-rebuilt        : ScopeId(13): ["L"]
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 22, end: 23 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(4): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(4): [Span { start: 129, end: 130 }]
-rebuilt        : SymbolId(6): []
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22), ReferenceId(23)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(6): [Span { start: 207, end: 208 }]
-rebuilt        : SymbolId(9): []
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(12): [ReferenceId(21)]
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(12): [Span { start: 325, end: 326 }]
-rebuilt        : SymbolId(14): []
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch:
-after transform: ReferenceId(0): Some("C")
-rebuilt        : ReferenceId(8): Some("C")
+  x Missing SymbolId: _A
+
+  x Missing SymbolId: C
+
+  x Missing SymbolId: _C
+
+  x Missing ReferenceId: _C
+
+  x Missing ReferenceId: G
+
+  x Missing ReferenceId: _C
+
+  x Missing ReferenceId: C
+
+  x Missing ReferenceId: C
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: _A
+
+  x Missing SymbolId: _M
+
+  x Missing ReferenceId: _M
+
+  x Missing ReferenceId: M
+
+  x Missing ReferenceId: M
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: D
+
+  x Missing SymbolId: _D
+
+  x Missing ReferenceId: _D
+
+  x Missing ReferenceId: H
+
+  x Missing ReferenceId: D
+
+  x Missing ReferenceId: D
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: _A
+
+  x Missing SymbolId: _F
+
+  x Missing ReferenceId: F
+
+  x Missing ReferenceId: F
+
+  x Missing SymbolId: G
+
+  x Missing SymbolId: _G
+
+  x Missing ReferenceId: G
+
+  x Missing ReferenceId: G
+
+  x Missing ReferenceId: A
+
+  x Missing ReferenceId: A
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6),
+  | SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6),
+  | SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
+  | rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
+  | rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
+  | rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(9): ["H", "I", "J", "K"]
+  | rebuilt        : ScopeId(9): ["H"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(9): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
+  | rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
+  | rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(13): ["L", "M"]
+  | rebuilt        : ScopeId(13): ["L"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(13): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): []
+  | rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function |
+  | NameSpaceModule | ValueModule)
+  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(4): [Span { start: 129, end: 130 }]
+  | rebuilt        : SymbolId(6): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export |
+  | Function | NameSpaceModule | ValueModule)
+  | rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22),
+  | ReferenceId(23)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(6): [Span { start: 207, end: 208 }]
+  | rebuilt        : SymbolId(9): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): []
+  | rebuilt        : SymbolId(12): [ReferenceId(21)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(14): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(12): []
+  | rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(12): [Span { start: 325, end: 326 }]
+  | rebuilt        : SymbolId(14): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(0): Some("C")
+  | rebuilt        : ReferenceId(8): Some("C")
+
 
 * namespace/nested-namespace/input.ts
-Missing SymbolId: A
-Missing SymbolId: _A
-Missing ReferenceId: _A
-Missing ReferenceId: G
-Missing ReferenceId: A
-Missing ReferenceId: A
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
-after transform: ScopeId(1): ["B", "G", "_A"]
-rebuilt        : ScopeId(1): ["G", "_A"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(4): ["G", "H"]
-rebuilt        : ScopeId(2): ["G"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(4)]
+  x Missing SymbolId: A
+
+  x Missing SymbolId: _A
+
+  x Missing ReferenceId: _A
+
+  x Missing ReferenceId: G
+
+  x Missing ReferenceId: A
+
+  x Missing ReferenceId: A
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["B", "G", "_A"]
+  | rebuilt        : ScopeId(1): ["G", "_A"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
+  | rebuilt        : ScopeId(1): [ScopeId(2)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["G", "H"]
+  | rebuilt        : ScopeId(2): ["G"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): []
+  | rebuilt        : SymbolId(2): [ReferenceId(4)]
+
 
 * namespace/nested-shorthand/input.ts
-Missing SymbolId: X
-Missing SymbolId: _X
-Missing SymbolId: Y
-Missing SymbolId: _Y
-Missing ReferenceId: _Y
-Missing ReferenceId: Y
-Missing ReferenceId: Y
-Missing ReferenceId: _X
-Missing ReferenceId: _X
-Missing ReferenceId: X
-Missing ReferenceId: X
-Missing SymbolId: proj
-Missing SymbolId: _proj
-Missing SymbolId: data
-Missing SymbolId: _data
-Missing SymbolId: util
-Missing SymbolId: _util
-Missing SymbolId: api
-Missing SymbolId: _api
-Missing ReferenceId: _api
-Missing ReferenceId: api
-Missing ReferenceId: api
-Missing ReferenceId: _util
-Missing ReferenceId: _util
-Missing ReferenceId: util
-Missing ReferenceId: util
-Missing ReferenceId: _data
-Missing ReferenceId: _data
-Missing ReferenceId: data
-Missing ReferenceId: data
-Missing ReferenceId: _proj
-Missing ReferenceId: _proj
-Missing ReferenceId: proj
-Missing ReferenceId: proj
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
-rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable | ConstVariable)
+  x Missing SymbolId: X
+
+  x Missing SymbolId: _X
+
+  x Missing SymbolId: Y
+
+  x Missing SymbolId: _Y
+
+  x Missing ReferenceId: _Y
+
+  x Missing ReferenceId: Y
+
+  x Missing ReferenceId: Y
+
+  x Missing ReferenceId: _X
+
+  x Missing ReferenceId: _X
+
+  x Missing ReferenceId: X
+
+  x Missing ReferenceId: X
+
+  x Missing SymbolId: proj
+
+  x Missing SymbolId: _proj
+
+  x Missing SymbolId: data
+
+  x Missing SymbolId: _data
+
+  x Missing SymbolId: util
+
+  x Missing SymbolId: _util
+
+  x Missing SymbolId: api
+
+  x Missing SymbolId: _api
+
+  x Missing ReferenceId: _api
+
+  x Missing ReferenceId: api
+
+  x Missing ReferenceId: api
+
+  x Missing ReferenceId: _util
+
+  x Missing ReferenceId: _util
+
+  x Missing ReferenceId: util
+
+  x Missing ReferenceId: util
+
+  x Missing ReferenceId: _data
+
+  x Missing ReferenceId: _data
+
+  x Missing ReferenceId: data
+
+  x Missing ReferenceId: data
+
+  x Missing ReferenceId: _proj
+
+  x Missing ReferenceId: _proj
+
+  x Missing ReferenceId: proj
+
+  x Missing ReferenceId: proj
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
+  | rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
+  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
+  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 * namespace/same-name/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N2
-Missing SymbolId: _N7
-Missing SymbolId: _N4
-Missing ReferenceId: _N7
-Missing ReferenceId: _N7
-Missing SymbolId: N
-Missing SymbolId: _N6
-Missing ReferenceId: _N6
-Missing ReferenceId: _N3
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing ReferenceId: _N2
-Missing ReferenceId: _N2
-Missing SymbolId: _N8
-Missing ReferenceId: _N8
-Missing ReferenceId: _N5
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing ReferenceId: _N2
-Missing ReferenceId: _N2
-Missing SymbolId: _N9
-Missing ReferenceId: _N9
-Missing ReferenceId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Missing ReferenceId: _N2
-Missing ReferenceId: _N2
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-Scope flags mismatch:
-after transform: ScopeId(8): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
-Symbol flags mismatch:
-after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
-rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(3)]
-Symbol flags mismatch:
-after transform: SymbolId(5): SymbolFlags(Export | Class)
-rebuilt        : SymbolId(9): SymbolFlags(Class)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(9): [ReferenceId(9)]
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
-rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(11): [ReferenceId(16)]
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N2
+
+  x Missing SymbolId: _N7
+
+  x Missing SymbolId: _N4
+
+  x Missing ReferenceId: _N7
+
+  x Missing ReferenceId: _N7
+
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N6
+
+  x Missing ReferenceId: _N6
+
+  x Missing ReferenceId: _N3
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: _N2
+
+  x Missing ReferenceId: _N2
+
+  x Missing SymbolId: _N8
+
+  x Missing ReferenceId: _N8
+
+  x Missing ReferenceId: _N5
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: _N2
+
+  x Missing ReferenceId: _N2
+
+  x Missing SymbolId: _N9
+
+  x Missing ReferenceId: _N9
+
+  x Missing ReferenceId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: _N2
+
+  x Missing ReferenceId: _N2
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
+  | rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
+  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(8): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(3)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(9): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): []
+  | rebuilt        : SymbolId(9): [ReferenceId(9)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(11): [ReferenceId(16)]
+
 
 * namespace/undeclared/input.ts
-Missing SymbolId: N
-Missing SymbolId: _N
-Missing ReferenceId: N
-Missing ReferenceId: N
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+  x Missing SymbolId: N
+
+  x Missing SymbolId: _N
+
+  x Missing ReferenceId: N
+
+  x Missing ReferenceId: N
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
 
 * optimize-const-enums/custom-values/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "w", "x", "y", "z"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * optimize-const-enums/custom-values-exported/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "w", "x", "y", "z"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+
 
 * optimize-const-enums/declare/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(0): Some("A")
+  | rebuilt        : ReferenceId(0): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["A"]
+
 
 * optimize-const-enums/export-const-enum/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "y"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+
 
 * optimize-const-enums/export-const-enum-type-and-value/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["WhitespaceFlag", "after", "before"]
+  | rebuilt        : ScopeId(1): ["WhitespaceFlag"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(8)]
+  | rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6),
+  | ReferenceId(7)]
+
 
 * optimize-const-enums/export-const-enum-type-no-deopt/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["WhitespaceFlag", "after", "before"]
+  | rebuilt        : ScopeId(1): ["WhitespaceFlag"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(8)]
+  | rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
+
 
 * optimize-const-enums/exported/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "y"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+
 
 * optimize-const-enums/local/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "x", "y"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * optimize-const-enums/local-shadowed/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "x"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 
 * optimize-const-enums/merged/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "x", "y"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["A", "z"]
+  | rebuilt        : ScopeId(2): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 36, end: 37 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * optimize-const-enums/merged-exported/input.ts
-x Output mismatch
+  x Output mismatch
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "x", "y"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["A", "z"]
+  | rebuilt        : ScopeId(2): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 50, end: 51 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * regression/15768/input.ts
-x Output mismatch
+  x Output mismatch
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: StateEnum
+
+  x Missing ReferenceId: StateEnum
+
+  x Missing ReferenceId: StateEnum
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["StateEnum", "ext", "ext2", "ext3", "nan",
+  | "nanReal", "neg", "negReal", "okay", "pos", "posReal"]
+  | rebuilt        : ScopeId(2): ["StateEnum"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(5)]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(6)]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(7)]
+  | rebuilt        : SymbolId(2): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(3)]
+  | rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9),
+  | ReferenceId(14), ReferenceId(17)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(4)]
+  | rebuilt        : SymbolId(4): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(16): [ReferenceId(8), ReferenceId(9),
+  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
+  | ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17),
+  | ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21),
+  | ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25),
+  | ReferenceId(26), ReferenceId(27), ReferenceId(28)]
+  | rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(3),
+  | ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8),
+  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
+  | ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19),
+  | ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23),
+  | ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27),
+  | ReferenceId(28), ReferenceId(29)]
+
 
 * type-arguments/call/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "f"]
+  | rebuilt        : ["f"]
+
 
 * type-arguments/expr/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "f"]
+  | rebuilt        : ["f"]
+
 
 * type-arguments/new/input.ts
-Unresolved references mismatch:
-after transform: ["C", "T"]
-rebuilt        : ["C"]
+  x Unresolved references mismatch:
+  | after transform: ["C", "T"]
+  | rebuilt        : ["C"]
+
 
 * type-arguments/optional-call/input.ts
-Unresolved references mismatch:
-after transform: ["Q", "T", "f", "x"]
-rebuilt        : ["f", "x"]
+  x Unresolved references mismatch:
+  | after transform: ["Q", "T", "f", "x"]
+  | rebuilt        : ["f", "x"]
+
 
 * type-arguments/tagged-template/input.ts
-Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
+  x Unresolved references mismatch:
+  | after transform: ["T", "f"]
+  | rebuilt        : ["f"]
 
 
-# babel-plugin-transform-react-jsx (124/144)
-* pure/false-pragma-comment-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* pure/false-pragma-option-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
+# babel-plugin-transform-react-jsx (123/145)
+* autoImport/after-polyfills-compiled-to-cjs/input.mjs
 
-* pure/true-pragma-comment-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* pure/true-pragma-option-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
+* react/dont-coerce-expression-containers/input.js
+  x Unresolved reference IDs mismatch for "Text":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
 
-* pure/unset-pragma-comment-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* pure/unset-pragma-option-automatic-runtime/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
+* react/honor-custom-jsx-comment/input.js
+  x Unresolved reference IDs mismatch for "Foo":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
 
-* react/should-disallow-spread-children/input.js
-Spread children are not supported in React.
+
+* react/honor-custom-jsx-comment-if-jsx-pragma-option-set/input.js
+  x Unresolved reference IDs mismatch for "Foo":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react/honor-custom-jsx-pragma-option/input.js
+  x Unresolved reference IDs mismatch for "Foo":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
+  x Unresolved reference IDs mismatch for "Composite":
+  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
+  | ReferenceId(6)]
+  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
+
 
 * react/should-disallow-valueless-key/input.js
   ! Please provide an explicit key value. Using "key" as a shorthand for
@@ -3508,6 +4984,12 @@ Spread children are not supported in React.
    `----
 
 
+* react/should-have-correct-comma-in-nested-children/input.js
+  x Unresolved reference IDs mismatch for "Component":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(4)]
+
+
 * react/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -3518,17 +5000,33 @@ Spread children are not supported in React.
    `----
 
 
-* react/should-warn-when-importSource-is-set/input.js
-importSource cannot be set when runtime is classic.
+* react/weird-symbols/input.js
+  x Unresolved reference IDs mismatch for "Text":
+  | after transform: [ReferenceId(1), ReferenceId(2)]
+  | rebuilt        : [ReferenceId(2)]
 
-* react/should-warn-when-importSource-pragma-is-set/input.js
-importSource cannot be set when runtime is classic.
 
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
 
-* react-automatic/should-disallow-spread-children/input.js
-Spread children are not supported in React.
+* react-automatic/dont-coerce-expression-containers/input.js
+  x Unresolved reference IDs mismatch for "Text":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react-automatic/handle-fragments-with-key/input.js
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1)]
+
+
+* react-automatic/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
+  x Unresolved reference IDs mismatch for "Composite":
+  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
+  | ReferenceId(6)]
+  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
+
 
 * react-automatic/should-disallow-valueless-key/input.js
   ! Please provide an explicit key value. Using "key" as a shorthand for
@@ -3550,6 +5048,12 @@ Spread children are not supported in React.
    `----
 
 
+* react-automatic/should-have-correct-comma-in-nested-children/input.js
+  x Unresolved reference IDs mismatch for "Component":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(4)]
+
+
 * react-automatic/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -3560,17 +5064,20 @@ Spread children are not supported in React.
    `----
 
 
-* react-automatic/should-warn-when-pragma-or-pragmaFrag-is-set/input.js
-pragma and pragmaFrag cannot be set when runtime is automatic.
+* react-automatic/weird-symbols/input.js
+  x Unresolved reference IDs mismatch for "Text":
+  | after transform: [ReferenceId(1), ReferenceId(2)]
+  | rebuilt        : [ReferenceId(2)]
+
 
 * spread-transform/transform-to-babel-extend/input.js
-x Output mismatch
+
 
 * spread-transform/transform-to-object-assign/input.js
-x Output mismatch
 
 
-# babel-plugin-transform-react-jsx-development (7/10)
+
+# babel-plugin-transform-react-jsx-development (6/10)
 * cross-platform/disallow-__self-as-jsx-attribute/input.js
   ! Duplicate __self prop found.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/input.js:1:14]
@@ -3587,7 +5094,37 @@ x Output mismatch
    `----
 
 
+* cross-platform/handle-fragments-with-key/input.js
+  x Unresolved reference IDs mismatch for "React":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(2)]
+
+
 * cross-platform/within-ts-module-block/input.ts
-x Output mismatch
+  x Output mismatch
+  x Missing SymbolId: Namespaced
+
+  x Missing SymbolId: _Namespaced
+
+  x Missing ReferenceId: _Namespaced
+
+  x Missing ReferenceId: Namespaced
+
+  x Missing ReferenceId: Namespaced
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 321/1024
+Passed: 329/1024
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -10,15 +10,15 @@ Passed: 321/1024
 * babel-plugin-transform-react-jsx-source
 
 
-# babel-preset-env (101/585)
+# babel-preset-env (109/585)
 * .plugins-overlapping/chrome-49/input.js
-
+x Output mismatch
 
 * .plugins-overlapping/chrome-50/input.js
-
+x Output mismatch
 
 * .plugins-overlapping/chrome-54/input.js
-
+x Output mismatch
 
 * bugfixes/_esmodules/input.js
 Targets: The `esmodules` is not supported
@@ -27,2008 +27,1813 @@ Targets: The `esmodules` is not supported
 Targets: The `esmodules` is not supported
 
 * bugfixes/edge-default-params-chrome-40/input.js
-
+x Output mismatch
 
 * bugfixes/edge-default-params-edge-14/input.js
-
+x Output mismatch
 
 * bugfixes/edge-default-params-edge-15/input.js
-
+x Output mismatch
 
 * bugfixes/edge-default-params-edge-17/input.js
-
+x Output mismatch
 
 * bugfixes/edge-default-params-edge-17-no-bugfixes/input.js
-
+x Output mismatch
 
 * bugfixes/edge-function-name-edge-14/input.js
-
+x Output mismatch
 
 * bugfixes/edge-function-name-edge-14-no-bugfixes/input.js
-
+x Output mismatch
 
 * bugfixes/edge-function-name-edge-15/input.js
-
+x Output mismatch
 
 * bugfixes/safari-block-scoping-safari-10/input.js
-
+x Output mismatch
 
 * bugfixes/safari-block-scoping-safari-10-no-bugfixes/input.js
-
+x Output mismatch
 
 * bugfixes/safari-block-scoping-safari-9/input.js
-
+x Output mismatch
 
 * bugfixes/safari-class-fields-safari-13/input.mjs
-
+x Output mismatch
 
 * bugfixes/safari-class-fields-safari-15/input.mjs
-
+x Output mismatch
 
 * bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15/input.js
-
+x Output mismatch
 
 * bugfixes/safari-id-destructuring-collision-in-function-expression-safari-15-no-bugfixes/input.js
-
+x Output mismatch
 
 * bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89/input.js
-
+x Output mismatch
 
 * bugfixes/v8-spread-parameters-in-optional-chaining-chrome-89-no-bugfixes/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/class-in-computed-field-firefox-50/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/class-in-computed-field-firefox-90/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/static-class-fields-chrome-70/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/static-class-fields-chrome-90/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/static-class-fields-chrome-96/input.js
-
+x Output mismatch
 
 * bugfixes-always-enabled/static-class-fields-chrome-97/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/entry-all/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-chrome-48/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-chrome-49/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-chrome-66/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-chromeandroid/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-core-js-main/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-core-js-main-require/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-electron/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-ie-9/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-import/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-node/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-node-10.13/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-node-11/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-node-web/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/entry-require/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/entry-shippedProposals/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/exclude-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/exclude-include/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/exclude-regenerator/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/force-all-transforms/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/include-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-all/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs2-babel-7/usage-destructuring-assignment/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-destructuring-catch/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-destructuring-for-x/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-destructuring-params/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-destructuring-variable-declaration/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-evaluated-class-methods/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-evaluated-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-evaluated-not-confident/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-for-of/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-for-of-destructure-with/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-instance-methods-native-support/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-modules-transform/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-native-support/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-number-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-promise-all/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-promise-finally/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-promise-race/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-regenerator-used-async/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-regenerator-used-generator/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-remove-babel-polyfill-import/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-shippedProposals/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/usage-source-type-script/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/usage-source-type-script-query/input.js
-
+x Output mismatch
 
 * corejs2-babel-7/usage-symbol-iterator/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-symbol-iterator-in/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-timers/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-typed-array/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-typed-array-static/input.mjs
-
+x Output mismatch
 
 * corejs2-babel-7/usage-yield-star/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-all/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-all-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-chrome-48/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-chrome-49/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-chrome-66/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-chromeandroid/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-electron/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-es-proposals-stage/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-es-proposals-stage-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-features/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-features-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-missed/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-mixed/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-mixed-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-modules/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-modules-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-proposals/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-stable/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-stage/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-stage-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-web/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-entries-web-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-ie-9/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-import/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-node/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-node-10.13/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-node-11/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-node-web/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-normalization/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-require/input.js
-
+x Output mismatch
 
 * corejs3/entry-require-all/input.js
-
+x Output mismatch
 
 * corejs3/entry-require-es-chrome-71/input.js
-
+x Output mismatch
 
 * corejs3/entry-require-es-proposals/input.js
-
+x Output mismatch
 
 * corejs3/entry-specified-imports/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["fromEntries", "reflect"]
-  | rebuilt        : ScopeId(0): ["reflect"]
-
+x Output mismatch
 
 * corejs3/entry-stable/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/entry-stable-samsung-8.2/input.mjs
-
+x Output mismatch
 
 * corejs3/exclude-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs3/exclude-include/input.mjs
-
+x Output mismatch
 
 * corejs3/force-all-transforms/input.mjs
-
+x Output mismatch
 
 * corejs3/include-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-all-proposals/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-all-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs3/usage-determanated-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-for-of-destructure-with/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-modules-transform/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-number-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-object-destructuring/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-object-destructuring-with-rest/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-promise-all/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-promise-finally/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-promise-race/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-regenerator-used-async-native-support/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-shippedProposals/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-source-type-script/input.js
-
+x Output mismatch
 
 * corejs3/usage-source-type-script-query/input.js
-
+x Output mismatch
 
 * corejs3/usage-static-methods/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-timers/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-typed-array/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-typed-array-edge-13/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-typed-array-static/input.mjs
-
+x Output mismatch
 
 * corejs3/usage-yield-star/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-all/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-all-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-chrome-48/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-chrome-49/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-chrome-66/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-chromeandroid/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-electron/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-es-proposals-stage/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-es-proposals-stage-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-features/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-features-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-missed/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-mixed/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-mixed-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-modules/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-modules-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-proposals/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-stable/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-stage/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-stage-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-web/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-entries-web-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-ie-9/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-import/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-node/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-node-10.13/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-node-11/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-node-web/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-normalization/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-require/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/entry-require-all/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/entry-require-es-chrome-71/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/entry-require-es-proposals/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/entry-specified-imports/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["fromEntries", "reflect"]
-  | rebuilt        : ScopeId(0): ["reflect"]
-
+x Output mismatch
 
 * corejs3-babel-7/entry-stable/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/entry-stable-samsung-8.2/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/exclude/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/exclude-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/exclude-include/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/exclude-regenerator/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/force-all-transforms/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/include-built-ins/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-all/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-all-proposals/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-all-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-browserslist-config-ignore/input.mjs
 Targets: The `esmodules` is not supported
 
 * corejs3-babel-7/usage-built-in-from-global-object/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-assignment/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-catch/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-for-x/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-iife/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-params/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-destructuring-variable-declaration/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-determanated-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-dynamic-import/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-evaluated-class-methods/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-evaluated-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-fetch/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-for-of/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-for-of-destructure-with/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-in/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-instance-methods/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-modules-transform/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-number-ie-11/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-object-destructuring/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-object-destructuring-with-rest/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-promise-all/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-promise-finally/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-promise-race/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-regenerator-used-async/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-regenerator-used-async-native-support/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-regenerator-used-generator/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-shippedProposals/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-source-type-script/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/usage-source-type-script-query/input.js
-
+x Output mismatch
 
 * corejs3-babel-7/usage-spread/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-static-methods/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-symbol-iterator/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-symbol-iterator-in/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-timers/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-typed-array/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-typed-array-edge-13/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-typed-array-static/input.mjs
-
+x Output mismatch
 
 * corejs3-babel-7/usage-yield-star/input.mjs
-
+x Output mismatch
 
 * debug/browserslist-env/input.mjs
-
+x Output mismatch
 
 * debug/browserslists-android-3/input.mjs
-
+x Output mismatch
 
 * debug/browserslists-defaults/input.mjs
-
+x Output mismatch
 
 * debug/browserslists-defaults-not-ie/input.mjs
-
+x Output mismatch
 
 * debug/browserslists-last-2-versions-not-ie/input.mjs
-
+x Output mismatch
 
 * debug/corejs-without-usebuiltins/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-all/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-all-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-android/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-babel-polyfill/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-electron/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-es/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-es-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-es-proposals/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-es-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-force-all-transforms/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-no-import/input.js
-
+x Output mismatch
 
 * debug/entry-corejs3-proposals/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-runtime-only/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-runtime-only-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-specific-entries/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-specific-entries-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-specific-targets/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-stable/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-stable-samsung-8.2/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-stage/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-stage-chrome-71/input.mjs
-
-
-* debug/entry-corejs3-versions-decimals/input.mjs
-
-
-* debug/entry-corejs3-versions-strings/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-versions-strings-minor-3.0/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-versions-strings-minor-3.1/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-web/input.mjs
-
+x Output mismatch
 
 * debug/entry-corejs3-web-chrome-71/input.mjs
-
-
-* debug/entry-no-corejs/input.mjs
-
-
-* debug/entry-no-corejs-no-import/input.js
-
+x Output mismatch
 
 * debug/plugins-only/input.mjs
-
+x Output mismatch
 
 * debug/shippedProposals-chrome-80/input.mjs
-
+x Output mismatch
 
 * debug/shippedProposals-chrome-84/input.mjs
-
+x Output mismatch
 
 * debug/top-level-targets/input.mjs
-
+x Output mismatch
 
 * debug/top-level-targets-shadowed/input.mjs
-
+x Output mismatch
 
 * debug/usage-corejs3-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-none-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-none-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-proposals-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-proposals-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-proposals-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-proposals-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-shippedProposals-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-shippedProposals-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-versions-strings-minor-3.0-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-versions-strings-minor-3.0-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-versions-strings-minor-3.1-1/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-versions-strings-minor-3.1-2/input.js
-
+x Output mismatch
 
 * debug/usage-corejs3-with-import/input.mjs
-
-
-* debug/usage-no-corejs/input.js
-
-
-* debug/usage-no-corejs-none/input.js
-
+x Output mismatch
 
 * debug-babel-7/browserslists-android-3/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/browserslists-defaults/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/browserslists-defaults-not-ie/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/browserslists-last-2-versions-not-ie/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/corejs-without-usebuiltins/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-android/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-electron/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-force-all-transforms/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-no-import/input.js
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-proposals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-shippedProposals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-shippedProposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-specific-targets/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-versions-decimals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs2-versions-strings/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-all/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-all-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-android/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-babel-polyfill/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-electron/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-es/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-es-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-es-proposals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-es-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-force-all-transforms/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-no-import/input.js
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-proposals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-proposals-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-runtime-only/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-runtime-only-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-specific-entries/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-specific-entries-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-specific-targets/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-stable/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-stable-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-stable-samsung-8.2/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-stage/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-stage-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-versions-decimals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-versions-strings/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-versions-strings-minor-3.0/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-versions-strings-minor-3.1/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-web/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-corejs3-web-chrome-71/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-no-corejs/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/entry-no-corejs-no-import/input.js
-
+x Output mismatch
 
 * debug-babel-7/entry-no-corejs-shippedProposals/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/plugins-only/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/shippedProposals-chrome-80/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/shippedProposals-chrome-84/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/top-level-targets/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/top-level-targets-shadowed/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-none-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-none-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-proposals-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-proposals-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-proposals-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-proposals-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-shippedProposals-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-shippedProposals-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs2-with-import/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-none-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-none-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-proposals-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-proposals-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-proposals-chrome-71-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-proposals-chrome-71-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-shippedProposals-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-shippedProposals-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.0-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.0-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.1-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-versions-strings-minor-3.1-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-corejs3-with-import/input.mjs
-
+x Output mismatch
 
 * debug-babel-7/usage-no-corejs-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-no-corejs-2/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-no-corejs-none-1/input.js
-
+x Output mismatch
 
 * debug-babel-7/usage-no-corejs-none-2/input.js
-
+x Output mismatch
 
 * dynamic-import/auto-esm-unsupported-import-unsupported/input.mjs
-
+x Output mismatch
 
 * dynamic-import/modules-amd/input.js
-
+x Output mismatch
 
 * dynamic-import/modules-cjs/input.mjs
-
+x Output mismatch
 
 * dynamic-import/modules-systemjs/input.mjs
-
+x Output mismatch
 
 * dynamic-import/modules-umd/input.mjs
-
+x Output mismatch
 
 * dynamic-import-babel-7/auto-esm-unsupported-import-unsupported/input.mjs
-
+x Output mismatch
 
 * dynamic-import-babel-7/modules-amd/input.js
-
+x Output mismatch
 
 * dynamic-import-babel-7/modules-cjs/input.mjs
-
+x Output mismatch
 
 * dynamic-import-babel-7/modules-systemjs/input.mjs
-
+x Output mismatch
 
 * dynamic-import-babel-7/modules-umd/input.mjs
-
+x Output mismatch
 
 * export-namespace-from/auto-esm-not-supported/input.mjs
-
+x Output mismatch
 
 * export-namespace-from/auto-export-namespace-not-supported/input.mjs
-
+x Output mismatch
 
 * export-namespace-from/false-export-namespace-not-supported/input.mjs
-
+x Output mismatch
 
 * export-namespace-from/false-export-namespace-not-supported-caller-supported/input.mjs
-
+x Output mismatch
 
 * modules/auto-cjs/input.mjs
-
+x Output mismatch
 
 * modules/auto-unknown/input.mjs
-
+x Output mismatch
 
 * modules/modules-cjs/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["a"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * modules/modules-commonjs/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["a"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * modules/modules-false/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["a"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * modules/modules-systemjs/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["a"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * modules/modules-umd/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["a"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * plugins-integration/block-scoping-inside-generator/input.js
-
+x Output mismatch
 
 * plugins-integration/class-arrow-super-tagged-expr/input.js
-
+x Output mismatch
 
 * plugins-integration/class-features-node-12/input.js
-
+x Output mismatch
 
 * plugins-integration/for-of-array-block-scoping/input.js
-
+x Output mismatch
 
 * plugins-integration/for-of-array-block-scoping-2/input.js
-
+x Output mismatch
 
 * plugins-integration/issue-10662/input.mjs
-
+x Output mismatch
 
 * plugins-integration/issue-11278/input.mjs
-
+x Output mismatch
 
 * plugins-integration/issue-15012/input.js
-
+x Output mismatch
 
 * plugins-integration/issue-15170/input.js
-
+x Output mismatch
 
 * plugins-integration/issue-16155/input.mjs
-
+x Output mismatch
 
 * plugins-integration/issue-7527/input.mjs
-
+x Output mismatch
 
 * plugins-integration/issue-9935/input.js
-
+x Output mismatch
 
 * plugins-integration/regression-2892/input.mjs
-
+x Output mismatch
 
 * plugins-integration/regression-4855/input.js
-
+x Output mismatch
 
 * plugins-integration/spread-super-firefox-40/input.js
-
+x Output mismatch
 
 * preset-options/browserslist-config-ignore-config-with-false/input.mjs
-
+x Output mismatch
 
 * preset-options/browserslist-config-ignore-package-with-false/input.mjs
-
+x Output mismatch
 
 * preset-options/browserslist-defaults/input.mjs
-
+x Output mismatch
 
 * preset-options/browserslist-defaults-not-ie/input.mjs
 Targets: node `current` is not supported
 
 * preset-options/deno-1_0/input.mjs
-
+x Output mismatch
 
 * preset-options/destructuring-edge/input.js
-
+x Output mismatch
 
 * preset-options/duplicate-named-capturing-groups-regex-chrome-123/input.js
-
+x Output mismatch
 
 * preset-options/empty-options/input.mjs
-
+x Output mismatch
 
 * preset-options/esmodules-async-functions/input.mjs
 Targets: The `esmodules` is not supported
 
 * preset-options/include/input.mjs
-
+x Output mismatch
 
 * preset-options/include-scoped/input.mjs
-
+x Output mismatch
 
 * preset-options/ios-6/input.mjs
-
+x Output mismatch
 
 * preset-options/no-options/input.mjs
-
-
-* preset-options/removed-loose/input.js
-
-
-* preset-options/removed-spec/input.js
-
+x Output mismatch
 
 * preset-options/reserved-keys-ie8/input.mjs
-
+x Output mismatch
 
 * preset-options/reserved-names-ie8/input.mjs
-
+x Output mismatch
 
 * preset-options/rhino-1_7_13/input.mjs
-
+x Output mismatch
 
 * preset-options/safari-10_3-block-scoped/input.js
-
+x Output mismatch
 
 * preset-options/safari-tagged-template-literals/input.js
-
+x Output mismatch
 
 * preset-options/safari-tp/input.js
 failed to resolve query: failed to parse the rest of input: ...''
 
 * preset-options/unicode-property-regex-chrome-49/input.js
-
+x Output mismatch
 
 * preset-options/unicode-sets-regex-chrome-111/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/browserslist-config-ignore-config-with-false/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/browserslist-config-ignore-package-with-false/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/browserslist-defaults/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/browserslist-defaults-not-ie/input.mjs
 Targets: node `current` is not supported
 
 * preset-options-babel-7/deno-1_0/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/destructuring-edge/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/duplicate-named-capturing-groups-regex-chrome-120/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/empty-options/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/esmodules-async-functions/input.mjs
 Targets: The `esmodules` is not supported
 
 * preset-options-babel-7/include/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/include-scoped/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/ios-10/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/ios-10_3/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/ios-6/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/loose-typeof-symbol/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/loose-with-typeof-symbol-includes/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/no-options/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/reserved-keys-ie8/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/reserved-names-ie8/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/rhino-1_7_13/input.mjs
-
+x Output mismatch
 
 * preset-options-babel-7/safari-10_3-block-scoped/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/safari-tagged-template-literals/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/safari-tp/input.js
 failed to resolve query: failed to parse the rest of input: ...''
 
 * preset-options-babel-7/shippedProposals/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/spec/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/unicode-property-regex-chrome-49/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/unicode-sets-regex-chrome-111/input.js
-
+x Output mismatch
 
 * preset-options-babel-7/useBuiltIns-false/input.mjs
-
+x Output mismatch
 
 * sanity/block-scoping-for-of/input.js
-
+x Output mismatch
 
 * sanity/regex-dot-all/input.js
-
+x Output mismatch
 
 * sanity/transform-duplicate-keys/input.js
-
+x Output mismatch
 
 * shipped-proposals/import-assertions/input.mjs
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["packageJson"]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * shipped-proposals/new-class-features-chrome-90/input.js
-
+x Output mismatch
 
 * shipped-proposals/new-class-features-firefox-70/input.js
-
+x Output mismatch
 
 
 # babel-plugin-transform-logical-assignment-operators (0/6)
 * logical-assignment/anonymous-functions-transform/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(6): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+Reference flags mismatch:
+after transform: ReferenceId(4): ReferenceFlags(Write)
+rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(6): ReferenceFlags(Write)
+rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(8): ReferenceFlags(Write)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/arrow-functions-transform/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(6): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+Reference flags mismatch:
+after transform: ReferenceId(4): ReferenceFlags(Write)
+rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(6): ReferenceFlags(Write)
+rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(8): ReferenceFlags(Write)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/general-semantics/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(117), ReferenceId(118),
-  | ReferenceId(121)]
-  | rebuilt        : SymbolId(8): [ReferenceId(87), ReferenceId(91)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(122), ReferenceId(123),
-  | ReferenceId(126)]
-  | rebuilt        : SymbolId(10): [ReferenceId(99), ReferenceId(103)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(19): [ReferenceId(127), ReferenceId(128),
-  | ReferenceId(131)]
-  | rebuilt        : SymbolId(12): [ReferenceId(111), ReferenceId(115)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(21): [ReferenceId(132), ReferenceId(133),
-  | ReferenceId(136)]
-  | rebuilt        : SymbolId(14): [ReferenceId(123), ReferenceId(127)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(98): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(97): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(29): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(100): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(33): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(99): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(35): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(102): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(39): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(101): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(41): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(104): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(45): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(103): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(47): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(107): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(52): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(105): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(55): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(110): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(61): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(108): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(64): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(113): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(70): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(111): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(73): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(116): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(79): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(114): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(82): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(118): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(87): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(120): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(89): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(119): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(92): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(123): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(99): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(125): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(101): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(124): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(104): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(128): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(111): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(130): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(113): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(129): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(116): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(133): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(123): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(135): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(125): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(134): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(128): ReferenceFlags(Read)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(117), ReferenceId(118), ReferenceId(121)]
+rebuilt        : SymbolId(8): [ReferenceId(87), ReferenceId(91)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): [ReferenceId(122), ReferenceId(123), ReferenceId(126)]
+rebuilt        : SymbolId(10): [ReferenceId(99), ReferenceId(103)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): [ReferenceId(127), ReferenceId(128), ReferenceId(131)]
+rebuilt        : SymbolId(12): [ReferenceId(111), ReferenceId(115)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(21): [ReferenceId(132), ReferenceId(133), ReferenceId(136)]
+rebuilt        : SymbolId(14): [ReferenceId(123), ReferenceId(127)]
+Reference flags mismatch:
+after transform: ReferenceId(98): ReferenceFlags(Write)
+rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(97): ReferenceFlags(Write)
+rebuilt        : ReferenceId(29): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(100): ReferenceFlags(Write)
+rebuilt        : ReferenceId(33): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(99): ReferenceFlags(Write)
+rebuilt        : ReferenceId(35): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(102): ReferenceFlags(Write)
+rebuilt        : ReferenceId(39): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(101): ReferenceFlags(Write)
+rebuilt        : ReferenceId(41): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(104): ReferenceFlags(Write)
+rebuilt        : ReferenceId(45): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(103): ReferenceFlags(Write)
+rebuilt        : ReferenceId(47): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(107): ReferenceFlags(Write)
+rebuilt        : ReferenceId(52): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(105): ReferenceFlags(Write)
+rebuilt        : ReferenceId(55): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(110): ReferenceFlags(Write)
+rebuilt        : ReferenceId(61): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(108): ReferenceFlags(Write)
+rebuilt        : ReferenceId(64): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(113): ReferenceFlags(Write)
+rebuilt        : ReferenceId(70): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(111): ReferenceFlags(Write)
+rebuilt        : ReferenceId(73): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(116): ReferenceFlags(Write)
+rebuilt        : ReferenceId(79): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(114): ReferenceFlags(Write)
+rebuilt        : ReferenceId(82): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(118): ReferenceFlags(Write)
+rebuilt        : ReferenceId(87): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(120): ReferenceFlags(Write)
+rebuilt        : ReferenceId(89): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(119): ReferenceFlags(Write)
+rebuilt        : ReferenceId(92): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(123): ReferenceFlags(Write)
+rebuilt        : ReferenceId(99): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(125): ReferenceFlags(Write)
+rebuilt        : ReferenceId(101): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(124): ReferenceFlags(Write)
+rebuilt        : ReferenceId(104): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(128): ReferenceFlags(Write)
+rebuilt        : ReferenceId(111): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(130): ReferenceFlags(Write)
+rebuilt        : ReferenceId(113): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(129): ReferenceFlags(Write)
+rebuilt        : ReferenceId(116): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(133): ReferenceFlags(Write)
+rebuilt        : ReferenceId(123): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(135): ReferenceFlags(Write)
+rebuilt        : ReferenceId(125): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(134): ReferenceFlags(Write)
+rebuilt        : ReferenceId(128): ReferenceFlags(Read)
 
 * logical-assignment/named-functions-transform/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(6): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+Reference flags mismatch:
+after transform: ReferenceId(4): ReferenceFlags(Write)
+rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(6): ReferenceFlags(Write)
+rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(8): ReferenceFlags(Write)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/null-coalescing/input.js
-  x Output mismatch
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(86), ReferenceId(87),
-  | ReferenceId(90)]
-  | rebuilt        : SymbolId(12): [ReferenceId(73), ReferenceId(79)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(20): [ReferenceId(94), ReferenceId(95),
-  | ReferenceId(98)]
-  | rebuilt        : SymbolId(14): [ReferenceId(88), ReferenceId(94)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(65): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(27): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(64): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(31): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(70): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(36): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(69): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(40): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(76): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(48): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(74): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(53): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(82): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(60): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(80): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(65): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(87): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(73): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(89): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(75): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(88): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(80): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(95): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(88): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(97): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(90): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(96): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(95): ReferenceFlags(Read)
-
+x Output mismatch
 
 * logical-assignment/null-coalescing-without-other/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(8)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-  | rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(3), ReferenceId(6)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(6): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(5): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(4): ReferenceFlags(Read)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(10): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(9): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(9): ReferenceFlags(Read)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(11)]
+rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6)]
+Reference flags mismatch:
+after transform: ReferenceId(4): ReferenceFlags(Write)
+rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(6): ReferenceFlags(Write)
+rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(5): ReferenceFlags(Write)
+rebuilt        : ReferenceId(4): ReferenceFlags(Read)
+Reference flags mismatch:
+after transform: ReferenceId(8): ReferenceFlags(Write)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(10): ReferenceFlags(Write)
+rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(9): ReferenceFlags(Write)
+rebuilt        : ReferenceId(9): ReferenceFlags(Read)
 
 
 # babel-plugin-transform-nullish-coalescing-operator (5/12)
 * assumption-noDocumentAll/transform/input.js
-
+x Output mismatch
 
 * assumption-noDocumentAll/transform-in-default-destructuring/input.js
-
+x Output mismatch
 
 * assumption-noDocumentAll/transform-in-default-param/input.js
-
+x Output mismatch
 
 * assumption-noDocumentAll/transform-in-function/input.js
-
+x Output mismatch
 
 * assumption-noDocumentAll/transform-static-refs-in-default/input.js
-
+x Output mismatch
 
 * assumption-noDocumentAll/transform-static-refs-in-function/input.js
-
+x Output mismatch
 
 * nullish-coalescing/transform-loose/input.js
-
+x Output mismatch
 
 
 # babel-plugin-transform-object-rest-spread (5/59)
 * assumption-ignoreFunctionLength/parameters-object-rest-used-in-default/input.js
-
+x Output mismatch
 
 * assumption-objectRestNoSymbols/rest-assignment-expression/input.js
-
+x Output mismatch
 
 * assumption-objectRestNoSymbols/rest-computed/input.js
-
+x Output mismatch
 
 * assumption-objectRestNoSymbols/rest-nested/input.js
-
+x Output mismatch
 
 * assumption-objectRestNoSymbols/rest-var-declaration/input.js
-
+x Output mismatch
 
 * assumption-pureGetters/rest-remove-unused-excluded-keys/input.js
-
+x Output mismatch
 
 * assumption-pureGetters/spread-single-call/input.js
-
+x Output mismatch
 
 * assumption-setSpreadProperties/assignment/input.js
-
+x Output mismatch
 
 * assumption-setSpreadProperties/expression/input.js
-
+x Output mismatch
 
 * assumption-setSpreadProperties/targets-support-object-assign/input.js
-
+x Output mismatch
 
 * assumption-setSpreadProperties-with-useBuiltIns/assignment/input.js
-
+x Output mismatch
 
 * assumption-setSpreadProperties-with-useBuiltIns/expression/input.js
-
+x Output mismatch
 
 * object-rest/assignment-expression/input.js
-
+x Output mismatch
 
 * object-rest/catch-clause/input.js
-
+x Output mismatch
 
 * object-rest/duplicate-decl-bug/input.js
-
+x Output mismatch
 
 * object-rest/export/input.mjs
-
+x Output mismatch
 
 * object-rest/for-x/input.js
-
+x Output mismatch
 
 * object-rest/for-x-array-pattern/input.js
-
+x Output mismatch
 
 * object-rest/for-x-completion-record/input.js
-
+x Output mismatch
 
 * object-rest/impure-computed/input.js
-
+x Output mismatch
 
 * object-rest/nested/input.js
-
+x Output mismatch
 
 * object-rest/nested-2/input.js
-
+x Output mismatch
 
 * object-rest/nested-array/input.js
-
+x Output mismatch
 
 * object-rest/nested-array-2/input.js
-
+x Output mismatch
 
 * object-rest/nested-computed-key/input.js
-
+x Output mismatch
 
 * object-rest/nested-default-value/input.js
-
+x Output mismatch
 
 * object-rest/nested-literal-property/input.js
-
+x Output mismatch
 
 * object-rest/nested-order/input.js
-
+x Output mismatch
 
 * object-rest/non-string-computed/input.js
-
+x Output mismatch
 
 * object-rest/null-destructuring/input.js
-
+x Output mismatch
 
 * object-rest/object-ref-computed/input.js
-
+x Output mismatch
 
 * object-rest/parameters/input.js
-
+x Output mismatch
 
 * object-rest/parameters-object-rest-used-in-default/input.js
-
+x Output mismatch
 
 * object-rest/remove-unused-excluded-keys-loose/input.js
-
+x Output mismatch
 
 * object-rest/symbol/input.js
-
+x Output mismatch
 
 * object-rest/template-literal-allLiterals-true-no-hoisting/input.js
-
+x Output mismatch
 
 * object-rest/template-literal-property-allLiterals-false/input.js
-
+x Output mismatch
 
 * object-rest/template-literal-property-allLiterals-true/input.js
-
+x Output mismatch
 
 * object-rest/variable-destructuring/input.js
-
+x Output mismatch
 
 * object-rest/with-array-rest/input.js
-
+x Output mismatch
 
 * object-spread/expression/input.js
-
+x Output mismatch
 
 * object-spread/side-effect/input.js
-
+x Output mismatch
 
 * object-spread-loose/assignment/input.js
-
+x Output mismatch
 
 * object-spread-loose/expression/input.js
-
+x Output mismatch
 
 * object-spread-loose/parameters-object-rest-used-in-default/input.js
-
+x Output mismatch
 
 * object-spread-loose/side-effect/input.js
-
+x Output mismatch
 
 * object-spread-loose/variable-declaration/input.js
-
+x Output mismatch
 
 * object-spread-loose-builtins/expression/input.js
-
+x Output mismatch
 
 * object-spread-loose-builtins/side-effect/input.js
-
+x Output mismatch
 
 * regression/gh-4904/input.js
-
+x Output mismatch
 
 * regression/gh-5151/input.js
-
+x Output mismatch
 
 * regression/gh-7304/input.mjs
-
+x Output mismatch
 
 * regression/gh-7388/input.js
-
+x Output mismatch
 
 * regression/gh-8323/input.js
-
+x Output mismatch
 
 
 # babel-plugin-transform-exponentiation-operator (1/4)
 * exponentiation-operator/assignment/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(2): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(1): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(2): ReferenceFlags(Read)
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+Reference flags mismatch:
+after transform: ReferenceId(2): ReferenceFlags(Write)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+Reference flags mismatch:
+after transform: ReferenceId(1): ReferenceFlags(Write)
+rebuilt        : ReferenceId(2): ReferenceFlags(Read)
 
 * regression/4349/input.js
-
+x Output mismatch
 
 * regression/4403/input.js
-  x Reference flags mismatch:
-  | after transform: ReferenceId(3): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-
+Reference flags mismatch:
+after transform: ReferenceId(3): ReferenceFlags(Write)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
 
 
 # babel-plugin-transform-arrow-functions (1/6)
 * assumption-newableArrowFunctions-false/basic/input.js
-
+x Output mismatch
 
 * assumption-newableArrowFunctions-false/naming/input.js
-
+x Output mismatch
 
 * assumption-newableArrowFunctions-false/self-referential/input.js
-
+x Output mismatch
 
 * spec/newableArrowFunction-default/input.js
-
+x Output mismatch
 
 * spec/newableArrowFunction-vs-spec-false/input.js
-
+x Output mismatch
 
 
 # babel-preset-typescript (5/10)
@@ -2042,48 +1847,32 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * node-extensions/import-in-cts/input.cts
-
+x Output mismatch
 
 * node-extensions/type-assertion-in-ts/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
-
+Unresolved references mismatch:
+after transform: ["T", "x"]
+rebuilt        : ["x"]
 
 * node-extensions/type-param-arrow-in-ts/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["T"]
-  | rebuilt        : ScopeId(1): []
-
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
 
 * opts/optimizeConstEnums/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "x"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+x Output mismatch
 
 
-
-# babel-plugin-transform-typescript (41/154)
+# babel-plugin-transform-typescript (39/154)
 * cast/as-expression/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
-
+Unresolved references mismatch:
+after transform: ["T", "x"]
+rebuilt        : ["x"]
 
 * cast/type-assertion/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
-
+Unresolved references mismatch:
+after transform: ["T", "x"]
+rebuilt        : ["x"]
 
 * class/accessor-allowDeclareFields-false/input.ts
 TS(18010)
@@ -2110,673 +1899,340 @@ TS(18010)
 
 
 * class/head/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["T"]
-  | rebuilt        : ScopeId(1): []
-
-  x Unresolved references mismatch:
-  | after transform: ["D", "I"]
-  | rebuilt        : ["D"]
-
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Unresolved references mismatch:
+after transform: ["D", "I"]
+rebuilt        : ["D"]
 
 * class/methods/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4),
-  | ScopeId(5)]
-  | rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 
 * class/private-method-override/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-  | rebuilt        : ScopeId(1): [ScopeId(2)]
-
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
 
 * declarations/const-enum/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["E"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["E"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 * declarations/erased/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["E", "I", "M", "N", "T", "m", "x"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["E", "I", "M", "N", "T", "m", "x"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): []
 
 * declarations/export-declare-enum/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 * declarations/nested-namespace/input.mjs
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["P"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["P"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 * enum/boolean-value/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "E"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/const/input.ts
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/constant-folding/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h",
-  | "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/enum-merging-inner-references/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
-  | rebuilt        : ScopeId(1): ["Animals"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["Animals", "CatDog"]
-  | rebuilt        : ScopeId(2): ["Animals"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 41, end: 48 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["Cat", "Dog"]
-  | rebuilt        : []
-
+Bindings mismatch:
+after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
+rebuilt        : ScopeId(1): ["Animals"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["Animals", "CatDog"]
+rebuilt        : ScopeId(2): ["Animals"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 41, end: 48 }]
+rebuilt        : SymbolId(0): []
+Unresolved references mismatch:
+after transform: ["Cat", "Dog"]
+rebuilt        : []
 
 * enum/enum-merging-inner-references-shadow/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["Animals", "Cat"]
-  | rebuilt        : ScopeId(1): ["Animals"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["Animals", "Dog"]
-  | rebuilt        : ScopeId(2): ["Animals"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): ["Animals", "CatDog"]
-  | rebuilt        : ScopeId(3): ["Animals"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(3): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0)]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(1)]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(2): [Span { start: 65, end: 72 }, Span { start:
-  | 92, end: 99 }]
-  | rebuilt        : SymbolId(2): []
-
+Bindings mismatch:
+after transform: ScopeId(1): ["Animals", "Cat"]
+rebuilt        : ScopeId(1): ["Animals"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["Animals", "Dog"]
+rebuilt        : ScopeId(2): ["Animals"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["Animals", "CatDog"]
+rebuilt        : ScopeId(3): ["Animals"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 65, end: 72 }, Span { start: 92, end: 99 }]
+rebuilt        : SymbolId(2): []
 
 * enum/export/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "E"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["B", "E"]
-  | rebuilt        : ScopeId(2): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 40, end: 41 }]
-  | rebuilt        : SymbolId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["B", "E"]
+rebuilt        : ScopeId(2): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 40, end: 41 }]
+rebuilt        : SymbolId(0): []
 
 * enum/inferred/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["E", "x", "y"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "x", "y"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/inner-references/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["E", "a", "b"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "a", "b"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/mix-references/input.ts
-  x Output mismatch
-  x Missing ReferenceId: Foo
-
-  x Missing ReferenceId: Bar
-
-  x Missing ReferenceId: Baz
-
-  x Missing ReferenceId: A
-
-  x Missing ReferenceId: A
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
-  | rebuilt        : ScopeId(1): ["Foo"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["Bar", "D", "E", "F", "G"]
-  | rebuilt        : ScopeId(2): ["Bar"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): ["Baz", "a", "b", "x"]
-  | rebuilt        : ScopeId(3): ["Baz"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(3): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(4): ["A", "a", "b", "c"]
-  | rebuilt        : ScopeId(4): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(4): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(7),
-  | ReferenceId(18)]
-  | rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(20)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(19): [ReferenceId(11), ReferenceId(12),
-  | ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16),
-  | ReferenceId(17)]
-  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(8)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(20): [ReferenceId(19), ReferenceId(20),
-  | ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24),
-  | ReferenceId(25), ReferenceId(26), ReferenceId(27)]
-  | rebuilt        : SymbolId(4): [ReferenceId(10), ReferenceId(11),
-  | ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15),
-  | ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(21)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(10): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(21): [ReferenceId(29), ReferenceId(30),
-  | ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34),
-  | ReferenceId(35)]
-  | rebuilt        : SymbolId(6): [ReferenceId(23), ReferenceId(24),
-  | ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28),
-  | ReferenceId(29), ReferenceId(30)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(14): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(22): [ReferenceId(37), ReferenceId(38),
-  | ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42),
-  | ReferenceId(43)]
-  | rebuilt        : SymbolId(8): [ReferenceId(32), ReferenceId(33),
-  | ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37),
-  | ReferenceId(38), ReferenceId(39), ReferenceId(40)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(9)]
-  | rebuilt        : SymbolId(9): []
-
+x Output mismatch
 
 * enum/non-foldable-constant/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["E", "a", "b"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "a", "b"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/non-scoped/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["E", "x", "y"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["E", "z"]
-  | rebuilt        : ScopeId(2): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 40, end: 41 }]
-  | rebuilt        : SymbolId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "x", "y"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["E", "z"]
+rebuilt        : ScopeId(2): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 40, end: 41 }]
+rebuilt        : SymbolId(0): []
 
 * enum/outer-references/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
-  | rebuilt        : ScopeId(1): ["socketType"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE",
-  | "UV_WRITABLE", "constants"]
-  | rebuilt        : ScopeId(2): ["constants"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(10)]
-  | rebuilt        : SymbolId(0): [ReferenceId(7)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
+rebuilt        : ScopeId(1): ["socketType"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE", "UV_WRITABLE", "constants"]
+rebuilt        : ScopeId(2): ["constants"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
+rebuilt        : SymbolId(0): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 * enum/reverse-mappings-syntactically-determinable/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "B", "C", "D", "E", "Foo"]
-  | rebuilt        : ScopeId(1): ["Foo"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-  | rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7),
-  | ReferenceId(10)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-
+x Output mismatch
 
 * enum/scoped/input.ts
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * enum/string-value/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/string-value-template/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "E"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/string-values-computed/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "E"]
-  | rebuilt        : ScopeId(1): ["E"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/ts5.0-const-foldable/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["First", "Second", "Third", "Values"]
-  | rebuilt        : ScopeId(1): ["Values"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["Invoices", "Parts", "Routes", "x", "y"]
-  | rebuilt        : ScopeId(2): ["Routes"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4)]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5),
-  | ReferenceId(16)]
-  | rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(11)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(6)]
-  | rebuilt        : SymbolId(5): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(8): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-
+x Output mismatch
 
 * exports/declare-namespace/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
-  | | Ambient)
-  | rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 83, end: 84 }]
-  | rebuilt        : SymbolId(0): []
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(1)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 83, end: 84 }]
+rebuilt        : SymbolId(0): []
 
 * exports/declare-shadowed/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-  x Unresolved references mismatch:
-  | after transform: ["Signal", "Signal2"]
-  | rebuilt        : []
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Unresolved references mismatch:
+after transform: ["Signal", "Signal2"]
+rebuilt        : []
 
 * exports/declared-types/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["AA", "AA2", "BB", "BB2", "Bar", "C2", "E",
-  | "I", "II2", "II3", "M", "N", "T", "foo", "m", "x"]
-  | rebuilt        : ScopeId(0): ["BB", "BB2", "C2", "foo"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9),
-  | ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14),
-  | ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(12): ["BB", "K"]
-  | rebuilt        : ScopeId(2): ["BB"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(12): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(13): ["BB", "L"]
-  | rebuilt        : ScopeId(3): ["BB"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(13): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(16): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(10): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(10): [Span { start: 495, end: 497 }]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(15): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(0): Some("x")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(0): ReferenceFlags(Read)
-  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(2): Some("E")
-  | rebuilt        : ReferenceId(1): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(2): ReferenceFlags(Read)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Type)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(8): Some("x")
-  | rebuilt        : ReferenceId(2): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Read)
-  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Type)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(11): Some("E")
-  | rebuilt        : ReferenceId(3): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(11): ReferenceFlags(Read)
-  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Type)
-
-  x Unresolved references mismatch:
-  | after transform: ["Bar", "C", "M", "N", "f"]
-  | rebuilt        : ["Bar", "E", "x"]
-
+x Output mismatch
 
 * exports/default-function/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 * exports/export-const-enums/input.ts
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : SymbolId(0): [ReferenceId(1)]
-
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 * exports/export-import=/input.ts
-  x Missing SymbolId: JGraph
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
-  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-
+Missing SymbolId: JGraph
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 
 * exports/export-type/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 * exports/export=/input.ts
   ! `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -2799,250 +2255,190 @@ TS(18010)
 
 
 * exports/imported-types/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "C"]
-  | rebuilt        : ScopeId(0): ["C"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C"]
+rebuilt        : ScopeId(0): ["C"]
 
 * exports/imported-types-only-remove-type-imports/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "C"]
-  | rebuilt        : ScopeId(0): ["C"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C"]
+rebuilt        : ScopeId(0): ["C"]
 
 * exports/interface/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "I"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
+x Output mismatch
 
 * exports/issue-9916-1/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
-  | rebuilt        : ScopeId(0): ["a"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
+rebuilt        : ScopeId(0): ["a"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["PromiseLike"]
+rebuilt        : []
 
 * exports/issue-9916-2/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["PromiseLike"]
+rebuilt        : []
 
 * exports/issue-9916-3/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
-  | rebuilt        : ScopeId(0): ["a"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
+rebuilt        : ScopeId(0): ["a"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["PromiseLike"]
+rebuilt        : []
 
 * exports/type-only-export-specifier-1/input.ts
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0)]
-  | rebuilt        : SymbolId(0): []
-
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
 
 * function/overloads/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 * function/overloads-exports/input.mjs
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 * function/parameters/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["T", "x", "y"]
-  | rebuilt        : ScopeId(1): ["x", "y"]
-
+Bindings mismatch:
+after transform: ScopeId(1): ["T", "x", "y"]
+rebuilt        : ScopeId(1): ["x", "y"]
 
 * imports/elide-preact/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["FooBar", "Fragment", "h", "x"]
-  | rebuilt        : ScopeId(0): ["x"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["FooBar", "Fragment", "h", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 * imports/elide-preact-no-1/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Fragment", "h", "render"]
-  | rebuilt        : ScopeId(0): ["Fragment", "h"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Fragment", "h", "render"]
+rebuilt        : ScopeId(0): ["Fragment", "h"]
 
 * imports/elide-preact-no-2/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Fragment", "render"]
-  | rebuilt        : ScopeId(0): ["Fragment"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Fragment", "render"]
+rebuilt        : ScopeId(0): ["Fragment"]
 
 * imports/elide-react/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["React", "x"]
-  | rebuilt        : ScopeId(0): ["x"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["React", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 * imports/elide-type-referenced-in-imports-equal-no/input.ts
-  x Missing SymbolId: foo
-
-  x Missing SymbolId: bar
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
-  | SymbolId(3)]
-  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
-  | SymbolId(3)]
-
+Missing SymbolId: foo
+Missing SymbolId: bar
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 
 * imports/elide-typeof/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "x"]
-  | rebuilt        : ScopeId(0): ["x"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 * imports/elision/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "C", "D", "Used", "Used2",
-  | "Used3", "x", "y", "z"]
-  | rebuilt        : ScopeId(0): ["Used", "Used2", "Used3", "x", "y", "z"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "D", "Used", "Used2", "Used3", "x", "y", "z"]
+rebuilt        : ScopeId(0): ["Used", "Used2", "Used3", "x", "y", "z"]
 
 * imports/elision-export-type/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "T", "T1"]
-  | rebuilt        : ScopeId(0): ["A", "B"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "T", "T1"]
+rebuilt        : ScopeId(0): ["A", "B"]
 
 * imports/elision-locations/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G",
-  | "H", "Iface", "x", "y"]
-  | rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G", "H", "Iface", "x", "y"]
+rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 
 * imports/elision-qualifiedname/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "x"]
-  | rebuilt        : ScopeId(0): ["x"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 * imports/elision-rename/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["B", "x"]
-  | rebuilt        : ScopeId(0): ["x"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["B", "x"]
+rebuilt        : ScopeId(0): ["x"]
 
 * imports/enum-id/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "Enum"]
-  | rebuilt        : ScopeId(0): ["Enum"]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "Enum"]
-  | rebuilt        : ScopeId(1): ["Enum"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "Enum"]
+rebuilt        : ScopeId(0): ["Enum"]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "Enum"]
+rebuilt        : ScopeId(1): ["Enum"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * imports/enum-value/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["Enum", "id"]
-  | rebuilt        : ScopeId(1): ["Enum"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-
+Bindings mismatch:
+after transform: ScopeId(1): ["Enum", "id"]
+rebuilt        : ScopeId(1): ["Enum"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 * imports/import-removed-exceptions/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["H", "I", "I2", "J", "a", "b", "c2", "d",
-  | "d2", "e", "e4"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["H", "I", "I2", "J", "a", "b", "c2", "d", "d2", "e", "e4"]
+rebuilt        : ScopeId(0): []
 
 * imports/import-type/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B", "T", "Types"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "T", "Types"]
+rebuilt        : ScopeId(0): []
 
 * imports/import-type-func-with-duplicate-name/input.ts
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function
-  | | TypeImport)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
-
-  x Symbol span mismatch:
-  | after transform: SymbolId(0): Span { start: 13, end: 16 }
-  | rebuilt        : SymbolId(0): Span { start: 70, end: 73 }
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 70, end: 73 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function
-  | | TypeImport)
-  | rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
-
-  x Symbol span mismatch:
-  | after transform: SymbolId(1): Span { start: 43, end: 47 }
-  | rebuilt        : SymbolId(1): Span { start: 87, end: 91 }
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(1): [Span { start: 87, end: 91 }]
-  | rebuilt        : SymbolId(1): []
-
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | TypeImport)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 13, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 70, end: 73 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 70, end: 73 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function | TypeImport)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
+Symbol span mismatch:
+after transform: SymbolId(1): Span { start: 43, end: 47 }
+rebuilt        : SymbolId(1): Span { start: 87, end: 91 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 87, end: 91 }]
+rebuilt        : SymbolId(1): []
 
 * imports/import-type-not-removed/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "B"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B"]
+rebuilt        : ScopeId(0): []
 
 * imports/import=-module/input.ts
   ! `import lib = require(...);` is only supported when compiling modules
@@ -3071,1059 +2467,645 @@ TS(18010)
 
 
 * imports/only-remove-type-imports/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["H", "I", "I2", "J", "K1", "K2", "L1", "L2",
-  | "L3", "a", "b", "c2", "d", "d2", "e", "e4"]
-  | rebuilt        : ScopeId(0): ["K1", "K2", "L1", "L2", "L3", "a", "b",
-  | "c2", "d", "d2", "e", "e4"]
-
+x Output mismatch
 
 * imports/property-signature/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "obj"]
-  | rebuilt        : ScopeId(0): ["obj"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "obj"]
+rebuilt        : ScopeId(0): ["obj"]
 
 * imports/type-only-export-specifier-1/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["bar", "baz", "foo"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["bar", "baz", "foo"]
+rebuilt        : ScopeId(0): []
 
 * imports/type-only-export-specifier-2/input.ts
-  x Output mismatch
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0)]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(Export | Import)
-  | rebuilt        : SymbolId(1): SymbolFlags(Import)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(1)]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(Export | TypeImport)
-  | rebuilt        : SymbolId(2): SymbolFlags(TypeImport)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(2)]
-  | rebuilt        : SymbolId(2): []
-
+x Output mismatch
 
 * imports/type-only-import-specifier-1/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Foo1", "Foo2"]
-  | rebuilt        : ScopeId(0): ["Foo1"]
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Foo1", "Foo2"]
+rebuilt        : ScopeId(0): ["Foo1"]
 
 * imports/type-only-import-specifier-2/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Foo1", "Foo2"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Foo1", "Foo2"]
+rebuilt        : ScopeId(0): []
 
 * imports/type-only-import-specifier-3/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Foo1", "Foo2"]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Foo1", "Foo2"]
+rebuilt        : ScopeId(0): []
 
 * imports/type-only-import-specifier-4/input.ts
-
+x Output mismatch
 
 * lvalues/TSTypeParameterInstantiation/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["M"]
-  | rebuilt        : ScopeId(1): []
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2),
-  | ReferenceId(3)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
-  | rebuilt        : SymbolId(1): [ReferenceId(1)]
-
+Bindings mismatch:
+after transform: ScopeId(1): ["M"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(1): [ReferenceId(1)]
 
 * namespace/alias/input.ts
-  x Missing SymbolId: b
+Missing SymbolId: b
+Missing SymbolId: AliasModule
+Bindings mismatch:
+after transform: ScopeId(0): ["AliasModule", "LongNameModule", "b", "babel", "bar", "baz", "node", "some", "str"]
+rebuilt        : ScopeId(0): ["AliasModule", "b", "babel", "bar", "baz", "node", "some", "str"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("AliasModule")
+rebuilt        : ReferenceId(2): Some("AliasModule")
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("AliasModule")
+rebuilt        : ReferenceId(3): Some("AliasModule")
+Unresolved reference IDs mismatch for "LongNameModule":
+after transform: [ReferenceId(1), ReferenceId(5)]
+rebuilt        : [ReferenceId(1)]
 
-  x Missing SymbolId: AliasModule
+* namespace/ambient-module-nested/input.ts
+Ambient modules cannot be nested in other modules or namespaces.
 
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["AliasModule", "LongNameModule", "b",
-  | "babel", "bar", "baz", "node", "some", "str"]
-  | rebuilt        : ScopeId(0): ["AliasModule", "b", "babel", "bar", "baz",
-  | "node", "some", "str"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(3): Some("AliasModule")
-  | rebuilt        : ReferenceId(2): Some("AliasModule")
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(4): Some("AliasModule")
-  | rebuilt        : ReferenceId(3): Some("AliasModule")
-
-  x Unresolved reference IDs mismatch for "LongNameModule":
-  | after transform: [ReferenceId(1), ReferenceId(5)]
-  | rebuilt        : [ReferenceId(1)]
-
+* namespace/ambient-module-nested-exported/input.ts
+Ambient modules cannot be nested in other modules or namespaces.
 
 * namespace/clobber-class/input.ts
-  x Missing SymbolId: _A
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: A
-
-  x Missing ReferenceId: A
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
-  | ValueModule)
-  | rebuilt        : SymbolId(0): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): []
-  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
+Missing SymbolId: _A
+Missing ReferenceId: _A
+Missing ReferenceId: A
+Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/clobber-enum/input.ts
-  x Missing SymbolId: _A
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: A
-
-  x Missing ReferenceId: A
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "C"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
-  | rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule
-  | | ValueModule)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(3)]
-  | rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5),
-  | ReferenceId(6)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 30, end: 31 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
+Missing SymbolId: _A
+Missing ReferenceId: _A
+Missing ReferenceId: A
+Missing ReferenceId: A
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "C"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(6)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 30, end: 31 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/clobber-export/input.ts
-  x Missing SymbolId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
-  | | ValueModule)
-  | rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 35, end: 36 }]
-  | rebuilt        : SymbolId(0): []
-
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 35, end: 36 }]
+rebuilt        : SymbolId(0): []
 
 * namespace/contentious-names/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N
-
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N2
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Missing SymbolId: constructor
-
-  x Missing SymbolId: _constructor
-
-  x Missing ReferenceId: constructor
-
-  x Missing ReferenceId: constructor
-
-  x Missing SymbolId: length
-
-  x Missing SymbolId: _length
-
-  x Missing ReferenceId: length
-
-  x Missing ReferenceId: length
-
-  x Missing SymbolId: concat
-
-  x Missing SymbolId: _concat
-
-  x Missing ReferenceId: concat
-
-  x Missing ReferenceId: concat
-
-  x Missing SymbolId: copyWithin
-
-  x Missing SymbolId: _copyWithin
-
-  x Missing ReferenceId: copyWithin
-
-  x Missing ReferenceId: copyWithin
-
-  x Missing SymbolId: fill
-
-  x Missing SymbolId: _fill
-
-  x Missing ReferenceId: fill
-
-  x Missing ReferenceId: fill
-
-  x Missing SymbolId: find
-
-  x Missing SymbolId: _find
-
-  x Missing ReferenceId: find
-
-  x Missing ReferenceId: find
-
-  x Missing SymbolId: findIndex
-
-  x Missing SymbolId: _findIndex
-
-  x Missing ReferenceId: findIndex
-
-  x Missing ReferenceId: findIndex
-
-  x Missing SymbolId: lastIndexOf
-
-  x Missing SymbolId: _lastIndexOf
-
-  x Missing ReferenceId: lastIndexOf
-
-  x Missing ReferenceId: lastIndexOf
-
-  x Missing SymbolId: pop
-
-  x Missing SymbolId: _pop
-
-  x Missing ReferenceId: pop
-
-  x Missing ReferenceId: pop
-
-  x Missing SymbolId: push
-
-  x Missing SymbolId: _push
-
-  x Missing ReferenceId: push
-
-  x Missing ReferenceId: push
-
-  x Missing SymbolId: reverse
-
-  x Missing SymbolId: _reverse
-
-  x Missing ReferenceId: reverse
-
-  x Missing ReferenceId: reverse
-
-  x Missing SymbolId: shift
-
-  x Missing SymbolId: _shift
-
-  x Missing ReferenceId: shift
-
-  x Missing ReferenceId: shift
-
-  x Missing SymbolId: unshift
-
-  x Missing SymbolId: _unshift
-
-  x Missing ReferenceId: unshift
-
-  x Missing ReferenceId: unshift
-
-  x Missing SymbolId: slice
-
-  x Missing SymbolId: _slice
-
-  x Missing ReferenceId: slice
-
-  x Missing ReferenceId: slice
-
-  x Missing SymbolId: sort
-
-  x Missing SymbolId: _sort
-
-  x Missing ReferenceId: sort
-
-  x Missing ReferenceId: sort
-
-  x Missing SymbolId: splice
-
-  x Missing SymbolId: _splice
-
-  x Missing ReferenceId: splice
-
-  x Missing ReferenceId: splice
-
-  x Missing SymbolId: includes
-
-  x Missing SymbolId: _includes
-
-  x Missing ReferenceId: includes
-
-  x Missing ReferenceId: includes
-
-  x Missing SymbolId: indexOf
-
-  x Missing SymbolId: _indexOf
-
-  x Missing ReferenceId: indexOf
-
-  x Missing ReferenceId: indexOf
-
-  x Missing SymbolId: join
-
-  x Missing SymbolId: _join
-
-  x Missing ReferenceId: join
-
-  x Missing ReferenceId: join
-
-  x Missing SymbolId: keys
-
-  x Missing SymbolId: _keys
-
-  x Missing ReferenceId: keys
-
-  x Missing ReferenceId: keys
-
-  x Missing SymbolId: entries
-
-  x Missing SymbolId: _entries
-
-  x Missing ReferenceId: entries
-
-  x Missing ReferenceId: entries
-
-  x Missing SymbolId: values
-
-  x Missing SymbolId: _values
-
-  x Missing ReferenceId: values
-
-  x Missing ReferenceId: values
-
-  x Missing SymbolId: forEach
-
-  x Missing SymbolId: _forEach
-
-  x Missing ReferenceId: forEach
-
-  x Missing ReferenceId: forEach
-
-  x Missing SymbolId: filter
-
-  x Missing SymbolId: _filter
-
-  x Missing ReferenceId: filter
-
-  x Missing ReferenceId: filter
-
-  x Missing SymbolId: map
-
-  x Missing SymbolId: _map
-
-  x Missing ReferenceId: map
-
-  x Missing ReferenceId: map
-
-  x Missing SymbolId: every
-
-  x Missing SymbolId: _every
-
-  x Missing ReferenceId: every
-
-  x Missing ReferenceId: every
-
-  x Missing SymbolId: some
-
-  x Missing SymbolId: _some
-
-  x Missing ReferenceId: some
-
-  x Missing ReferenceId: some
-
-  x Missing SymbolId: reduce
-
-  x Missing SymbolId: _reduce
-
-  x Missing ReferenceId: reduce
-
-  x Missing ReferenceId: reduce
-
-  x Missing SymbolId: reduceRight
-
-  x Missing SymbolId: _reduceRight
-
-  x Missing ReferenceId: reduceRight
-
-  x Missing ReferenceId: reduceRight
-
-  x Missing SymbolId: toLocaleString
-
-  x Missing SymbolId: _toLocaleString
-
-  x Missing ReferenceId: toLocaleString
-
-  x Missing ReferenceId: toLocaleString
-
-  x Missing SymbolId: toString
-
-  x Missing SymbolId: _toString
-
-  x Missing ReferenceId: toString
-
-  x Missing ReferenceId: toString
-
-  x Missing SymbolId: flat
-
-  x Missing SymbolId: _flat
-
-  x Missing ReferenceId: flat
-
-  x Missing ReferenceId: flat
-
-  x Missing SymbolId: flatMap
-
-  x Missing SymbolId: _flatMap
-
-  x Missing ReferenceId: flatMap
-
-  x Missing ReferenceId: flatMap
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5),
-  | SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15),
-  | SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25),
-  | SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35),
-  | SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45),
-  | SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55),
-  | SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65),
-  | SymbolId(67), SymbolId(69)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5),
-  | SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20),
-  | SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35),
-  | SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50),
-  | SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65),
-  | SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80),
-  | SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95),
-  | SymbolId(98), SymbolId(101)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
-  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
-  | rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
-  | rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
-  | rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
-  | rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
-  | rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
-  | rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
-  | rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
-  | rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
-  | rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
-  | rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
-  | rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
-  | rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
-  | rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
-  | rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
-  | rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
-  | rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
-  | rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
-  | rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
-  | rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
-  | rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
-  | rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
-  | rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
-  | rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
-  | rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
-  | rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
-  | rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
-  | rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
-  | rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
-  | rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
-  | rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
-  | rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
-  | rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
-
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing SymbolId: N
+Missing SymbolId: _N2
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing SymbolId: constructor
+Missing SymbolId: _constructor
+Missing ReferenceId: constructor
+Missing ReferenceId: constructor
+Missing SymbolId: length
+Missing SymbolId: _length
+Missing ReferenceId: length
+Missing ReferenceId: length
+Missing SymbolId: concat
+Missing SymbolId: _concat
+Missing ReferenceId: concat
+Missing ReferenceId: concat
+Missing SymbolId: copyWithin
+Missing SymbolId: _copyWithin
+Missing ReferenceId: copyWithin
+Missing ReferenceId: copyWithin
+Missing SymbolId: fill
+Missing SymbolId: _fill
+Missing ReferenceId: fill
+Missing ReferenceId: fill
+Missing SymbolId: find
+Missing SymbolId: _find
+Missing ReferenceId: find
+Missing ReferenceId: find
+Missing SymbolId: findIndex
+Missing SymbolId: _findIndex
+Missing ReferenceId: findIndex
+Missing ReferenceId: findIndex
+Missing SymbolId: lastIndexOf
+Missing SymbolId: _lastIndexOf
+Missing ReferenceId: lastIndexOf
+Missing ReferenceId: lastIndexOf
+Missing SymbolId: pop
+Missing SymbolId: _pop
+Missing ReferenceId: pop
+Missing ReferenceId: pop
+Missing SymbolId: push
+Missing SymbolId: _push
+Missing ReferenceId: push
+Missing ReferenceId: push
+Missing SymbolId: reverse
+Missing SymbolId: _reverse
+Missing ReferenceId: reverse
+Missing ReferenceId: reverse
+Missing SymbolId: shift
+Missing SymbolId: _shift
+Missing ReferenceId: shift
+Missing ReferenceId: shift
+Missing SymbolId: unshift
+Missing SymbolId: _unshift
+Missing ReferenceId: unshift
+Missing ReferenceId: unshift
+Missing SymbolId: slice
+Missing SymbolId: _slice
+Missing ReferenceId: slice
+Missing ReferenceId: slice
+Missing SymbolId: sort
+Missing SymbolId: _sort
+Missing ReferenceId: sort
+Missing ReferenceId: sort
+Missing SymbolId: splice
+Missing SymbolId: _splice
+Missing ReferenceId: splice
+Missing ReferenceId: splice
+Missing SymbolId: includes
+Missing SymbolId: _includes
+Missing ReferenceId: includes
+Missing ReferenceId: includes
+Missing SymbolId: indexOf
+Missing SymbolId: _indexOf
+Missing ReferenceId: indexOf
+Missing ReferenceId: indexOf
+Missing SymbolId: join
+Missing SymbolId: _join
+Missing ReferenceId: join
+Missing ReferenceId: join
+Missing SymbolId: keys
+Missing SymbolId: _keys
+Missing ReferenceId: keys
+Missing ReferenceId: keys
+Missing SymbolId: entries
+Missing SymbolId: _entries
+Missing ReferenceId: entries
+Missing ReferenceId: entries
+Missing SymbolId: values
+Missing SymbolId: _values
+Missing ReferenceId: values
+Missing ReferenceId: values
+Missing SymbolId: forEach
+Missing SymbolId: _forEach
+Missing ReferenceId: forEach
+Missing ReferenceId: forEach
+Missing SymbolId: filter
+Missing SymbolId: _filter
+Missing ReferenceId: filter
+Missing ReferenceId: filter
+Missing SymbolId: map
+Missing SymbolId: _map
+Missing ReferenceId: map
+Missing ReferenceId: map
+Missing SymbolId: every
+Missing SymbolId: _every
+Missing ReferenceId: every
+Missing ReferenceId: every
+Missing SymbolId: some
+Missing SymbolId: _some
+Missing ReferenceId: some
+Missing ReferenceId: some
+Missing SymbolId: reduce
+Missing SymbolId: _reduce
+Missing ReferenceId: reduce
+Missing ReferenceId: reduce
+Missing SymbolId: reduceRight
+Missing SymbolId: _reduceRight
+Missing ReferenceId: reduceRight
+Missing ReferenceId: reduceRight
+Missing SymbolId: toLocaleString
+Missing SymbolId: _toLocaleString
+Missing ReferenceId: toLocaleString
+Missing ReferenceId: toLocaleString
+Missing SymbolId: toString
+Missing SymbolId: _toString
+Missing ReferenceId: toString
+Missing ReferenceId: toString
+Missing SymbolId: flat
+Missing SymbolId: _flat
+Missing ReferenceId: flat
+Missing ReferenceId: flat
+Missing SymbolId: flatMap
+Missing SymbolId: _flatMap
+Missing ReferenceId: flatMap
+Missing ReferenceId: flatMap
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45), SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55), SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65), SymbolId(67), SymbolId(69)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80), SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95), SymbolId(98), SymbolId(101)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
+rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
+rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
+rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
+rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
+rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
+rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
+rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
+rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
+rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
+rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
+rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
+Binding symbols mismatch:
+after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
+rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
+Binding symbols mismatch:
+after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
+rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
+rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
+Binding symbols mismatch:
+after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
+rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
+Binding symbols mismatch:
+after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
+rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
+rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
+Binding symbols mismatch:
+after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
+rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
+Binding symbols mismatch:
+after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
+rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
+Binding symbols mismatch:
+after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
+rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
+Binding symbols mismatch:
+after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
+rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
+Binding symbols mismatch:
+after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
+rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
+rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
+Binding symbols mismatch:
+after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
+rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
+Binding symbols mismatch:
+after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
+rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
+Binding symbols mismatch:
+after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
+rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
+Binding symbols mismatch:
+after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
+rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
+Binding symbols mismatch:
+after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
+rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
+Binding symbols mismatch:
+after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
+rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
+Binding symbols mismatch:
+after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
+rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
+Binding symbols mismatch:
+after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
+rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
+Binding symbols mismatch:
+after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
+rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
+Binding symbols mismatch:
+after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
+rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
 
 * namespace/declare/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["B", "_N", "e", "v"]
-  | rebuilt        : ScopeId(1): ["_N"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4),
-  | ScopeId(5)]
-  | rebuilt        : ScopeId(1): []
-
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["B", "_N", "e", "v"]
+rebuilt        : ScopeId(1): ["_N"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+rebuilt        : ScopeId(1): []
 
 * namespace/declare-global-nested-namespace/input.ts
-  x Missing SymbolId: X
-
-  x Missing SymbolId: _X
-
-  x Missing ReferenceId: X
-
-  x Missing ReferenceId: X
-
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["X", "global", "i18n"]
-  | rebuilt        : ScopeId(0): ["X", "i18n"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-
+Missing SymbolId: X
+Missing SymbolId: _X
+Missing ReferenceId: X
+Missing ReferenceId: X
+Bindings mismatch:
+after transform: ScopeId(0): ["X", "global", "i18n"]
+rebuilt        : ScopeId(0): ["X", "i18n"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 * namespace/empty-removed/input.ts
-  x Missing SymbolId: a
-
-  x Missing SymbolId: _a
-
-  x Missing SymbolId: c
-
-  x Missing SymbolId: _c
-
-  x Missing ReferenceId: c
-
-  x Missing ReferenceId: c
-
-  x Missing ReferenceId: a
-
-  x Missing ReferenceId: a
-
-  x Missing SymbolId: WithTypes
-
-  x Missing SymbolId: _WithTypes
-
-  x Missing SymbolId: d
-
-  x Missing SymbolId: _d2
-
-  x Missing ReferenceId: d
-
-  x Missing ReferenceId: d
-
-  x Missing ReferenceId: WithTypes
-
-  x Missing ReferenceId: WithTypes
-
-  x Missing SymbolId: WithValues
-
-  x Missing SymbolId: _WithValues
-
-  x Missing SymbolId: a
-
-  x Missing SymbolId: _a3
-
-  x Missing ReferenceId: a
-
-  x Missing ReferenceId: a
-
-  x Missing SymbolId: b
-
-  x Missing SymbolId: _b3
-
-  x Missing ReferenceId: b
-
-  x Missing ReferenceId: b
-
-  x Missing SymbolId: c
-
-  x Missing SymbolId: _c3
-
-  x Missing ReferenceId: c
-
-  x Missing ReferenceId: c
-
-  x Missing SymbolId: d
-
-  x Missing SymbolId: _d3
-
-  x Missing ReferenceId: d
-
-  x Missing ReferenceId: d
-
-  x Missing SymbolId: e
-
-  x Missing SymbolId: _e2
-
-  x Missing ReferenceId: e
-
-  x Missing ReferenceId: e
-
-  x Missing ReferenceId: WithValues
-
-  x Missing ReferenceId: WithValues
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
-  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["_a", "b", "c", "d"]
-  | rebuilt        : ScopeId(1): ["_a", "c"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-  | rebuilt        : ScopeId(1): [ScopeId(2)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
-  | rebuilt        : ScopeId(3): ["_WithTypes", "d"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(6): [ScopeId(7), ScopeId(9), ScopeId(11),
-  | ScopeId(12)]
-  | rebuilt        : ScopeId(3): [ScopeId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(12): [SymbolId(33)]
-  | rebuilt        : ScopeId(4): [SymbolId(8)]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(12): [ScopeId(13)]
-  | rebuilt        : ScopeId(4): []
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19),
-  | SymbolId(21), SymbolId(23), SymbolId(34)]
-  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14),
-  | SymbolId(18), SymbolId(21), SymbolId(24)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
-  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
-  | rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(18): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
-  | rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
-  | rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(22): [SymbolId(39)]
-  | rebuilt        : ScopeId(13): [SymbolId(25)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(18): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
-  | rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
-
+Missing SymbolId: a
+Missing SymbolId: _a
+Missing SymbolId: c
+Missing SymbolId: _c
+Missing ReferenceId: c
+Missing ReferenceId: c
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: WithTypes
+Missing SymbolId: _WithTypes
+Missing SymbolId: d
+Missing SymbolId: _d2
+Missing ReferenceId: d
+Missing ReferenceId: d
+Missing ReferenceId: WithTypes
+Missing ReferenceId: WithTypes
+Missing SymbolId: WithValues
+Missing SymbolId: _WithValues
+Missing SymbolId: a
+Missing SymbolId: _a3
+Missing ReferenceId: a
+Missing ReferenceId: a
+Missing SymbolId: b
+Missing SymbolId: _b3
+Missing ReferenceId: b
+Missing ReferenceId: b
+Missing SymbolId: c
+Missing SymbolId: _c3
+Missing ReferenceId: c
+Missing ReferenceId: c
+Missing SymbolId: d
+Missing SymbolId: _d3
+Missing ReferenceId: d
+Missing ReferenceId: d
+Missing SymbolId: e
+Missing SymbolId: _e2
+Missing ReferenceId: e
+Missing ReferenceId: e
+Missing ReferenceId: WithValues
+Missing ReferenceId: WithValues
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_a", "b", "c", "d"]
+rebuilt        : ScopeId(1): ["_a", "c"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
+rebuilt        : ScopeId(3): ["_WithTypes", "d"]
+Scope children mismatch:
+after transform: ScopeId(6): [ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12)]
+rebuilt        : ScopeId(3): [ScopeId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(33)]
+rebuilt        : ScopeId(4): [SymbolId(8)]
+Scope children mismatch:
+after transform: ScopeId(12): [ScopeId(13)]
+rebuilt        : ScopeId(4): []
+Binding symbols mismatch:
+after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(34)]
+rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14), SymbolId(18), SymbolId(21), SymbolId(24)]
+Binding symbols mismatch:
+after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
+rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+Binding symbols mismatch:
+after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
+rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
+rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
+Binding symbols mismatch:
+after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
+rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
+Binding symbols mismatch:
+after transform: ScopeId(22): [SymbolId(39)]
+rebuilt        : ScopeId(13): [SymbolId(25)]
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
 
 * namespace/export/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 * namespace/export-type-only/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Platform"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["Platform"]
-  | rebuilt        : []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["Platform"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["Platform"]
+rebuilt        : []
 
 * namespace/module-nested/input.ts
-  x Missing SymbolId: src
-
-  x Missing SymbolId: _src
-
-  x Missing SymbolId: ns1
-
-  x Missing SymbolId: _ns
-
-  x Missing ReferenceId: _ns
-
-  x Missing ReferenceId: foo
-
-  x Missing ReferenceId: ns1
-
-  x Missing ReferenceId: ns1
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: _src
-
-  x Missing SymbolId: ns2
-
-  x Missing SymbolId: _ns2
-
-  x Missing ReferenceId: _ns2
-
-  x Missing ReferenceId: foo
-
-  x Missing ReferenceId: ns2
-
-  x Missing ReferenceId: ns2
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: src
-
-  x Missing ReferenceId: src
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(4): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): []
-  | rebuilt        : SymbolId(4): [ReferenceId(1)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(7): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): []
-  | rebuilt        : SymbolId(7): [ReferenceId(7)]
-
+Missing SymbolId: src
+Missing SymbolId: _src
+Missing SymbolId: ns1
+Missing SymbolId: _ns
+Missing ReferenceId: _ns
+Missing ReferenceId: foo
+Missing ReferenceId: ns1
+Missing ReferenceId: ns1
+Missing ReferenceId: _src
+Missing ReferenceId: _src
+Missing SymbolId: ns2
+Missing SymbolId: _ns2
+Missing ReferenceId: _ns2
+Missing ReferenceId: foo
+Missing ReferenceId: ns2
+Missing ReferenceId: ns2
+Missing ReferenceId: _src
+Missing ReferenceId: _src
+Missing ReferenceId: src
+Missing ReferenceId: src
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(7): [ReferenceId(7)]
 
 * namespace/module-nested-export/input.ts
-  x Missing SymbolId: src
-
-  x Missing SymbolId: _src
-
-  x Missing SymbolId: ns1
-
-  x Missing SymbolId: _ns
-
-  x Missing ReferenceId: _ns
-
-  x Missing ReferenceId: foo
-
-  x Missing ReferenceId: ns1
-
-  x Missing ReferenceId: ns1
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: _src
-
-  x Missing SymbolId: ns2
-
-  x Missing SymbolId: _ns2
-
-  x Missing ReferenceId: _ns2
-
-  x Missing ReferenceId: foo
-
-  x Missing ReferenceId: ns2
-
-  x Missing ReferenceId: ns2
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: _src
-
-  x Missing ReferenceId: src
-
-  x Missing ReferenceId: src
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(4): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): []
-  | rebuilt        : SymbolId(4): [ReferenceId(1)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(7): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): []
-  | rebuilt        : SymbolId(7): [ReferenceId(7)]
-
+Missing SymbolId: src
+Missing SymbolId: _src
+Missing SymbolId: ns1
+Missing SymbolId: _ns
+Missing ReferenceId: _ns
+Missing ReferenceId: foo
+Missing ReferenceId: ns1
+Missing ReferenceId: ns1
+Missing ReferenceId: _src
+Missing ReferenceId: _src
+Missing SymbolId: ns2
+Missing SymbolId: _ns2
+Missing ReferenceId: _ns2
+Missing ReferenceId: foo
+Missing ReferenceId: ns2
+Missing ReferenceId: ns2
+Missing ReferenceId: _src
+Missing ReferenceId: _src
+Missing ReferenceId: src
+Missing ReferenceId: src
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(7): [ReferenceId(7)]
 
 * namespace/multiple/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Missing SymbolId: _N2
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing SymbolId: _N2
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 
 * namespace/mutable-fail/input.ts
   ! Namespaces exporting non-const are not supported by Babel. Change to const
@@ -4147,822 +3129,390 @@ TS(18010)
 
 
 * namespace/nested/input.ts
-  x Missing SymbolId: _A
-
-  x Missing SymbolId: C
-
-  x Missing SymbolId: _C
-
-  x Missing ReferenceId: _C
-
-  x Missing ReferenceId: G
-
-  x Missing ReferenceId: _C
-
-  x Missing ReferenceId: C
-
-  x Missing ReferenceId: C
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: _A
-
-  x Missing SymbolId: _M
-
-  x Missing ReferenceId: _M
-
-  x Missing ReferenceId: M
-
-  x Missing ReferenceId: M
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: D
-
-  x Missing SymbolId: _D
-
-  x Missing ReferenceId: _D
-
-  x Missing ReferenceId: H
-
-  x Missing ReferenceId: D
-
-  x Missing ReferenceId: D
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: _A
-
-  x Missing SymbolId: _F
-
-  x Missing ReferenceId: F
-
-  x Missing ReferenceId: F
-
-  x Missing SymbolId: G
-
-  x Missing SymbolId: _G
-
-  x Missing ReferenceId: G
-
-  x Missing ReferenceId: G
-
-  x Missing ReferenceId: A
-
-  x Missing ReferenceId: A
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6),
-  | SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
-  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6),
-  | SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
-  | rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
-  | rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
-  | rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(9): ["H", "I", "J", "K"]
-  | rebuilt        : ScopeId(9): ["H"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(9): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
-  | rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
-  | rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(13): ["L", "M"]
-  | rebuilt        : ScopeId(13): ["L"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(13): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
-  | ValueModule)
-  | rebuilt        : SymbolId(0): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): []
-  | rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(4): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): []
-  | rebuilt        : SymbolId(4): [ReferenceId(1)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function |
-  | NameSpaceModule | ValueModule)
-  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): []
-  | rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(4): [Span { start: 129, end: 130 }]
-  | rebuilt        : SymbolId(6): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export |
-  | Function | NameSpaceModule | ValueModule)
-  | rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): []
-  | rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22),
-  | ReferenceId(23)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(6): [Span { start: 207, end: 208 }]
-  | rebuilt        : SymbolId(9): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): []
-  | rebuilt        : SymbolId(12): [ReferenceId(21)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule |
-  | ValueModule)
-  | rebuilt        : SymbolId(14): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(12): []
-  | rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(12): [Span { start: 325, end: 326 }]
-  | rebuilt        : SymbolId(14): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(0): Some("C")
-  | rebuilt        : ReferenceId(8): Some("C")
-
+Missing SymbolId: _A
+Missing SymbolId: C
+Missing SymbolId: _C
+Missing ReferenceId: _C
+Missing ReferenceId: G
+Missing ReferenceId: _C
+Missing ReferenceId: C
+Missing ReferenceId: C
+Missing ReferenceId: _A
+Missing ReferenceId: _A
+Missing SymbolId: _M
+Missing ReferenceId: _M
+Missing ReferenceId: M
+Missing ReferenceId: M
+Missing ReferenceId: _A
+Missing ReferenceId: D
+Missing SymbolId: _D
+Missing ReferenceId: _D
+Missing ReferenceId: H
+Missing ReferenceId: D
+Missing ReferenceId: D
+Missing ReferenceId: _A
+Missing ReferenceId: _A
+Missing SymbolId: _F
+Missing ReferenceId: F
+Missing ReferenceId: F
+Missing SymbolId: G
+Missing SymbolId: _G
+Missing ReferenceId: G
+Missing ReferenceId: G
+Missing ReferenceId: A
+Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6), SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
+rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
+rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
+Bindings mismatch:
+after transform: ScopeId(9): ["H", "I", "J", "K"]
+rebuilt        : ScopeId(9): ["H"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
+rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
+rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
+Bindings mismatch:
+after transform: ScopeId(13): ["L", "M"]
+rebuilt        : ScopeId(13): ["L"]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(4): [Span { start: 129, end: 130 }]
+rebuilt        : SymbolId(6): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22), ReferenceId(23)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(6): [Span { start: 207, end: 208 }]
+rebuilt        : SymbolId(9): []
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(12): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): []
+rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(12): [Span { start: 325, end: 326 }]
+rebuilt        : SymbolId(14): []
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("C")
+rebuilt        : ReferenceId(8): Some("C")
 
 * namespace/nested-namespace/input.ts
-  x Missing SymbolId: A
-
-  x Missing SymbolId: _A
-
-  x Missing ReferenceId: _A
-
-  x Missing ReferenceId: G
-
-  x Missing ReferenceId: A
-
-  x Missing ReferenceId: A
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["B", "G", "_A"]
-  | rebuilt        : ScopeId(1): ["G", "_A"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-  | rebuilt        : ScopeId(1): [ScopeId(2)]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(4): ["G", "H"]
-  | rebuilt        : ScopeId(2): ["G"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(4): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): []
-  | rebuilt        : SymbolId(2): [ReferenceId(4)]
-
+Missing SymbolId: A
+Missing SymbolId: _A
+Missing ReferenceId: _A
+Missing ReferenceId: G
+Missing ReferenceId: A
+Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["B", "G", "_A"]
+rebuilt        : ScopeId(1): ["G", "_A"]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Bindings mismatch:
+after transform: ScopeId(4): ["G", "H"]
+rebuilt        : ScopeId(2): ["G"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(4)]
 
 * namespace/nested-shorthand/input.ts
-  x Missing SymbolId: X
-
-  x Missing SymbolId: _X
-
-  x Missing SymbolId: Y
-
-  x Missing SymbolId: _Y
-
-  x Missing ReferenceId: _Y
-
-  x Missing ReferenceId: Y
-
-  x Missing ReferenceId: Y
-
-  x Missing ReferenceId: _X
-
-  x Missing ReferenceId: _X
-
-  x Missing ReferenceId: X
-
-  x Missing ReferenceId: X
-
-  x Missing SymbolId: proj
-
-  x Missing SymbolId: _proj
-
-  x Missing SymbolId: data
-
-  x Missing SymbolId: _data
-
-  x Missing SymbolId: util
-
-  x Missing SymbolId: _util
-
-  x Missing SymbolId: api
-
-  x Missing SymbolId: _api
-
-  x Missing ReferenceId: _api
-
-  x Missing ReferenceId: api
-
-  x Missing ReferenceId: api
-
-  x Missing ReferenceId: _util
-
-  x Missing ReferenceId: _util
-
-  x Missing ReferenceId: util
-
-  x Missing ReferenceId: util
-
-  x Missing ReferenceId: _data
-
-  x Missing ReferenceId: _data
-
-  x Missing ReferenceId: data
-
-  x Missing ReferenceId: data
-
-  x Missing ReferenceId: _proj
-
-  x Missing ReferenceId: _proj
-
-  x Missing ReferenceId: proj
-
-  x Missing ReferenceId: proj
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
-  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
-  | rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
-  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
-  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(7): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
+Missing SymbolId: X
+Missing SymbolId: _X
+Missing SymbolId: Y
+Missing SymbolId: _Y
+Missing ReferenceId: _Y
+Missing ReferenceId: Y
+Missing ReferenceId: Y
+Missing ReferenceId: _X
+Missing ReferenceId: _X
+Missing ReferenceId: X
+Missing ReferenceId: X
+Missing SymbolId: proj
+Missing SymbolId: _proj
+Missing SymbolId: data
+Missing SymbolId: _data
+Missing SymbolId: util
+Missing SymbolId: _util
+Missing SymbolId: api
+Missing SymbolId: _api
+Missing ReferenceId: _api
+Missing ReferenceId: api
+Missing ReferenceId: api
+Missing ReferenceId: _util
+Missing ReferenceId: _util
+Missing ReferenceId: util
+Missing ReferenceId: util
+Missing ReferenceId: _data
+Missing ReferenceId: _data
+Missing ReferenceId: data
+Missing ReferenceId: data
+Missing ReferenceId: _proj
+Missing ReferenceId: _proj
+Missing ReferenceId: proj
+Missing ReferenceId: proj
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
+rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
+rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
+rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 * namespace/same-name/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N2
-
-  x Missing SymbolId: _N7
-
-  x Missing SymbolId: _N4
-
-  x Missing ReferenceId: _N7
-
-  x Missing ReferenceId: _N7
-
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N6
-
-  x Missing ReferenceId: _N6
-
-  x Missing ReferenceId: _N3
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: _N2
-
-  x Missing ReferenceId: _N2
-
-  x Missing SymbolId: _N8
-
-  x Missing ReferenceId: _N8
-
-  x Missing ReferenceId: _N5
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: _N2
-
-  x Missing ReferenceId: _N2
-
-  x Missing SymbolId: _N9
-
-  x Missing ReferenceId: _N9
-
-  x Missing ReferenceId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: _N2
-
-  x Missing ReferenceId: _N2
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
-  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
-  | rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
-  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(8): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export
-  | | Function)
-  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): []
-  | rebuilt        : SymbolId(7): [ReferenceId(3)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(5): SymbolFlags(Export | Class)
-  | rebuilt        : SymbolId(9): SymbolFlags(Class)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): []
-  | rebuilt        : SymbolId(9): [ReferenceId(9)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
-  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): []
-  | rebuilt        : SymbolId(11): [ReferenceId(16)]
-
+Missing SymbolId: N
+Missing SymbolId: _N2
+Missing SymbolId: _N7
+Missing SymbolId: _N4
+Missing ReferenceId: _N7
+Missing ReferenceId: _N7
+Missing SymbolId: N
+Missing SymbolId: _N6
+Missing ReferenceId: _N6
+Missing ReferenceId: _N3
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing ReferenceId: _N2
+Missing ReferenceId: _N2
+Missing SymbolId: _N8
+Missing ReferenceId: _N8
+Missing ReferenceId: _N5
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing ReferenceId: _N2
+Missing ReferenceId: _N2
+Missing SymbolId: _N9
+Missing ReferenceId: _N9
+Missing ReferenceId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Missing ReferenceId: _N2
+Missing ReferenceId: _N2
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(7): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(9): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(11): [ReferenceId(16)]
 
 * namespace/undeclared/input.ts
-  x Missing SymbolId: N
-
-  x Missing SymbolId: _N
-
-  x Missing ReferenceId: N
-
-  x Missing ReferenceId: N
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-
+Missing SymbolId: N
+Missing SymbolId: _N
+Missing ReferenceId: N
+Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 * optimize-const-enums/custom-values/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "w", "x", "y", "z"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+x Output mismatch
 
 * optimize-const-enums/custom-values-exported/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "w", "x", "y", "z"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
+x Output mismatch
 
 * optimize-const-enums/declare/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(0): Some("A")
-  | rebuilt        : ReferenceId(0): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["A"]
-
+x Output mismatch
 
 * optimize-const-enums/export-const-enum/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "y"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
+x Output mismatch
 
 * optimize-const-enums/export-const-enum-type-and-value/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["WhitespaceFlag", "after", "before"]
-  | rebuilt        : ScopeId(1): ["WhitespaceFlag"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(8)]
-  | rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6),
-  | ReferenceId(7)]
-
+x Output mismatch
 
 * optimize-const-enums/export-const-enum-type-no-deopt/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["WhitespaceFlag", "after", "before"]
-  | rebuilt        : ScopeId(1): ["WhitespaceFlag"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(8)]
-  | rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
-
+x Output mismatch
 
 * optimize-const-enums/exported/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "y"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-
+x Output mismatch
 
 * optimize-const-enums/local/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "x", "y"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+x Output mismatch
 
 * optimize-const-enums/local-shadowed/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "x"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
+x Output mismatch
 
 * optimize-const-enums/merged/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "x", "y"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["A", "z"]
-  | rebuilt        : ScopeId(2): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 36, end: 37 }]
-  | rebuilt        : SymbolId(0): []
-
+x Output mismatch
 
 * optimize-const-enums/merged-exported/input.ts
-  x Output mismatch
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "x", "y"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["A", "z"]
-  | rebuilt        : ScopeId(2): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 50, end: 51 }]
-  | rebuilt        : SymbolId(0): []
-
+x Output mismatch
 
 * regression/15768/input.ts
-  x Output mismatch
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: StateEnum
-
-  x Missing ReferenceId: StateEnum
-
-  x Missing ReferenceId: StateEnum
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["StateEnum", "ext", "ext2", "ext3", "nan",
-  | "nanReal", "neg", "negReal", "okay", "pos", "posReal"]
-  | rebuilt        : ScopeId(2): ["StateEnum"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(5)]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(6)]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(7)]
-  | rebuilt        : SymbolId(2): []
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(3)]
-  | rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9),
-  | ReferenceId(14), ReferenceId(17)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(4)]
-  | rebuilt        : SymbolId(4): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(8), ReferenceId(9),
-  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
-  | ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17),
-  | ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21),
-  | ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25),
-  | ReferenceId(26), ReferenceId(27), ReferenceId(28)]
-  | rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(3),
-  | ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8),
-  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
-  | ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19),
-  | ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23),
-  | ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27),
-  | ReferenceId(28), ReferenceId(29)]
-
+x Output mismatch
 
 * type-arguments/call/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
-
+Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
 
 * type-arguments/expr/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
-
+Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
 
 * type-arguments/new/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["C", "T"]
-  | rebuilt        : ["C"]
-
+Unresolved references mismatch:
+after transform: ["C", "T"]
+rebuilt        : ["C"]
 
 * type-arguments/optional-call/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["Q", "T", "f", "x"]
-  | rebuilt        : ["f", "x"]
-
+Unresolved references mismatch:
+after transform: ["Q", "T", "f", "x"]
+rebuilt        : ["f", "x"]
 
 * type-arguments/tagged-template/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
+Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
 
 
-
-# babel-plugin-transform-react-jsx (123/145)
+# babel-plugin-transform-react-jsx (124/145)
 * autoImport/after-polyfills-compiled-to-cjs/input.mjs
+x Output mismatch
 
+* pure/false-pragma-comment-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* react/dont-coerce-expression-containers/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
+* pure/false-pragma-option-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
+* pure/true-pragma-comment-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* react/honor-custom-jsx-comment/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
+* pure/true-pragma-option-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
+* pure/unset-pragma-comment-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* react/honor-custom-jsx-comment-if-jsx-pragma-option-set/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
+* pure/unset-pragma-option-automatic-runtime/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
-
-* react/honor-custom-jsx-pragma-option/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
-  x Unresolved reference IDs mismatch for "Composite":
-  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
-  | ReferenceId(6)]
-  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
-
+* react/should-disallow-spread-children/input.js
+Spread children are not supported in React.
 
 * react/should-disallow-valueless-key/input.js
   ! Please provide an explicit key value. Using "key" as a shorthand for
@@ -4984,12 +3534,6 @@ TS(18010)
    `----
 
 
-* react/should-have-correct-comma-in-nested-children/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(4)]
-
-
 * react/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -5000,33 +3544,17 @@ TS(18010)
    `----
 
 
-* react/weird-symbols/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(2)]
+* react/should-warn-when-importSource-is-set/input.js
+importSource cannot be set when runtime is classic.
 
+* react/should-warn-when-importSource-pragma-is-set/input.js
+importSource cannot be set when runtime is classic.
 
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
 
-* react-automatic/dont-coerce-expression-containers/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/handle-fragments-with-key/input.js
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-
-* react-automatic/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
-  x Unresolved reference IDs mismatch for "Composite":
-  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
-  | ReferenceId(6)]
-  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
-
+* react-automatic/should-disallow-spread-children/input.js
+Spread children are not supported in React.
 
 * react-automatic/should-disallow-valueless-key/input.js
   ! Please provide an explicit key value. Using "key" as a shorthand for
@@ -5048,12 +3576,6 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    `----
 
 
-* react-automatic/should-have-correct-comma-in-nested-children/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(4)]
-
-
 * react-automatic/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -5064,20 +3586,17 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    `----
 
 
-* react-automatic/weird-symbols/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(2)]
-
+* react-automatic/should-warn-when-pragma-or-pragmaFrag-is-set/input.js
+pragma and pragmaFrag cannot be set when runtime is automatic.
 
 * spread-transform/transform-to-babel-extend/input.js
-
+x Output mismatch
 
 * spread-transform/transform-to-object-assign/input.js
+x Output mismatch
 
 
-
-# babel-plugin-transform-react-jsx-development (6/10)
+# babel-plugin-transform-react-jsx-development (7/10)
 * cross-platform/disallow-__self-as-jsx-attribute/input.js
   ! Duplicate __self prop found.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/input.js:1:14]
@@ -5094,37 +3613,7 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    `----
 
 
-* cross-platform/handle-fragments-with-key/input.js
-  x Unresolved reference IDs mismatch for "React":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* cross-platform/within-ts-module-block/input.ts
-  x Output mismatch
-  x Missing SymbolId: Namespaced
-
-  x Missing SymbolId: _Namespaced
-
-  x Missing ReferenceId: _Namespaced
-
-  x Missing ReferenceId: Namespaced
-
-  x Missing ReferenceId: Namespaced
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-  | rebuilt        : ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | ArrowFunction)
-  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
+* cross-platform/within-ts-module-block/input.tsx
+x Output mismatch
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 21/50
+Passed: 41/53
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -11,1269 +11,173 @@ Passed: 21/50
 
 # babel-plugin-transform-arrow-functions (1/2)
 * with-this-member-expression/input.jsx
+x Output mismatch
 
 
-
-# babel-plugin-transform-typescript (2/8)
+# babel-plugin-transform-typescript (1/8)
 * class-property-definition/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["const"]
-  | rebuilt        : []
-
+Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
 
 * computed-constant-value/input.ts
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Missing ReferenceId: Infinity
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
-  | rebuilt        : ScopeId(1): ["A"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
-  | rebuilt        : ScopeId(2): ["B"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(2): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): ["C", "a", "b", "c"]
-  | rebuilt        : ScopeId(3): ["C"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(3): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
-
-  x Bindings mismatch:
-  | after transform: ScopeId(4): ["D", "a", "b", "c"]
-  | rebuilt        : ScopeId(4): ["D"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(4): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(6): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(12): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-
-  x Unresolved references mismatch:
-  | after transform: ["Infinity", "NaN"]
-  | rebuilt        : ["Infinity"]
-
-  x Unresolved reference IDs mismatch for "Infinity":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2),
-  | ReferenceId(3)]
-  | rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8),
-  | ReferenceId(12)]
-
+Missing ReferenceId: Infinity
+Missing ReferenceId: Infinity
+Missing ReferenceId: Infinity
+Missing ReferenceId: Infinity
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
+rebuilt        : ScopeId(2): ["B"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["C", "a", "b", "c"]
+rebuilt        : ScopeId(3): ["C"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["D", "a", "b", "c"]
+rebuilt        : ScopeId(4): ["D"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Unresolved references mismatch:
+after transform: ["Infinity", "NaN"]
+rebuilt        : ["Infinity"]
+Unresolved reference IDs mismatch for "Infinity":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
 
 * elimination-declare/input.ts
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["A", "ReactiveMarkerSymbol"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "ReactiveMarkerSymbol"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
 
 * enum-member-reference/input.ts
-  x Missing ReferenceId: Foo
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
-  | rebuilt        : ScopeId(1): ["Foo"]
-
-  x Scope flags mismatch:
-  | after transform: ScopeId(1): ScopeFlags(StrictMode)
-  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4),
-  | ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(8)]
-
+Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(1): ["Foo", "a", "b", "c"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
 
 * export-elimination/input.ts
-  x Missing SymbolId: Name
-
-  x Missing SymbolId: _Name
-
-  x Missing ReferenceId: _Name
-
-  x Missing ReferenceId: Name
-
-  x Missing ReferenceId: Name
-
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["Baq", "Bar", "Baz", "Foo", "Func", "Im",
-  | "Name", "Ok", "T"]
-  | rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok",
-  | "T"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
-  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export |
-  | Function | TypeAlias)
-  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | Export
-  | | Function)
-
-  x Symbol span mismatch:
-  | after transform: SymbolId(9): Span { start: 205, end: 206 }
-  | rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
-  | rebuilt        : SymbolId(8): [ReferenceId(9)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(9): [Span { start: 226, end: 227 }]
-  | rebuilt        : SymbolId(8): []
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(7): Some("Name")
-  | rebuilt        : ReferenceId(8): Some("Name")
-
+Missing SymbolId: Name
+Missing SymbolId: _Name
+Missing ReferenceId: _Name
+Missing ReferenceId: Name
+Missing ReferenceId: Name
+Bindings mismatch:
+after transform: ScopeId(0): ["Baq", "Bar", "Baz", "Foo", "Func", "Im", "Name", "Ok", "T"]
+rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
+rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+Symbol span mismatch:
+after transform: SymbolId(9): Span { start: 205, end: 206 }
+rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
+rebuilt        : SymbolId(8): [ReferenceId(9)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(9): [Span { start: 226, end: 227 }]
+rebuilt        : SymbolId(8): []
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("Name")
+rebuilt        : ReferenceId(8): Some("Name")
 
 * redeclarations/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | Import)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-
-  x Symbol span mismatch:
-  | after transform: SymbolId(0): Span { start: 57, end: 58 }
-  | rebuilt        : SymbolId(0): Span { start: 79, end: 83 }
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(0): [Span { start: 79, end: 83 }]
-  | rebuilt        : SymbolId(0): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(Export | Import | TypeAlias)
-  | rebuilt        : SymbolId(1): SymbolFlags(Export | Import)
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(1): [Span { start: 170, end: 171 }]
-  | rebuilt        : SymbolId(1): []
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | Import | TypeAlias)
-  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-
-  x Symbol span mismatch:
-  | after transform: SymbolId(2): Span { start: 267, end: 268 }
-  | rebuilt        : SymbolId(2): Span { start: 289, end: 293 }
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
-  | rebuilt        : SymbolId(2): [ReferenceId(2)]
-
-  x Symbol redeclarations mismatch:
-  | after transform: SymbolId(2): [Span { start: 289, end: 293 }, Span
-  | { start: 304, end: 305 }]
-  | rebuilt        : SymbolId(2): []
-
-
-
-# babel-plugin-transform-react-jsx (6/28)
-* refresh/can-handle-implicit-arrow-returns/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(9): [ReferenceId(23), ReferenceId(24),
-  | ReferenceId(25)]
-  | rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(10): [ReferenceId(26), ReferenceId(27),
-  | ReferenceId(29)]
-  | rebuilt        : SymbolId(1): [ReferenceId(10), ReferenceId(13)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(11): [ReferenceId(30), ReferenceId(31),
-  | ReferenceId(32)]
-  | rebuilt        : SymbolId(2): [ReferenceId(18), ReferenceId(19)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(12): [ReferenceId(33), ReferenceId(34),
-  | ReferenceId(36)]
-  | rebuilt        : SymbolId(3): [ReferenceId(22), ReferenceId(25)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(13): [ReferenceId(37), ReferenceId(38),
-  | ReferenceId(39), ReferenceId(40)]
-  | rebuilt        : SymbolId(4): [ReferenceId(29), ReferenceId(32),
-  | ReferenceId(33)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(14): [ReferenceId(41), ReferenceId(42),
-  | ReferenceId(44)]
-  | rebuilt        : SymbolId(5): [ReferenceId(38), ReferenceId(41)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(14), ReferenceId(45),
-  | ReferenceId(46)]
-  | rebuilt        : SymbolId(10): [ReferenceId(15), ReferenceId(46)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(16), ReferenceId(47),
-  | ReferenceId(48)]
-  | rebuilt        : SymbolId(11): [ReferenceId(27), ReferenceId(48)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): [ReferenceId(18), ReferenceId(49),
-  | ReferenceId(50)]
-  | rebuilt        : SymbolId(12): [ReferenceId(31), ReferenceId(50)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(19), ReferenceId(51),
-  | ReferenceId(52)]
-  | rebuilt        : SymbolId(13): [ReferenceId(36), ReferenceId(52)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(21), ReferenceId(53),
-  | ReferenceId(54)]
-  | rebuilt        : SymbolId(14): [ReferenceId(43), ReferenceId(54)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(23): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(26): Some("_s2")
-  | rebuilt        : ReferenceId(1): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(30): Some("_s3")
-  | rebuilt        : ReferenceId(2): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(33): Some("_s4")
-  | rebuilt        : ReferenceId(3): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(37): Some("_s5")
-  | rebuilt        : ReferenceId(4): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(41): Some("_s6")
-  | rebuilt        : ReferenceId(5): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(18): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(31): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(45): Some("_c")
-  | rebuilt        : ReferenceId(45): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(47): Some("_c2")
-  | rebuilt        : ReferenceId(47): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(49): Some("_c3")
-  | rebuilt        : ReferenceId(49): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(51): Some("_c4")
-  | rebuilt        : ReferenceId(51): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(53): Some("_c5")
-  | rebuilt        : ReferenceId(53): None
-
-  x Unresolved references mismatch:
-  | after transform: ["X", "memo", "module", "useContext"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "X", "memo", "module",
-  | "useContext"]
-
-
-* refresh/does-not-consider-require-like-methods-to-be-hocs/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(10), ReferenceId(17),
-  | ReferenceId(18)]
-  | rebuilt        : SymbolId(7): [ReferenceId(15), ReferenceId(18)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(17): Some("_c")
-  | rebuilt        : ReferenceId(17): None
-
-  x Unresolved references mismatch:
-  | after transform: ["foo", "gk", "require", "requireCond"]
-  | rebuilt        : ["$RefreshReg$", "foo", "gk", "require", "requireCond"]
-
-
-* refresh/does-not-get-tripped-by-iifes/input.jsx
-  x Bindings mismatch:
-  | after transform: ScopeId(0): []
-  | rebuilt        : ScopeId(0): ["_s"]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(1): ["_s"]
-  | rebuilt        : ScopeId(1): []
-
-  x Symbol scope ID mismatch:
-  | after transform: SymbolId(1): ScopeId(1)
-  | rebuilt        : SymbolId(0): ScopeId(0)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4),
-  | ReferenceId(5)]
-  | rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(3): Some("_s")
-  | rebuilt        : ReferenceId(1): None
-
-  x Unresolved references mismatch:
-  | after transform: ["item", "useFoo"]
-  | rebuilt        : ["$RefreshSig$", "item", "useFoo"]
-
-
-* refresh/generates-signatures-for-function-declarations-calling-hooks/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(3), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(11)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "useState"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "useState"]
-
-
-* refresh/generates-signatures-for-function-expressions-calling-hooks/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(22): [ReferenceId(26), ReferenceId(27),
-  | ReferenceId(28), ReferenceId(29), ReferenceId(30)]
-  | rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5),
-  | ReferenceId(8), ReferenceId(9)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(23): [ReferenceId(32), ReferenceId(33),
-  | ReferenceId(34), ReferenceId(35), ReferenceId(36)]
-  | rebuilt        : SymbolId(2): [ReferenceId(17), ReferenceId(20),
-  | ReferenceId(23), ReferenceId(24)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(24): [ReferenceId(38), ReferenceId(39),
-  | ReferenceId(40)]
-  | rebuilt        : SymbolId(14): [ReferenceId(33), ReferenceId(34)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(17), ReferenceId(41),
-  | ReferenceId(42)]
-  | rebuilt        : SymbolId(19): [ReferenceId(7), ReferenceId(42)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(18), ReferenceId(43),
-  | ReferenceId(44)]
-  | rebuilt        : SymbolId(20): [ReferenceId(4), ReferenceId(44)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(19), ReferenceId(45),
-  | ReferenceId(46)]
-  | rebuilt        : SymbolId(21): [ReferenceId(15), ReferenceId(46)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(18): [ReferenceId(21), ReferenceId(47),
-  | ReferenceId(48)]
-  | rebuilt        : SymbolId(22): [ReferenceId(22), ReferenceId(48)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(19): [ReferenceId(22), ReferenceId(49),
-  | ReferenceId(50)]
-  | rebuilt        : SymbolId(23): [ReferenceId(19), ReferenceId(50)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(20): [ReferenceId(23), ReferenceId(51),
-  | ReferenceId(52)]
-  | rebuilt        : SymbolId(24): [ReferenceId(30), ReferenceId(52)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(26): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(32): Some("_s2")
-  | rebuilt        : ReferenceId(1): None
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(18): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(17): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(22): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(19): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(21): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(22): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(38): Some("_s3")
-  | rebuilt        : ReferenceId(32): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(41): Some("_c")
-  | rebuilt        : ReferenceId(41): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(43): Some("_c2")
-  | rebuilt        : ReferenceId(43): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(45): Some("_c3")
-  | rebuilt        : ReferenceId(45): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(47): Some("_c4")
-  | rebuilt        : ReferenceId(47): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(49): Some("_c5")
-  | rebuilt        : ReferenceId(49): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(51): Some("_c6")
-  | rebuilt        : ReferenceId(51): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "ref", "useState"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "ref",
-  | "useState"]
-
-
-* refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
-  x Missing ScopeId
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(10): [ReferenceId(17), ReferenceId(18),
-  | ReferenceId(20)]
-  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(16)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12),
-  | ReferenceId(14)]
-  | rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(7)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(21),
-  | ReferenceId(22)]
-  | rebuilt        : SymbolId(10): [ReferenceId(19), ReferenceId(22)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(17): Some("_s2")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(11): Some("_s")
-  | rebuilt        : ReferenceId(2): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(21): Some("_c")
-  | rebuilt        : ReferenceId(21): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "useFancyEffect", "useThePlatform"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React",
-  | "useFancyEffect", "useThePlatform"]
-
-
-* refresh/includes-custom-hooks-into-the-signatures/input.jsx
-  x Missing ScopeId
-
-  x Missing ScopeId
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(5), ScopeId(6)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(10),
-  | ReferenceId(12)]
-  | rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(7)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14),
-  | ReferenceId(16)]
-  | rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(12)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(10): [ReferenceId(19), ReferenceId(20),
-  | ReferenceId(22)]
-  | rebuilt        : SymbolId(3): [ReferenceId(14), ReferenceId(18)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): [ReferenceId(6), ReferenceId(23),
-  | ReferenceId(24)]
-  | rebuilt        : SymbolId(10): [ReferenceId(21), ReferenceId(24)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(9): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(13): Some("_s2")
-  | rebuilt        : ReferenceId(1): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(19): Some("_s3")
-  | rebuilt        : ReferenceId(2): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(23): Some("_c")
-  | rebuilt        : ReferenceId(23): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React"]
-
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Import)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(0): Span { start: 79, end: 83 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(0)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 79, end: 83 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Import | TypeAlias)
+rebuilt        : SymbolId(1): SymbolFlags(Export | Import)
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 170, end: 171 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Import | TypeAlias)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+Symbol span mismatch:
+after transform: SymbolId(2): Span { start: 267, end: 268 }
+rebuilt        : SymbolId(2): Span { start: 289, end: 293 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 289, end: 293 }, Span { start: 304, end: 305 }]
+rebuilt        : SymbolId(2): []
+
+* ts-declaration-empty-output/input.d.ts
+x Output mismatch
+
+
+# babel-plugin-transform-react-jsx (27/31)
+* refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
+x Output mismatch
 
 * refresh/includes-custom-hooks-into-the-signatures-when-commonjs-target-is-used/input.jsx
-  x Output mismatch
-  x Missing ScopeId
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(5)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(11)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$"]
-
-
-* refresh/registers-capitalized-identifiers-in-hoc-calls/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(6), ReferenceId(14),
-  | ReferenceId(15)]
-  | rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(15)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(8), ReferenceId(16),
-  | ReferenceId(17)]
-  | rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(17)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(9), ReferenceId(18),
-  | ReferenceId(19)]
-  | rebuilt        : SymbolId(6): [ReferenceId(8), ReferenceId(19)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): [ReferenceId(11), ReferenceId(20),
-  | ReferenceId(21)]
-  | rebuilt        : SymbolId(7): [ReferenceId(12), ReferenceId(21)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(14): Some("_c")
-  | rebuilt        : ReferenceId(14): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(16): Some("_c2")
-  | rebuilt        : ReferenceId(16): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(18): Some("_c3")
-  | rebuilt        : ReferenceId(18): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(20): Some("_c4")
-  | rebuilt        : ReferenceId(20): None
-
-  x Unresolved references mismatch:
-  | after transform: ["hoc"]
-  | rebuilt        : ["$RefreshReg$", "hoc"]
-
-
-* refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
-  x Output mismatch
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(44),
-  | ReferenceId(45)]
-  | rebuilt        : SymbolId(15): [ReferenceId(2), ReferenceId(45)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(46),
-  | ReferenceId(47)]
-  | rebuilt        : SymbolId(16): [ReferenceId(5), ReferenceId(47)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(48),
-  | ReferenceId(49)]
-  | rebuilt        : SymbolId(17): [ReferenceId(11), ReferenceId(49)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(50),
-  | ReferenceId(51)]
-  | rebuilt        : SymbolId(18): [ReferenceId(34), ReferenceId(51)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(52),
-  | ReferenceId(53)]
-  | rebuilt        : SymbolId(19): [ReferenceId(38), ReferenceId(53)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(54),
-  | ReferenceId(55)]
-  | rebuilt        : SymbolId(20): [ReferenceId(42), ReferenceId(55)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(44): Some("_c")
-  | rebuilt        : ReferenceId(44): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(46): Some("_c2")
-  | rebuilt        : ReferenceId(46): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(48): Some("_c3")
-  | rebuilt        : ReferenceId(48): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(50): Some("_c4")
-  | rebuilt        : ReferenceId(50): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(52): Some("_c5")
-  | rebuilt        : ReferenceId(52): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(54): Some("_c6")
-  | rebuilt        : ReferenceId(54): None
-
-  x Unresolved references mismatch:
-  | after transform: ["funny", "hoc", "styled", "wow"]
-  | rebuilt        : ["$RefreshReg$", "funny", "hoc", "styled", "wow"]
-
-
-* refresh/registers-identifiers-used-in-react-create-element-at-definition-site/input.jsx
-  x Output mismatch
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(13): [ReferenceId(33), ReferenceId(45),
-  | ReferenceId(46)]
-  | rebuilt        : SymbolId(13): [ReferenceId(2), ReferenceId(46)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(14): [ReferenceId(35), ReferenceId(47),
-  | ReferenceId(48)]
-  | rebuilt        : SymbolId(14): [ReferenceId(5), ReferenceId(48)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(37), ReferenceId(49),
-  | ReferenceId(50)]
-  | rebuilt        : SymbolId(15): [ReferenceId(11), ReferenceId(50)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(39), ReferenceId(51),
-  | ReferenceId(52)]
-  | rebuilt        : SymbolId(16): [ReferenceId(33), ReferenceId(52)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(41), ReferenceId(53),
-  | ReferenceId(54)]
-  | rebuilt        : SymbolId(17): [ReferenceId(39), ReferenceId(54)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(18): [ReferenceId(43), ReferenceId(55),
-  | ReferenceId(56)]
-  | rebuilt        : SymbolId(18): [ReferenceId(43), ReferenceId(56)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(45): Some("_c")
-  | rebuilt        : ReferenceId(45): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(47): Some("_c2")
-  | rebuilt        : ReferenceId(47): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(49): Some("_c3")
-  | rebuilt        : ReferenceId(49): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(51): Some("_c4")
-  | rebuilt        : ReferenceId(51): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(53): Some("_c5")
-  | rebuilt        : ReferenceId(53): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(55): Some("_c6")
-  | rebuilt        : ReferenceId(55): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "funny", "hoc", "jsx", "styled", "wow"]
-  | rebuilt        : ["$RefreshReg$", "React", "funny", "hoc", "jsx",
-  | "styled", "wow"]
-
-
-* refresh/registers-likely-hocs-with-inline-functions-1/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(5), ReferenceId(18),
-  | ReferenceId(19)]
-  | rebuilt        : SymbolId(5): [ReferenceId(1), ReferenceId(19)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(20),
-  | ReferenceId(21)]
-  | rebuilt        : SymbolId(6): [ReferenceId(3), ReferenceId(21)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): [ReferenceId(8), ReferenceId(22),
-  | ReferenceId(23)]
-  | rebuilt        : SymbolId(7): [ReferenceId(8), ReferenceId(23)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(24),
-  | ReferenceId(25)]
-  | rebuilt        : SymbolId(8): [ReferenceId(6), ReferenceId(25)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(10), ReferenceId(26),
-  | ReferenceId(27)]
-  | rebuilt        : SymbolId(9): [ReferenceId(10), ReferenceId(27)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(9): [ReferenceId(12), ReferenceId(28),
-  | ReferenceId(29)]
-  | rebuilt        : SymbolId(10): [ReferenceId(16), ReferenceId(29)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(10): [ReferenceId(13), ReferenceId(30),
-  | ReferenceId(31)]
-  | rebuilt        : SymbolId(11): [ReferenceId(14), ReferenceId(31)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(11): [ReferenceId(14), ReferenceId(32),
-  | ReferenceId(33)]
-  | rebuilt        : SymbolId(12): [ReferenceId(12), ReferenceId(33)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(5): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(9): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(6): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(8): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(8): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(14): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(12): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(13): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(14): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(12): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(18): Some("_c")
-  | rebuilt        : ReferenceId(18): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(20): Some("_c2")
-  | rebuilt        : ReferenceId(20): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(22): Some("_c3")
-  | rebuilt        : ReferenceId(22): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(24): Some("_c4")
-  | rebuilt        : ReferenceId(24): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(26): Some("_c5")
-  | rebuilt        : ReferenceId(26): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(28): Some("_c6")
-  | rebuilt        : ReferenceId(28): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(30): Some("_c7")
-  | rebuilt        : ReferenceId(30): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(32): Some("_c8")
-  | rebuilt        : ReferenceId(32): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef", "memo"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef", "memo"]
-
-
-* refresh/registers-likely-hocs-with-inline-functions-2/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(2): [ReferenceId(2), ReferenceId(6),
-  | ReferenceId(7)]
-  | rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(7)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(3), ReferenceId(8),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(5): [ReferenceId(0), ReferenceId(11)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(3): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(2): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_c")
-  | rebuilt        : ReferenceId(6): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(8): Some("_c2")
-  | rebuilt        : ReferenceId(8): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c3")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
-
-
-* refresh/registers-likely-hocs-with-inline-functions-3/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(6),
-  | ReferenceId(7)]
-  | rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(9)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(4), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(6): [ReferenceId(0), ReferenceId(11)]
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(4): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(3): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-
-  x Reference flags mismatch:
-  | after transform: ReferenceId(2): ReferenceFlags(Write)
-  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_c")
-  | rebuilt        : ReferenceId(6): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(8): Some("_c2")
-  | rebuilt        : ReferenceId(8): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c3")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
-
-
-* refresh/registers-top-level-exported-function-declarations/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(4), ReferenceId(13),
-  | ReferenceId(14)]
-  | rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(14)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(6), ReferenceId(15),
-  | ReferenceId(16)]
-  | rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(16)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(9): [ReferenceId(8), ReferenceId(17),
-  | ReferenceId(18)]
-  | rebuilt        : SymbolId(10): [ReferenceId(9), ReferenceId(18)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(13): Some("_c")
-  | rebuilt        : ReferenceId(13): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(15): Some("_c2")
-  | rebuilt        : ReferenceId(15): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(17): Some("_c3")
-  | rebuilt        : ReferenceId(17): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
-
-* refresh/registers-top-level-exported-named-arrow-functions/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(3), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(11)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(5), ReferenceId(12),
-  | ReferenceId(13)]
-  | rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(13)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c")
-  | rebuilt        : ReferenceId(10): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(12): Some("_c2")
-  | rebuilt        : ReferenceId(12): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
-
-* refresh/registers-top-level-function-declarations/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(8),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(5): [ReferenceId(6), ReferenceId(11)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(8): Some("_c")
-  | rebuilt        : ReferenceId(8): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c2")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
-
-* refresh/registers-top-level-variable-declarations-with-arrow-functions/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(5): [ReferenceId(2), ReferenceId(11),
-  | ReferenceId(12)]
-  | rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(12)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): [ReferenceId(4), ReferenceId(13),
-  | ReferenceId(14)]
-  | rebuilt        : SymbolId(7): [ReferenceId(6), ReferenceId(14)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(6), ReferenceId(15),
-  | ReferenceId(16)]
-  | rebuilt        : SymbolId(8): [ReferenceId(9), ReferenceId(16)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(11): Some("_c")
-  | rebuilt        : ReferenceId(11): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(13): Some("_c2")
-  | rebuilt        : ReferenceId(13): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(15): Some("_c3")
-  | rebuilt        : ReferenceId(15): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
-
-* refresh/registers-top-level-variable-declarations-with-function-expressions/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(7): [ReferenceId(2), ReferenceId(8),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(9)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(8): [ReferenceId(4), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(11)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(8): Some("_c")
-  | rebuilt        : ReferenceId(8): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c2")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
+x Output mismatch
 
 * refresh/supports-typescript-namespace-syntax/input.tsx
-  x Output mismatch
-  x Missing SymbolId: Foo
+x Output mismatch
 
-  x Missing SymbolId: _Foo
-
-  x Missing SymbolId: Bar
-
-  x Missing SymbolId: _Bar
-
-  x Missing ReferenceId: _Bar
-
-  x Missing ReferenceId: _Bar
-
-  x Missing ReferenceId: Bar
-
-  x Missing ReferenceId: Bar
-
-  x Missing ReferenceId: _Foo
-
-  x Missing ReferenceId: _Foo
-
-  x Missing ReferenceId: _Foo
-
-  x Missing ReferenceId: _Foo
-
-  x Missing ReferenceId: D
-
-  x Missing SymbolId: NotExported
-
-  x Missing SymbolId: _NotExported
-
-  x Missing ReferenceId: _NotExported
-
-  x Missing ReferenceId: NotExported
-
-  x Missing ReferenceId: NotExported
-
-  x Missing ReferenceId: Foo
-
-  x Missing ReferenceId: Foo
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(0): [SymbolId(0)]
-  | rebuilt        : ScopeId(0): [SymbolId(0)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(1): [SymbolId(1), SymbolId(5), SymbolId(6),
-  | SymbolId(7), SymbolId(9)]
-  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(7),
-  | SymbolId(8), SymbolId(9)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4),
-  | SymbolId(10)]
-  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5),
-  | SymbolId(6)]
-
-  x Binding symbols mismatch:
-  | after transform: ScopeId(7): [SymbolId(8), SymbolId(11)]
-  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | ArrowFunction)
-  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
-  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export)
-  | rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | ArrowFunction)
-  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export
-  | | Function)
-  | rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(6): []
-  | rebuilt        : SymbolId(8): [ReferenceId(9)]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | Export | ArrowFunction)
-  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
-
-
-* refresh/uses-custom-identifiers-for-refresh-reg-and-refresh-sig/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(3): [ReferenceId(6), ReferenceId(7),
-  | ReferenceId(9)]
-  | rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(10),
-  | ReferenceId(11)]
-  | rebuilt        : SymbolId(3): [ReferenceId(8), ReferenceId(11)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_s")
-  | rebuilt        : ReferenceId(0): None
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(10): Some("_c")
-  | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["Foo", "X", "useContext"]
-  | rebuilt        : ["Foo", "X", "import.meta.refreshReg",
-  | "import.meta.refreshSig", "useContext"]
-
-
-* refresh/uses-original-function-declaration-if-it-get-reassigned/input.jsx
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6),
-  | ReferenceId(7)]
-  | rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(7)]
-
-  x Reference symbol mismatch:
-  | after transform: ReferenceId(6): Some("_c")
-  | rebuilt        : ReferenceId(6): None
-
-  x Unresolved references mismatch:
-  | after transform: ["connect"]
-  | rebuilt        : ["$RefreshReg$", "connect"]
-
+* unicode/input.jsx
+x Output mismatch
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 41/52
+Passed: 21/50
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -11,170 +11,1269 @@ Passed: 41/52
 
 # babel-plugin-transform-arrow-functions (1/2)
 * with-this-member-expression/input.jsx
-x Output mismatch
 
 
-# babel-plugin-transform-typescript (1/8)
+
+# babel-plugin-transform-typescript (2/8)
 * class-property-definition/input.ts
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
+  x Unresolved references mismatch:
+  | after transform: ["const"]
+  | rebuilt        : []
+
 
 * computed-constant-value/input.ts
-Missing ReferenceId: Infinity
-Missing ReferenceId: Infinity
-Missing ReferenceId: Infinity
-Missing ReferenceId: Infinity
-Bindings mismatch:
-after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(1): ["A"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
-rebuilt        : ScopeId(2): ["B"]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(3): ["C", "a", "b", "c"]
-rebuilt        : ScopeId(3): ["C"]
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(0x0)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["D", "a", "b", "c"]
-rebuilt        : ScopeId(4): ["D"]
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(0x0)
-rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(6): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(12): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol flags mismatch:
-after transform: SymbolId(16): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Unresolved references mismatch:
-after transform: ["Infinity", "NaN"]
-rebuilt        : ["Infinity"]
-Unresolved reference IDs mismatch for "Infinity":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Missing ReferenceId: Infinity
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
+  | rebuilt        : ScopeId(2): ["B"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["C", "a", "b", "c"]
+  | rebuilt        : ScopeId(3): ["C"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(3): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["D", "a", "b", "c"]
+  | rebuilt        : ScopeId(4): ["D"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(12): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
+  x Unresolved references mismatch:
+  | after transform: ["Infinity", "NaN"]
+  | rebuilt        : ["Infinity"]
+
+  x Unresolved reference IDs mismatch for "Infinity":
+  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2),
+  | ReferenceId(3)]
+  | rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8),
+  | ReferenceId(12)]
+
 
 * elimination-declare/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "ReactiveMarkerSymbol"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["A", "ReactiveMarkerSymbol"]
+  | rebuilt        : ScopeId(0): []
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): []
+
 
 * enum-member-reference/input.ts
-Missing ReferenceId: Foo
-Bindings mismatch:
-after transform: ScopeId(1): ["Foo", "a", "b", "c"]
-rebuilt        : ScopeId(1): ["Foo"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
+  x Missing ReferenceId: Foo
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
+  | rebuilt        : ScopeId(1): ["Foo"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4),
+  | ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(8)]
+
 
 * export-elimination/input.ts
-Missing SymbolId: Name
-Missing SymbolId: _Name
-Missing ReferenceId: _Name
-Missing ReferenceId: Name
-Missing ReferenceId: Name
-Bindings mismatch:
-after transform: ScopeId(0): ["Baq", "Bar", "Baz", "Foo", "Func", "Im", "Name", "Ok", "T"]
-rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol flags mismatch:
-after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
-rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
-Symbol span mismatch:
-after transform: SymbolId(9): Span { start: 205, end: 206 }
-rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(8): [ReferenceId(9)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(9): [Span { start: 226, end: 227 }]
-rebuilt        : SymbolId(8): []
-Reference symbol mismatch:
-after transform: ReferenceId(7): Some("Name")
-rebuilt        : ReferenceId(8): Some("Name")
+  x Missing SymbolId: Name
+
+  x Missing SymbolId: _Name
+
+  x Missing ReferenceId: _Name
+
+  x Missing ReferenceId: Name
+
+  x Missing ReferenceId: Name
+
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Baq", "Bar", "Baz", "Foo", "Func", "Im",
+  | "Name", "Ok", "T"]
+  | rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok",
+  | "T"]
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export |
+  | Function | TypeAlias)
+  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(9): Span { start: 205, end: 206 }
+  | rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
+  | rebuilt        : SymbolId(8): [ReferenceId(9)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(9): [Span { start: 226, end: 227 }]
+  | rebuilt        : SymbolId(8): []
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(7): Some("Name")
+  | rebuilt        : ReferenceId(8): Some("Name")
+
 
 * redeclarations/input.ts
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Import)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-Symbol span mismatch:
-after transform: SymbolId(0): Span { start: 57, end: 58 }
-rebuilt        : SymbolId(0): Span { start: 79, end: 83 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(0)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(0): [Span { start: 79, end: 83 }]
-rebuilt        : SymbolId(0): []
-Symbol flags mismatch:
-after transform: SymbolId(1): SymbolFlags(Export | Import | TypeAlias)
-rebuilt        : SymbolId(1): SymbolFlags(Export | Import)
-Symbol redeclarations mismatch:
-after transform: SymbolId(1): [Span { start: 170, end: 171 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch:
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Import | TypeAlias)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-Symbol span mismatch:
-after transform: SymbolId(2): Span { start: 267, end: 268 }
-rebuilt        : SymbolId(2): Span { start: 289, end: 293 }
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Symbol redeclarations mismatch:
-after transform: SymbolId(2): [Span { start: 289, end: 293 }, Span { start: 304, end: 305 }]
-rebuilt        : SymbolId(2): []
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+  | rebuilt        : ScopeId(0): []
 
-* ts-declaration-empty-output/input.d.ts
-x Output mismatch
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | Import)
+  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(0): Span { start: 57, end: 58 }
+  | rebuilt        : SymbolId(0): Span { start: 79, end: 83 }
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 79, end: 83 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(Export | Import | TypeAlias)
+  | rebuilt        : SymbolId(1): SymbolFlags(Export | Import)
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(1): [Span { start: 170, end: 171 }]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | Import | TypeAlias)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(2): Span { start: 267, end: 268 }
+  | rebuilt        : SymbolId(2): Span { start: 289, end: 293 }
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+  | rebuilt        : SymbolId(2): [ReferenceId(2)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(2): [Span { start: 289, end: 293 }, Span
+  | { start: 304, end: 305 }]
+  | rebuilt        : SymbolId(2): []
 
 
-# babel-plugin-transform-react-jsx (27/30)
-* refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
-x Output mismatch
+
+# babel-plugin-transform-react-jsx (6/28)
+* refresh/can-handle-implicit-arrow-returns/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(23), ReferenceId(24),
+  | ReferenceId(25)]
+  | rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(26), ReferenceId(27),
+  | ReferenceId(29)]
+  | rebuilt        : SymbolId(1): [ReferenceId(10), ReferenceId(13)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(11): [ReferenceId(30), ReferenceId(31),
+  | ReferenceId(32)]
+  | rebuilt        : SymbolId(2): [ReferenceId(18), ReferenceId(19)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(12): [ReferenceId(33), ReferenceId(34),
+  | ReferenceId(36)]
+  | rebuilt        : SymbolId(3): [ReferenceId(22), ReferenceId(25)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(13): [ReferenceId(37), ReferenceId(38),
+  | ReferenceId(39), ReferenceId(40)]
+  | rebuilt        : SymbolId(4): [ReferenceId(29), ReferenceId(32),
+  | ReferenceId(33)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(14): [ReferenceId(41), ReferenceId(42),
+  | ReferenceId(44)]
+  | rebuilt        : SymbolId(5): [ReferenceId(38), ReferenceId(41)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(14), ReferenceId(45),
+  | ReferenceId(46)]
+  | rebuilt        : SymbolId(10): [ReferenceId(15), ReferenceId(46)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(16), ReferenceId(47),
+  | ReferenceId(48)]
+  | rebuilt        : SymbolId(11): [ReferenceId(27), ReferenceId(48)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(18), ReferenceId(49),
+  | ReferenceId(50)]
+  | rebuilt        : SymbolId(12): [ReferenceId(31), ReferenceId(50)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(19), ReferenceId(51),
+  | ReferenceId(52)]
+  | rebuilt        : SymbolId(13): [ReferenceId(36), ReferenceId(52)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(21), ReferenceId(53),
+  | ReferenceId(54)]
+  | rebuilt        : SymbolId(14): [ReferenceId(43), ReferenceId(54)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(23): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(26): Some("_s2")
+  | rebuilt        : ReferenceId(1): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(30): Some("_s3")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(33): Some("_s4")
+  | rebuilt        : ReferenceId(3): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(37): Some("_s5")
+  | rebuilt        : ReferenceId(4): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(41): Some("_s6")
+  | rebuilt        : ReferenceId(5): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(18): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(31): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(45): Some("_c")
+  | rebuilt        : ReferenceId(45): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(47): Some("_c2")
+  | rebuilt        : ReferenceId(47): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(49): Some("_c3")
+  | rebuilt        : ReferenceId(49): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(51): Some("_c4")
+  | rebuilt        : ReferenceId(51): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(53): Some("_c5")
+  | rebuilt        : ReferenceId(53): None
+
+  x Unresolved references mismatch:
+  | after transform: ["X", "memo", "module", "useContext"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "X", "memo", "module",
+  | "useContext"]
+
+
+* refresh/does-not-consider-require-like-methods-to-be-hocs/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(10), ReferenceId(17),
+  | ReferenceId(18)]
+  | rebuilt        : SymbolId(7): [ReferenceId(15), ReferenceId(18)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(17): Some("_c")
+  | rebuilt        : ReferenceId(17): None
+
+  x Unresolved references mismatch:
+  | after transform: ["foo", "gk", "require", "requireCond"]
+  | rebuilt        : ["$RefreshReg$", "foo", "gk", "require", "requireCond"]
+
+
+* refresh/does-not-get-tripped-by-iifes/input.jsx
+  x Bindings mismatch:
+  | after transform: ScopeId(0): []
+  | rebuilt        : ScopeId(0): ["_s"]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["_s"]
+  | rebuilt        : ScopeId(1): []
+
+  x Symbol scope ID mismatch:
+  | after transform: SymbolId(1): ScopeId(1)
+  | rebuilt        : SymbolId(0): ScopeId(0)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4),
+  | ReferenceId(5)]
+  | rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(3): Some("_s")
+  | rebuilt        : ReferenceId(1): None
+
+  x Unresolved references mismatch:
+  | after transform: ["item", "useFoo"]
+  | rebuilt        : ["$RefreshSig$", "item", "useFoo"]
+
+
+* refresh/generates-signatures-for-function-declarations-calling-hooks/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(3), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(11)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "useState"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "useState"]
+
+
+* refresh/generates-signatures-for-function-expressions-calling-hooks/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(22): [ReferenceId(26), ReferenceId(27),
+  | ReferenceId(28), ReferenceId(29), ReferenceId(30)]
+  | rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5),
+  | ReferenceId(8), ReferenceId(9)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(23): [ReferenceId(32), ReferenceId(33),
+  | ReferenceId(34), ReferenceId(35), ReferenceId(36)]
+  | rebuilt        : SymbolId(2): [ReferenceId(17), ReferenceId(20),
+  | ReferenceId(23), ReferenceId(24)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(24): [ReferenceId(38), ReferenceId(39),
+  | ReferenceId(40)]
+  | rebuilt        : SymbolId(14): [ReferenceId(33), ReferenceId(34)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(15): [ReferenceId(17), ReferenceId(41),
+  | ReferenceId(42)]
+  | rebuilt        : SymbolId(19): [ReferenceId(7), ReferenceId(42)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(16): [ReferenceId(18), ReferenceId(43),
+  | ReferenceId(44)]
+  | rebuilt        : SymbolId(20): [ReferenceId(4), ReferenceId(44)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(19), ReferenceId(45),
+  | ReferenceId(46)]
+  | rebuilt        : SymbolId(21): [ReferenceId(15), ReferenceId(46)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(18): [ReferenceId(21), ReferenceId(47),
+  | ReferenceId(48)]
+  | rebuilt        : SymbolId(22): [ReferenceId(22), ReferenceId(48)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(19): [ReferenceId(22), ReferenceId(49),
+  | ReferenceId(50)]
+  | rebuilt        : SymbolId(23): [ReferenceId(19), ReferenceId(50)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(20): [ReferenceId(23), ReferenceId(51),
+  | ReferenceId(52)]
+  | rebuilt        : SymbolId(24): [ReferenceId(30), ReferenceId(52)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(26): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(32): Some("_s2")
+  | rebuilt        : ReferenceId(1): None
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(18): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(17): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(22): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(19): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(21): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(22): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(38): Some("_s3")
+  | rebuilt        : ReferenceId(32): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(41): Some("_c")
+  | rebuilt        : ReferenceId(41): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(43): Some("_c2")
+  | rebuilt        : ReferenceId(43): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(45): Some("_c3")
+  | rebuilt        : ReferenceId(45): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(47): Some("_c4")
+  | rebuilt        : ReferenceId(47): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(49): Some("_c5")
+  | rebuilt        : ReferenceId(49): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(51): Some("_c6")
+  | rebuilt        : ReferenceId(51): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "ref", "useState"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "ref",
+  | "useState"]
+
+
+* refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
+  x Missing ScopeId
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(17), ReferenceId(18),
+  | ReferenceId(20)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(16)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12),
+  | ReferenceId(14)]
+  | rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(21),
+  | ReferenceId(22)]
+  | rebuilt        : SymbolId(10): [ReferenceId(19), ReferenceId(22)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(17): Some("_s2")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(11): Some("_s")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(21): Some("_c")
+  | rebuilt        : ReferenceId(21): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "useFancyEffect", "useThePlatform"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React",
+  | "useFancyEffect", "useThePlatform"]
+
+
+* refresh/includes-custom-hooks-into-the-signatures/input.jsx
+  x Missing ScopeId
+
+  x Missing ScopeId
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
+  | ScopeId(5), ScopeId(6)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(10),
+  | ReferenceId(12)]
+  | rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14),
+  | ReferenceId(16)]
+  | rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(12)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(19), ReferenceId(20),
+  | ReferenceId(22)]
+  | rebuilt        : SymbolId(3): [ReferenceId(14), ReferenceId(18)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(6), ReferenceId(23),
+  | ReferenceId(24)]
+  | rebuilt        : SymbolId(10): [ReferenceId(21), ReferenceId(24)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(9): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(13): Some("_s2")
+  | rebuilt        : ReferenceId(1): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(19): Some("_s3")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(23): Some("_c")
+  | rebuilt        : ReferenceId(23): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React"]
+
+
+* refresh/includes-custom-hooks-into-the-signatures-when-commonjs-target-is-used/input.jsx
+  x Output mismatch
+  x Missing ScopeId
+
+  x Scope children mismatch:
+  | after transform: ScopeId(0): [ScopeId(1)]
+  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(5)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(11)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$"]
+
+
+* refresh/registers-capitalized-identifiers-in-hoc-calls/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(6), ReferenceId(14),
+  | ReferenceId(15)]
+  | rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(15)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(8), ReferenceId(16),
+  | ReferenceId(17)]
+  | rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(17)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(9), ReferenceId(18),
+  | ReferenceId(19)]
+  | rebuilt        : SymbolId(6): [ReferenceId(8), ReferenceId(19)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(11), ReferenceId(20),
+  | ReferenceId(21)]
+  | rebuilt        : SymbolId(7): [ReferenceId(12), ReferenceId(21)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(14): Some("_c")
+  | rebuilt        : ReferenceId(14): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(16): Some("_c2")
+  | rebuilt        : ReferenceId(16): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(18): Some("_c3")
+  | rebuilt        : ReferenceId(18): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(20): Some("_c4")
+  | rebuilt        : ReferenceId(20): None
+
+  x Unresolved references mismatch:
+  | after transform: ["hoc"]
+  | rebuilt        : ["$RefreshReg$", "hoc"]
+
+
+* refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
+  x Output mismatch
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(44),
+  | ReferenceId(45)]
+  | rebuilt        : SymbolId(15): [ReferenceId(2), ReferenceId(45)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(46),
+  | ReferenceId(47)]
+  | rebuilt        : SymbolId(16): [ReferenceId(5), ReferenceId(47)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(48),
+  | ReferenceId(49)]
+  | rebuilt        : SymbolId(17): [ReferenceId(11), ReferenceId(49)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(50),
+  | ReferenceId(51)]
+  | rebuilt        : SymbolId(18): [ReferenceId(34), ReferenceId(51)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(52),
+  | ReferenceId(53)]
+  | rebuilt        : SymbolId(19): [ReferenceId(38), ReferenceId(53)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(54),
+  | ReferenceId(55)]
+  | rebuilt        : SymbolId(20): [ReferenceId(42), ReferenceId(55)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(44): Some("_c")
+  | rebuilt        : ReferenceId(44): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(46): Some("_c2")
+  | rebuilt        : ReferenceId(46): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(48): Some("_c3")
+  | rebuilt        : ReferenceId(48): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(50): Some("_c4")
+  | rebuilt        : ReferenceId(50): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(52): Some("_c5")
+  | rebuilt        : ReferenceId(52): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(54): Some("_c6")
+  | rebuilt        : ReferenceId(54): None
+
+  x Unresolved references mismatch:
+  | after transform: ["funny", "hoc", "styled", "wow"]
+  | rebuilt        : ["$RefreshReg$", "funny", "hoc", "styled", "wow"]
+
+
+* refresh/registers-identifiers-used-in-react-create-element-at-definition-site/input.jsx
+  x Output mismatch
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(13): [ReferenceId(33), ReferenceId(45),
+  | ReferenceId(46)]
+  | rebuilt        : SymbolId(13): [ReferenceId(2), ReferenceId(46)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(14): [ReferenceId(35), ReferenceId(47),
+  | ReferenceId(48)]
+  | rebuilt        : SymbolId(14): [ReferenceId(5), ReferenceId(48)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(15): [ReferenceId(37), ReferenceId(49),
+  | ReferenceId(50)]
+  | rebuilt        : SymbolId(15): [ReferenceId(11), ReferenceId(50)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(16): [ReferenceId(39), ReferenceId(51),
+  | ReferenceId(52)]
+  | rebuilt        : SymbolId(16): [ReferenceId(33), ReferenceId(52)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(41), ReferenceId(53),
+  | ReferenceId(54)]
+  | rebuilt        : SymbolId(17): [ReferenceId(39), ReferenceId(54)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(18): [ReferenceId(43), ReferenceId(55),
+  | ReferenceId(56)]
+  | rebuilt        : SymbolId(18): [ReferenceId(43), ReferenceId(56)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(45): Some("_c")
+  | rebuilt        : ReferenceId(45): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(47): Some("_c2")
+  | rebuilt        : ReferenceId(47): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(49): Some("_c3")
+  | rebuilt        : ReferenceId(49): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(51): Some("_c4")
+  | rebuilt        : ReferenceId(51): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(53): Some("_c5")
+  | rebuilt        : ReferenceId(53): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(55): Some("_c6")
+  | rebuilt        : ReferenceId(55): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "funny", "hoc", "jsx", "styled", "wow"]
+  | rebuilt        : ["$RefreshReg$", "React", "funny", "hoc", "jsx",
+  | "styled", "wow"]
+
+
+* refresh/registers-likely-hocs-with-inline-functions-1/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(5), ReferenceId(18),
+  | ReferenceId(19)]
+  | rebuilt        : SymbolId(5): [ReferenceId(1), ReferenceId(19)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(6), ReferenceId(20),
+  | ReferenceId(21)]
+  | rebuilt        : SymbolId(6): [ReferenceId(3), ReferenceId(21)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(8), ReferenceId(22),
+  | ReferenceId(23)]
+  | rebuilt        : SymbolId(7): [ReferenceId(8), ReferenceId(23)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(24),
+  | ReferenceId(25)]
+  | rebuilt        : SymbolId(8): [ReferenceId(6), ReferenceId(25)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(10), ReferenceId(26),
+  | ReferenceId(27)]
+  | rebuilt        : SymbolId(9): [ReferenceId(10), ReferenceId(27)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(12), ReferenceId(28),
+  | ReferenceId(29)]
+  | rebuilt        : SymbolId(10): [ReferenceId(16), ReferenceId(29)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(13), ReferenceId(30),
+  | ReferenceId(31)]
+  | rebuilt        : SymbolId(11): [ReferenceId(14), ReferenceId(31)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(11): [ReferenceId(14), ReferenceId(32),
+  | ReferenceId(33)]
+  | rebuilt        : SymbolId(12): [ReferenceId(12), ReferenceId(33)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(5): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(9): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(6): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(8): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(8): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(14): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(12): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(13): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(14): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(12): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(18): Some("_c")
+  | rebuilt        : ReferenceId(18): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(20): Some("_c2")
+  | rebuilt        : ReferenceId(20): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(22): Some("_c3")
+  | rebuilt        : ReferenceId(22): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(24): Some("_c4")
+  | rebuilt        : ReferenceId(24): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(26): Some("_c5")
+  | rebuilt        : ReferenceId(26): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(28): Some("_c6")
+  | rebuilt        : ReferenceId(28): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(30): Some("_c7")
+  | rebuilt        : ReferenceId(30): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(32): Some("_c8")
+  | rebuilt        : ReferenceId(32): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "forwardRef", "memo"]
+  | rebuilt        : ["$RefreshReg$", "React", "forwardRef", "memo"]
+
+
+* refresh/registers-likely-hocs-with-inline-functions-2/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(2), ReferenceId(6),
+  | ReferenceId(7)]
+  | rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(3), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(5): [ReferenceId(0), ReferenceId(11)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(3): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(2): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_c")
+  | rebuilt        : ReferenceId(6): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(8): Some("_c2")
+  | rebuilt        : ReferenceId(8): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c3")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "forwardRef"]
+  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
+
+
+* refresh/registers-likely-hocs-with-inline-functions-3/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(6),
+  | ReferenceId(7)]
+  | rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(9)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(4), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(6): [ReferenceId(0), ReferenceId(11)]
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(4): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(3): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
+
+  x Reference flags mismatch:
+  | after transform: ReferenceId(2): ReferenceFlags(Write)
+  | rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_c")
+  | rebuilt        : ReferenceId(6): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(8): Some("_c2")
+  | rebuilt        : ReferenceId(8): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c3")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "forwardRef"]
+  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
+
+
+* refresh/registers-top-level-exported-function-declarations/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(4), ReferenceId(13),
+  | ReferenceId(14)]
+  | rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(14)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(6), ReferenceId(15),
+  | ReferenceId(16)]
+  | rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(16)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(8), ReferenceId(17),
+  | ReferenceId(18)]
+  | rebuilt        : SymbolId(10): [ReferenceId(9), ReferenceId(18)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(13): Some("_c")
+  | rebuilt        : ReferenceId(13): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(15): Some("_c2")
+  | rebuilt        : ReferenceId(15): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(17): Some("_c3")
+  | rebuilt        : ReferenceId(17): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$"]
+
+
+* refresh/registers-top-level-exported-named-arrow-functions/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(3), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(11)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(5), ReferenceId(12),
+  | ReferenceId(13)]
+  | rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(13)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c")
+  | rebuilt        : ReferenceId(10): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(12): Some("_c2")
+  | rebuilt        : ReferenceId(12): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$"]
+
+
+* refresh/registers-top-level-function-declarations/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(5): [ReferenceId(6), ReferenceId(11)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(8): Some("_c")
+  | rebuilt        : ReferenceId(8): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c2")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$"]
+
+
+* refresh/registers-top-level-variable-declarations-with-arrow-functions/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(2), ReferenceId(11),
+  | ReferenceId(12)]
+  | rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(12)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(4), ReferenceId(13),
+  | ReferenceId(14)]
+  | rebuilt        : SymbolId(7): [ReferenceId(6), ReferenceId(14)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(6), ReferenceId(15),
+  | ReferenceId(16)]
+  | rebuilt        : SymbolId(8): [ReferenceId(9), ReferenceId(16)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(11): Some("_c")
+  | rebuilt        : ReferenceId(11): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(13): Some("_c2")
+  | rebuilt        : ReferenceId(13): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(15): Some("_c3")
+  | rebuilt        : ReferenceId(15): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$"]
+
+
+* refresh/registers-top-level-variable-declarations-with-function-expressions/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(2), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(9)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(4), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(11)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(8): Some("_c")
+  | rebuilt        : ReferenceId(8): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c2")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: []
+  | rebuilt        : ["$RefreshReg$"]
+
 
 * refresh/supports-typescript-namespace-syntax/input.tsx
-x Output mismatch
+  x Output mismatch
+  x Missing SymbolId: Foo
 
-* unicode/input.jsx
-x Output mismatch
+  x Missing SymbolId: _Foo
+
+  x Missing SymbolId: Bar
+
+  x Missing SymbolId: _Bar
+
+  x Missing ReferenceId: _Bar
+
+  x Missing ReferenceId: _Bar
+
+  x Missing ReferenceId: Bar
+
+  x Missing ReferenceId: Bar
+
+  x Missing ReferenceId: _Foo
+
+  x Missing ReferenceId: _Foo
+
+  x Missing ReferenceId: _Foo
+
+  x Missing ReferenceId: _Foo
+
+  x Missing ReferenceId: D
+
+  x Missing SymbolId: NotExported
+
+  x Missing SymbolId: _NotExported
+
+  x Missing ReferenceId: _NotExported
+
+  x Missing ReferenceId: NotExported
+
+  x Missing ReferenceId: NotExported
+
+  x Missing ReferenceId: Foo
+
+  x Missing ReferenceId: Foo
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(5), SymbolId(6),
+  | SymbolId(7), SymbolId(9)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(7),
+  | SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4),
+  | SymbolId(10)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5),
+  | SymbolId(6)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(8), SymbolId(11)]
+  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
+  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+  | rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(8): [ReferenceId(9)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+
+* refresh/uses-custom-identifiers-for-refresh-reg-and-refresh-sig/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(6), ReferenceId(7),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(10),
+  | ReferenceId(11)]
+  | rebuilt        : SymbolId(3): [ReferenceId(8), ReferenceId(11)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_c")
+  | rebuilt        : ReferenceId(10): None
+
+  x Unresolved references mismatch:
+  | after transform: ["Foo", "X", "useContext"]
+  | rebuilt        : ["Foo", "X", "import.meta.refreshReg",
+  | "import.meta.refreshSig", "useContext"]
+
+
+* refresh/uses-original-function-declaration-if-it-get-reassigned/input.jsx
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6),
+  | ReferenceId(7)]
+  | rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(7)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(6): Some("_c")
+  | rebuilt        : ReferenceId(6): None
+
+  x Unresolved references mismatch:
+  | after transform: ["connect"]
+  | rebuilt        : ["$RefreshReg$", "connect"]
+
 
 

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -59,6 +59,9 @@ pub(crate) const PLUGINS: &[&str] = &[
 
     // RegExp tests ported from esbuild + a few additions
     "regexp",
+    
+    // CommonJS formats should be supported, but needs manually opening the option
+    "transform-modules-commonjs",
 ];
 
 pub(crate) const PLUGINS_NOT_SUPPORTED_YET: &[&str] = &[
@@ -66,7 +69,6 @@ pub(crate) const PLUGINS_NOT_SUPPORTED_YET: &[&str] = &[
     "transform-class-properties",
     "transform-classes",
     "transform-destructuring",
-    "transform-modules-commonjs",
     "transform-optional-chaining",
     "transform-parameters",
     "transform-private-methods",

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -59,7 +59,6 @@ pub(crate) const PLUGINS: &[&str] = &[
 
     // RegExp tests ported from esbuild + a few additions
     "regexp",
-    
     // CommonJS formats should be supported, but needs manually opening the option
     "transform-modules-commonjs",
 ];


### PR DESCRIPTION
Related issue
* #4050

@DonIsaac, I believe this PR cannot close the issue as it lacks support for `interop` and `esModule`. I have an idea to support these features, but it may contain excessive code for review.

This PR only transforms imports and exports, and it is not yet ready for production. Additionally, the tests have not been passed.