### PR TITLE
refactor(linter/jest): fix indentation in code comment

### DIFF
--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -152,7 +152,7 @@ pub fn collect_possible_jest_call_node<'a, 'b>(
     // ```
     // import { jest as Jest } from '@jest/globals';
     // Jest.setTimeout(800);
-    //     test('test', () => {
+    // test('test', () => {
     //     expect(1 + 2).toEqual(3);
     // });
     // ```


### PR DESCRIPTION
previously, `test('...` was indented, making it look like it was inside a block statement/callback.

this PR corrects this by fixing the indentation