### PR TITLE
refactor(linter/oxc): improve code comment for `no-accumulating-spread`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -185,7 +185,8 @@ fn check_loop_usage<'a>(
     let AstKind::VariableDeclaration(declaration) = declaration_node.kind() else {
         return;
     };
-
+    // if the accumulator's declaration is not a `let`, then we know it's never
+    // reassigned, hence cannot be a violation of the rule
     if !matches!(declaration.kind, VariableDeclarationKind::Let) {
         return;
     }


### PR DESCRIPTION
mentioned here: https://github.com/oxc-project/oxc/pull/5302#discussion_r1735759462
it's not exactly clear why we check that it's a `let` declaration kind.

