### PR TITLE
refactor(linter/oxc): improve diagnostic for `no-accumulating-spread` in loops

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_accumulating_spread.snap
+++ b/crates/oxc_linter/src/snapshots/no_accumulating_spread.snap
@@ -315,141 +315,155 @@ source: crates/oxc_linter/src/tester.rs
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (let i = 0; i < 10; i++) { foo = [...foo, i]; }
-   ·               ─┬─                                   ───┬──
-   ·                │                                       ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                   ───┬──
+   ·      │         │                                       ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (const i = 0; i < 10; i++) { foo = [...foo, i]; }
-   ·               ─┬─                                     ───┬──
-   ·                │                                         ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                     ───┬──
+   ·      │         │                                         ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (let i in [1,2,3]) { foo = [...foo, i]; }
-   ·               ─┬─                             ───┬──
-   ·                │                                 ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                             ───┬──
+   ·      │         │                                 ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (const i in [1,2,3]) { foo = [...foo, i]; }
-   ·               ─┬─                               ───┬──
-   ·                │                                   ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                               ───┬──
+   ·      │         │                                   ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (let i of [1,2,3]) { foo = [...foo, i]; }
-   ·               ─┬─                             ───┬──
-   ·                │                                 ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                             ───┬──
+   ·      │         │                                 ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; for (const i of [1,2,3]) { foo = [...foo, i]; }
-   ·               ─┬─                               ───┬──
-   ·                │                                   ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                               ───┬──
+   ·      │         │                                   ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = []; while (foo.length < 10) { foo = [...foo, foo.length]; }
-   ·               ──┬──                            ───┬──
-   ·                 │                                 ╰── From this spread
-   ·                 ╰── For this loop
+   ·     ─┬─       ──┬──                            ───┬──
+   ·      │          │                                 ╰── From this spread
+   ·      │          ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (let i = 0; i < 10; i++) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                                    ───┬──
-   ·                │                                        ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                    ───┬──
+   ·      │         │                                        ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (const i = 0; i < 10; i++) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                                      ───┬──
-   ·                │                                          ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                      ───┬──
+   ·      │         │                                          ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (let i in [1,2,3]) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                              ───┬──
-   ·                │                                  ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                              ───┬──
+   ·      │         │                                  ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (const i in [1,2,3]) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                                ───┬──
-   ·                │                                    ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                ───┬──
+   ·      │         │                                    ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (let i of [1,2,3]) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                              ───┬──
-   ·                │                                  ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                              ───┬──
+   ·      │         │                                  ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; for (const i of [1,2,3]) { foo = { ...foo, [i]: i }; }
-   ·               ─┬─                                ───┬──
-   ·                │                                    ╰── From this spread
-   ·                ╰── For this loop
+   ·     ─┬─       ─┬─                                ───┬──
+   ·      │         │                                    ╰── From this spread
+   ·      │         ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:15]
+   ╭─[no_accumulating_spread.tsx:1:5]
  1 │ let foo = {}; while (Object.keys(foo).length < 10) { foo = { ...foo, [Object.keys(foo).length]: Object.keys(foo).length }; }
-   ·               ──┬──                                          ───┬──
-   ·                 │                                               ╰── From this spread
-   ·                 ╰── For this loop
+   ·     ─┬─       ──┬──                                          ───┬──
+   ·      │          │                                               ╰── From this spread
+   ·      │          ╰── For this loop
+   ·      ╰── From this accumulator
    ╰────
   help: Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.
         Using spreads within accumulators leads to `O(n^2)` time complexity.


### PR DESCRIPTION
when reporting diagnotics for code such as 

```ts
let foo = {};
for (let i = 0; i < 10; i++) {
    foo = { ...foo, [i]: i };
}
```

we do not currently report **where** the accumulator is defined.
since this is constant for `Array.prototype.reduce`, it is not necessary.
however for loops, it makes sense to add this span to clearly show the user where the accumator is defined.