### PR TITLE
refactor(linter/oxc): update rule docs for `erasing-op`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -31,12 +31,16 @@ declare_oxc_lint!(
     /// The whole expression can be replaced by zero. This is most likely not the intended outcome and should probably be corrected.
     ///
     /// ### Example
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// // Bad
     /// let x = 1;
     /// let y = x * 0;
+    /// ```
     ///
-    /// // Good
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
     /// let x = 1;
     /// let y = 0;
     /// ```


### PR DESCRIPTION
updates the rule docs to align with the template:

https://github.com/oxc-project/oxc/blob/a266b4516784eb03e4610b5dc55d0248dc9f554c/tasks/rulegen/template.txt#L13