### PR TITLE
chore: typo fix

### DIFF
--- a/crates/oxc_index/src/macros.rs
+++ b/crates/oxc_index/src/macros.rs
@@ -78,7 +78,7 @@
 ///
 /// #### `DEFAULT = <expr>;`
 /// If provided, we'll implement `Default` for the index type using this
-/// expresson.
+/// expression.
 ///
 /// Example:
 ///

--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -135,9 +135,9 @@ const fn binary_byte_to_value(b: u8) -> u8 {
 /// It's safe because we're sure this number is an integer - if it wasn't, it
 /// would be a [`Kind::Float`] instead. It's fast because shifting usually takes
 /// 1 clock cycle on the ALU, while multiplication+addition uses the FPU and is
-/// much slower. Addtiionally, this loop often gets unrolled by rustc since
+/// much slower. Additionally, this loop often gets unrolled by rustc since
 /// these numbers are usually not long. On x84_64, FMUL has a latency of 4 clock
-/// cycles, which doesn't include addition. Some platorms support mul + add in a
+/// cycles, which doesn't include addition. Some platforms support mul + add in a
 /// single instruction, but many others do not.
 ///
 /// Unfortunately, this approach has the chance to overflow for excessively


### PR DESCRIPTION
fixed #5379
Fix typos so `just ready` works