### PR TITLE
chore(prettier): Update conformance tests to Prettier v3.3.3

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -27,4 +27,4 @@ runs:
       with:
         repository: prettier/prettier
         path: tasks/prettier_conformance/prettier
-        ref: 7142cf354cce2558f41574f44b967baf11d5b603 # v3.2.5
+        ref: 52829385bcc4d785e58ae2602c0b098a643523c9 # v3.3.3

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ submodules:
   just clone-submodule tasks/coverage/test262 git@github.com:tc39/test262.git d62fa93c8f9ce5e687c0bbaa5d2b59670ab2ff60
   just clone-submodule tasks/coverage/babel git@github.com:babel/babel.git 3bcfee232506a4cebe410f02042fb0f0adeeb0b1
   just clone-submodule tasks/coverage/typescript git@github.com:microsoft/TypeScript.git a709f9899c2a544b6de65a0f2623ecbbe1394eab
-  just clone-submodule tasks/prettier_conformance/prettier git@github.com:prettier/prettier.git 7142cf354cce2558f41574f44b967baf11d5b603
+  just clone-submodule tasks/prettier_conformance/prettier git@github.com:prettier/prettier.git 52829385bcc4d785e58ae2602c0b098a643523c9
 
 # Install git pre-commit to format files
 install-hook:

--- a/tasks/prettier_conformance/prettier.js.snap.md
+++ b/tasks/prettier_conformance/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 264/586 (45.05%)
+js compatibility: 265/593 (44.69%)
 
 # Failed
 
@@ -202,6 +202,10 @@ js compatibility: 264/586 (45.05%)
 * directives/newline.js
 * directives/test.js
 
+### dynamic-import
+* dynamic-import/import-phase.js
+* dynamic-import/template-literal.js
+
 ### empty-paren-comment
 * empty-paren-comment/class-property.js
 * empty-paren-comment/class.js
@@ -223,6 +227,7 @@ js compatibility: 264/586 (45.05%)
 * for/continue-and-break-comment-1.js
 * for/continue-and-break-comment-2.js
 * for/continue-and-break-comment-without-blocks.js
+* for/for-in-with-initializer.js
 
 ### function
 * function/issue-10277.js
@@ -265,6 +270,10 @@ js compatibility: 264/586 (45.05%)
 ### import-attributes
 * import-attributes/empty.js
 * import-attributes/keyword-detect.js
+* import-attributes/long-sources.js
+
+### import-attributes/quote-props
+* import-attributes/quote-props/quoted-keys.js
 
 ### label
 * label/comment.js
@@ -337,6 +346,9 @@ js compatibility: 264/586 (45.05%)
 
 ### no-semi-babylon-extensions
 * no-semi-babylon-extensions/no-semi.js
+
+### nullish-coalescing
+* nullish-coalescing/nullish_coalesing_operator.js
 
 ### object-prop-break-in
 * object-prop-break-in/short-keys.js

--- a/tasks/prettier_conformance/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 50/528 (9.47%)
+ts compatibility: 50/526 (9.51%)
 
 # Failed
 
@@ -86,7 +86,6 @@ ts compatibility: 50/528 (9.47%)
 * class/declare-readonly-field-initializer-w-annotation.ts
 * class/declare-readonly-field-initializer.ts
 * class/dunder.ts
-* class/duplicates-access-modifier.ts
 * class/empty-method-body.ts
 * class/extends_implements.ts
 * class/generics.ts
@@ -396,7 +395,6 @@ ts compatibility: 50/528 (9.47%)
 * declare/declare_class_fields.ts
 * declare/declare_enum.ts
 * declare/declare_function.ts
-* declare/declare_function_with_body.ts
 * declare/declare_interface.ts
 * declare/declare_module.ts
 * declare/declare_namespace.ts

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -63,8 +63,8 @@ fn fixtures_root() -> PathBuf {
     project_root().join(root()).join("prettier/tests/format")
 }
 
-const SNAP_NAME: &str = "jsfmt.spec.js";
-const SNAP_RELATIVE_PATH: &str = "__snapshots__/jsfmt.spec.js.snap";
+const SNAP_NAME: &str = "format.test.js";
+const SNAP_RELATIVE_PATH: &str = "__snapshots__/format.test.js.snap";
 const LF: char = '\u{a}';
 const CR: char = '\u{d}';
 


### PR DESCRIPTION
- v3.3.3 is latest released version
- Test file name was changed from v3.3.x
  - https://github.com/prettier/prettier/pull/16244