### PR TITLE
feat(napi/transform)!: align output API `sourceText` -> `code` with babel

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -18,16 +18,16 @@ export interface Es2015BindingOptions {
 }
 
 /** TypeScript Isolated Declarations for Standalone DTS Emit */
-export declare function isolatedDeclaration(filename: string, sourceText: string, options: IsolatedDeclarationsOptions): IsolatedDeclarationsResult
+function isolatedDeclaration(filename: string, sourceText: string, options: IsolatedDeclarationsOptions): IsolatedDeclarationsResult
 
 export interface IsolatedDeclarationsOptions {
   sourcemap: boolean
 }
 
 export interface IsolatedDeclarationsResult {
+  code: string
+  map?: SourceMap
   errors: Array<string>
-  sourceText: string
-  sourceMap?: SourceMap
 }
 
 /**
@@ -136,7 +136,7 @@ export interface SourceMap {
  * @returns an object containing the transformed code, source maps, and any
  * errors that occurred during parsing or transformation.
  */
-export declare function transform(filename: string, sourceText: string, options?: TransformOptions | undefined | null): TransformResult
+function transform(filename: string, sourceText: string, options?: TransformOptions | undefined | null): TransformResult
 
 /**
  * Options for transforming a JavaScript or TypeScript file.
@@ -180,13 +180,13 @@ export interface TransformResult {
    *
    * If parsing failed, this will be an empty string.
    */
-  sourceText: string
+  code: string
   /**
    * The source map for the transformed code.
    *
    * This will be set if {@link TransformOptions#sourcemap} is `true`.
    */
-  sourceMap?: SourceMap
+  map?: SourceMap
   /**
    * The `.d.ts` declaration file for the transformed code. Declarations are
    * only generated if `declaration` is set to `true` and a TypeScript file

--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -9,9 +9,9 @@ use crate::{context::TransformContext, SourceMap, TransformOptions};
 
 #[napi(object)]
 pub struct IsolatedDeclarationsResult {
+    pub code: String,
+    pub map: Option<SourceMap>,
     pub errors: Vec<String>,
-    pub source_text: String,
-    pub source_map: Option<SourceMap>,
 }
 
 #[napi(object)]
@@ -39,9 +39,9 @@ pub fn isolated_declaration(
     let transformed_ret = build_declarations(&ctx);
 
     IsolatedDeclarationsResult {
+        code: transformed_ret.source_text,
+        map: options.sourcemap.then(|| transformed_ret.source_map.map(Into::into)).flatten(),
         errors: ctx.take_and_render_reports(),
-        source_text: transformed_ret.source_text,
-        source_map: options.sourcemap.then(|| transformed_ret.source_map.map(Into::into)).flatten(),
     }
 }
 

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -7,19 +7,20 @@ use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::Transformer;
 
-// NOTE: use JSDoc syntax for all doc comments, not rustdoc.
+// NOTE: Use JSDoc syntax for all doc comments, not rustdoc.
+// NOTE: Types must be aligned with [@types/babel__core](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/babel__core/index.d.ts).
 
 #[napi(object)]
 pub struct TransformResult {
     /// The transformed code.
     ///
     /// If parsing failed, this will be an empty string.
-    pub source_text: String,
+    pub code: String,
 
     /// The source map for the transformed code.
     ///
     /// This will be set if {@link TransformOptions#sourcemap} is `true`.
-    pub source_map: Option<SourceMap>,
+    pub map: Option<SourceMap>,
 
     /// The `.d.ts` declaration file for the transformed code. Declarations are
     /// only generated if `declaration` is set to `true` and a TypeScript file
@@ -54,7 +55,7 @@ pub struct TransformResult {
 ///
 /// @returns an object containing the transformed code, source maps, and any
 /// errors that occurred during parsing or transformation.
-#[allow(clippy::needless_pass_by_value, dead_code)]
+#[allow(clippy::needless_pass_by_value)]
 #[napi]
 pub fn transform(
     filename: String,
@@ -89,8 +90,8 @@ pub fn transform(
         .map_or((None, None), |d| (Some(d.source_text), d.source_map.map(Into::into)));
 
     TransformResult {
-        source_text: transpile_result.source_text,
-        source_map: transpile_result.source_map.map(Into::into),
+        code: transpile_result.source_text,
+        map: transpile_result.source_map.map(Into::into),
         declaration,
         declaration_map,
         errors: ctx.take_and_render_reports(),


### PR DESCRIPTION
And `sourceMap` -> `map`

closes #5397