### PR TITLE
perf(linter/react): add should_run conditions for react rules

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -147,6 +147,10 @@ impl Rule for JsxBooleanValue {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 impl JsxBooleanValue {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -120,6 +120,10 @@ impl Rule for JsxPropsNoSpreadMulti {
             );
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]


### PR DESCRIPTION
Only run the React rules on files containing JSX elements.