### PR TITLE
refactor(linter): `react/jsx_no_undef` rule `get_member_ident` do not return Option

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -37,14 +37,14 @@ fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a Identifi
     match node {
         JSXElementName::Identifier(_) | JSXElementName::NamespacedName(_) => None,
         JSXElementName::IdentifierReference(ref ident) => Some(ident),
-        JSXElementName::MemberExpression(expr) => get_member_ident(expr),
+        JSXElementName::MemberExpression(expr) => Some(get_member_ident(expr)),
     }
 }
 
-fn get_member_ident<'a>(mut expr: &'a JSXMemberExpression<'a>) -> Option<&'a IdentifierReference> {
+fn get_member_ident<'a>(mut expr: &'a JSXMemberExpression<'a>) -> &'a IdentifierReference {
     loop {
         match &expr.object {
-            JSXMemberExpressionObject::IdentifierReference(ident) => return Some(ident),
+            JSXMemberExpressionObject::IdentifierReference(ident) => return ident,
             JSXMemberExpressionObject::MemberExpression(next_expr) => {
                 expr = next_expr;
             }


### PR DESCRIPTION
Small tidy-up after #5358. `get_member_ident` now always returns a value, never `None`, so no need for it to return an `Option`.