### PR TITLE
test(transformer): add tests for nested JSX `this` member expressions in arrow function transform

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/input.jsx
@@ -1,3 +1,3 @@
-() => {
-  <this.foo></this.foo>
-}
+() => <this.foo></this.foo>;
+() => <this.foo.bar></this.foo.bar>;
+() => <this.foo.bar.qux />;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/output.js
@@ -1,4 +1,10 @@
 var _this = this;
 (function() {
-       <_this.foo></_this.foo>;
+       return <_this.foo></_this.foo>;
+});
+(function() {
+       return <_this.foo.bar></_this.foo.bar>;
+});
+(function() {
+       return <_this.foo.bar.qux />;
 });


### PR DESCRIPTION
Follow-up after #5356. Handle nested JSX member expressions with `this` as base object in arrow functions transform (e.g. `<this.foo.bar />`).