### PR TITLE
fix(transformer): do not create double reference in JSX transform

### DIFF
--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -621,7 +621,7 @@ impl<'a> ReactJsx<'a> {
         // TODO(improve-on-babel): Change this if we can handle differing output in tests.
         let argument_expr = match e {
             JSXElementOrFragment::Element(e) => {
-                self.transform_element_name(&e.opening_element.name, ctx)
+                self.transform_element_name(&e.opening_element.name)
             }
             JSXElementOrFragment::Fragment(_) => self.get_fragment(ctx),
         };
@@ -697,11 +697,7 @@ impl<'a> ReactJsx<'a> {
         )
     }
 
-    fn transform_element_name(
-        &self,
-        name: &JSXElementName<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> Expression<'a> {
+    fn transform_element_name(&self, name: &JSXElementName<'a>) -> Expression<'a> {
         match name {
             JSXElementName::Identifier(ident) => {
                 if ident.name == "this" {
@@ -714,7 +710,7 @@ impl<'a> ReactJsx<'a> {
                 self.ast().expression_from_identifier_reference(ident.as_ref().clone())
             }
             JSXElementName::MemberExpression(member_expr) => {
-                self.transform_jsx_member_expression(member_expr, ctx)
+                self.transform_jsx_member_expression(member_expr)
             }
             JSXElementName::NamespacedName(namespaced) => {
                 if self.options.throw_if_namespace {
@@ -776,22 +772,17 @@ impl<'a> ReactJsx<'a> {
         }
     }
 
-    fn transform_jsx_member_expression(
-        &self,
-        expr: &JSXMemberExpression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> Expression<'a> {
+    fn transform_jsx_member_expression(&self, expr: &JSXMemberExpression<'a>) -> Expression<'a> {
         let object = match &expr.object {
             JSXMemberExpressionObject::IdentifierReference(ident) => {
                 if ident.name == "this" {
                     self.ast().expression_this(ident.span)
                 } else {
-                    let ident = get_read_identifier_reference(ident.span, ident.name.clone(), ctx);
-                    self.ast().expression_from_identifier_reference(ident)
+                    self.ast().expression_from_identifier_reference(ident.as_ref().clone())
                 }
             }
             JSXMemberExpressionObject::MemberExpression(expr) => {
-                self.transform_jsx_member_expression(expr, ctx)
+                self.transform_jsx_member_expression(expr)
             }
         };
         let property = IdentifierName::new(expr.property.span, expr.property.name.clone());

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -40538,10 +40538,10 @@ Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Component")
 rebuilt        : ReferenceId(48): None
 Reference symbol mismatch:
-after transform: ReferenceId(76): Some("Namespace")
+after transform: ReferenceId(10): Some("Namespace")
 rebuilt        : ReferenceId(51): None
 Reference symbol mismatch:
-after transform: ReferenceId(79): Some("Namespace")
+after transform: ReferenceId(11): Some("Namespace")
 rebuilt        : ReferenceId(54): None
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Component")
@@ -40717,9 +40717,6 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName8.tsx
 semantic error: Unresolved references mismatch:
@@ -40757,7 +40754,7 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
 rebuilt        : SymbolId(6): [ReferenceId(2)]
 Reference symbol mismatch:
-after transform: ReferenceId(8): Some("Dotted")
+after transform: ReferenceId(1): Some("Dotted")
 rebuilt        : ReferenceId(13): Some("Dotted")
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
@@ -41200,9 +41197,6 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
-Reference symbol mismatch:
-after transform: ReferenceId(2): Some("A")
-rebuilt        : ReferenceId(2): None
 Unresolved reference IDs mismatch for "A":
 after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(2)]

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 310/1021
+Passed: 314/1021
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -4976,7 +4976,7 @@ TS(18010)
 
 
 
-# babel-plugin-transform-react-jsx (115/144)
+# babel-plugin-transform-react-jsx (119/144)
 * react/arrow-functions/input.js
   x Unresolved references mismatch:
   | after transform: ["React", "this"]
@@ -5003,18 +5003,6 @@ TS(18010)
 
 * react/honor-custom-jsx-pragma-option/input.js
   x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-allow-deeper-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-allow-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
   | after transform: [ReferenceId(0), ReferenceId(1)]
   | rebuilt        : [ReferenceId(1)]
 
@@ -5091,21 +5079,8 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 * react-automatic/handle-fragments-with-key/input.js
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
-  | ReferenceId(2)]
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
   | rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-
-* react-automatic/should-allow-deeper-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/should-allow-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
 
 
 * react-automatic/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
@@ -5189,7 +5164,7 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 * cross-platform/handle-fragments-with-key/input.js
   x Unresolved reference IDs mismatch for "React":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+  | after transform: [ReferenceId(0), ReferenceId(1)]
   | rebuilt        : [ReferenceId(2)]
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -670,61 +670,57 @@ Passed: 11/41
 * refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
   x Output mismatch
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(9): [ReferenceId(17), ReferenceId(42)]
-  | rebuilt        : SymbolId(11): [ReferenceId(33)]
-
-  x Symbol reference IDs mismatch:
-  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(45),
-  | ReferenceId(46)]
+  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(44),
+  | ReferenceId(45)]
   | rebuilt        : SymbolId(15): [ReferenceId(2), ReferenceId(45)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(47),
-  | ReferenceId(48)]
+  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(46),
+  | ReferenceId(47)]
   | rebuilt        : SymbolId(16): [ReferenceId(5), ReferenceId(47)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(49),
-  | ReferenceId(50)]
+  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(48),
+  | ReferenceId(49)]
   | rebuilt        : SymbolId(17): [ReferenceId(11), ReferenceId(49)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(51),
-  | ReferenceId(52)]
+  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(50),
+  | ReferenceId(51)]
   | rebuilt        : SymbolId(18): [ReferenceId(34), ReferenceId(51)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(53),
-  | ReferenceId(54)]
+  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(52),
+  | ReferenceId(53)]
   | rebuilt        : SymbolId(19): [ReferenceId(38), ReferenceId(53)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(55),
-  | ReferenceId(56)]
+  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(54),
+  | ReferenceId(55)]
   | rebuilt        : SymbolId(20): [ReferenceId(42), ReferenceId(55)]
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(45): Some("_c")
+  | after transform: ReferenceId(44): Some("_c")
   | rebuilt        : ReferenceId(44): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(47): Some("_c2")
+  | after transform: ReferenceId(46): Some("_c2")
   | rebuilt        : ReferenceId(46): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(49): Some("_c3")
+  | after transform: ReferenceId(48): Some("_c3")
   | rebuilt        : ReferenceId(48): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(51): Some("_c4")
+  | after transform: ReferenceId(50): Some("_c4")
   | rebuilt        : ReferenceId(50): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(53): Some("_c5")
+  | after transform: ReferenceId(52): Some("_c5")
   | rebuilt        : ReferenceId(52): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(55): Some("_c6")
+  | after transform: ReferenceId(54): Some("_c6")
   | rebuilt        : ReferenceId(54): None
 
   x Unresolved references mismatch:


### PR DESCRIPTION
Follow on after #5358. Don't create a new `IdentifierReference` with a new `ReferenceId` when we already have one which is correctly resolved.