### PR TITLE
refactor(linter): use "parsed pattern" in `no_div_regex` rule.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "oxc_index",
  "oxc_macros",
  "oxc_parser",
+ "oxc_regular_expression",
  "oxc_resolver",
  "oxc_semantic",
  "oxc_span",

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use oxc_allocator::CloneIn;
+use oxc_regular_expression::ast::Pattern;
 use oxc_span::{cmp::ContentEq, Atom, Span};
 use oxc_syntax::number::NumberBase;
 
@@ -135,6 +136,28 @@ impl<'a> RegExpPattern<'a> {
         match self {
             Self::Raw(raw) | Self::Invalid(raw) => raw,
             Self::Pattern(pat) => pat.span.source_text(source_text),
+        }
+    }
+
+    /// # Panics
+    /// If `self` is anything but `RegExpPattern::Pattern`.
+    pub fn require_pattern(&self) -> &Pattern<'a> {
+        if let Some(it) = self.as_pattern() {
+            it
+        } else {
+            unreachable!(
+                "Required `{}` to be `{}`",
+                stringify!(RegExpPattern),
+                stringify!(Pattern)
+            );
+        }
+    }
+
+    pub fn as_pattern(&self) -> Option<&Pattern<'a>> {
+        if let Self::Pattern(it) = self {
+            Some(it.as_ref())
+        } else {
+            None
         }
     }
 }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -20,18 +20,19 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_allocator   = { workspace = true }
-oxc_parser      = { workspace = true }
-oxc_span        = { workspace = true, features = ["schemars", "serialize"] }
-oxc_ast         = { workspace = true }
-oxc_cfg         = { workspace = true }
-oxc_diagnostics = { workspace = true }
-oxc_index       = { workspace = true }
-oxc_macros      = { workspace = true }
-oxc_semantic    = { workspace = true }
-oxc_syntax      = { workspace = true }
-oxc_codegen     = { workspace = true }
-oxc_resolver    = { workspace = true }
+oxc_allocator          = { workspace = true }
+oxc_parser             = { workspace = true }
+oxc_span               = { workspace = true, features = ["schemars", "serialize"] }
+oxc_ast                = { workspace = true }
+oxc_cfg                = { workspace = true }
+oxc_diagnostics        = { workspace = true }
+oxc_index              = { workspace = true }
+oxc_macros             = { workspace = true }
+oxc_semantic           = { workspace = true }
+oxc_syntax             = { workspace = true }
+oxc_codegen            = { workspace = true }
+oxc_resolver           = { workspace = true }
+oxc_regular_expression = { workspace = true }
 
 rayon               = { workspace = true }
 bitflags            = { workspace = true }


### PR DESCRIPTION
Part of #5416, Paves the road for upcoming refactors by adding the `oxc_regular_expression` dependency and a helper method for ease of access.