### PR TITLE
perf(syntax): further optimize `is_identifier_name`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
 name = "oxc_syntax"
 version = "0.26.0"
 dependencies = [
+ "assert-unchecked",
  "bitflags 2.6.0",
  "dashmap 6.0.1",
  "nonmax",

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -25,6 +25,7 @@ oxc_span       = { workspace = true }
 oxc_ast_macros = { workspace = true }
 oxc_allocator  = { workspace = true }
 
+assert-unchecked = { workspace = true }
 unicode-id-start = { workspace = true }
 bitflags         = { workspace = true }
 rustc-hash       = { workspace = true }


### PR DESCRIPTION
Follow-on after #5425. Further optimize `oxc_syntax::identifier::is_identifier_name` by processing string in blocks of 8 bytes, and checking if all bytes in a block are ASCII in one go, rather than testing each byte individually.