### PR TITLE
chore: bundle wasm with different flag

### DIFF
--- a/justfile
+++ b/justfile
@@ -123,10 +123,18 @@ oxlint:
   cargo oxlint
 
 watch-wasm:
-  cargo watch --no-vcs-ignores -i 'npm/oxc-wasm/**' -- just build-wasm
+  cargo watch --no-vcs-ignores -i 'npm/oxc-wasm/**' -- just build-wasm dev
 
+<<<<<<< Updated upstream
 build-wasm:
   wasm-pack build --out-dir ../../npm/oxc-wasm --target web --scope oxc crates/oxc_wasm
+||||||| Stash base
+build-wasm:
+  wasm-pack build --out-dir ../../npm/oxc-wasm --target web --dev --scope oxc crates/oxc_wasm
+=======
+build-wasm mode="release":
+  wasm-pack build --out-dir ../../npm/oxc-wasm --target web --{{mode}} --scope oxc crates/oxc_wasm
+>>>>>>> Stashed changes
 
 # Generate the JavaScript global variables. See `tasks/javascript_globals`
 javascript-globals:

--- a/justfile
+++ b/justfile
@@ -125,16 +125,8 @@ oxlint:
 watch-wasm:
   cargo watch --no-vcs-ignores -i 'npm/oxc-wasm/**' -- just build-wasm dev
 
-<<<<<<< Updated upstream
-build-wasm:
-  wasm-pack build --out-dir ../../npm/oxc-wasm --target web --scope oxc crates/oxc_wasm
-||||||| Stash base
-build-wasm:
-  wasm-pack build --out-dir ../../npm/oxc-wasm --target web --dev --scope oxc crates/oxc_wasm
-=======
 build-wasm mode="release":
   wasm-pack build --out-dir ../../npm/oxc-wasm --target web --{{mode}} --scope oxc crates/oxc_wasm
->>>>>>> Stashed changes
 
 # Generate the JavaScript global variables. See `tasks/javascript_globals`
 javascript-globals:


### PR DESCRIPTION
1. wasm-pack with release flag will increase wasm bundling time, which hurts dx when developing playground.
2. only enable `release` flag when `build-wasm`.