### PR TITLE
feat(parser): add syntax error for hyphen in `JSXMemberExpression` `<Foo.bar-baz />`

### DIFF
--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -198,7 +198,12 @@ impl<'a> ParserImpl<'a> {
             }
 
             // <foo.bar>
-            property = Some(self.parse_jsx_identifier()?);
+            let ident = self.parse_jsx_identifier()?;
+            // `<foo.bar- />` is a syntax error.
+            if ident.name.contains('-') {
+                return Err(diagnostics::unexpected_token(ident.span));
+            }
+            property = Some(ident);
             span = self.end_span(span);
         }
 

--- a/tasks/coverage/misc/fail/oxc-5355.jsx
+++ b/tasks/coverage/misc/fail/oxc-5355.jsx
@@ -1,0 +1,1 @@
+<Foo.bar-baz />

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 27/27 (100.00%)
 Positive Passed: 27/27 (100.00%)
-Negative Passed: 16/16 (100.00%)
+Negative Passed: 17/17 (100.00%)
 
   × Unexpected token
    ╭─[misc/fail/oxc-169.js:2:1]
@@ -236,6 +236,12 @@ Negative Passed: 16/16 (100.00%)
  4 │     accessor x?: Foo
    ·               ─
  5 │ }
+   ╰────
+
+  × Unexpected token
+   ╭─[misc/fail/oxc-5355.jsx:1:6]
+ 1 │ <Foo.bar-baz />
+   ·      ───────
    ╰────
 
   × The keyword 'let' is reserved


### PR DESCRIPTION
closes #5355