### PR TITLE
fix(semantic): `IdentifierReference` within `TSPropertySignature` cannot reference type-only import binding

### DIFF
--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/oxc_semantic/tests/main.rs
-input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.ts
+input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
 ---
 [
   {
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [],
         "flags": "ScopeFlags(StrictMode)",
         "id": 2,
-        "node": "TSTypeAliasDeclaration",
+        "node": "TSInterfaceDeclaration",
         "symbols": []
       }
     ],
@@ -25,38 +25,38 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
-        "name": "x",
-        "node": "VariableDeclarator(x)",
+        "name": "X",
+        "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
-            "name": "x",
-            "node_id": 14
+            "name": "X",
+            "node_id": 15
           }
         ]
       },
       {
         "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
-        "name": "T",
+        "name": "B",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
             "flags": "ReferenceFlags(Type)",
             "id": 1,
-            "name": "T",
-            "node_id": 18
+            "name": "B",
+            "node_id": 19
           }
         ]
       },
       {
-        "flags": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(Export | Interface)",
         "id": 2,
         "name": "A",
-        "node": "TSTypeAliasDeclaration",
+        "node": "TSInterfaceDeclaration",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
@@ -1,0 +1,7 @@
+import type X from 'mod';
+
+type B = number;
+
+export interface A {
+  [X]: B
+}

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -12996,9 +12996,6 @@ rebuilt        : ScopeId(0): ["A", "B"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Reference flags mismatch:
-after transform: ReferenceId(12): ReferenceFlags(Type)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read)
 Unresolved references mismatch:
 after transform: ["Extract", "Parameters"]
 rebuilt        : []
@@ -14600,15 +14597,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), Sc
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-Reference flags mismatch:
-after transform: ReferenceId(1): ReferenceFlags(Type)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(2): ReferenceFlags(Type)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(3): ReferenceFlags(Type)
-rebuilt        : ReferenceId(2): ReferenceFlags(Read)
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation5.ts
 semantic error: Bindings mismatch:
@@ -31028,12 +31016,6 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(12)]
 rebuilt        : SymbolId(3): []
-Reference flags mismatch:
-after transform: ReferenceId(1): ReferenceFlags(Type)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read)
-Reference flags mismatch:
-after transform: ReferenceId(3): ReferenceFlags(Type)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
 semantic error: Missing SymbolId: M


### PR DESCRIPTION
close: #5435

The behavior of `IdentifierReference` in `TSPropertySignature` is the same as in `TSTypeQuery`, both allow only reference value bindings and type-only import bindings.

I still use `ReferenceFlags::TSTypeQuery` here because I want to avoid producing many changes unrelated to the bug in this PR. I will refactor it in the follow-up PR soon