### PR TITLE
refactor(semantic): change the reference flag to `ReferenceFlags::Type` if it is used within a `TSTypeQuery`

### DIFF
--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -117,6 +117,6 @@ impl Reference {
     /// Returns `true` if this reference is used in a type context.
     #[inline]
     pub fn is_type(&self) -> bool {
-        self.flags.is_type() || self.flags.is_ts_type_query()
+        self.flags.is_type()
     }
 }

--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flags": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "X",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "node_id": 8
           },
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "A",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flags": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "node": "Function(makeBox)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "makeBox",
             "node_id": 27

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(arg)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "arg",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(k)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "k",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "Function(foo)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "foo",
             "node_id": 29

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "x",
             "node_id": 9

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -51,22 +51,17 @@ bitflags! {
     /// There are three general categories of references:
     /// 1. Values being referenced as values
     /// 2. Types being referenced as types
-    /// 3. Values being referenced as types
+    /// 3. Values being used in type contexts
     ///
-    /// ## Values
-    /// Reading a value is indicated by [`Read`], writing a value
-    /// is indicated by [`Write`]. References can be both a read
-    /// and a write, such as in this scenario:
+    /// ## Value as Type
+    /// The [`ValueAsType`] flag is a temporary marker for references that need to
+    /// resolve to value symbols initially, but will ultimately be treated as type references.
+    /// This flag is crucial in scenarios like TypeScript's `typeof` operator.
     ///
-    /// ```js
-    /// let a = 1;
-    /// a++;
-    /// ```
-    ///
-    /// When a value symbol is used as a type, such as in `typeof a`, it has
-    /// [`TSTypeQuery`] added to its flags. It is, however, still
-    /// considered a read. A good rule of thumb is that if a reference has [`Read`]
-    /// or [`Write`] in its flags, it is referencing a value symbol.
+    /// For example, in `type T = typeof a`:
+    /// 1. The reference to 'a' is initially flagged with [`ValueAsType`].
+    /// 2. This ensures that during symbol resolution, 'a' should be a value symbol.
+    /// 3. However, the final resolved reference's flags will be treated as a type.
     ///
     /// ## Types
     /// Type references are indicated by [`Type`]. These are used primarily in
@@ -75,7 +70,8 @@ bitflags! {
     ///
     /// [`Read`]: ReferenceFlags::Read
     /// [`Write`]: ReferenceFlags::Write
-    /// [`TSTypeQuery`]: ReferenceFlags::TSTypeQuery
+    /// [`Type`]: ReferenceFlags::Type
+    /// [`ValueAsType`]: ReferenceFlags::ValueAsType
     #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
     #[cfg_attr(feature = "serialize", derive(Serialize))]
     pub struct ReferenceFlags: u8 {
@@ -84,10 +80,10 @@ bitflags! {
         const Read = 1 << 0;
         /// A symbol is being written to in a Value context.
         const Write = 1 << 1;
-        // Used in type definitions.
+        /// Used in type definitions.
         const Type = 1 << 2;
-        // Used in `typeof xx`
-        const TSTypeQuery = 1 << 3;
+        /// A value symbol is used in a type context, such as in `typeof` expressions.
+        const ValueAsType = 1 << 3;
         /// The symbol being referenced is a value.
         ///
         /// Note that this does not necessarily indicate the reference is used
@@ -144,10 +140,10 @@ impl ReferenceFlags {
         self.contains(Self::Read | Self::Write)
     }
 
-    /// The identifier is used in a type referenced
+    /// Checks if the reference is a value being used in a type context.
     #[inline]
-    pub fn is_ts_type_query(&self) -> bool {
-        self.contains(Self::TSTypeQuery)
+    pub fn is_value_as_type(&self) -> bool {
+        self.contains(Self::ValueAsType)
     }
 
     /// The identifier is used in a type definition.


### PR DESCRIPTION
So far, the `ReferenceFlags::TSTypeQuery` only used indicates it is referenced by `TSTypeQuery` that we can confirm the reference should be regarded as a type reference, namely `ReferenceFlags::Type`.

This PR adds a `ReferenceFlags::ValueAsType` instead of `ReferenceFlags::TSTypeQuery`.  The new flag has the same behavior as the previous one. But it looks more general and is not only used in `TSTypeQuery`. But now it is a temporary flag. We use it to resolve the symbol correctly and replace `ReferenceFlags::ValueAsTyoe` with `ReferenceFlags::Type` after resolved. 

Also, this change eliminates the inconsistency in behavior between the `Reference::is_type` and `ReferenceFlags::is_type` methods.