### PR TITLE
fix(linter): `eslint/radix` rule correctly check for unbound symbols

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -70,7 +70,7 @@ impl Rule for Radix {
             match call_expr.callee.without_parenthesized() {
                 Expression::Identifier(ident) => {
                     if ident.name == "parseInt"
-                        && ctx.symbols().get_symbol_id_from_name("parseInt").is_none()
+                        && ctx.symbols().is_global_reference(ident.reference_id().unwrap())
                     {
                         Self::check_arguments(self, call_expr, ctx);
                     }
@@ -81,7 +81,7 @@ impl Rule for Radix {
                     {
                         if ident.name == "Number"
                             && member_expr.property.name == "parseInt"
-                            && ctx.symbols().get_symbol_id_from_name("Number").is_none()
+                            && ctx.symbols().is_global_reference(ident.reference_id().unwrap())
                         {
                             Self::check_arguments(self, call_expr, ctx);
                         }
@@ -92,7 +92,7 @@ impl Rule for Radix {
                         if let Expression::Identifier(ident) = member_expr.object() {
                             if ident.name == "Number"
                                 && member_expr.static_property_name() == Some("parseInt")
-                                && ctx.symbols().get_symbol_id_from_name("Number").is_none()
+                                && ctx.symbols().is_global_reference(ident.reference_id().unwrap())
                             {
                                 Self::check_arguments(self, call_expr, ctx);
                             }
@@ -224,6 +224,9 @@ fn test() {
         (r#"Number?.parseInt("10");"#, None),
         (r#"(Number?.parseInt)("10");"#, None),
         ("function *f(){ yield(Number).parseInt() }", None), // { "ecmaVersion": 6 },
+        ("{ let parseInt; } parseInt();", None),
+        ("{ let Number; } Number.parseInt();", None),
+        ("{ let Number; } (Number?.parseInt)();", None),
     ];
 
     Tester::new(Radix::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/radix.snap
+++ b/crates/oxc_linter/src/snapshots/radix.snap
@@ -156,3 +156,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(Number).parseInt() }
    ·                     ───────────────────
    ╰────
+
+  ⚠ eslint(radix): Missing parameters.
+   ╭─[radix.tsx:1:19]
+ 1 │ { let parseInt; } parseInt();
+   ·                   ──────────
+   ╰────
+
+  ⚠ eslint(radix): Missing parameters.
+   ╭─[radix.tsx:1:17]
+ 1 │ { let Number; } Number.parseInt();
+   ·                 ─────────────────
+   ╰────
+
+  ⚠ eslint(radix): Missing parameters.
+   ╭─[radix.tsx:1:17]
+ 1 │ { let Number; } (Number?.parseInt)();
+   ·                 ────────────────────
+   ╰────


### PR DESCRIPTION
`SymbolTable::get_symbol_id_from_name(name).is_none()` is not always correct, because it will return `false` if there is a binding *anywhere* in the AST with that name, whereas what we actually want to know is whether *this* `IdentifierReference` is referring to a global or not.

Instead, look up whether this reference is resolved or not using `SymbolTable::is_global_reference`.

The 3 test cases added were not working prior to this change.