### PR TITLE
refactor(ast)!: rename `Expression::without_parentheses`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -173,7 +173,7 @@ impl<'a> Expression<'a> {
     }
 
     /// Remove nested parentheses from this expression.
-    pub fn without_parenthesized(&self) -> &Self {
+    pub fn without_parentheses(&self) -> &Self {
         let mut expr = self;
         while let Expression::ParenthesizedExpression(paran_expr) = expr {
             expr = &paran_expr.expression;
@@ -511,12 +511,12 @@ impl<'a> MemberExpression<'a> {
     }
 
     pub fn through_optional_is_specific_member_access(&self, object: &str, property: &str) -> bool {
-        let object_matches = match self.object().without_parenthesized() {
+        let object_matches = match self.object().without_parentheses() {
             Expression::ChainExpression(x) => match &x.expression {
                 ChainElement::CallExpression(_) => false,
                 match_member_expression!(ChainElement) => {
                     let member_expr = x.expression.to_member_expression();
-                    member_expr.object().without_parenthesized().is_specific_id(object)
+                    member_expr.object().without_parentheses().is_specific_id(object)
                 }
             },
             x => x.is_specific_id(object),

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -21,15 +21,15 @@ pub enum Binaryish<'a> {
 impl<'a> Binaryish<'a> {
     pub fn left(&self) -> &'a Expression<'a> {
         match self {
-            Self::Binary(e) => e.left.without_parenthesized(),
-            Self::Logical(e) => e.left.without_parenthesized(),
+            Self::Binary(e) => e.left.without_parentheses(),
+            Self::Logical(e) => e.left.without_parentheses(),
         }
     }
 
     pub fn right(&self) -> &'a Expression<'a> {
         match self {
-            Self::Binary(e) => e.right.without_parenthesized(),
-            Self::Logical(e) => e.right.without_parenthesized(),
+            Self::Binary(e) => e.right.without_parentheses(),
+            Self::Logical(e) => e.right.without_parentheses(),
         }
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1558,7 +1558,7 @@ impl<'a> Gen for ObjectProperty<'a> {
 
         let mut shorthand = false;
         if let PropertyKey::StaticIdentifier(key) = &self.key {
-            if let Expression::Identifier(ident) = self.value.without_parenthesized() {
+            if let Expression::Identifier(ident) = self.value.without_parentheses() {
                 if key.name == p.get_identifier_reference_name(ident) && key.name != "__proto__" {
                     shorthand = true;
                 }

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -325,12 +325,12 @@ pub fn is_method_call<'a>(
         }
     }
 
-    let Some(member_expr) = call_expr.callee.without_parenthesized().as_member_expression() else {
+    let Some(member_expr) = call_expr.callee.without_parentheses().as_member_expression() else {
         return false;
     };
 
     if let Some(objects) = objects {
-        let Expression::Identifier(ident) = member_expr.object().without_parenthesized() else {
+        let Expression::Identifier(ident) = member_expr.object().without_parentheses() else {
             return false;
         };
         if !objects.contains(&ident.name.as_str()) {
@@ -367,7 +367,7 @@ pub fn is_new_expression<'a>(
         }
     }
 
-    let Expression::Identifier(ident) = new_expr.callee.without_parenthesized() else {
+    let Expression::Identifier(ident) = new_expr.callee.without_parentheses() else {
         return false;
     };
 
@@ -381,12 +381,12 @@ pub fn is_new_expression<'a>(
 pub fn call_expr_method_callee_info<'a>(
     call_expr: &'a CallExpression<'a>,
 ) -> Option<(Span, &'a str)> {
-    let member_expr = call_expr.callee.without_parenthesized().as_member_expression()?;
+    let member_expr = call_expr.callee.without_parentheses().as_member_expression()?;
     member_expr.static_property_info()
 }
 
 pub fn get_new_expr_ident_name<'a>(new_expr: &'a NewExpression<'a>) -> Option<&'a str> {
-    let Expression::Identifier(ident) = new_expr.callee.without_parenthesized() else {
+    let Expression::Identifier(ident) = new_expr.callee.without_parentheses() else {
         return None;
     };
 

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -95,7 +95,7 @@ impl GetterReturn {
     }
 
     fn handle_actual_expression<'a>(callee: &'a Expression<'a>) -> bool {
-        match callee.without_parenthesized() {
+        match callee.without_parentheses() {
             expr @ match_member_expression!(Expression) => {
                 Self::handle_member_expression(expr.to_member_expression())
             }
@@ -112,7 +112,7 @@ impl GetterReturn {
     }
 
     fn handle_paren_expr<'a>(expr: &'a Expression<'a>) -> bool {
-        match expr.without_parenthesized() {
+        match expr.without_parentheses() {
             Expression::CallExpression(ce) => Self::handle_actual_expression(&ce.callee),
             _ => false,
         }

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -121,12 +121,12 @@ fn is_bool_fn_or_constructor_call(node: &AstNode) -> bool {
     match node.kind() {
         AstKind::CallExpression(expr) => expr
             .callee
-            .without_parenthesized()
+            .without_parentheses()
             .get_identifier_reference()
             .is_some_and(|x| x.name == "Boolean"),
         AstKind::NewExpression(expr) => expr
             .callee
-            .without_parenthesized()
+            .without_parentheses()
             .get_identifier_reference()
             .is_some_and(|x| x.name == "Boolean"),
         _ => false,
@@ -137,14 +137,14 @@ fn is_first_arg(node: &AstNode, parent: &AstNode) -> bool {
     match parent.kind() {
         AstKind::CallExpression(expr) => expr.arguments.first().map_or(false, |arg| {
             if let Some(expr) = arg.as_expression() {
-                expr.without_parenthesized().span() == node.kind().span()
+                expr.without_parentheses().span() == node.kind().span()
             } else {
                 false
             }
         }),
         AstKind::NewExpression(expr) => expr.arguments.first().map_or(false, |arg| {
             if let Some(expr) = arg.as_expression() {
-                expr.without_parenthesized().span() == node.kind().span()
+                expr.without_parentheses().span() == node.kind().span()
             } else {
                 false
             }
@@ -156,23 +156,23 @@ fn is_first_arg(node: &AstNode, parent: &AstNode) -> bool {
 fn is_inside_test_condition(node: &AstNode, ctx: &LintContext) -> bool {
     get_real_parent(node, ctx).map_or(false, |parent| match parent.kind() {
         AstKind::IfStatement(stmt) => {
-            let expr_span = stmt.test.get_inner_expression().without_parenthesized().span();
+            let expr_span = stmt.test.get_inner_expression().without_parentheses().span();
             expr_span == node.kind().span()
         }
         AstKind::DoWhileStatement(stmt) => {
-            let expr_span = stmt.test.get_inner_expression().without_parenthesized().span();
+            let expr_span = stmt.test.get_inner_expression().without_parentheses().span();
             expr_span == node.kind().span()
         }
         AstKind::WhileStatement(stmt) => {
-            let expr_span = stmt.test.get_inner_expression().without_parenthesized().span();
+            let expr_span = stmt.test.get_inner_expression().without_parentheses().span();
             expr_span == node.kind().span()
         }
         AstKind::ConditionalExpression(stmt) => {
-            let expr_span = stmt.test.get_inner_expression().without_parenthesized().span();
+            let expr_span = stmt.test.get_inner_expression().without_parentheses().span();
             expr_span == node.kind().span()
         }
         AstKind::ForStatement(stmt) => stmt.test.as_ref().map_or(false, |expr| {
-            let expr_span = expr.get_inner_expression().without_parenthesized().span();
+            let expr_span = expr.get_inner_expression().without_parentheses().span();
             expr_span == node.kind().span()
         }),
         _ => false,

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -84,7 +84,7 @@ impl NoSelfAssign {
         match left {
             match_simple_assignment_target!(AssignmentTarget) => {
                 let simple_assignment_target = left.to_simple_assignment_target();
-                if let Expression::Identifier(id2) = right.without_parenthesized() {
+                if let Expression::Identifier(id2) = right.without_parentheses() {
                     let self_assign = matches!(simple_assignment_target.get_expression(), Some(Expression::Identifier(id1)) if id1.name == id2.name)
                         || matches!(simple_assignment_target, SimpleAssignmentTarget::AssignmentTargetIdentifier(id1) if id1.name == id2.name);
 
@@ -94,7 +94,7 @@ impl NoSelfAssign {
                 }
 
                 if let Some(member_target) = simple_assignment_target.as_member_expression() {
-                    if let Some(member_expr) = right.without_parenthesized().get_member_expr() {
+                    if let Some(member_expr) = right.without_parentheses().get_member_expr() {
                         if self.is_member_expression_same_reference(member_expr, member_target) {
                             ctx.diagnostic(no_self_assign_diagnostic(member_expr.span()));
                         }
@@ -103,7 +103,7 @@ impl NoSelfAssign {
             }
 
             AssignmentTarget::ArrayAssignmentTarget(array_pattern) => {
-                if let Expression::ArrayExpression(array_expr) = right.without_parenthesized() {
+                if let Expression::ArrayExpression(array_expr) = right.without_parentheses() {
                     let end =
                         std::cmp::min(array_pattern.elements.len(), array_expr.elements.len());
                     let mut i = 0;
@@ -236,7 +236,7 @@ impl NoSelfAssign {
                         &**obj_prop
                     {
                         if key.static_name().is_some_and(|name| name == id1.binding.name) {
-                            if let Expression::Identifier(id2) = expr.without_parenthesized() {
+                            if let Expression::Identifier(id2) = expr.without_parentheses() {
                                 if id1.binding.name == id2.name {
                                     ctx.diagnostic(no_self_assign_diagnostic(*span));
                                 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -67,8 +67,7 @@ impl Rule for PreferExponentiationOperator {
                     return;
                 }
 
-                if let Expression::Identifier(ident) = member_expr.object().without_parenthesized()
-                {
+                if let Expression::Identifier(ident) = member_expr.object().without_parentheses() {
                     if GLOBAL_OBJECT_NAMES.contains(ident.name.as_str())
                         && ctx.semantic().is_reference_to_global_variable(ident)
                     {

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
 impl Rule for PreferNumericLiterals {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::CallExpression(call_expr) = node.kind() {
-            match &call_expr.callee.without_parenthesized() {
+            match &call_expr.callee.without_parentheses() {
                 Expression::Identifier(ident) if ident.name == "parseInt" => {
                     if is_parse_int_call(ctx, ident, None) {
                         check_arguments(call_expr, ctx);

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -67,7 +67,7 @@ impl Rule for Radix {
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::CallExpression(call_expr) = node.kind() {
-            match call_expr.callee.without_parenthesized() {
+            match call_expr.callee.without_parentheses() {
                 Expression::Identifier(ident) => {
                     if ident.name == "parseInt"
                         && ctx.symbols().is_global_reference(ident.reference_id().unwrap())
@@ -76,8 +76,7 @@ impl Rule for Radix {
                     }
                 }
                 Expression::StaticMemberExpression(member_expr) => {
-                    if let Expression::Identifier(ident) =
-                        member_expr.object.without_parenthesized()
+                    if let Expression::Identifier(ident) = member_expr.object.without_parentheses()
                     {
                         if ident.name == "Number"
                             && member_expr.property.name == "parseInt"

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -79,7 +79,7 @@ impl Rule for InlineScriptId {
                     }
                     JSXAttributeItem::SpreadAttribute(spread_attr) => {
                         if let Expression::ObjectExpression(obj_expr) =
-                            spread_attr.argument.without_parenthesized()
+                            spread_attr.argument.without_parentheses()
                         {
                             for prop in &obj_expr.properties {
                                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop {

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -81,7 +81,7 @@ fn resolve_flags<'a>(
     expr: &'a Expression<'a>,
     ctx: &LintContext<'a>,
 ) -> Option<(RegExpFlags, Span)> {
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::RegExpLiteral(regexp_literal) => {
             Some((regexp_literal.regex.flags, regexp_literal.span))
         }

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -80,13 +80,13 @@ impl Rule for ConstComparisons {
         }
 
         let Some((right_cmp_op, right_expr, right_const_expr, _)) =
-            comparison_to_const(logical_expr.right.without_parenthesized())
+            comparison_to_const(logical_expr.right.without_parentheses())
         else {
             return;
         };
 
         for (left_cmp_op, left_expr, left_const_expr, left_span) in
-            all_and_comparison_to_const(logical_expr.left.without_parenthesized())
+            all_and_comparison_to_const(logical_expr.left.without_parentheses())
         {
             let Some(ordering) = left_const_expr.value.partial_cmp(&right_const_expr.value) else {
                 return;
@@ -135,7 +135,7 @@ impl Rule for ConstComparisons {
 
                 ctx.diagnostic(impossible(
                     left_span,
-                    logical_expr.right.without_parenthesized().span(),
+                    logical_expr.right.without_parentheses().span(),
                     &format!(
                         "`{} {} {}` ",
                         expr_str,
@@ -162,8 +162,7 @@ fn comparison_to_const<'a, 'b>(
 ) -> Option<(CmpOp, &'b Expression<'a>, &'b NumericLiteral<'a>, Span)> {
     if let Expression::BinaryExpression(bin_expr) = expr {
         if let Ok(cmp_op) = CmpOp::try_from(bin_expr.operator) {
-            match (&bin_expr.left.without_parenthesized(), &bin_expr.right.without_parenthesized())
-            {
+            match (&bin_expr.left.without_parentheses(), &bin_expr.right.without_parentheses()) {
                 (Expression::NumericLiteral(lit), _) => {
                     return Some((cmp_op.reverse(), &bin_expr.right, lit, bin_expr.span));
                 }
@@ -185,9 +184,8 @@ fn all_and_comparison_to_const<'a, 'b>(
         Expression::LogicalExpression(logical_expr)
             if logical_expr.operator == LogicalOperator::And =>
         {
-            let left_iter = all_and_comparison_to_const(logical_expr.left.without_parenthesized());
-            let right_iter =
-                all_and_comparison_to_const(logical_expr.right.without_parenthesized());
+            let left_iter = all_and_comparison_to_const(logical_expr.left.without_parentheses());
+            let right_iter = all_and_comparison_to_const(logical_expr.right.without_parentheses());
             Box::new(left_iter.chain(right_iter))
         }
         _ => {

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -72,7 +72,7 @@ impl Rule for ErasingOp {
 }
 
 fn is_number_value(expr: &Expression, value: f64) -> bool {
-    if let Expression::NumericLiteral(number_literal) = expr.without_parenthesized() {
+    if let Expression::NumericLiteral(number_literal) = expr.without_parentheses() {
         (number_literal.value - value).abs() < f64::EPSILON
     } else {
         false

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -172,7 +172,7 @@ impl ButtonHasType {
     }
 
     fn is_valid_button_type_prop_expression(&self, expr: &Expression) -> bool {
-        match expr.without_parenthesized() {
+        match expr.without_parentheses() {
             Expression::StringLiteral(str) => {
                 self.is_valid_button_type_prop_string_literal(str.value.as_str())
             }

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -119,7 +119,7 @@ impl Rule for JsxBooleanValue {
                 }
                 Some(JSXAttributeValue::ExpressionContainer(container)) => {
                     if let Some(expr) = container.expression.as_expression() {
-                        if let Expression::BooleanLiteral(expr) = expr.without_parenthesized() {
+                        if let Expression::BooleanLiteral(expr) = expr.without_parentheses() {
                             if expr.value && self.is_never(ident.name.as_str()) {
                                 let span = Span::new(ident.span.end, jsx_attr.span.end);
                                 ctx.diagnostic_with_fix(

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -194,7 +194,7 @@ fn is_in_array_or_iter<'a, 'b>(
                 return Some(InsideArrayOrIterator::Array);
             }
             AstKind::CallExpression(v) => {
-                let callee = &v.callee.without_parenthesized();
+                let callee = &v.callee.without_parentheses();
 
                 if let Some(v) = callee.as_member_expression() {
                     if let Some((span, ident)) = v.static_property_info() {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -66,7 +66,7 @@ impl Rule for JsxPropsNoSpreadMulti {
             let mut duplicate_spreads: FxHashMap<&Atom, Vec<Span>> = FxHashMap::default();
 
             for spread_attr in spread_attrs {
-                let argument_without_parenthesized = spread_attr.argument.without_parenthesized();
+                let argument_without_parenthesized = spread_attr.argument.without_parentheses();
 
                 if let Some(identifier_name) =
                     argument_without_parenthesized.get_identifier_reference().map(|arg| &arg.name)

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -47,7 +47,7 @@ impl ReactPerfRule for JsxNoJsxAsProp {
 }
 
 fn check_expression(expr: &Expression) -> Option<Span> {
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::JSXElement(expr) => Some(expr.span),
         Expression::LogicalExpression(expr) => {
             check_expression(&expr.left).or_else(|| check_expression(&expr.right))

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -64,7 +64,7 @@ impl ReactPerfRule for JsxNoNewArrayAsProp {
 }
 
 fn check_expression(expr: &Expression) -> Option<Span> {
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::ArrayExpression(expr) => Some(expr.span),
         Expression::CallExpression(expr) => {
             if is_constructor_matching_name(&expr.callee, "Array")

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -57,7 +57,7 @@ impl ReactPerfRule for JsxNoNewFunctionAsProp {
 }
 
 fn check_expression(expr: &Expression) -> Option<Span> {
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::ArrowFunctionExpression(expr) => Some(expr.span),
         Expression::FunctionExpression(expr) => Some(expr.span),
         Expression::CallExpression(expr) => {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -63,7 +63,7 @@ impl ReactPerfRule for JsxNoNewObjectAsProp {
 }
 
 fn check_expression(expr: &Expression) -> Option<Span> {
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::ObjectExpression(expr) => Some(expr.span),
         Expression::CallExpression(expr) => {
             if is_constructor_matching_name(&expr.callee, "Object")

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -548,7 +548,7 @@ fn is_function_argument(parent: &AstNode, callee: Option<&AstNode>) -> bool {
         return true;
     }
 
-    match call_expr.callee.without_parenthesized() {
+    match call_expr.callee.without_parentheses() {
         Expression::FunctionExpression(func_expr) => {
             let AstKind::Function(callee_func_expr) = callee.unwrap().kind() else { return false };
             func_expr.span != callee_func_expr.span

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -33,8 +33,7 @@ impl Rule for NoExtraNonNullAssertion {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let expr = match node.kind() {
             AstKind::TSNonNullExpression(expr) => {
-                if let Expression::TSNonNullExpression(expr) =
-                    expr.expression.without_parenthesized()
+                if let Expression::TSNonNullExpression(expr) = expr.expression.without_parentheses()
                 {
                     Some(expr)
                 } else {
@@ -42,15 +41,14 @@ impl Rule for NoExtraNonNullAssertion {
                 }
             }
             AstKind::MemberExpression(expr) if expr.optional() => {
-                if let Expression::TSNonNullExpression(expr) = expr.object().without_parenthesized()
-                {
+                if let Expression::TSNonNullExpression(expr) = expr.object().without_parentheses() {
                     Some(expr)
                 } else {
                     None
                 }
             }
             AstKind::CallExpression(expr) if expr.optional => {
-                if let Expression::TSNonNullExpression(expr) = expr.callee.without_parenthesized() {
+                if let Expression::TSNonNullExpression(expr) = expr.callee.without_parentheses() {
                     Some(expr)
                 } else {
                     None

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -141,7 +141,7 @@ impl CatchErrorName {
         ctx: &LintContext,
     ) -> Option<OxcDiagnostic> {
         let expr = arg0.as_expression()?;
-        let expr = expr.without_parenthesized();
+        let expr = expr.without_parentheses();
 
         if let Expression::ArrowFunctionExpression(arrow_expr) = expr {
             if let Some(arg0) = arrow_expr.params.items.first() {

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -53,7 +53,7 @@ impl Rule for NewForBuiltins {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::NewExpression(new_expr) => {
-                let callee = new_expr.callee.without_parenthesized();
+                let callee = new_expr.callee.without_parentheses();
 
                 let Some(builtin_name) = is_expr_global_builtin(callee, ctx) else {
                     return;
@@ -65,7 +65,7 @@ impl Rule for NewForBuiltins {
             }
             AstKind::CallExpression(call_expr) => {
                 let Some(builtin_name) =
-                    is_expr_global_builtin(call_expr.callee.without_parenthesized(), ctx)
+                    is_expr_global_builtin(call_expr.callee.without_parentheses(), ctx)
                 else {
                     return;
                 };

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -70,15 +70,14 @@ impl Rule for NoAwaitInPromiseMethods {
         let Some(first_argument) = call_expr.arguments[0].as_expression() else {
             return;
         };
-        let first_argument = first_argument.without_parenthesized();
+        let first_argument = first_argument.without_parentheses();
         let Expression::ArrayExpression(first_argument_array_expr) = first_argument else {
             return;
         };
 
         for element in &first_argument_array_expr.elements {
             if let Some(element_expr) = element.as_expression() {
-                if let Expression::AwaitExpression(await_expr) =
-                    element_expr.without_parenthesized()
+                if let Expression::AwaitExpression(await_expr) = element_expr.without_parentheses()
                 {
                     let property_name = call_expr
                         .callee

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -117,7 +117,7 @@ fn is_document_cookie_reference<'a, 'b>(
                 return false;
             }
 
-            if let Expression::Identifier(ident) = member_expr.object().without_parenthesized() {
+            if let Expression::Identifier(ident) = member_expr.object().without_parentheses() {
                 if !GLOBAL_OBJECT_NAMES.contains(ident.name.as_str()) {
                     return false;
                 }

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -41,7 +41,7 @@ impl Rule for NoInstanceofArray {
             return;
         }
 
-        match &expr.right.without_parenthesized() {
+        match &expr.right.without_parentheses() {
             Expression::Identifier(identifier) if identifier.name == "Array" => {
                 ctx.diagnostic_with_fix(no_instanceof_array_diagnostic(expr.span), |fixer| {
                     let modified_code = {

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -60,7 +60,7 @@ impl Rule for NoLengthAsSliceEnd {
         let Some(MemberExpression::StaticMemberExpression(second_argument)) = call_expr.arguments
             [1]
         .as_expression()
-        .map(oxc_ast::ast::Expression::without_parenthesized)
+        .map(oxc_ast::ast::Expression::without_parentheses)
         .and_then(|e| e.get_member_expr()) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -56,7 +56,7 @@ impl Rule for NoMagicArrayFlatDepth {
 
         let first_arg = call_expression.arguments.first().expect("missing argument");
         let Some(Expression::NumericLiteral(arg)) =
-            first_arg.as_expression().map(oxc_ast::ast::Expression::without_parenthesized)
+            first_arg.as_expression().map(oxc_ast::ast::Expression::without_parentheses)
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -65,10 +65,10 @@ impl Rule for NoNegatedCondition {
                     return;
                 }
 
-                if_stmt.test.without_parenthesized()
+                if_stmt.test.without_parentheses()
             }
             AstKind::ConditionalExpression(conditional_expr) => {
-                conditional_expr.test.without_parenthesized()
+                conditional_expr.test.without_parentheses()
             }
             _ => {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -41,7 +41,7 @@ impl Rule for NoNewBuffer {
             return;
         };
 
-        let Expression::Identifier(ident) = &new_expr.callee.without_parenthesized() else {
+        let Expression::Identifier(ident) = &new_expr.callee.without_parentheses() else {
             return;
         };
         if ident.name != "Buffer" {

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -47,8 +47,7 @@ impl Rule for NoObjectAsDefaultParameter {
             return;
         };
 
-        let Expression::ObjectExpression(object_expr) =
-            &assignment_pat.right.without_parenthesized()
+        let Expression::ObjectExpression(object_expr) = &assignment_pat.right.without_parentheses()
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -62,7 +62,7 @@ impl Rule for NoThisAssignment {
                     return;
                 };
 
-                if !matches!(init.without_parenthesized(), Expression::ThisExpression(_)) {
+                if !matches!(init.without_parentheses(), Expression::ThisExpression(_)) {
                     return;
                 }
 
@@ -78,7 +78,7 @@ impl Rule for NoThisAssignment {
             }
             AstKind::AssignmentExpression(assignment_expr) => {
                 if !matches!(
-                    assignment_expr.right.without_parenthesized(),
+                    assignment_expr.right.without_parentheses(),
                     Expression::ThisExpression(_)
                 ) {
                     return;

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -53,7 +53,7 @@ impl Rule for NoUnreadableIife {
         };
 
         let Expression::ArrowFunctionExpression(arrow_expr) =
-            &call_expr.callee.without_parenthesized()
+            &call_expr.callee.without_parentheses()
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -50,7 +50,7 @@ impl Rule for NoUselessFallbackInSpread {
         }
 
         let Expression::ObjectExpression(object_expression) =
-            &logical_expression.right.without_parenthesized()
+            &logical_expression.right.without_parentheses()
         else {
             return;
         };
@@ -90,7 +90,7 @@ impl Rule for NoUselessFallbackInSpread {
 
 fn can_fix(left: &Expression<'_>) -> bool {
     const BANNED_IDENTIFIERS: [&str; 3] = ["undefined", "NaN", "Infinity"];
-    match left.without_parenthesized() {
+    match left.without_parentheses() {
         Expression::Identifier(ident) => !BANNED_IDENTIFIERS.contains(&ident.name.as_str()),
         Expression::LogicalExpression(expr) => can_fix(&expr.left),
         Expression::ObjectExpression(_)

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -85,7 +85,7 @@ fn is_useless_check<'a>(
     let mut binary_expression_span: Option<Span> = None;
     let mut call_expression_span: Option<Span> = None;
 
-    let l = match left.without_parenthesized() {
+    let l = match left.without_parentheses() {
         Expression::BinaryExpression(expr) => {
             let left_expr = expr.left.get_inner_expression().as_member_expression()?;
             array_name = left_expr.object().get_identifier_reference()?.name.as_str();
@@ -109,7 +109,7 @@ fn is_useless_check<'a>(
         _ => false,
     };
 
-    let r = match right.without_parenthesized() {
+    let r = match right.without_parentheses() {
         Expression::BinaryExpression(expr) => {
             let left_expr = expr.left.get_inner_expression().as_member_expression()?;
             let ident_name = left_expr.object().get_identifier_reference()?.name.as_str();
@@ -170,7 +170,7 @@ impl Rule for NoUselessLengthCheck {
 }
 
 fn flat_logical_expression<'a>(node: &'a LogicalExpression<'a>) -> Vec<&'a Expression<'a>> {
-    let left = match &node.left.without_parenthesized() {
+    let left = match &node.left.without_parentheses() {
         Expression::LogicalExpression(le) => {
             if le.operator == node.operator {
                 flat_logical_expression(le)
@@ -181,7 +181,7 @@ fn flat_logical_expression<'a>(node: &'a LogicalExpression<'a>) -> Vec<&'a Expre
         _ => vec![&node.left],
     };
 
-    let right = match &node.right.without_parenthesized() {
+    let right = match &node.right.without_parentheses() {
         Expression::LogicalExpression(le) => {
             if le.operator == node.operator {
                 flat_logical_expression(le)

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -307,7 +307,7 @@ fn check_useless_iterable_to_array<'a>(
 
     match parent.kind() {
         AstKind::ForOfStatement(for_of_stmt) => {
-            if for_of_stmt.right.without_parenthesized().span() == array_expr.span {
+            if for_of_stmt.right.without_parentheses().span() == array_expr.span {
                 ctx.diagnostic(iterable_to_array_in_for_of(span));
                 return true;
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -53,7 +53,7 @@ impl Rule for PreferArrayFlatMap {
         let Some(member_expr) = flat_call_expr.callee.as_member_expression() else {
             return;
         };
-        let Expression::CallExpression(call_expr) = &member_expr.object().without_parenthesized()
+        let Expression::CallExpression(call_expr) = &member_expr.object().without_parentheses()
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -100,7 +100,7 @@ impl Rule for PreferArraySome {
                 }
 
                 let Some(left_member_expr) =
-                    bin_expr.left.without_parenthesized().as_member_expression()
+                    bin_expr.left.without_parentheses().as_member_expression()
                 else {
                     return;
                 };
@@ -114,7 +114,7 @@ impl Rule for PreferArraySome {
                 }
 
                 let Expression::CallExpression(left_call_expr) =
-                    &left_member_expr.object().without_parenthesized()
+                    &left_member_expr.object().without_parentheses()
                 else {
                     return;
                 };
@@ -206,7 +206,7 @@ fn is_checking_undefined<'a, 'b>(
         return false;
     };
 
-    let right_without_paren = bin_expr.right.without_parenthesized();
+    let right_without_paren = bin_expr.right.without_parentheses();
 
     if matches!(
         bin_expr.operator,
@@ -214,7 +214,7 @@ fn is_checking_undefined<'a, 'b>(
             | BinaryOperator::Equality
             | BinaryOperator::StrictInequality
             | BinaryOperator::StrictEquality
-    ) && right_without_paren.without_parenthesized().is_undefined()
+    ) && right_without_paren.without_parentheses().is_undefined()
     {
         return true;
     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -58,7 +58,7 @@ impl Rule for PreferDomNodeRemove {
             return;
         };
 
-        let expr = expr.without_parenthesized();
+        let expr = expr.without_parentheses();
         if matches!(
             expr,
             Expression::ArrayExpression(_)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -50,7 +50,7 @@ impl Rule for PreferIncludes {
             return;
         };
 
-        let Expression::CallExpression(left_call_expr) = &bin_expr.left.without_parenthesized()
+        let Expression::CallExpression(left_call_expr) = &bin_expr.left.without_parentheses()
         else {
             return;
         };
@@ -67,7 +67,7 @@ impl Rule for PreferIncludes {
                 | BinaryOperator::StrictEquality
                 | BinaryOperator::Equality
         ) {
-            if !is_negative_one(bin_expr.right.without_parenthesized()) {
+            if !is_negative_one(bin_expr.right.without_parentheses()) {
                 return;
             }
 
@@ -78,7 +78,7 @@ impl Rule for PreferIncludes {
 
         if matches!(bin_expr.operator, BinaryOperator::GreaterEqualThan | BinaryOperator::LessThan)
         {
-            let Expression::NumericLiteral(num_lit) = bin_expr.right.without_parenthesized() else {
+            let Expression::NumericLiteral(num_lit) = bin_expr.right.without_parentheses() else {
                 return;
             };
 
@@ -101,7 +101,7 @@ fn is_negative_one(expr: &Expression) -> bool {
         return false;
     }
 
-    let Expression::NumericLiteral(num_lit) = unary_expr.argument.without_parenthesized() else {
+    let Expression::NumericLiteral(num_lit) = unary_expr.argument.without_parentheses() else {
         return false;
     };
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -217,7 +217,7 @@ fn check_multiplication<'a, 'b>(
 fn flat_plus_expression<'a>(expression: &'a Expression<'a>) -> Vec<&'a Expression<'a>> {
     let mut expressions = Vec::new();
 
-    match expression.without_parenthesized() {
+    match expression.without_parentheses() {
         Expression::BinaryExpression(bin_expr) => {
             if matches!(bin_expr.operator, BinaryOperator::Addition) {
                 expressions.append(&mut flat_plus_expression(&bin_expr.left));
@@ -233,11 +233,11 @@ fn flat_plus_expression<'a>(expression: &'a Expression<'a>) -> Vec<&'a Expressio
 }
 
 fn is_pow_2_expression(expression: &Expression, ctx: &LintContext<'_>) -> bool {
-    if let Expression::BinaryExpression(bin_expr) = expression.without_parenthesized() {
+    if let Expression::BinaryExpression(bin_expr) = expression.without_parentheses() {
         match bin_expr.operator {
             BinaryOperator::Exponential => {
                 if let Expression::NumericLiteral(number_lit) =
-                    &bin_expr.right.without_parenthesized()
+                    &bin_expr.right.without_parentheses()
                 {
                     (number_lit.value - 2_f64).abs() < f64::EPSILON
                 } else {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -130,7 +130,7 @@ fn get_returned_ident<'a>(stmt: &'a Statement, is_arrow: bool) -> Option<&'a str
         if let Statement::ExpressionStatement(expr_stmt) = &stmt {
             return expr_stmt
                 .expression
-                .without_parenthesized()
+                .without_parentheses()
                 .get_identifier_reference()
                 .map(|v| v.name.as_str());
         }
@@ -145,7 +145,7 @@ fn get_returned_ident<'a>(stmt: &'a Statement, is_arrow: bool) -> Option<&'a str
     if let Statement::ReturnStatement(return_statement) = &stmt {
         if let Some(return_expr) = &return_statement.argument {
             return return_expr
-                .without_parenthesized()
+                .without_parentheses()
                 .get_identifier_reference()
                 .map(|v| v.name.as_str());
         }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -57,7 +57,7 @@ impl Rule for PreferPrototypeMethods {
         if call_expr.optional {
             return;
         }
-        match call_expr.callee.without_parenthesized() {
+        match call_expr.callee.without_parentheses() {
             Expression::StaticMemberExpression(member_expr) if !member_expr.optional => {}
             Expression::PrivateFieldExpression(member_expr) if !member_expr.optional => {}
             _ => return,
@@ -69,7 +69,7 @@ impl Rule for PreferPrototypeMethods {
         // `Reflect.apply({}.foo, …)`
         if is_method_call(call_expr, Some(&["Reflect"]), Some(&["apply"]), Some(1), None) {
             if let Some(argument_expr) = call_expr.arguments[0].as_expression() {
-                method_expr = Some(argument_expr.without_parenthesized());
+                method_expr = Some(argument_expr.without_parentheses());
             }
         }
         // `[].foo.{apply,bind,call}(…)`
@@ -78,7 +78,7 @@ impl Rule for PreferPrototypeMethods {
             method_expr = call_expr
                 .callee
                 .get_member_expr()
-                .map(|member_expr| member_expr.object().without_parenthesized());
+                .map(|member_expr| member_expr.object().without_parentheses());
         }
 
         let Some(method_expr) = method_expr else {
@@ -87,7 +87,7 @@ impl Rule for PreferPrototypeMethods {
         let Some(method_expr) = method_expr.as_member_expression() else {
             return;
         };
-        let object_expr = method_expr.object().without_parenthesized();
+        let object_expr = method_expr.object().without_parentheses();
 
         if !is_empty_array_expression(object_expr) && !is_empty_object_expression(object_expr) {
             return;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -57,7 +57,7 @@ impl Rule for PreferSetSize {
             return;
         }
 
-        let Expression::ArrayExpression(array_expr) = member_expr.object().without_parenthesized()
+        let Expression::ArrayExpression(array_expr) = member_expr.object().without_parentheses()
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -47,7 +47,7 @@ impl Rule for PreferSpread {
             return;
         };
 
-        let Some(member_expr) = call_expr.callee.without_parenthesized().as_member_expression()
+        let Some(member_expr) = call_expr.callee.without_parentheses().as_member_expression()
         else {
             return;
         };
@@ -66,11 +66,11 @@ impl Rule for PreferSpread {
                 let Some(expr) = call_expr.arguments[0].as_expression() else {
                     return;
                 };
-                if matches!(expr.without_parenthesized(), Expression::ObjectExpression(_)) {
+                if matches!(expr.without_parentheses(), Expression::ObjectExpression(_)) {
                     return;
                 }
 
-                let Expression::Identifier(ident) = member_expr.object().without_parenthesized()
+                let Expression::Identifier(ident) = member_expr.object().without_parentheses()
                 else {
                     return;
                 };
@@ -83,7 +83,7 @@ impl Rule for PreferSpread {
             }
             // `array.concat()`
             "concat" => {
-                if is_not_array(member_expr.object().without_parenthesized(), ctx) {
+                if is_not_array(member_expr.object().without_parentheses(), ctx) {
                     return;
                 }
 
@@ -95,7 +95,7 @@ impl Rule for PreferSpread {
                     return;
                 }
 
-                let member_expr_obj = member_expr.object().without_parenthesized();
+                let member_expr_obj = member_expr.object().without_parentheses();
 
                 if matches!(
                     member_expr_obj,
@@ -114,7 +114,7 @@ impl Rule for PreferSpread {
                     let Some(first_arg) = first_arg.as_expression() else {
                         return;
                     };
-                    if let Expression::NumericLiteral(num_lit) = first_arg.without_parenthesized() {
+                    if let Expression::NumericLiteral(num_lit) = first_arg.without_parentheses() {
                         if num_lit.value != 0.0 {
                             return;
                         }
@@ -132,7 +132,7 @@ impl Rule for PreferSpread {
                 }
 
                 if matches!(
-                    member_expr.object().without_parenthesized(),
+                    member_expr.object().without_parentheses(),
                     Expression::ArrayExpression(_)
                 ) {
                     return;
@@ -149,7 +149,7 @@ impl Rule for PreferSpread {
                 let Some(expr) = call_expr.arguments[0].as_expression() else {
                     return;
                 };
-                let Expression::StringLiteral(string_lit) = expr.without_parenthesized() else {
+                let Expression::StringLiteral(string_lit) = expr.without_parentheses() else {
                     return;
                 };
 
@@ -160,7 +160,7 @@ impl Rule for PreferSpread {
                 ctx.diagnostic_with_fix(
                     prefer_spread_diagnostic(call_expr.span, "string.split()"),
                     |fixer| {
-                        let callee_obj = member_expr.object().without_parenthesized();
+                        let callee_obj = member_expr.object().without_parentheses();
                         fixer.replace(
                             call_expr.span,
                             format!("[...{}]", callee_obj.span().source_text(ctx.source_text())),
@@ -183,7 +183,7 @@ const IGNORED_SLICE_CALLEE: phf::Set<&'static str> = phf_set! {
 
 fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
     if matches!(
-        expr.without_parenthesized(),
+        expr.without_parentheses(),
         Expression::TemplateLiteral(_) | Expression::BinaryExpression(_)
     ) {
         return true;
@@ -193,7 +193,7 @@ fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
     }
 
     if let Expression::CallExpression(call_expr) = expr {
-        if let Some(member_expr) = call_expr.callee.without_parenthesized().as_member_expression() {
+        if let Some(member_expr) = call_expr.callee.without_parentheses().as_member_expression() {
             if Some("join") == member_expr.static_property_name() && call_expr.arguments.len() < 2 {
                 return true;
             }
@@ -202,7 +202,7 @@ fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
         return false;
     }
 
-    let ident = match expr.without_parenthesized() {
+    let ident = match expr.without_parentheses() {
         Expression::Identifier(ident) => {
             if let Some(symbol_id) = ast_util::get_symbol_id_of_variable(ident, ctx) {
                 let symbol_table = ctx.semantic().symbols();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -70,7 +70,7 @@ impl Rule for PreferStringStartsEndsWith {
             return;
         }
 
-        let Expression::RegExpLiteral(regex) = &member_expr.object().without_parenthesized() else {
+        let Expression::RegExpLiteral(regex) = &member_expr.object().without_parentheses() else {
             return;
         };
 
@@ -117,7 +117,7 @@ fn can_replace(call_expr: &CallExpression) -> Option<Span> {
 
     let arg = &call_expr.arguments[0];
     let expr = arg.as_expression()?;
-    match expr.without_parenthesized() {
+    match expr.without_parentheses() {
         Expression::StringLiteral(s) => Some(s.span),
         Expression::TemplateLiteral(s) => Some(s.span),
         Expression::Identifier(ident) => Some(ident.span),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -90,8 +90,7 @@ impl Rule for PreferStructuredClone {
                 return;
             };
 
-            let Expression::CallExpression(inner_call_expr) =
-                first_argument.without_parenthesized()
+            let Expression::CallExpression(inner_call_expr) = first_argument.without_parentheses()
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -52,8 +52,7 @@ impl Rule for PreferTypeError {
             return;
         };
 
-        let Expression::NewExpression(new_expr) = &throw_stmt.argument.without_parenthesized()
-        else {
+        let Expression::NewExpression(new_expr) = &throw_stmt.argument.without_parentheses() else {
             return;
         };
 

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -65,7 +65,7 @@ impl Rule for ThrowNewError {
             return;
         };
 
-        match call_expr.callee.without_parenthesized() {
+        match call_expr.callee.without_parentheses() {
             Expression::Identifier(v) => {
                 if !CUSTOM_ERROR_REGEX_PATTERN.is_match(&v.name) {
                     return;

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -63,7 +63,7 @@ pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
         test: conditional_test, ..
     }) = parent.kind()
     {
-        let expr_span = conditional_test.get_inner_expression().without_parenthesized().span();
+        let expr_span = conditional_test.get_inner_expression().without_parentheses().span();
         return expr_span == node.kind().span();
     }
 


### PR DESCRIPTION
Rename `without_parenthesized` to `without_parentheses`. Both are hard-to-spell words, but "without parenthesized" does not make sense.