### PR TITLE
feat(semantic): check for non-declared, non-abstract class accessors without bodies

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1423,6 +1423,11 @@ impl MethodDefinitionKind {
         matches!(self, Self::Get)
     }
 
+    /// Returns `true` if this method is a getter or a setter.
+    pub fn is_accessor(&self) -> bool {
+        matches!(self, Self::Get | Self::Set)
+    }
+
     pub fn scope_flags(self) -> ScopeFlags {
         match self {
             Self::Constructor => ScopeFlags::Constructor | ScopeFlags::Function,

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 3bcfee23
 parser_babel Summary:
 AST Parsed     : 2093/2101 (99.62%)
 Positive Passed: 2083/2101 (99.14%)
-Negative Passed: 1381/1493 (92.50%)
+Negative Passed: 1382/1493 (92.57%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -39,7 +39,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-invalid-order-modifiers-3/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-type-parameters/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-type-parameters-babel-7/input.ts
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-accessor/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-field-initializer/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-initializer/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-method/input.ts
@@ -10037,6 +10036,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  7 │   accessor #d?;
    ·              ─
  8 │   abstract accessor f = 1;
+   ╰────
+
+  × Getters and setters must have an implementation.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/declare-accessor/input.ts:2:15]
+ 1 │ class Foo {
+ 2 │   declare get foo()
+   ·               ───
+ 3 │   declare set foo(v)
+   ╰────
+
+  × Getters and setters must have an implementation.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/declare-accessor/input.ts:3:15]
+ 2 │   declare get foo()
+ 3 │   declare set foo(v)
+   ·               ───
+ 4 │ }
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -5021,6 +5021,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFro
    ╰────
   help: Try insert a semicolon here
 
+  × Getters and setters must have an implementation.
+    ╭─[typescript/tests/cases/compiler/abstractPropertyNegative.ts:16:9]
+ 15 │     abstract notAllowed: string;
+ 16 │     get concreteWithNoBody(): string;
+    ·         ──────────────────
+ 17 │ }
+    ╰────
+
   × TS(1253): Abstract properties can only appear within an abstract class.
     ╭─[typescript/tests/cases/compiler/abstractPropertyNegative.ts:15:14]
  14 │     readonly ro = "readonly please";


### PR DESCRIPTION
This should be causing more negative tests to fail than it actually is. This is
because our typescript coverage tests use the "declarations" option to change
the source type to `.d.ts`, which is incorrect. This setting enables `.d.ts`
emits, it does not mean that input files should be treated as `.d.ts`
themselves.