### PR TITLE
refactor(ast, ast_tools): use full method path for generated derives trait calls.

### DIFF
--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -21,8 +21,8 @@ impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
     type Cloned = BooleanLiteral;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         BooleanLiteral {
-            span: self.span.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -30,7 +30,7 @@ impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
 impl<'alloc> CloneIn<'alloc> for NullLiteral {
     type Cloned = NullLiteral;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        NullLiteral { span: self.span.clone_in(allocator) }
+        NullLiteral { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -38,10 +38,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'old_alloc> 
     type Cloned = NumericLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NumericLiteral {
-            span: self.span.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            raw: self.raw.clone_in(allocator),
-            base: self.base.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+            base: CloneIn::clone_in(&self.base, allocator),
         }
     }
 }
@@ -50,9 +50,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'old_alloc> {
     type Cloned = BigIntLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
-            span: self.span.clone_in(allocator),
-            raw: self.raw.clone_in(allocator),
-            base: self.base.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+            base: CloneIn::clone_in(&self.base, allocator),
         }
     }
 }
@@ -61,9 +61,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'old_alloc> {
     type Cloned = RegExpLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         RegExpLiteral {
-            span: self.span.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            regex: self.regex.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            regex: CloneIn::clone_in(&self.regex, allocator),
         }
     }
 }
@@ -71,7 +71,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'old_alloc> {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExp<'old_alloc> {
     type Cloned = RegExp<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExp { pattern: self.pattern.clone_in(allocator), flags: self.flags.clone_in(allocator) }
+        RegExp {
+            pattern: CloneIn::clone_in(&self.pattern, allocator),
+            flags: CloneIn::clone_in(&self.flags, allocator),
+        }
     }
 }
 
@@ -79,9 +82,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'old_alloc> {
     type Cloned = RegExpPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Raw(it) => RegExpPattern::Raw(it.clone_in(allocator)),
-            Self::Invalid(it) => RegExpPattern::Invalid(it.clone_in(allocator)),
-            Self::Pattern(it) => RegExpPattern::Pattern(it.clone_in(allocator)),
+            Self::Raw(it) => RegExpPattern::Raw(CloneIn::clone_in(it, allocator)),
+            Self::Invalid(it) => RegExpPattern::Invalid(CloneIn::clone_in(it, allocator)),
+            Self::Pattern(it) => RegExpPattern::Pattern(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -96,7 +99,10 @@ impl<'alloc> CloneIn<'alloc> for EmptyObject {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StringLiteral<'old_alloc> {
     type Cloned = StringLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StringLiteral { span: self.span.clone_in(allocator), value: self.value.clone_in(allocator) }
+        StringLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
     }
 }
 
@@ -104,11 +110,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Program<'old_alloc> {
     type Cloned = Program<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Program {
-            span: self.span.clone_in(allocator),
-            source_type: self.source_type.clone_in(allocator),
-            hashbang: self.hashbang.clone_in(allocator),
-            directives: self.directives.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            source_type: CloneIn::clone_in(&self.source_type, allocator),
+            hashbang: CloneIn::clone_in(&self.hashbang, allocator),
+            directives: CloneIn::clone_in(&self.directives, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -118,71 +124,111 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Expression<'old_alloc> {
     type Cloned = Expression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::BooleanLiteral(it) => Expression::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => Expression::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => Expression::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => Expression::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => Expression::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => Expression::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => Expression::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => Expression::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => Expression::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => Expression::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => Expression::ArrayExpression(it.clone_in(allocator)),
+            Self::BooleanLiteral(it) => {
+                Expression::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => Expression::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => {
+                Expression::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => Expression::BigIntLiteral(CloneIn::clone_in(it, allocator)),
+            Self::RegExpLiteral(it) => Expression::RegExpLiteral(CloneIn::clone_in(it, allocator)),
+            Self::StringLiteral(it) => Expression::StringLiteral(CloneIn::clone_in(it, allocator)),
+            Self::TemplateLiteral(it) => {
+                Expression::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => Expression::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => Expression::MetaProperty(CloneIn::clone_in(it, allocator)),
+            Self::Super(it) => Expression::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                Expression::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                Expression::ArrowFunctionExpression(it.clone_in(allocator))
+                Expression::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                Expression::AssignmentExpression(it.clone_in(allocator))
+                Expression::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => Expression::AwaitExpression(it.clone_in(allocator)),
-            Self::BinaryExpression(it) => Expression::BinaryExpression(it.clone_in(allocator)),
-            Self::CallExpression(it) => Expression::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => Expression::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => Expression::ClassExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                Expression::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BinaryExpression(it) => {
+                Expression::BinaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::CallExpression(it) => {
+                Expression::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                Expression::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                Expression::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                Expression::ConditionalExpression(it.clone_in(allocator))
+                Expression::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::FunctionExpression(it) => Expression::FunctionExpression(it.clone_in(allocator)),
-            Self::ImportExpression(it) => Expression::ImportExpression(it.clone_in(allocator)),
-            Self::LogicalExpression(it) => Expression::LogicalExpression(it.clone_in(allocator)),
-            Self::NewExpression(it) => Expression::NewExpression(it.clone_in(allocator)),
-            Self::ObjectExpression(it) => Expression::ObjectExpression(it.clone_in(allocator)),
+            Self::FunctionExpression(it) => {
+                Expression::FunctionExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ImportExpression(it) => {
+                Expression::ImportExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::LogicalExpression(it) => {
+                Expression::LogicalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::NewExpression(it) => Expression::NewExpression(CloneIn::clone_in(it, allocator)),
+            Self::ObjectExpression(it) => {
+                Expression::ObjectExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ParenthesizedExpression(it) => {
-                Expression::ParenthesizedExpression(it.clone_in(allocator))
+                Expression::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::SequenceExpression(it) => Expression::SequenceExpression(it.clone_in(allocator)),
+            Self::SequenceExpression(it) => {
+                Expression::SequenceExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TaggedTemplateExpression(it) => {
-                Expression::TaggedTemplateExpression(it.clone_in(allocator))
+                Expression::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => Expression::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => Expression::UnaryExpression(it.clone_in(allocator)),
-            Self::UpdateExpression(it) => Expression::UpdateExpression(it.clone_in(allocator)),
-            Self::YieldExpression(it) => Expression::YieldExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => {
+                Expression::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                Expression::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UpdateExpression(it) => {
+                Expression::UpdateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::YieldExpression(it) => {
+                Expression::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::PrivateInExpression(it) => {
-                Expression::PrivateInExpression(it.clone_in(allocator))
+                Expression::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => Expression::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => Expression::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => Expression::TSAsExpression(it.clone_in(allocator)),
+            Self::JSXElement(it) => Expression::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => Expression::JSXFragment(CloneIn::clone_in(it, allocator)),
+            Self::TSAsExpression(it) => {
+                Expression::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                Expression::TSSatisfiesExpression(it.clone_in(allocator))
+                Expression::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => Expression::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                Expression::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNonNullExpression(it) => {
-                Expression::TSNonNullExpression(it.clone_in(allocator))
+                Expression::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                Expression::TSInstantiationExpression(it.clone_in(allocator))
+                Expression::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                Expression::ComputedMemberExpression(it.clone_in(allocator))
+                Expression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                Expression::StaticMemberExpression(it.clone_in(allocator))
+                Expression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                Expression::PrivateFieldExpression(it.clone_in(allocator))
+                Expression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -191,7 +237,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Expression<'old_alloc> {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierName<'old_alloc> {
     type Cloned = IdentifierName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        IdentifierName { span: self.span.clone_in(allocator), name: self.name.clone_in(allocator) }
+        IdentifierName {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
     }
 }
 
@@ -199,8 +248,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'old_al
     type Cloned = IdentifierReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierReference {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
             reference_id: Default::default(),
         }
     }
@@ -210,8 +259,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'old_allo
     type Cloned = BindingIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingIdentifier {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
             symbol_id: Default::default(),
         }
     }
@@ -220,14 +269,17 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'old_allo
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'old_alloc> {
     type Cloned = LabelIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        LabelIdentifier { span: self.span.clone_in(allocator), name: self.name.clone_in(allocator) }
+        LabelIdentifier {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for ThisExpression {
     type Cloned = ThisExpression;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        ThisExpression { span: self.span.clone_in(allocator) }
+        ThisExpression { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -235,9 +287,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'old_alloc>
     type Cloned = ArrayExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayExpression {
-            span: self.span.clone_in(allocator),
-            elements: self.elements.clone_in(allocator),
-            trailing_comma: self.trailing_comma.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            elements: CloneIn::clone_in(&self.elements, allocator),
+            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 }
@@ -247,122 +299,132 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'old
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::SpreadElement(it) => {
-                ArrayExpressionElement::SpreadElement(it.clone_in(allocator))
+                ArrayExpressionElement::SpreadElement(CloneIn::clone_in(it, allocator))
             }
-            Self::Elision(it) => ArrayExpressionElement::Elision(it.clone_in(allocator)),
+            Self::Elision(it) => ArrayExpressionElement::Elision(CloneIn::clone_in(it, allocator)),
             Self::BooleanLiteral(it) => {
-                ArrayExpressionElement::BooleanLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::BooleanLiteral(CloneIn::clone_in(it, allocator))
             }
-            Self::NullLiteral(it) => ArrayExpressionElement::NullLiteral(it.clone_in(allocator)),
+            Self::NullLiteral(it) => {
+                ArrayExpressionElement::NullLiteral(CloneIn::clone_in(it, allocator))
+            }
             Self::NumericLiteral(it) => {
-                ArrayExpressionElement::NumericLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::NumericLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::BigIntLiteral(it) => {
-                ArrayExpressionElement::BigIntLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::BigIntLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::RegExpLiteral(it) => {
-                ArrayExpressionElement::RegExpLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::RegExpLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::StringLiteral(it) => {
-                ArrayExpressionElement::StringLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::StringLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::TemplateLiteral(it) => {
-                ArrayExpressionElement::TemplateLiteral(it.clone_in(allocator))
+                ArrayExpressionElement::TemplateLiteral(CloneIn::clone_in(it, allocator))
             }
-            Self::Identifier(it) => ArrayExpressionElement::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => ArrayExpressionElement::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => ArrayExpressionElement::Super(it.clone_in(allocator)),
+            Self::Identifier(it) => {
+                ArrayExpressionElement::Identifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::MetaProperty(it) => {
+                ArrayExpressionElement::MetaProperty(CloneIn::clone_in(it, allocator))
+            }
+            Self::Super(it) => ArrayExpressionElement::Super(CloneIn::clone_in(it, allocator)),
             Self::ArrayExpression(it) => {
-                ArrayExpressionElement::ArrayExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ArrayExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ArrowFunctionExpression(it) => {
-                ArrayExpressionElement::ArrowFunctionExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                ArrayExpressionElement::AssignmentExpression(it.clone_in(allocator))
+                ArrayExpressionElement::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AwaitExpression(it) => {
-                ArrayExpressionElement::AwaitExpression(it.clone_in(allocator))
+                ArrayExpressionElement::AwaitExpression(CloneIn::clone_in(it, allocator))
             }
             Self::BinaryExpression(it) => {
-                ArrayExpressionElement::BinaryExpression(it.clone_in(allocator))
+                ArrayExpressionElement::BinaryExpression(CloneIn::clone_in(it, allocator))
             }
             Self::CallExpression(it) => {
-                ArrayExpressionElement::CallExpression(it.clone_in(allocator))
+                ArrayExpressionElement::CallExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ChainExpression(it) => {
-                ArrayExpressionElement::ChainExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ChainExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ClassExpression(it) => {
-                ArrayExpressionElement::ClassExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ClassExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ConditionalExpression(it) => {
-                ArrayExpressionElement::ConditionalExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::FunctionExpression(it) => {
-                ArrayExpressionElement::FunctionExpression(it.clone_in(allocator))
+                ArrayExpressionElement::FunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ImportExpression(it) => {
-                ArrayExpressionElement::ImportExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ImportExpression(CloneIn::clone_in(it, allocator))
             }
             Self::LogicalExpression(it) => {
-                ArrayExpressionElement::LogicalExpression(it.clone_in(allocator))
+                ArrayExpressionElement::LogicalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::NewExpression(it) => {
-                ArrayExpressionElement::NewExpression(it.clone_in(allocator))
+                ArrayExpressionElement::NewExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ObjectExpression(it) => {
-                ArrayExpressionElement::ObjectExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ObjectExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ParenthesizedExpression(it) => {
-                ArrayExpressionElement::ParenthesizedExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
             Self::SequenceExpression(it) => {
-                ArrayExpressionElement::SequenceExpression(it.clone_in(allocator))
+                ArrayExpressionElement::SequenceExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TaggedTemplateExpression(it) => {
-                ArrayExpressionElement::TaggedTemplateExpression(it.clone_in(allocator))
+                ArrayExpressionElement::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ThisExpression(it) => {
-                ArrayExpressionElement::ThisExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ThisExpression(CloneIn::clone_in(it, allocator))
             }
             Self::UnaryExpression(it) => {
-                ArrayExpressionElement::UnaryExpression(it.clone_in(allocator))
+                ArrayExpressionElement::UnaryExpression(CloneIn::clone_in(it, allocator))
             }
             Self::UpdateExpression(it) => {
-                ArrayExpressionElement::UpdateExpression(it.clone_in(allocator))
+                ArrayExpressionElement::UpdateExpression(CloneIn::clone_in(it, allocator))
             }
             Self::YieldExpression(it) => {
-                ArrayExpressionElement::YieldExpression(it.clone_in(allocator))
+                ArrayExpressionElement::YieldExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateInExpression(it) => {
-                ArrayExpressionElement::PrivateInExpression(it.clone_in(allocator))
+                ArrayExpressionElement::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => ArrayExpressionElement::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => ArrayExpressionElement::JSXFragment(it.clone_in(allocator)),
+            Self::JSXElement(it) => {
+                ArrayExpressionElement::JSXElement(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSXFragment(it) => {
+                ArrayExpressionElement::JSXFragment(CloneIn::clone_in(it, allocator))
+            }
             Self::TSAsExpression(it) => {
-                ArrayExpressionElement::TSAsExpression(it.clone_in(allocator))
+                ArrayExpressionElement::TSAsExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSSatisfiesExpression(it) => {
-                ArrayExpressionElement::TSSatisfiesExpression(it.clone_in(allocator))
+                ArrayExpressionElement::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSTypeAssertion(it) => {
-                ArrayExpressionElement::TSTypeAssertion(it.clone_in(allocator))
+                ArrayExpressionElement::TSTypeAssertion(CloneIn::clone_in(it, allocator))
             }
             Self::TSNonNullExpression(it) => {
-                ArrayExpressionElement::TSNonNullExpression(it.clone_in(allocator))
+                ArrayExpressionElement::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                ArrayExpressionElement::TSInstantiationExpression(it.clone_in(allocator))
+                ArrayExpressionElement::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                ArrayExpressionElement::ComputedMemberExpression(it.clone_in(allocator))
+                ArrayExpressionElement::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                ArrayExpressionElement::StaticMemberExpression(it.clone_in(allocator))
+                ArrayExpressionElement::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                ArrayExpressionElement::PrivateFieldExpression(it.clone_in(allocator))
+                ArrayExpressionElement::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -371,7 +433,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'old
 impl<'alloc> CloneIn<'alloc> for Elision {
     type Cloned = Elision;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        Elision { span: self.span.clone_in(allocator) }
+        Elision { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -379,9 +441,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'old_alloc
     type Cloned = ObjectExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectExpression {
-            span: self.span.clone_in(allocator),
-            properties: self.properties.clone_in(allocator),
-            trailing_comma: self.trailing_comma.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            properties: CloneIn::clone_in(&self.properties, allocator),
+            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 }
@@ -390,8 +452,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectPropertyKind<'old_all
     type Cloned = ObjectPropertyKind<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::ObjectProperty(it) => ObjectPropertyKind::ObjectProperty(it.clone_in(allocator)),
-            Self::SpreadProperty(it) => ObjectPropertyKind::SpreadProperty(it.clone_in(allocator)),
+            Self::ObjectProperty(it) => {
+                ObjectPropertyKind::ObjectProperty(CloneIn::clone_in(it, allocator))
+            }
+            Self::SpreadProperty(it) => {
+                ObjectPropertyKind::SpreadProperty(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -400,14 +466,14 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'old_alloc> 
     type Cloned = ObjectProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectProperty {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            init: self.init.clone_in(allocator),
-            method: self.method.clone_in(allocator),
-            shorthand: self.shorthand.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            init: CloneIn::clone_in(&self.init, allocator),
+            method: CloneIn::clone_in(&self.method, allocator),
+            shorthand: CloneIn::clone_in(&self.shorthand, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
         }
     }
 }
@@ -416,73 +482,117 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PropertyKey<'old_alloc> {
     type Cloned = PropertyKey<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::StaticIdentifier(it) => PropertyKey::StaticIdentifier(it.clone_in(allocator)),
-            Self::PrivateIdentifier(it) => PropertyKey::PrivateIdentifier(it.clone_in(allocator)),
-            Self::BooleanLiteral(it) => PropertyKey::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => PropertyKey::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => PropertyKey::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => PropertyKey::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => PropertyKey::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => PropertyKey::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => PropertyKey::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => PropertyKey::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => PropertyKey::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => PropertyKey::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => PropertyKey::ArrayExpression(it.clone_in(allocator)),
+            Self::StaticIdentifier(it) => {
+                PropertyKey::StaticIdentifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::PrivateIdentifier(it) => {
+                PropertyKey::PrivateIdentifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::BooleanLiteral(it) => {
+                PropertyKey::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => PropertyKey::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => {
+                PropertyKey::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => PropertyKey::BigIntLiteral(CloneIn::clone_in(it, allocator)),
+            Self::RegExpLiteral(it) => PropertyKey::RegExpLiteral(CloneIn::clone_in(it, allocator)),
+            Self::StringLiteral(it) => PropertyKey::StringLiteral(CloneIn::clone_in(it, allocator)),
+            Self::TemplateLiteral(it) => {
+                PropertyKey::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => PropertyKey::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => PropertyKey::MetaProperty(CloneIn::clone_in(it, allocator)),
+            Self::Super(it) => PropertyKey::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                PropertyKey::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                PropertyKey::ArrowFunctionExpression(it.clone_in(allocator))
+                PropertyKey::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                PropertyKey::AssignmentExpression(it.clone_in(allocator))
+                PropertyKey::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => PropertyKey::AwaitExpression(it.clone_in(allocator)),
-            Self::BinaryExpression(it) => PropertyKey::BinaryExpression(it.clone_in(allocator)),
-            Self::CallExpression(it) => PropertyKey::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => PropertyKey::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => PropertyKey::ClassExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                PropertyKey::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BinaryExpression(it) => {
+                PropertyKey::BinaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::CallExpression(it) => {
+                PropertyKey::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                PropertyKey::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                PropertyKey::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                PropertyKey::ConditionalExpression(it.clone_in(allocator))
+                PropertyKey::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::FunctionExpression(it) => PropertyKey::FunctionExpression(it.clone_in(allocator)),
-            Self::ImportExpression(it) => PropertyKey::ImportExpression(it.clone_in(allocator)),
-            Self::LogicalExpression(it) => PropertyKey::LogicalExpression(it.clone_in(allocator)),
-            Self::NewExpression(it) => PropertyKey::NewExpression(it.clone_in(allocator)),
-            Self::ObjectExpression(it) => PropertyKey::ObjectExpression(it.clone_in(allocator)),
+            Self::FunctionExpression(it) => {
+                PropertyKey::FunctionExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ImportExpression(it) => {
+                PropertyKey::ImportExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::LogicalExpression(it) => {
+                PropertyKey::LogicalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::NewExpression(it) => PropertyKey::NewExpression(CloneIn::clone_in(it, allocator)),
+            Self::ObjectExpression(it) => {
+                PropertyKey::ObjectExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ParenthesizedExpression(it) => {
-                PropertyKey::ParenthesizedExpression(it.clone_in(allocator))
+                PropertyKey::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::SequenceExpression(it) => PropertyKey::SequenceExpression(it.clone_in(allocator)),
+            Self::SequenceExpression(it) => {
+                PropertyKey::SequenceExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TaggedTemplateExpression(it) => {
-                PropertyKey::TaggedTemplateExpression(it.clone_in(allocator))
+                PropertyKey::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => PropertyKey::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => PropertyKey::UnaryExpression(it.clone_in(allocator)),
-            Self::UpdateExpression(it) => PropertyKey::UpdateExpression(it.clone_in(allocator)),
-            Self::YieldExpression(it) => PropertyKey::YieldExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => {
+                PropertyKey::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                PropertyKey::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UpdateExpression(it) => {
+                PropertyKey::UpdateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::YieldExpression(it) => {
+                PropertyKey::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::PrivateInExpression(it) => {
-                PropertyKey::PrivateInExpression(it.clone_in(allocator))
+                PropertyKey::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => PropertyKey::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => PropertyKey::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => PropertyKey::TSAsExpression(it.clone_in(allocator)),
+            Self::JSXElement(it) => PropertyKey::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => PropertyKey::JSXFragment(CloneIn::clone_in(it, allocator)),
+            Self::TSAsExpression(it) => {
+                PropertyKey::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                PropertyKey::TSSatisfiesExpression(it.clone_in(allocator))
+                PropertyKey::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => PropertyKey::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                PropertyKey::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNonNullExpression(it) => {
-                PropertyKey::TSNonNullExpression(it.clone_in(allocator))
+                PropertyKey::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                PropertyKey::TSInstantiationExpression(it.clone_in(allocator))
+                PropertyKey::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                PropertyKey::ComputedMemberExpression(it.clone_in(allocator))
+                PropertyKey::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                PropertyKey::StaticMemberExpression(it.clone_in(allocator))
+                PropertyKey::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                PropertyKey::PrivateFieldExpression(it.clone_in(allocator))
+                PropertyKey::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -503,9 +613,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'old_alloc>
     type Cloned = TemplateLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateLiteral {
-            span: self.span.clone_in(allocator),
-            quasis: self.quasis.clone_in(allocator),
-            expressions: self.expressions.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            quasis: CloneIn::clone_in(&self.quasis, allocator),
+            expressions: CloneIn::clone_in(&self.expressions, allocator),
         }
     }
 }
@@ -514,10 +624,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'o
     type Cloned = TaggedTemplateExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TaggedTemplateExpression {
-            span: self.span.clone_in(allocator),
-            tag: self.tag.clone_in(allocator),
-            quasi: self.quasi.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            tag: CloneIn::clone_in(&self.tag, allocator),
+            quasi: CloneIn::clone_in(&self.quasi, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -526,9 +636,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TemplateElement<'old_alloc>
     type Cloned = TemplateElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElement {
-            span: self.span.clone_in(allocator),
-            tail: self.tail.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            tail: CloneIn::clone_in(&self.tail, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -537,8 +647,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TemplateElementValue<'old_a
     type Cloned = TemplateElementValue<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElementValue {
-            raw: self.raw.clone_in(allocator),
-            cooked: self.cooked.clone_in(allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+            cooked: CloneIn::clone_in(&self.cooked, allocator),
         }
     }
 }
@@ -548,13 +658,13 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for MemberExpression<'old_alloc
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::ComputedMemberExpression(it) => {
-                MemberExpression::ComputedMemberExpression(it.clone_in(allocator))
+                MemberExpression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                MemberExpression::StaticMemberExpression(it.clone_in(allocator))
+                MemberExpression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                MemberExpression::PrivateFieldExpression(it.clone_in(allocator))
+                MemberExpression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -564,10 +674,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'o
     type Cloned = ComputedMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ComputedMemberExpression {
-            span: self.span.clone_in(allocator),
-            object: self.object.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -576,10 +686,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'old
     type Cloned = StaticMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticMemberExpression {
-            span: self.span.clone_in(allocator),
-            object: self.object.clone_in(allocator),
-            property: self.property.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -588,10 +698,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'old
     type Cloned = PrivateFieldExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateFieldExpression {
-            span: self.span.clone_in(allocator),
-            object: self.object.clone_in(allocator),
-            field: self.field.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            field: CloneIn::clone_in(&self.field, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -600,11 +710,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CallExpression<'old_alloc> 
     type Cloned = CallExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CallExpression {
-            span: self.span.clone_in(allocator),
-            callee: self.callee.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            arguments: self.arguments.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            callee: CloneIn::clone_in(&self.callee, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            arguments: CloneIn::clone_in(&self.arguments, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -613,10 +723,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NewExpression<'old_alloc> {
     type Cloned = NewExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NewExpression {
-            span: self.span.clone_in(allocator),
-            callee: self.callee.clone_in(allocator),
-            arguments: self.arguments.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            callee: CloneIn::clone_in(&self.callee, allocator),
+            arguments: CloneIn::clone_in(&self.arguments, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -625,9 +735,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for MetaProperty<'old_alloc> {
     type Cloned = MetaProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MetaProperty {
-            span: self.span.clone_in(allocator),
-            meta: self.meta.clone_in(allocator),
-            property: self.property.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            meta: CloneIn::clone_in(&self.meta, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
         }
     }
 }
@@ -636,8 +746,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SpreadElement<'old_alloc> {
     type Cloned = SpreadElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SpreadElement {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -646,68 +756,102 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Argument<'old_alloc> {
     type Cloned = Argument<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::SpreadElement(it) => Argument::SpreadElement(it.clone_in(allocator)),
-            Self::BooleanLiteral(it) => Argument::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => Argument::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => Argument::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => Argument::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => Argument::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => Argument::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => Argument::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => Argument::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => Argument::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => Argument::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => Argument::ArrayExpression(it.clone_in(allocator)),
+            Self::SpreadElement(it) => Argument::SpreadElement(CloneIn::clone_in(it, allocator)),
+            Self::BooleanLiteral(it) => Argument::BooleanLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NullLiteral(it) => Argument::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => Argument::NumericLiteral(CloneIn::clone_in(it, allocator)),
+            Self::BigIntLiteral(it) => Argument::BigIntLiteral(CloneIn::clone_in(it, allocator)),
+            Self::RegExpLiteral(it) => Argument::RegExpLiteral(CloneIn::clone_in(it, allocator)),
+            Self::StringLiteral(it) => Argument::StringLiteral(CloneIn::clone_in(it, allocator)),
+            Self::TemplateLiteral(it) => {
+                Argument::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => Argument::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => Argument::MetaProperty(CloneIn::clone_in(it, allocator)),
+            Self::Super(it) => Argument::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                Argument::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                Argument::ArrowFunctionExpression(it.clone_in(allocator))
+                Argument::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                Argument::AssignmentExpression(it.clone_in(allocator))
+                Argument::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => Argument::AwaitExpression(it.clone_in(allocator)),
-            Self::BinaryExpression(it) => Argument::BinaryExpression(it.clone_in(allocator)),
-            Self::CallExpression(it) => Argument::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => Argument::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => Argument::ClassExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                Argument::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BinaryExpression(it) => {
+                Argument::BinaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::CallExpression(it) => Argument::CallExpression(CloneIn::clone_in(it, allocator)),
+            Self::ChainExpression(it) => {
+                Argument::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                Argument::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                Argument::ConditionalExpression(it.clone_in(allocator))
+                Argument::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::FunctionExpression(it) => Argument::FunctionExpression(it.clone_in(allocator)),
-            Self::ImportExpression(it) => Argument::ImportExpression(it.clone_in(allocator)),
-            Self::LogicalExpression(it) => Argument::LogicalExpression(it.clone_in(allocator)),
-            Self::NewExpression(it) => Argument::NewExpression(it.clone_in(allocator)),
-            Self::ObjectExpression(it) => Argument::ObjectExpression(it.clone_in(allocator)),
+            Self::FunctionExpression(it) => {
+                Argument::FunctionExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ImportExpression(it) => {
+                Argument::ImportExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::LogicalExpression(it) => {
+                Argument::LogicalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::NewExpression(it) => Argument::NewExpression(CloneIn::clone_in(it, allocator)),
+            Self::ObjectExpression(it) => {
+                Argument::ObjectExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ParenthesizedExpression(it) => {
-                Argument::ParenthesizedExpression(it.clone_in(allocator))
+                Argument::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::SequenceExpression(it) => Argument::SequenceExpression(it.clone_in(allocator)),
+            Self::SequenceExpression(it) => {
+                Argument::SequenceExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TaggedTemplateExpression(it) => {
-                Argument::TaggedTemplateExpression(it.clone_in(allocator))
+                Argument::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => Argument::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => Argument::UnaryExpression(it.clone_in(allocator)),
-            Self::UpdateExpression(it) => Argument::UpdateExpression(it.clone_in(allocator)),
-            Self::YieldExpression(it) => Argument::YieldExpression(it.clone_in(allocator)),
-            Self::PrivateInExpression(it) => Argument::PrivateInExpression(it.clone_in(allocator)),
-            Self::JSXElement(it) => Argument::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => Argument::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => Argument::TSAsExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => Argument::ThisExpression(CloneIn::clone_in(it, allocator)),
+            Self::UnaryExpression(it) => {
+                Argument::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UpdateExpression(it) => {
+                Argument::UpdateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::YieldExpression(it) => {
+                Argument::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::PrivateInExpression(it) => {
+                Argument::PrivateInExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSXElement(it) => Argument::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => Argument::JSXFragment(CloneIn::clone_in(it, allocator)),
+            Self::TSAsExpression(it) => Argument::TSAsExpression(CloneIn::clone_in(it, allocator)),
             Self::TSSatisfiesExpression(it) => {
-                Argument::TSSatisfiesExpression(it.clone_in(allocator))
+                Argument::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => Argument::TSTypeAssertion(it.clone_in(allocator)),
-            Self::TSNonNullExpression(it) => Argument::TSNonNullExpression(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                Argument::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSNonNullExpression(it) => {
+                Argument::TSNonNullExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSInstantiationExpression(it) => {
-                Argument::TSInstantiationExpression(it.clone_in(allocator))
+                Argument::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                Argument::ComputedMemberExpression(it.clone_in(allocator))
+                Argument::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                Argument::StaticMemberExpression(it.clone_in(allocator))
+                Argument::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                Argument::PrivateFieldExpression(it.clone_in(allocator))
+                Argument::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -717,10 +861,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'old_alloc
     type Cloned = UpdateExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UpdateExpression {
-            span: self.span.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            prefix: self.prefix.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            prefix: CloneIn::clone_in(&self.prefix, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -729,9 +873,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'old_alloc>
     type Cloned = UnaryExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UnaryExpression {
-            span: self.span.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -740,10 +884,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'old_alloc
     type Cloned = BinaryExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BinaryExpression {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -752,10 +896,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'old_al
     type Cloned = PrivateInExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateInExpression {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -764,10 +908,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'old_allo
     type Cloned = LogicalExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LogicalExpression {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -776,10 +920,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'old_
     type Cloned = ConditionalExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ConditionalExpression {
-            span: self.span.clone_in(allocator),
-            test: self.test.clone_in(allocator),
-            consequent: self.consequent.clone_in(allocator),
-            alternate: self.alternate.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
+            consequent: CloneIn::clone_in(&self.consequent, allocator),
+            alternate: CloneIn::clone_in(&self.alternate, allocator),
         }
     }
 }
@@ -788,10 +932,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'old_a
     type Cloned = AssignmentExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentExpression {
-            span: self.span.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -801,33 +945,37 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTarget<'old_alloc
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::AssignmentTargetIdentifier(it) => {
-                AssignmentTarget::AssignmentTargetIdentifier(it.clone_in(allocator))
+                AssignmentTarget::AssignmentTargetIdentifier(CloneIn::clone_in(it, allocator))
             }
-            Self::TSAsExpression(it) => AssignmentTarget::TSAsExpression(it.clone_in(allocator)),
+            Self::TSAsExpression(it) => {
+                AssignmentTarget::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                AssignmentTarget::TSSatisfiesExpression(it.clone_in(allocator))
+                AssignmentTarget::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSNonNullExpression(it) => {
-                AssignmentTarget::TSNonNullExpression(it.clone_in(allocator))
+                AssignmentTarget::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => AssignmentTarget::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                AssignmentTarget::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSInstantiationExpression(it) => {
-                AssignmentTarget::TSInstantiationExpression(it.clone_in(allocator))
+                AssignmentTarget::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                AssignmentTarget::ComputedMemberExpression(it.clone_in(allocator))
+                AssignmentTarget::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                AssignmentTarget::StaticMemberExpression(it.clone_in(allocator))
+                AssignmentTarget::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                AssignmentTarget::PrivateFieldExpression(it.clone_in(allocator))
+                AssignmentTarget::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ArrayAssignmentTarget(it) => {
-                AssignmentTarget::ArrayAssignmentTarget(it.clone_in(allocator))
+                AssignmentTarget::ArrayAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
             Self::ObjectAssignmentTarget(it) => {
-                AssignmentTarget::ObjectAssignmentTarget(it.clone_in(allocator))
+                AssignmentTarget::ObjectAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -838,31 +986,31 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SimpleAssignmentTarget<'old
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::AssignmentTargetIdentifier(it) => {
-                SimpleAssignmentTarget::AssignmentTargetIdentifier(it.clone_in(allocator))
+                SimpleAssignmentTarget::AssignmentTargetIdentifier(CloneIn::clone_in(it, allocator))
             }
             Self::TSAsExpression(it) => {
-                SimpleAssignmentTarget::TSAsExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::TSAsExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSSatisfiesExpression(it) => {
-                SimpleAssignmentTarget::TSSatisfiesExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSNonNullExpression(it) => {
-                SimpleAssignmentTarget::TSNonNullExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSTypeAssertion(it) => {
-                SimpleAssignmentTarget::TSTypeAssertion(it.clone_in(allocator))
+                SimpleAssignmentTarget::TSTypeAssertion(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                SimpleAssignmentTarget::TSInstantiationExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                SimpleAssignmentTarget::ComputedMemberExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                SimpleAssignmentTarget::StaticMemberExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                SimpleAssignmentTarget::PrivateFieldExpression(it.clone_in(allocator))
+                SimpleAssignmentTarget::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -873,10 +1021,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPattern<'ol
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::ArrayAssignmentTarget(it) => {
-                AssignmentTargetPattern::ArrayAssignmentTarget(it.clone_in(allocator))
+                AssignmentTargetPattern::ArrayAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
             Self::ObjectAssignmentTarget(it) => {
-                AssignmentTargetPattern::ObjectAssignmentTarget(it.clone_in(allocator))
+                AssignmentTargetPattern::ObjectAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -886,10 +1034,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'old_
     type Cloned = ArrayAssignmentTarget<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayAssignmentTarget {
-            span: self.span.clone_in(allocator),
-            elements: self.elements.clone_in(allocator),
-            rest: self.rest.clone_in(allocator),
-            trailing_comma: self.trailing_comma.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            elements: CloneIn::clone_in(&self.elements, allocator),
+            rest: CloneIn::clone_in(&self.rest, allocator),
+            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 }
@@ -898,9 +1046,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'old
     type Cloned = ObjectAssignmentTarget<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectAssignmentTarget {
-            span: self.span.clone_in(allocator),
-            properties: self.properties.clone_in(allocator),
-            rest: self.rest.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            properties: CloneIn::clone_in(&self.properties, allocator),
+            rest: CloneIn::clone_in(&self.rest, allocator),
         }
     }
 }
@@ -909,8 +1057,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'old_a
     type Cloned = AssignmentTargetRest<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetRest {
-            span: self.span.clone_in(allocator),
-            target: self.target.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            target: CloneIn::clone_in(&self.target, allocator),
         }
     }
 }
@@ -920,40 +1068,54 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetMaybeDefaul
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::AssignmentTargetWithDefault(it) => {
-                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::AssignmentTargetIdentifier(it) => {
-                AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::TSAsExpression(it) => {
-                AssignmentTargetMaybeDefault::TSAsExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::TSAsExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSSatisfiesExpression(it) => {
-                AssignmentTargetMaybeDefault::TSSatisfiesExpression(it.clone_in(allocator))
-            }
+            Self::TSSatisfiesExpression(it) => AssignmentTargetMaybeDefault::TSSatisfiesExpression(
+                CloneIn::clone_in(it, allocator),
+            ),
             Self::TSNonNullExpression(it) => {
-                AssignmentTargetMaybeDefault::TSNonNullExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSTypeAssertion(it) => {
-                AssignmentTargetMaybeDefault::TSTypeAssertion(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::TSTypeAssertion(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                AssignmentTargetMaybeDefault::TSInstantiationExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::TSInstantiationExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::ComputedMemberExpression(it) => {
-                AssignmentTargetMaybeDefault::ComputedMemberExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::ComputedMemberExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::StaticMemberExpression(it) => {
-                AssignmentTargetMaybeDefault::StaticMemberExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::StaticMemberExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::PrivateFieldExpression(it) => {
-                AssignmentTargetMaybeDefault::PrivateFieldExpression(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::PrivateFieldExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
-            Self::ArrayAssignmentTarget(it) => {
-                AssignmentTargetMaybeDefault::ArrayAssignmentTarget(it.clone_in(allocator))
-            }
+            Self::ArrayAssignmentTarget(it) => AssignmentTargetMaybeDefault::ArrayAssignmentTarget(
+                CloneIn::clone_in(it, allocator),
+            ),
             Self::ObjectAssignmentTarget(it) => {
-                AssignmentTargetMaybeDefault::ObjectAssignmentTarget(it.clone_in(allocator))
+                AssignmentTargetMaybeDefault::ObjectAssignmentTarget(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
         }
     }
@@ -963,9 +1125,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault
     type Cloned = AssignmentTargetWithDefault<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetWithDefault {
-            span: self.span.clone_in(allocator),
-            binding: self.binding.clone_in(allocator),
-            init: self.init.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            binding: CloneIn::clone_in(&self.binding, allocator),
+            init: CloneIn::clone_in(&self.init, allocator),
         }
     }
 }
@@ -975,10 +1137,14 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetProperty<'o
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::AssignmentTargetPropertyIdentifier(it) => {
-                AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(it.clone_in(allocator))
+                AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::AssignmentTargetPropertyProperty(it) => {
-                AssignmentTargetProperty::AssignmentTargetPropertyProperty(it.clone_in(allocator))
+                AssignmentTargetProperty::AssignmentTargetPropertyProperty(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
         }
     }
@@ -990,9 +1156,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc>
     type Cloned = AssignmentTargetPropertyIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
-            span: self.span.clone_in(allocator),
-            binding: self.binding.clone_in(allocator),
-            init: self.init.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            binding: CloneIn::clone_in(&self.binding, allocator),
+            init: CloneIn::clone_in(&self.init, allocator),
         }
     }
 }
@@ -1001,9 +1167,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyPro
     type Cloned = AssignmentTargetPropertyProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            binding: self.binding.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            binding: CloneIn::clone_in(&self.binding, allocator),
         }
     }
 }
@@ -1012,8 +1178,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'old_all
     type Cloned = SequenceExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SequenceExpression {
-            span: self.span.clone_in(allocator),
-            expressions: self.expressions.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expressions: CloneIn::clone_in(&self.expressions, allocator),
         }
     }
 }
@@ -1021,7 +1187,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'old_all
 impl<'alloc> CloneIn<'alloc> for Super {
     type Cloned = Super;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        Super { span: self.span.clone_in(allocator) }
+        Super { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -1029,8 +1195,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'old_alloc>
     type Cloned = AwaitExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AwaitExpression {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -1039,8 +1205,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ChainExpression<'old_alloc>
     type Cloned = ChainExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ChainExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -1049,15 +1215,17 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ChainElement<'old_alloc> {
     type Cloned = ChainElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::CallExpression(it) => ChainElement::CallExpression(it.clone_in(allocator)),
+            Self::CallExpression(it) => {
+                ChainElement::CallExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ComputedMemberExpression(it) => {
-                ChainElement::ComputedMemberExpression(it.clone_in(allocator))
+                ChainElement::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                ChainElement::StaticMemberExpression(it.clone_in(allocator))
+                ChainElement::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                ChainElement::PrivateFieldExpression(it.clone_in(allocator))
+                ChainElement::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1067,8 +1235,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'ol
     type Cloned = ParenthesizedExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ParenthesizedExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -1077,51 +1245,79 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Statement<'old_alloc> {
     type Cloned = Statement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::BlockStatement(it) => Statement::BlockStatement(it.clone_in(allocator)),
-            Self::BreakStatement(it) => Statement::BreakStatement(it.clone_in(allocator)),
-            Self::ContinueStatement(it) => Statement::ContinueStatement(it.clone_in(allocator)),
-            Self::DebuggerStatement(it) => Statement::DebuggerStatement(it.clone_in(allocator)),
-            Self::DoWhileStatement(it) => Statement::DoWhileStatement(it.clone_in(allocator)),
-            Self::EmptyStatement(it) => Statement::EmptyStatement(it.clone_in(allocator)),
-            Self::ExpressionStatement(it) => Statement::ExpressionStatement(it.clone_in(allocator)),
-            Self::ForInStatement(it) => Statement::ForInStatement(it.clone_in(allocator)),
-            Self::ForOfStatement(it) => Statement::ForOfStatement(it.clone_in(allocator)),
-            Self::ForStatement(it) => Statement::ForStatement(it.clone_in(allocator)),
-            Self::IfStatement(it) => Statement::IfStatement(it.clone_in(allocator)),
-            Self::LabeledStatement(it) => Statement::LabeledStatement(it.clone_in(allocator)),
-            Self::ReturnStatement(it) => Statement::ReturnStatement(it.clone_in(allocator)),
-            Self::SwitchStatement(it) => Statement::SwitchStatement(it.clone_in(allocator)),
-            Self::ThrowStatement(it) => Statement::ThrowStatement(it.clone_in(allocator)),
-            Self::TryStatement(it) => Statement::TryStatement(it.clone_in(allocator)),
-            Self::WhileStatement(it) => Statement::WhileStatement(it.clone_in(allocator)),
-            Self::WithStatement(it) => Statement::WithStatement(it.clone_in(allocator)),
-            Self::VariableDeclaration(it) => Statement::VariableDeclaration(it.clone_in(allocator)),
-            Self::FunctionDeclaration(it) => Statement::FunctionDeclaration(it.clone_in(allocator)),
-            Self::ClassDeclaration(it) => Statement::ClassDeclaration(it.clone_in(allocator)),
+            Self::BlockStatement(it) => Statement::BlockStatement(CloneIn::clone_in(it, allocator)),
+            Self::BreakStatement(it) => Statement::BreakStatement(CloneIn::clone_in(it, allocator)),
+            Self::ContinueStatement(it) => {
+                Statement::ContinueStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::DebuggerStatement(it) => {
+                Statement::DebuggerStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::DoWhileStatement(it) => {
+                Statement::DoWhileStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::EmptyStatement(it) => Statement::EmptyStatement(CloneIn::clone_in(it, allocator)),
+            Self::ExpressionStatement(it) => {
+                Statement::ExpressionStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::ForInStatement(it) => Statement::ForInStatement(CloneIn::clone_in(it, allocator)),
+            Self::ForOfStatement(it) => Statement::ForOfStatement(CloneIn::clone_in(it, allocator)),
+            Self::ForStatement(it) => Statement::ForStatement(CloneIn::clone_in(it, allocator)),
+            Self::IfStatement(it) => Statement::IfStatement(CloneIn::clone_in(it, allocator)),
+            Self::LabeledStatement(it) => {
+                Statement::LabeledStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::ReturnStatement(it) => {
+                Statement::ReturnStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::SwitchStatement(it) => {
+                Statement::SwitchStatement(CloneIn::clone_in(it, allocator))
+            }
+            Self::ThrowStatement(it) => Statement::ThrowStatement(CloneIn::clone_in(it, allocator)),
+            Self::TryStatement(it) => Statement::TryStatement(CloneIn::clone_in(it, allocator)),
+            Self::WhileStatement(it) => Statement::WhileStatement(CloneIn::clone_in(it, allocator)),
+            Self::WithStatement(it) => Statement::WithStatement(CloneIn::clone_in(it, allocator)),
+            Self::VariableDeclaration(it) => {
+                Statement::VariableDeclaration(CloneIn::clone_in(it, allocator))
+            }
+            Self::FunctionDeclaration(it) => {
+                Statement::FunctionDeclaration(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassDeclaration(it) => {
+                Statement::ClassDeclaration(CloneIn::clone_in(it, allocator))
+            }
             Self::TSTypeAliasDeclaration(it) => {
-                Statement::TSTypeAliasDeclaration(it.clone_in(allocator))
+                Statement::TSTypeAliasDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSInterfaceDeclaration(it) => {
-                Statement::TSInterfaceDeclaration(it.clone_in(allocator))
+                Statement::TSInterfaceDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::TSEnumDeclaration(it) => Statement::TSEnumDeclaration(it.clone_in(allocator)),
-            Self::TSModuleDeclaration(it) => Statement::TSModuleDeclaration(it.clone_in(allocator)),
+            Self::TSEnumDeclaration(it) => {
+                Statement::TSEnumDeclaration(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSModuleDeclaration(it) => {
+                Statement::TSModuleDeclaration(CloneIn::clone_in(it, allocator))
+            }
             Self::TSImportEqualsDeclaration(it) => {
-                Statement::TSImportEqualsDeclaration(it.clone_in(allocator))
+                Statement::TSImportEqualsDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::ImportDeclaration(it) => Statement::ImportDeclaration(it.clone_in(allocator)),
+            Self::ImportDeclaration(it) => {
+                Statement::ImportDeclaration(CloneIn::clone_in(it, allocator))
+            }
             Self::ExportAllDeclaration(it) => {
-                Statement::ExportAllDeclaration(it.clone_in(allocator))
+                Statement::ExportAllDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ExportDefaultDeclaration(it) => {
-                Statement::ExportDefaultDeclaration(it.clone_in(allocator))
+                Statement::ExportDefaultDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ExportNamedDeclaration(it) => {
-                Statement::ExportNamedDeclaration(it.clone_in(allocator))
+                Statement::ExportNamedDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::TSExportAssignment(it) => Statement::TSExportAssignment(it.clone_in(allocator)),
+            Self::TSExportAssignment(it) => {
+                Statement::TSExportAssignment(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNamespaceExportDeclaration(it) => {
-                Statement::TSNamespaceExportDeclaration(it.clone_in(allocator))
+                Statement::TSNamespaceExportDeclaration(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1131,9 +1327,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Directive<'old_alloc> {
     type Cloned = Directive<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Directive {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            directive: self.directive.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            directive: CloneIn::clone_in(&self.directive, allocator),
         }
     }
 }
@@ -1141,7 +1337,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Directive<'old_alloc> {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Hashbang<'old_alloc> {
     type Cloned = Hashbang<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Hashbang { span: self.span.clone_in(allocator), value: self.value.clone_in(allocator) }
+        Hashbang {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
     }
 }
 
@@ -1149,8 +1348,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BlockStatement<'old_alloc> 
     type Cloned = BlockStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BlockStatement {
-            span: self.span.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1161,24 +1360,28 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Declaration<'old_alloc> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::VariableDeclaration(it) => {
-                Declaration::VariableDeclaration(it.clone_in(allocator))
+                Declaration::VariableDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::FunctionDeclaration(it) => {
-                Declaration::FunctionDeclaration(it.clone_in(allocator))
+                Declaration::FunctionDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::ClassDeclaration(it) => Declaration::ClassDeclaration(it.clone_in(allocator)),
+            Self::ClassDeclaration(it) => {
+                Declaration::ClassDeclaration(CloneIn::clone_in(it, allocator))
+            }
             Self::TSTypeAliasDeclaration(it) => {
-                Declaration::TSTypeAliasDeclaration(it.clone_in(allocator))
+                Declaration::TSTypeAliasDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSInterfaceDeclaration(it) => {
-                Declaration::TSInterfaceDeclaration(it.clone_in(allocator))
+                Declaration::TSInterfaceDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::TSEnumDeclaration(it) => Declaration::TSEnumDeclaration(it.clone_in(allocator)),
+            Self::TSEnumDeclaration(it) => {
+                Declaration::TSEnumDeclaration(CloneIn::clone_in(it, allocator))
+            }
             Self::TSModuleDeclaration(it) => {
-                Declaration::TSModuleDeclaration(it.clone_in(allocator))
+                Declaration::TSModuleDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSImportEqualsDeclaration(it) => {
-                Declaration::TSImportEqualsDeclaration(it.clone_in(allocator))
+                Declaration::TSImportEqualsDeclaration(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1188,10 +1391,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'old_al
     type Cloned = VariableDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclaration {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            declarations: self.declarations.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            declarations: CloneIn::clone_in(&self.declarations, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
         }
     }
 }
@@ -1213,11 +1416,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'old_all
     type Cloned = VariableDeclarator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclarator {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            init: self.init.clone_in(allocator),
-            definite: self.definite.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            init: CloneIn::clone_in(&self.init, allocator),
+            definite: CloneIn::clone_in(&self.definite, allocator),
         }
     }
 }
@@ -1225,7 +1428,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'old_all
 impl<'alloc> CloneIn<'alloc> for EmptyStatement {
     type Cloned = EmptyStatement;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        EmptyStatement { span: self.span.clone_in(allocator) }
+        EmptyStatement { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -1233,8 +1436,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'old_al
     type Cloned = ExpressionStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExpressionStatement {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -1243,10 +1446,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IfStatement<'old_alloc> {
     type Cloned = IfStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IfStatement {
-            span: self.span.clone_in(allocator),
-            test: self.test.clone_in(allocator),
-            consequent: self.consequent.clone_in(allocator),
-            alternate: self.alternate.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
+            consequent: CloneIn::clone_in(&self.consequent, allocator),
+            alternate: CloneIn::clone_in(&self.alternate, allocator),
         }
     }
 }
@@ -1255,9 +1458,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'old_alloc
     type Cloned = DoWhileStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DoWhileStatement {
-            span: self.span.clone_in(allocator),
-            body: self.body.clone_in(allocator),
-            test: self.test.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
         }
     }
 }
@@ -1266,9 +1469,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WhileStatement<'old_alloc> 
     type Cloned = WhileStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WhileStatement {
-            span: self.span.clone_in(allocator),
-            test: self.test.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -1277,11 +1480,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForStatement<'old_alloc> {
     type Cloned = ForStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForStatement {
-            span: self.span.clone_in(allocator),
-            init: self.init.clone_in(allocator),
-            test: self.test.clone_in(allocator),
-            update: self.update.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            init: CloneIn::clone_in(&self.init, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
+            update: CloneIn::clone_in(&self.update, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1292,87 +1495,127 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForStatementInit<'old_alloc
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::VariableDeclaration(it) => {
-                ForStatementInit::VariableDeclaration(it.clone_in(allocator))
+                ForStatementInit::VariableDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::BooleanLiteral(it) => ForStatementInit::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => ForStatementInit::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => ForStatementInit::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => ForStatementInit::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => ForStatementInit::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => ForStatementInit::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => ForStatementInit::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => ForStatementInit::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => ForStatementInit::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => ForStatementInit::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => ForStatementInit::ArrayExpression(it.clone_in(allocator)),
+            Self::BooleanLiteral(it) => {
+                ForStatementInit::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => {
+                ForStatementInit::NullLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NumericLiteral(it) => {
+                ForStatementInit::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => {
+                ForStatementInit::BigIntLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::RegExpLiteral(it) => {
+                ForStatementInit::RegExpLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                ForStatementInit::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::TemplateLiteral(it) => {
+                ForStatementInit::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => ForStatementInit::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => {
+                ForStatementInit::MetaProperty(CloneIn::clone_in(it, allocator))
+            }
+            Self::Super(it) => ForStatementInit::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                ForStatementInit::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                ForStatementInit::ArrowFunctionExpression(it.clone_in(allocator))
+                ForStatementInit::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                ForStatementInit::AssignmentExpression(it.clone_in(allocator))
+                ForStatementInit::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => ForStatementInit::AwaitExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                ForStatementInit::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::BinaryExpression(it) => {
-                ForStatementInit::BinaryExpression(it.clone_in(allocator))
+                ForStatementInit::BinaryExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::CallExpression(it) => ForStatementInit::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => ForStatementInit::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => ForStatementInit::ClassExpression(it.clone_in(allocator)),
+            Self::CallExpression(it) => {
+                ForStatementInit::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                ForStatementInit::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                ForStatementInit::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                ForStatementInit::ConditionalExpression(it.clone_in(allocator))
+                ForStatementInit::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::FunctionExpression(it) => {
-                ForStatementInit::FunctionExpression(it.clone_in(allocator))
+                ForStatementInit::FunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ImportExpression(it) => {
-                ForStatementInit::ImportExpression(it.clone_in(allocator))
+                ForStatementInit::ImportExpression(CloneIn::clone_in(it, allocator))
             }
             Self::LogicalExpression(it) => {
-                ForStatementInit::LogicalExpression(it.clone_in(allocator))
+                ForStatementInit::LogicalExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::NewExpression(it) => ForStatementInit::NewExpression(it.clone_in(allocator)),
+            Self::NewExpression(it) => {
+                ForStatementInit::NewExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ObjectExpression(it) => {
-                ForStatementInit::ObjectExpression(it.clone_in(allocator))
+                ForStatementInit::ObjectExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ParenthesizedExpression(it) => {
-                ForStatementInit::ParenthesizedExpression(it.clone_in(allocator))
+                ForStatementInit::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
             Self::SequenceExpression(it) => {
-                ForStatementInit::SequenceExpression(it.clone_in(allocator))
+                ForStatementInit::SequenceExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TaggedTemplateExpression(it) => {
-                ForStatementInit::TaggedTemplateExpression(it.clone_in(allocator))
+                ForStatementInit::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => ForStatementInit::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => ForStatementInit::UnaryExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => {
+                ForStatementInit::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                ForStatementInit::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::UpdateExpression(it) => {
-                ForStatementInit::UpdateExpression(it.clone_in(allocator))
+                ForStatementInit::UpdateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::YieldExpression(it) => ForStatementInit::YieldExpression(it.clone_in(allocator)),
+            Self::YieldExpression(it) => {
+                ForStatementInit::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::PrivateInExpression(it) => {
-                ForStatementInit::PrivateInExpression(it.clone_in(allocator))
+                ForStatementInit::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => ForStatementInit::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => ForStatementInit::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => ForStatementInit::TSAsExpression(it.clone_in(allocator)),
+            Self::JSXElement(it) => ForStatementInit::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => {
+                ForStatementInit::JSXFragment(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSAsExpression(it) => {
+                ForStatementInit::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                ForStatementInit::TSSatisfiesExpression(it.clone_in(allocator))
+                ForStatementInit::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => ForStatementInit::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                ForStatementInit::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNonNullExpression(it) => {
-                ForStatementInit::TSNonNullExpression(it.clone_in(allocator))
+                ForStatementInit::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                ForStatementInit::TSInstantiationExpression(it.clone_in(allocator))
+                ForStatementInit::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                ForStatementInit::ComputedMemberExpression(it.clone_in(allocator))
+                ForStatementInit::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                ForStatementInit::StaticMemberExpression(it.clone_in(allocator))
+                ForStatementInit::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                ForStatementInit::PrivateFieldExpression(it.clone_in(allocator))
+                ForStatementInit::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1382,10 +1625,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForInStatement<'old_alloc> 
     type Cloned = ForInStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForInStatement {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            right: self.right.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1396,36 +1639,40 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForStatementLeft<'old_alloc
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::VariableDeclaration(it) => {
-                ForStatementLeft::VariableDeclaration(it.clone_in(allocator))
+                ForStatementLeft::VariableDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentTargetIdentifier(it) => {
-                ForStatementLeft::AssignmentTargetIdentifier(it.clone_in(allocator))
+                ForStatementLeft::AssignmentTargetIdentifier(CloneIn::clone_in(it, allocator))
             }
-            Self::TSAsExpression(it) => ForStatementLeft::TSAsExpression(it.clone_in(allocator)),
+            Self::TSAsExpression(it) => {
+                ForStatementLeft::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                ForStatementLeft::TSSatisfiesExpression(it.clone_in(allocator))
+                ForStatementLeft::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSNonNullExpression(it) => {
-                ForStatementLeft::TSNonNullExpression(it.clone_in(allocator))
+                ForStatementLeft::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => ForStatementLeft::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                ForStatementLeft::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSInstantiationExpression(it) => {
-                ForStatementLeft::TSInstantiationExpression(it.clone_in(allocator))
+                ForStatementLeft::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                ForStatementLeft::ComputedMemberExpression(it.clone_in(allocator))
+                ForStatementLeft::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                ForStatementLeft::StaticMemberExpression(it.clone_in(allocator))
+                ForStatementLeft::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                ForStatementLeft::PrivateFieldExpression(it.clone_in(allocator))
+                ForStatementLeft::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ArrayAssignmentTarget(it) => {
-                ForStatementLeft::ArrayAssignmentTarget(it.clone_in(allocator))
+                ForStatementLeft::ArrayAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
             Self::ObjectAssignmentTarget(it) => {
-                ForStatementLeft::ObjectAssignmentTarget(it.clone_in(allocator))
+                ForStatementLeft::ObjectAssignmentTarget(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1435,11 +1682,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'old_alloc> 
     type Cloned = ForOfStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForOfStatement {
-            span: self.span.clone_in(allocator),
-            r#await: self.r#await.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            right: self.right.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            r#await: CloneIn::clone_in(&self.r#await, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1449,8 +1696,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'old_allo
     type Cloned = ContinueStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ContinueStatement {
-            span: self.span.clone_in(allocator),
-            label: self.label.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            label: CloneIn::clone_in(&self.label, allocator),
         }
     }
 }
@@ -1459,8 +1706,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BreakStatement<'old_alloc> 
     type Cloned = BreakStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BreakStatement {
-            span: self.span.clone_in(allocator),
-            label: self.label.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            label: CloneIn::clone_in(&self.label, allocator),
         }
     }
 }
@@ -1469,8 +1716,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'old_alloc>
     type Cloned = ReturnStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ReturnStatement {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -1479,9 +1726,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WithStatement<'old_alloc> {
     type Cloned = WithStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithStatement {
-            span: self.span.clone_in(allocator),
-            object: self.object.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -1490,9 +1737,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'old_alloc>
     type Cloned = SwitchStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchStatement {
-            span: self.span.clone_in(allocator),
-            discriminant: self.discriminant.clone_in(allocator),
-            cases: self.cases.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            discriminant: CloneIn::clone_in(&self.discriminant, allocator),
+            cases: CloneIn::clone_in(&self.cases, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1502,9 +1749,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SwitchCase<'old_alloc> {
     type Cloned = SwitchCase<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchCase {
-            span: self.span.clone_in(allocator),
-            test: self.test.clone_in(allocator),
-            consequent: self.consequent.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            test: CloneIn::clone_in(&self.test, allocator),
+            consequent: CloneIn::clone_in(&self.consequent, allocator),
         }
     }
 }
@@ -1513,9 +1760,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'old_alloc
     type Cloned = LabeledStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabeledStatement {
-            span: self.span.clone_in(allocator),
-            label: self.label.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            label: CloneIn::clone_in(&self.label, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -1524,8 +1771,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'old_alloc> 
     type Cloned = ThrowStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThrowStatement {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -1534,10 +1781,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TryStatement<'old_alloc> {
     type Cloned = TryStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TryStatement {
-            span: self.span.clone_in(allocator),
-            block: self.block.clone_in(allocator),
-            handler: self.handler.clone_in(allocator),
-            finalizer: self.finalizer.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            block: CloneIn::clone_in(&self.block, allocator),
+            handler: CloneIn::clone_in(&self.handler, allocator),
+            finalizer: CloneIn::clone_in(&self.finalizer, allocator),
         }
     }
 }
@@ -1546,9 +1793,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchClause<'old_alloc> {
     type Cloned = CatchClause<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchClause {
-            span: self.span.clone_in(allocator),
-            param: self.param.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            param: CloneIn::clone_in(&self.param, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1558,8 +1805,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchParameter<'old_alloc> 
     type Cloned = CatchParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchParameter {
-            span: self.span.clone_in(allocator),
-            pattern: self.pattern.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            pattern: CloneIn::clone_in(&self.pattern, allocator),
         }
     }
 }
@@ -1567,7 +1814,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchParameter<'old_alloc> 
 impl<'alloc> CloneIn<'alloc> for DebuggerStatement {
     type Cloned = DebuggerStatement;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        DebuggerStatement { span: self.span.clone_in(allocator) }
+        DebuggerStatement { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -1575,9 +1822,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingPattern<'old_alloc> 
     type Cloned = BindingPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingPattern {
-            kind: self.kind.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -1587,12 +1834,16 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingPatternKind<'old_all
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::BindingIdentifier(it) => {
-                BindingPatternKind::BindingIdentifier(it.clone_in(allocator))
+                BindingPatternKind::BindingIdentifier(CloneIn::clone_in(it, allocator))
             }
-            Self::ObjectPattern(it) => BindingPatternKind::ObjectPattern(it.clone_in(allocator)),
-            Self::ArrayPattern(it) => BindingPatternKind::ArrayPattern(it.clone_in(allocator)),
+            Self::ObjectPattern(it) => {
+                BindingPatternKind::ObjectPattern(CloneIn::clone_in(it, allocator))
+            }
+            Self::ArrayPattern(it) => {
+                BindingPatternKind::ArrayPattern(CloneIn::clone_in(it, allocator))
+            }
             Self::AssignmentPattern(it) => {
-                BindingPatternKind::AssignmentPattern(it.clone_in(allocator))
+                BindingPatternKind::AssignmentPattern(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1602,9 +1853,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'old_allo
     type Cloned = AssignmentPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentPattern {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -1613,9 +1864,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'old_alloc> {
     type Cloned = ObjectPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectPattern {
-            span: self.span.clone_in(allocator),
-            properties: self.properties.clone_in(allocator),
-            rest: self.rest.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            properties: CloneIn::clone_in(&self.properties, allocator),
+            rest: CloneIn::clone_in(&self.rest, allocator),
         }
     }
 }
@@ -1624,11 +1875,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingProperty<'old_alloc>
     type Cloned = BindingProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingProperty {
-            span: self.span.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            shorthand: self.shorthand.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            shorthand: CloneIn::clone_in(&self.shorthand, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
         }
     }
 }
@@ -1637,9 +1888,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'old_alloc> {
     type Cloned = ArrayPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayPattern {
-            span: self.span.clone_in(allocator),
-            elements: self.elements.clone_in(allocator),
-            rest: self.rest.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            elements: CloneIn::clone_in(&self.elements, allocator),
+            rest: CloneIn::clone_in(&self.rest, allocator),
         }
     }
 }
@@ -1648,8 +1899,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'old_all
     type Cloned = BindingRestElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingRestElement {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -1658,17 +1909,17 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Function<'old_alloc> {
     type Cloned = Function<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Function {
-            r#type: self.r#type.clone_in(allocator),
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            generator: self.generator.clone_in(allocator),
-            r#async: self.r#async.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            this_param: self.this_param.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            generator: CloneIn::clone_in(&self.generator, allocator),
+            r#async: CloneIn::clone_in(&self.r#async, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            this_param: CloneIn::clone_in(&self.this_param, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1690,10 +1941,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FormalParameters<'old_alloc
     type Cloned = FormalParameters<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameters {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            items: self.items.clone_in(allocator),
-            rest: self.rest.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            items: CloneIn::clone_in(&self.items, allocator),
+            rest: CloneIn::clone_in(&self.rest, allocator),
         }
     }
 }
@@ -1702,12 +1953,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FormalParameter<'old_alloc>
     type Cloned = FormalParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameter {
-            span: self.span.clone_in(allocator),
-            decorators: self.decorators.clone_in(allocator),
-            pattern: self.pattern.clone_in(allocator),
-            accessibility: self.accessibility.clone_in(allocator),
-            readonly: self.readonly.clone_in(allocator),
-            r#override: self.r#override.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            decorators: CloneIn::clone_in(&self.decorators, allocator),
+            pattern: CloneIn::clone_in(&self.pattern, allocator),
+            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
+            readonly: CloneIn::clone_in(&self.readonly, allocator),
+            r#override: CloneIn::clone_in(&self.r#override, allocator),
         }
     }
 }
@@ -1728,9 +1979,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FunctionBody<'old_alloc> {
     type Cloned = FunctionBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FunctionBody {
-            span: self.span.clone_in(allocator),
-            directives: self.directives.clone_in(allocator),
-            statements: self.statements.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            directives: CloneIn::clone_in(&self.directives, allocator),
+            statements: CloneIn::clone_in(&self.statements, allocator),
         }
     }
 }
@@ -1739,13 +1990,13 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'ol
     type Cloned = ArrowFunctionExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrowFunctionExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            r#async: self.r#async.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            r#async: CloneIn::clone_in(&self.r#async, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1755,9 +2006,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for YieldExpression<'old_alloc>
     type Cloned = YieldExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         YieldExpression {
-            span: self.span.clone_in(allocator),
-            delegate: self.delegate.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            delegate: CloneIn::clone_in(&self.delegate, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -1766,17 +2017,17 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Class<'old_alloc> {
     type Cloned = Class<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Class {
-            r#type: self.r#type.clone_in(allocator),
-            span: self.span.clone_in(allocator),
-            decorators: self.decorators.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            super_class: self.super_class.clone_in(allocator),
-            super_type_parameters: self.super_type_parameters.clone_in(allocator),
-            implements: self.implements.clone_in(allocator),
-            body: self.body.clone_in(allocator),
-            r#abstract: self.r#abstract.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            decorators: CloneIn::clone_in(&self.decorators, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            super_class: CloneIn::clone_in(&self.super_class, allocator),
+            super_type_parameters: CloneIn::clone_in(&self.super_type_parameters, allocator),
+            implements: CloneIn::clone_in(&self.implements, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+            r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1795,7 +2046,10 @@ impl<'alloc> CloneIn<'alloc> for ClassType {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ClassBody<'old_alloc> {
     type Cloned = ClassBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        ClassBody { span: self.span.clone_in(allocator), body: self.body.clone_in(allocator) }
+        ClassBody {
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+        }
     }
 }
 
@@ -1803,13 +2057,19 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ClassElement<'old_alloc> {
     type Cloned = ClassElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::StaticBlock(it) => ClassElement::StaticBlock(it.clone_in(allocator)),
-            Self::MethodDefinition(it) => ClassElement::MethodDefinition(it.clone_in(allocator)),
-            Self::PropertyDefinition(it) => {
-                ClassElement::PropertyDefinition(it.clone_in(allocator))
+            Self::StaticBlock(it) => ClassElement::StaticBlock(CloneIn::clone_in(it, allocator)),
+            Self::MethodDefinition(it) => {
+                ClassElement::MethodDefinition(CloneIn::clone_in(it, allocator))
             }
-            Self::AccessorProperty(it) => ClassElement::AccessorProperty(it.clone_in(allocator)),
-            Self::TSIndexSignature(it) => ClassElement::TSIndexSignature(it.clone_in(allocator)),
+            Self::PropertyDefinition(it) => {
+                ClassElement::PropertyDefinition(CloneIn::clone_in(it, allocator))
+            }
+            Self::AccessorProperty(it) => {
+                ClassElement::AccessorProperty(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSIndexSignature(it) => {
+                ClassElement::TSIndexSignature(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -1818,17 +2078,17 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'old_alloc
     type Cloned = MethodDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MethodDefinition {
-            r#type: self.r#type.clone_in(allocator),
-            span: self.span.clone_in(allocator),
-            decorators: self.decorators.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
-            r#static: self.r#static.clone_in(allocator),
-            r#override: self.r#override.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
-            accessibility: self.accessibility.clone_in(allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            decorators: CloneIn::clone_in(&self.decorators, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
+            r#static: CloneIn::clone_in(&self.r#static, allocator),
+            r#override: CloneIn::clone_in(&self.r#override, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
+            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
         }
     }
 }
@@ -1847,20 +2107,20 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'old_all
     type Cloned = PropertyDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PropertyDefinition {
-            r#type: self.r#type.clone_in(allocator),
-            span: self.span.clone_in(allocator),
-            decorators: self.decorators.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
-            r#static: self.r#static.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
-            r#override: self.r#override.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
-            definite: self.definite.clone_in(allocator),
-            readonly: self.readonly.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            accessibility: self.accessibility.clone_in(allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            decorators: CloneIn::clone_in(&self.decorators, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
+            r#static: CloneIn::clone_in(&self.r#static, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
+            r#override: CloneIn::clone_in(&self.r#override, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
+            definite: CloneIn::clone_in(&self.definite, allocator),
+            readonly: CloneIn::clone_in(&self.readonly, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
         }
     }
 }
@@ -1893,8 +2153,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'old_allo
     type Cloned = PrivateIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateIdentifier {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
         }
     }
 }
@@ -1903,8 +2163,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StaticBlock<'old_alloc> {
     type Cloned = StaticBlock<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticBlock {
-            span: self.span.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
         }
     }
@@ -1915,22 +2175,22 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ModuleDeclaration<'old_allo
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::ImportDeclaration(it) => {
-                ModuleDeclaration::ImportDeclaration(it.clone_in(allocator))
+                ModuleDeclaration::ImportDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ExportAllDeclaration(it) => {
-                ModuleDeclaration::ExportAllDeclaration(it.clone_in(allocator))
+                ModuleDeclaration::ExportAllDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ExportDefaultDeclaration(it) => {
-                ModuleDeclaration::ExportDefaultDeclaration(it.clone_in(allocator))
+                ModuleDeclaration::ExportDefaultDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ExportNamedDeclaration(it) => {
-                ModuleDeclaration::ExportNamedDeclaration(it.clone_in(allocator))
+                ModuleDeclaration::ExportNamedDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSExportAssignment(it) => {
-                ModuleDeclaration::TSExportAssignment(it.clone_in(allocator))
+                ModuleDeclaration::TSExportAssignment(CloneIn::clone_in(it, allocator))
             }
             Self::TSNamespaceExportDeclaration(it) => {
-                ModuleDeclaration::TSNamespaceExportDeclaration(it.clone_in(allocator))
+                ModuleDeclaration::TSNamespaceExportDeclaration(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -1950,16 +2210,16 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'old_alloc
     type Cloned = AccessorProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AccessorProperty {
-            r#type: self.r#type.clone_in(allocator),
-            span: self.span.clone_in(allocator),
-            decorators: self.decorators.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
-            r#static: self.r#static.clone_in(allocator),
-            definite: self.definite.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            accessibility: self.accessibility.clone_in(allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            decorators: CloneIn::clone_in(&self.decorators, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
+            r#static: CloneIn::clone_in(&self.r#static, allocator),
+            definite: CloneIn::clone_in(&self.definite, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            accessibility: CloneIn::clone_in(&self.accessibility, allocator),
         }
     }
 }
@@ -1968,9 +2228,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportExpression<'old_alloc
     type Cloned = ImportExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportExpression {
-            span: self.span.clone_in(allocator),
-            source: self.source.clone_in(allocator),
-            arguments: self.arguments.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            source: CloneIn::clone_in(&self.source, allocator),
+            arguments: CloneIn::clone_in(&self.arguments, allocator),
         }
     }
 }
@@ -1979,11 +2239,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'old_allo
     type Cloned = ImportDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDeclaration {
-            span: self.span.clone_in(allocator),
-            specifiers: self.specifiers.clone_in(allocator),
-            source: self.source.clone_in(allocator),
-            with_clause: self.with_clause.clone_in(allocator),
-            import_kind: self.import_kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            specifiers: CloneIn::clone_in(&self.specifiers, allocator),
+            source: CloneIn::clone_in(&self.source, allocator),
+            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
+            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
         }
     }
 }
@@ -1993,13 +2253,15 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportDeclarationSpecifier<
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::ImportSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportSpecifier(it.clone_in(allocator))
+                ImportDeclarationSpecifier::ImportSpecifier(CloneIn::clone_in(it, allocator))
             }
             Self::ImportDefaultSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportDefaultSpecifier(it.clone_in(allocator))
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(CloneIn::clone_in(it, allocator))
             }
             Self::ImportNamespaceSpecifier(it) => {
-                ImportDeclarationSpecifier::ImportNamespaceSpecifier(it.clone_in(allocator))
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
         }
     }
@@ -2009,10 +2271,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'old_alloc>
     type Cloned = ImportSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportSpecifier {
-            span: self.span.clone_in(allocator),
-            imported: self.imported.clone_in(allocator),
-            local: self.local.clone_in(allocator),
-            import_kind: self.import_kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            imported: CloneIn::clone_in(&self.imported, allocator),
+            local: CloneIn::clone_in(&self.local, allocator),
+            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
         }
     }
 }
@@ -2021,8 +2283,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'old
     type Cloned = ImportDefaultSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDefaultSpecifier {
-            span: self.span.clone_in(allocator),
-            local: self.local.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            local: CloneIn::clone_in(&self.local, allocator),
         }
     }
 }
@@ -2031,8 +2293,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'o
     type Cloned = ImportNamespaceSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportNamespaceSpecifier {
-            span: self.span.clone_in(allocator),
-            local: self.local.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            local: CloneIn::clone_in(&self.local, allocator),
         }
     }
 }
@@ -2041,9 +2303,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WithClause<'old_alloc> {
     type Cloned = WithClause<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithClause {
-            span: self.span.clone_in(allocator),
-            attributes_keyword: self.attributes_keyword.clone_in(allocator),
-            with_entries: self.with_entries.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            attributes_keyword: CloneIn::clone_in(&self.attributes_keyword, allocator),
+            with_entries: CloneIn::clone_in(&self.with_entries, allocator),
         }
     }
 }
@@ -2052,9 +2314,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'old_alloc>
     type Cloned = ImportAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportAttribute {
-            span: self.span.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -2063,8 +2325,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportAttributeKey<'old_all
     type Cloned = ImportAttributeKey<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => ImportAttributeKey::Identifier(it.clone_in(allocator)),
-            Self::StringLiteral(it) => ImportAttributeKey::StringLiteral(it.clone_in(allocator)),
+            Self::Identifier(it) => {
+                ImportAttributeKey::Identifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                ImportAttributeKey::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2073,12 +2339,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'old
     type Cloned = ExportNamedDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportNamedDeclaration {
-            span: self.span.clone_in(allocator),
-            declaration: self.declaration.clone_in(allocator),
-            specifiers: self.specifiers.clone_in(allocator),
-            source: self.source.clone_in(allocator),
-            export_kind: self.export_kind.clone_in(allocator),
-            with_clause: self.with_clause.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            declaration: CloneIn::clone_in(&self.declaration, allocator),
+            specifiers: CloneIn::clone_in(&self.specifiers, allocator),
+            source: CloneIn::clone_in(&self.source, allocator),
+            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
+            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
         }
     }
 }
@@ -2087,9 +2353,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'o
     type Cloned = ExportDefaultDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
-            span: self.span.clone_in(allocator),
-            declaration: self.declaration.clone_in(allocator),
-            exported: self.exported.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            declaration: CloneIn::clone_in(&self.declaration, allocator),
+            exported: CloneIn::clone_in(&self.exported, allocator),
         }
     }
 }
@@ -2098,11 +2364,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'old_a
     type Cloned = ExportAllDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportAllDeclaration {
-            span: self.span.clone_in(allocator),
-            exported: self.exported.clone_in(allocator),
-            source: self.source.clone_in(allocator),
-            with_clause: self.with_clause.clone_in(allocator),
-            export_kind: self.export_kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            exported: CloneIn::clone_in(&self.exported, allocator),
+            source: CloneIn::clone_in(&self.source, allocator),
+            with_clause: CloneIn::clone_in(&self.with_clause, allocator),
+            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
         }
     }
 }
@@ -2111,10 +2377,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'old_alloc>
     type Cloned = ExportSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportSpecifier {
-            span: self.span.clone_in(allocator),
-            local: self.local.clone_in(allocator),
-            exported: self.exported.clone_in(allocator),
-            export_kind: self.export_kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            local: CloneIn::clone_in(&self.local, allocator),
+            exported: CloneIn::clone_in(&self.exported, allocator),
+            export_kind: CloneIn::clone_in(&self.export_kind, allocator),
         }
     }
 }
@@ -2124,137 +2390,155 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclarationKin
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::FunctionDeclaration(it) => {
-                ExportDefaultDeclarationKind::FunctionDeclaration(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::FunctionDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::ClassDeclaration(it) => {
-                ExportDefaultDeclarationKind::ClassDeclaration(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ClassDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSInterfaceDeclaration(it) => {
-                ExportDefaultDeclarationKind::TSInterfaceDeclaration(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TSInterfaceDeclaration(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::BooleanLiteral(it) => {
-                ExportDefaultDeclarationKind::BooleanLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::BooleanLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::NullLiteral(it) => {
-                ExportDefaultDeclarationKind::NullLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::NullLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::NumericLiteral(it) => {
-                ExportDefaultDeclarationKind::NumericLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::NumericLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::BigIntLiteral(it) => {
-                ExportDefaultDeclarationKind::BigIntLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::BigIntLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::RegExpLiteral(it) => {
-                ExportDefaultDeclarationKind::RegExpLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::RegExpLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::StringLiteral(it) => {
-                ExportDefaultDeclarationKind::StringLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::StringLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::TemplateLiteral(it) => {
-                ExportDefaultDeclarationKind::TemplateLiteral(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TemplateLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::Identifier(it) => {
-                ExportDefaultDeclarationKind::Identifier(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::Identifier(CloneIn::clone_in(it, allocator))
             }
             Self::MetaProperty(it) => {
-                ExportDefaultDeclarationKind::MetaProperty(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::MetaProperty(CloneIn::clone_in(it, allocator))
             }
-            Self::Super(it) => ExportDefaultDeclarationKind::Super(it.clone_in(allocator)),
+            Self::Super(it) => {
+                ExportDefaultDeclarationKind::Super(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrayExpression(it) => {
-                ExportDefaultDeclarationKind::ArrayExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ArrayExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ArrowFunctionExpression(it) => {
-                ExportDefaultDeclarationKind::ArrowFunctionExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ArrowFunctionExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::AssignmentExpression(it) => {
-                ExportDefaultDeclarationKind::AssignmentExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AwaitExpression(it) => {
-                ExportDefaultDeclarationKind::AwaitExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::AwaitExpression(CloneIn::clone_in(it, allocator))
             }
             Self::BinaryExpression(it) => {
-                ExportDefaultDeclarationKind::BinaryExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::BinaryExpression(CloneIn::clone_in(it, allocator))
             }
             Self::CallExpression(it) => {
-                ExportDefaultDeclarationKind::CallExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::CallExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ChainExpression(it) => {
-                ExportDefaultDeclarationKind::ChainExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ChainExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ClassExpression(it) => {
-                ExportDefaultDeclarationKind::ClassExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ClassExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ConditionalExpression(it) => {
-                ExportDefaultDeclarationKind::ConditionalExpression(it.clone_in(allocator))
-            }
+            Self::ConditionalExpression(it) => ExportDefaultDeclarationKind::ConditionalExpression(
+                CloneIn::clone_in(it, allocator),
+            ),
             Self::FunctionExpression(it) => {
-                ExportDefaultDeclarationKind::FunctionExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::FunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ImportExpression(it) => {
-                ExportDefaultDeclarationKind::ImportExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ImportExpression(CloneIn::clone_in(it, allocator))
             }
             Self::LogicalExpression(it) => {
-                ExportDefaultDeclarationKind::LogicalExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::LogicalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::NewExpression(it) => {
-                ExportDefaultDeclarationKind::NewExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::NewExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ObjectExpression(it) => {
-                ExportDefaultDeclarationKind::ObjectExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ObjectExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ParenthesizedExpression(it) => {
-                ExportDefaultDeclarationKind::ParenthesizedExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ParenthesizedExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::SequenceExpression(it) => {
-                ExportDefaultDeclarationKind::SequenceExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::SequenceExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TaggedTemplateExpression(it) => {
-                ExportDefaultDeclarationKind::TaggedTemplateExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TaggedTemplateExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::ThisExpression(it) => {
-                ExportDefaultDeclarationKind::ThisExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ThisExpression(CloneIn::clone_in(it, allocator))
             }
             Self::UnaryExpression(it) => {
-                ExportDefaultDeclarationKind::UnaryExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::UnaryExpression(CloneIn::clone_in(it, allocator))
             }
             Self::UpdateExpression(it) => {
-                ExportDefaultDeclarationKind::UpdateExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::UpdateExpression(CloneIn::clone_in(it, allocator))
             }
             Self::YieldExpression(it) => {
-                ExportDefaultDeclarationKind::YieldExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::YieldExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateInExpression(it) => {
-                ExportDefaultDeclarationKind::PrivateInExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
             Self::JSXElement(it) => {
-                ExportDefaultDeclarationKind::JSXElement(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::JSXElement(CloneIn::clone_in(it, allocator))
             }
             Self::JSXFragment(it) => {
-                ExportDefaultDeclarationKind::JSXFragment(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::JSXFragment(CloneIn::clone_in(it, allocator))
             }
             Self::TSAsExpression(it) => {
-                ExportDefaultDeclarationKind::TSAsExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TSAsExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSSatisfiesExpression(it) => {
-                ExportDefaultDeclarationKind::TSSatisfiesExpression(it.clone_in(allocator))
-            }
+            Self::TSSatisfiesExpression(it) => ExportDefaultDeclarationKind::TSSatisfiesExpression(
+                CloneIn::clone_in(it, allocator),
+            ),
             Self::TSTypeAssertion(it) => {
-                ExportDefaultDeclarationKind::TSTypeAssertion(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TSTypeAssertion(CloneIn::clone_in(it, allocator))
             }
             Self::TSNonNullExpression(it) => {
-                ExportDefaultDeclarationKind::TSNonNullExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                ExportDefaultDeclarationKind::TSInstantiationExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::TSInstantiationExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::ComputedMemberExpression(it) => {
-                ExportDefaultDeclarationKind::ComputedMemberExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::ComputedMemberExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::StaticMemberExpression(it) => {
-                ExportDefaultDeclarationKind::StaticMemberExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::StaticMemberExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
             Self::PrivateFieldExpression(it) => {
-                ExportDefaultDeclarationKind::PrivateFieldExpression(it.clone_in(allocator))
+                ExportDefaultDeclarationKind::PrivateFieldExpression(CloneIn::clone_in(
+                    it, allocator,
+                ))
             }
         }
     }
@@ -2264,11 +2548,15 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ModuleExportName<'old_alloc
     type Cloned = ModuleExportName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::IdentifierName(it) => ModuleExportName::IdentifierName(it.clone_in(allocator)),
-            Self::IdentifierReference(it) => {
-                ModuleExportName::IdentifierReference(it.clone_in(allocator))
+            Self::IdentifierName(it) => {
+                ModuleExportName::IdentifierName(CloneIn::clone_in(it, allocator))
             }
-            Self::StringLiteral(it) => ModuleExportName::StringLiteral(it.clone_in(allocator)),
+            Self::IdentifierReference(it) => {
+                ModuleExportName::IdentifierReference(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                ModuleExportName::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2277,9 +2565,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'old_alloc>
     type Cloned = TSThisParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisParameter {
-            span: self.span.clone_in(allocator),
-            this_span: self.this_span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            this_span: CloneIn::clone_in(&self.this_span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2288,11 +2576,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'old_allo
     type Cloned = TSEnumDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            members: self.members.clone_in(allocator),
-            r#const: self.r#const.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            members: CloneIn::clone_in(&self.members, allocator),
+            r#const: CloneIn::clone_in(&self.r#const, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
         }
     }
@@ -2302,9 +2590,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'old_alloc> {
     type Cloned = TSEnumMember<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumMember {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            initializer: self.initializer.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            initializer: CloneIn::clone_in(&self.initializer, allocator),
         }
     }
 }
@@ -2314,96 +2602,136 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumMemberName<'old_alloc
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::StaticIdentifier(it) => {
-                TSEnumMemberName::StaticIdentifier(it.clone_in(allocator))
+                TSEnumMemberName::StaticIdentifier(CloneIn::clone_in(it, allocator))
             }
             Self::StaticStringLiteral(it) => {
-                TSEnumMemberName::StaticStringLiteral(it.clone_in(allocator))
+                TSEnumMemberName::StaticStringLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::StaticTemplateLiteral(it) => {
-                TSEnumMemberName::StaticTemplateLiteral(it.clone_in(allocator))
+                TSEnumMemberName::StaticTemplateLiteral(CloneIn::clone_in(it, allocator))
             }
             Self::StaticNumericLiteral(it) => {
-                TSEnumMemberName::StaticNumericLiteral(it.clone_in(allocator))
+                TSEnumMemberName::StaticNumericLiteral(CloneIn::clone_in(it, allocator))
             }
-            Self::BooleanLiteral(it) => TSEnumMemberName::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => TSEnumMemberName::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => TSEnumMemberName::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => TSEnumMemberName::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => TSEnumMemberName::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => TSEnumMemberName::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => TSEnumMemberName::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => TSEnumMemberName::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => TSEnumMemberName::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => TSEnumMemberName::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => TSEnumMemberName::ArrayExpression(it.clone_in(allocator)),
+            Self::BooleanLiteral(it) => {
+                TSEnumMemberName::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => {
+                TSEnumMemberName::NullLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NumericLiteral(it) => {
+                TSEnumMemberName::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => {
+                TSEnumMemberName::BigIntLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::RegExpLiteral(it) => {
+                TSEnumMemberName::RegExpLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                TSEnumMemberName::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::TemplateLiteral(it) => {
+                TSEnumMemberName::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => TSEnumMemberName::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => {
+                TSEnumMemberName::MetaProperty(CloneIn::clone_in(it, allocator))
+            }
+            Self::Super(it) => TSEnumMemberName::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                TSEnumMemberName::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                TSEnumMemberName::ArrowFunctionExpression(it.clone_in(allocator))
+                TSEnumMemberName::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                TSEnumMemberName::AssignmentExpression(it.clone_in(allocator))
+                TSEnumMemberName::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => TSEnumMemberName::AwaitExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                TSEnumMemberName::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::BinaryExpression(it) => {
-                TSEnumMemberName::BinaryExpression(it.clone_in(allocator))
+                TSEnumMemberName::BinaryExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::CallExpression(it) => TSEnumMemberName::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => TSEnumMemberName::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => TSEnumMemberName::ClassExpression(it.clone_in(allocator)),
+            Self::CallExpression(it) => {
+                TSEnumMemberName::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                TSEnumMemberName::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                TSEnumMemberName::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                TSEnumMemberName::ConditionalExpression(it.clone_in(allocator))
+                TSEnumMemberName::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::FunctionExpression(it) => {
-                TSEnumMemberName::FunctionExpression(it.clone_in(allocator))
+                TSEnumMemberName::FunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ImportExpression(it) => {
-                TSEnumMemberName::ImportExpression(it.clone_in(allocator))
+                TSEnumMemberName::ImportExpression(CloneIn::clone_in(it, allocator))
             }
             Self::LogicalExpression(it) => {
-                TSEnumMemberName::LogicalExpression(it.clone_in(allocator))
+                TSEnumMemberName::LogicalExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::NewExpression(it) => TSEnumMemberName::NewExpression(it.clone_in(allocator)),
+            Self::NewExpression(it) => {
+                TSEnumMemberName::NewExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ObjectExpression(it) => {
-                TSEnumMemberName::ObjectExpression(it.clone_in(allocator))
+                TSEnumMemberName::ObjectExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ParenthesizedExpression(it) => {
-                TSEnumMemberName::ParenthesizedExpression(it.clone_in(allocator))
+                TSEnumMemberName::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
             Self::SequenceExpression(it) => {
-                TSEnumMemberName::SequenceExpression(it.clone_in(allocator))
+                TSEnumMemberName::SequenceExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TaggedTemplateExpression(it) => {
-                TSEnumMemberName::TaggedTemplateExpression(it.clone_in(allocator))
+                TSEnumMemberName::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => TSEnumMemberName::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => TSEnumMemberName::UnaryExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => {
+                TSEnumMemberName::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                TSEnumMemberName::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::UpdateExpression(it) => {
-                TSEnumMemberName::UpdateExpression(it.clone_in(allocator))
+                TSEnumMemberName::UpdateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::YieldExpression(it) => TSEnumMemberName::YieldExpression(it.clone_in(allocator)),
+            Self::YieldExpression(it) => {
+                TSEnumMemberName::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::PrivateInExpression(it) => {
-                TSEnumMemberName::PrivateInExpression(it.clone_in(allocator))
+                TSEnumMemberName::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => TSEnumMemberName::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => TSEnumMemberName::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => TSEnumMemberName::TSAsExpression(it.clone_in(allocator)),
+            Self::JSXElement(it) => TSEnumMemberName::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => {
+                TSEnumMemberName::JSXFragment(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSAsExpression(it) => {
+                TSEnumMemberName::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                TSEnumMemberName::TSSatisfiesExpression(it.clone_in(allocator))
+                TSEnumMemberName::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => TSEnumMemberName::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                TSEnumMemberName::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNonNullExpression(it) => {
-                TSEnumMemberName::TSNonNullExpression(it.clone_in(allocator))
+                TSEnumMemberName::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                TSEnumMemberName::TSInstantiationExpression(it.clone_in(allocator))
+                TSEnumMemberName::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                TSEnumMemberName::ComputedMemberExpression(it.clone_in(allocator))
+                TSEnumMemberName::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                TSEnumMemberName::StaticMemberExpression(it.clone_in(allocator))
+                TSEnumMemberName::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                TSEnumMemberName::PrivateFieldExpression(it.clone_in(allocator))
+                TSEnumMemberName::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -2413,8 +2741,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'old_alloc
     type Cloned = TSTypeAnnotation<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAnnotation {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2423,8 +2751,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'old_alloc> {
     type Cloned = TSLiteralType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSLiteralType {
-            span: self.span.clone_in(allocator),
-            literal: self.literal.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            literal: CloneIn::clone_in(&self.literal, allocator),
         }
     }
 }
@@ -2433,14 +2761,18 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSLiteral<'old_alloc> {
     type Cloned = TSLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::BooleanLiteral(it) => TSLiteral::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => TSLiteral::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => TSLiteral::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => TSLiteral::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => TSLiteral::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => TSLiteral::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => TSLiteral::TemplateLiteral(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => TSLiteral::UnaryExpression(it.clone_in(allocator)),
+            Self::BooleanLiteral(it) => TSLiteral::BooleanLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NullLiteral(it) => TSLiteral::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => TSLiteral::NumericLiteral(CloneIn::clone_in(it, allocator)),
+            Self::BigIntLiteral(it) => TSLiteral::BigIntLiteral(CloneIn::clone_in(it, allocator)),
+            Self::RegExpLiteral(it) => TSLiteral::RegExpLiteral(CloneIn::clone_in(it, allocator)),
+            Self::StringLiteral(it) => TSLiteral::StringLiteral(CloneIn::clone_in(it, allocator)),
+            Self::TemplateLiteral(it) => {
+                TSLiteral::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                TSLiteral::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2449,46 +2781,74 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSType<'old_alloc> {
     type Cloned = TSType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::TSAnyKeyword(it) => TSType::TSAnyKeyword(it.clone_in(allocator)),
-            Self::TSBigIntKeyword(it) => TSType::TSBigIntKeyword(it.clone_in(allocator)),
-            Self::TSBooleanKeyword(it) => TSType::TSBooleanKeyword(it.clone_in(allocator)),
-            Self::TSIntrinsicKeyword(it) => TSType::TSIntrinsicKeyword(it.clone_in(allocator)),
-            Self::TSNeverKeyword(it) => TSType::TSNeverKeyword(it.clone_in(allocator)),
-            Self::TSNullKeyword(it) => TSType::TSNullKeyword(it.clone_in(allocator)),
-            Self::TSNumberKeyword(it) => TSType::TSNumberKeyword(it.clone_in(allocator)),
-            Self::TSObjectKeyword(it) => TSType::TSObjectKeyword(it.clone_in(allocator)),
-            Self::TSStringKeyword(it) => TSType::TSStringKeyword(it.clone_in(allocator)),
-            Self::TSSymbolKeyword(it) => TSType::TSSymbolKeyword(it.clone_in(allocator)),
-            Self::TSUndefinedKeyword(it) => TSType::TSUndefinedKeyword(it.clone_in(allocator)),
-            Self::TSUnknownKeyword(it) => TSType::TSUnknownKeyword(it.clone_in(allocator)),
-            Self::TSVoidKeyword(it) => TSType::TSVoidKeyword(it.clone_in(allocator)),
-            Self::TSArrayType(it) => TSType::TSArrayType(it.clone_in(allocator)),
-            Self::TSConditionalType(it) => TSType::TSConditionalType(it.clone_in(allocator)),
-            Self::TSConstructorType(it) => TSType::TSConstructorType(it.clone_in(allocator)),
-            Self::TSFunctionType(it) => TSType::TSFunctionType(it.clone_in(allocator)),
-            Self::TSImportType(it) => TSType::TSImportType(it.clone_in(allocator)),
-            Self::TSIndexedAccessType(it) => TSType::TSIndexedAccessType(it.clone_in(allocator)),
-            Self::TSInferType(it) => TSType::TSInferType(it.clone_in(allocator)),
-            Self::TSIntersectionType(it) => TSType::TSIntersectionType(it.clone_in(allocator)),
-            Self::TSLiteralType(it) => TSType::TSLiteralType(it.clone_in(allocator)),
-            Self::TSMappedType(it) => TSType::TSMappedType(it.clone_in(allocator)),
-            Self::TSNamedTupleMember(it) => TSType::TSNamedTupleMember(it.clone_in(allocator)),
-            Self::TSQualifiedName(it) => TSType::TSQualifiedName(it.clone_in(allocator)),
-            Self::TSTemplateLiteralType(it) => {
-                TSType::TSTemplateLiteralType(it.clone_in(allocator))
+            Self::TSAnyKeyword(it) => TSType::TSAnyKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSBigIntKeyword(it) => TSType::TSBigIntKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSBooleanKeyword(it) => {
+                TSType::TSBooleanKeyword(CloneIn::clone_in(it, allocator))
             }
-            Self::TSThisType(it) => TSType::TSThisType(it.clone_in(allocator)),
-            Self::TSTupleType(it) => TSType::TSTupleType(it.clone_in(allocator)),
-            Self::TSTypeLiteral(it) => TSType::TSTypeLiteral(it.clone_in(allocator)),
-            Self::TSTypeOperatorType(it) => TSType::TSTypeOperatorType(it.clone_in(allocator)),
-            Self::TSTypePredicate(it) => TSType::TSTypePredicate(it.clone_in(allocator)),
-            Self::TSTypeQuery(it) => TSType::TSTypeQuery(it.clone_in(allocator)),
-            Self::TSTypeReference(it) => TSType::TSTypeReference(it.clone_in(allocator)),
-            Self::TSUnionType(it) => TSType::TSUnionType(it.clone_in(allocator)),
-            Self::TSParenthesizedType(it) => TSType::TSParenthesizedType(it.clone_in(allocator)),
-            Self::JSDocNullableType(it) => TSType::JSDocNullableType(it.clone_in(allocator)),
-            Self::JSDocNonNullableType(it) => TSType::JSDocNonNullableType(it.clone_in(allocator)),
-            Self::JSDocUnknownType(it) => TSType::JSDocUnknownType(it.clone_in(allocator)),
+            Self::TSIntrinsicKeyword(it) => {
+                TSType::TSIntrinsicKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSNeverKeyword(it) => TSType::TSNeverKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSNullKeyword(it) => TSType::TSNullKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSNumberKeyword(it) => TSType::TSNumberKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSObjectKeyword(it) => TSType::TSObjectKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSStringKeyword(it) => TSType::TSStringKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSSymbolKeyword(it) => TSType::TSSymbolKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSUndefinedKeyword(it) => {
+                TSType::TSUndefinedKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSUnknownKeyword(it) => {
+                TSType::TSUnknownKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSVoidKeyword(it) => TSType::TSVoidKeyword(CloneIn::clone_in(it, allocator)),
+            Self::TSArrayType(it) => TSType::TSArrayType(CloneIn::clone_in(it, allocator)),
+            Self::TSConditionalType(it) => {
+                TSType::TSConditionalType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSConstructorType(it) => {
+                TSType::TSConstructorType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSFunctionType(it) => TSType::TSFunctionType(CloneIn::clone_in(it, allocator)),
+            Self::TSImportType(it) => TSType::TSImportType(CloneIn::clone_in(it, allocator)),
+            Self::TSIndexedAccessType(it) => {
+                TSType::TSIndexedAccessType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSInferType(it) => TSType::TSInferType(CloneIn::clone_in(it, allocator)),
+            Self::TSIntersectionType(it) => {
+                TSType::TSIntersectionType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSLiteralType(it) => TSType::TSLiteralType(CloneIn::clone_in(it, allocator)),
+            Self::TSMappedType(it) => TSType::TSMappedType(CloneIn::clone_in(it, allocator)),
+            Self::TSNamedTupleMember(it) => {
+                TSType::TSNamedTupleMember(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSQualifiedName(it) => TSType::TSQualifiedName(CloneIn::clone_in(it, allocator)),
+            Self::TSTemplateLiteralType(it) => {
+                TSType::TSTemplateLiteralType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSThisType(it) => TSType::TSThisType(CloneIn::clone_in(it, allocator)),
+            Self::TSTupleType(it) => TSType::TSTupleType(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeLiteral(it) => TSType::TSTypeLiteral(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeOperatorType(it) => {
+                TSType::TSTypeOperatorType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSTypePredicate(it) => TSType::TSTypePredicate(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeQuery(it) => TSType::TSTypeQuery(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeReference(it) => TSType::TSTypeReference(CloneIn::clone_in(it, allocator)),
+            Self::TSUnionType(it) => TSType::TSUnionType(CloneIn::clone_in(it, allocator)),
+            Self::TSParenthesizedType(it) => {
+                TSType::TSParenthesizedType(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSDocNullableType(it) => {
+                TSType::JSDocNullableType(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSDocNonNullableType(it) => {
+                TSType::JSDocNonNullableType(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSDocUnknownType(it) => {
+                TSType::JSDocUnknownType(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2497,11 +2857,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'old_allo
     type Cloned = TSConditionalType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConditionalType {
-            span: self.span.clone_in(allocator),
-            check_type: self.check_type.clone_in(allocator),
-            extends_type: self.extends_type.clone_in(allocator),
-            true_type: self.true_type.clone_in(allocator),
-            false_type: self.false_type.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            check_type: CloneIn::clone_in(&self.check_type, allocator),
+            extends_type: CloneIn::clone_in(&self.extends_type, allocator),
+            true_type: CloneIn::clone_in(&self.true_type, allocator),
+            false_type: CloneIn::clone_in(&self.false_type, allocator),
             scope_id: Default::default(),
         }
     }
@@ -2510,7 +2870,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'old_allo
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSUnionType<'old_alloc> {
     type Cloned = TSUnionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSUnionType { span: self.span.clone_in(allocator), types: self.types.clone_in(allocator) }
+        TSUnionType {
+            span: CloneIn::clone_in(&self.span, allocator),
+            types: CloneIn::clone_in(&self.types, allocator),
+        }
     }
 }
 
@@ -2518,8 +2881,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'old_all
     type Cloned = TSIntersectionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntersectionType {
-            span: self.span.clone_in(allocator),
-            types: self.types.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            types: CloneIn::clone_in(&self.types, allocator),
         }
     }
 }
@@ -2528,8 +2891,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'old_al
     type Cloned = TSParenthesizedType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSParenthesizedType {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2538,9 +2901,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'old_alloc> 
     type Cloned = TSTypeOperator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeOperator {
-            span: self.span.clone_in(allocator),
-            operator: self.operator.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            operator: CloneIn::clone_in(&self.operator, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2560,8 +2923,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSArrayType<'old_alloc> {
     type Cloned = TSArrayType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSArrayType {
-            span: self.span.clone_in(allocator),
-            element_type: self.element_type.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            element_type: CloneIn::clone_in(&self.element_type, allocator),
         }
     }
 }
@@ -2570,9 +2933,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'old_al
     type Cloned = TSIndexedAccessType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexedAccessType {
-            span: self.span.clone_in(allocator),
-            object_type: self.object_type.clone_in(allocator),
-            index_type: self.index_type.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object_type: CloneIn::clone_in(&self.object_type, allocator),
+            index_type: CloneIn::clone_in(&self.index_type, allocator),
         }
     }
 }
@@ -2581,8 +2944,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTupleType<'old_alloc> {
     type Cloned = TSTupleType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTupleType {
-            span: self.span.clone_in(allocator),
-            element_types: self.element_types.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            element_types: CloneIn::clone_in(&self.element_types, allocator),
         }
     }
 }
@@ -2591,10 +2954,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'old_all
     type Cloned = TSNamedTupleMember<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
-            span: self.span.clone_in(allocator),
-            element_type: self.element_type.clone_in(allocator),
-            label: self.label.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            element_type: CloneIn::clone_in(&self.element_type, allocator),
+            label: CloneIn::clone_in(&self.label, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
         }
     }
 }
@@ -2603,8 +2966,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'old_alloc> 
     type Cloned = TSOptionalType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSOptionalType {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2613,8 +2976,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSRestType<'old_alloc> {
     type Cloned = TSRestType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSRestType {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2623,70 +2986,112 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'old_alloc> 
     type Cloned = TSTupleElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::TSOptionalType(it) => TSTupleElement::TSOptionalType(it.clone_in(allocator)),
-            Self::TSRestType(it) => TSTupleElement::TSRestType(it.clone_in(allocator)),
-            Self::TSAnyKeyword(it) => TSTupleElement::TSAnyKeyword(it.clone_in(allocator)),
-            Self::TSBigIntKeyword(it) => TSTupleElement::TSBigIntKeyword(it.clone_in(allocator)),
-            Self::TSBooleanKeyword(it) => TSTupleElement::TSBooleanKeyword(it.clone_in(allocator)),
+            Self::TSOptionalType(it) => {
+                TSTupleElement::TSOptionalType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSRestType(it) => TSTupleElement::TSRestType(CloneIn::clone_in(it, allocator)),
+            Self::TSAnyKeyword(it) => {
+                TSTupleElement::TSAnyKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSBigIntKeyword(it) => {
+                TSTupleElement::TSBigIntKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSBooleanKeyword(it) => {
+                TSTupleElement::TSBooleanKeyword(CloneIn::clone_in(it, allocator))
+            }
             Self::TSIntrinsicKeyword(it) => {
-                TSTupleElement::TSIntrinsicKeyword(it.clone_in(allocator))
+                TSTupleElement::TSIntrinsicKeyword(CloneIn::clone_in(it, allocator))
             }
-            Self::TSNeverKeyword(it) => TSTupleElement::TSNeverKeyword(it.clone_in(allocator)),
-            Self::TSNullKeyword(it) => TSTupleElement::TSNullKeyword(it.clone_in(allocator)),
-            Self::TSNumberKeyword(it) => TSTupleElement::TSNumberKeyword(it.clone_in(allocator)),
-            Self::TSObjectKeyword(it) => TSTupleElement::TSObjectKeyword(it.clone_in(allocator)),
-            Self::TSStringKeyword(it) => TSTupleElement::TSStringKeyword(it.clone_in(allocator)),
-            Self::TSSymbolKeyword(it) => TSTupleElement::TSSymbolKeyword(it.clone_in(allocator)),
+            Self::TSNeverKeyword(it) => {
+                TSTupleElement::TSNeverKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSNullKeyword(it) => {
+                TSTupleElement::TSNullKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSNumberKeyword(it) => {
+                TSTupleElement::TSNumberKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSObjectKeyword(it) => {
+                TSTupleElement::TSObjectKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSStringKeyword(it) => {
+                TSTupleElement::TSStringKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSSymbolKeyword(it) => {
+                TSTupleElement::TSSymbolKeyword(CloneIn::clone_in(it, allocator))
+            }
             Self::TSUndefinedKeyword(it) => {
-                TSTupleElement::TSUndefinedKeyword(it.clone_in(allocator))
+                TSTupleElement::TSUndefinedKeyword(CloneIn::clone_in(it, allocator))
             }
-            Self::TSUnknownKeyword(it) => TSTupleElement::TSUnknownKeyword(it.clone_in(allocator)),
-            Self::TSVoidKeyword(it) => TSTupleElement::TSVoidKeyword(it.clone_in(allocator)),
-            Self::TSArrayType(it) => TSTupleElement::TSArrayType(it.clone_in(allocator)),
+            Self::TSUnknownKeyword(it) => {
+                TSTupleElement::TSUnknownKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSVoidKeyword(it) => {
+                TSTupleElement::TSVoidKeyword(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSArrayType(it) => TSTupleElement::TSArrayType(CloneIn::clone_in(it, allocator)),
             Self::TSConditionalType(it) => {
-                TSTupleElement::TSConditionalType(it.clone_in(allocator))
+                TSTupleElement::TSConditionalType(CloneIn::clone_in(it, allocator))
             }
             Self::TSConstructorType(it) => {
-                TSTupleElement::TSConstructorType(it.clone_in(allocator))
+                TSTupleElement::TSConstructorType(CloneIn::clone_in(it, allocator))
             }
-            Self::TSFunctionType(it) => TSTupleElement::TSFunctionType(it.clone_in(allocator)),
-            Self::TSImportType(it) => TSTupleElement::TSImportType(it.clone_in(allocator)),
+            Self::TSFunctionType(it) => {
+                TSTupleElement::TSFunctionType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSImportType(it) => {
+                TSTupleElement::TSImportType(CloneIn::clone_in(it, allocator))
+            }
             Self::TSIndexedAccessType(it) => {
-                TSTupleElement::TSIndexedAccessType(it.clone_in(allocator))
+                TSTupleElement::TSIndexedAccessType(CloneIn::clone_in(it, allocator))
             }
-            Self::TSInferType(it) => TSTupleElement::TSInferType(it.clone_in(allocator)),
+            Self::TSInferType(it) => TSTupleElement::TSInferType(CloneIn::clone_in(it, allocator)),
             Self::TSIntersectionType(it) => {
-                TSTupleElement::TSIntersectionType(it.clone_in(allocator))
+                TSTupleElement::TSIntersectionType(CloneIn::clone_in(it, allocator))
             }
-            Self::TSLiteralType(it) => TSTupleElement::TSLiteralType(it.clone_in(allocator)),
-            Self::TSMappedType(it) => TSTupleElement::TSMappedType(it.clone_in(allocator)),
+            Self::TSLiteralType(it) => {
+                TSTupleElement::TSLiteralType(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSMappedType(it) => {
+                TSTupleElement::TSMappedType(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNamedTupleMember(it) => {
-                TSTupleElement::TSNamedTupleMember(it.clone_in(allocator))
+                TSTupleElement::TSNamedTupleMember(CloneIn::clone_in(it, allocator))
             }
-            Self::TSQualifiedName(it) => TSTupleElement::TSQualifiedName(it.clone_in(allocator)),
+            Self::TSQualifiedName(it) => {
+                TSTupleElement::TSQualifiedName(CloneIn::clone_in(it, allocator))
+            }
             Self::TSTemplateLiteralType(it) => {
-                TSTupleElement::TSTemplateLiteralType(it.clone_in(allocator))
+                TSTupleElement::TSTemplateLiteralType(CloneIn::clone_in(it, allocator))
             }
-            Self::TSThisType(it) => TSTupleElement::TSThisType(it.clone_in(allocator)),
-            Self::TSTupleType(it) => TSTupleElement::TSTupleType(it.clone_in(allocator)),
-            Self::TSTypeLiteral(it) => TSTupleElement::TSTypeLiteral(it.clone_in(allocator)),
+            Self::TSThisType(it) => TSTupleElement::TSThisType(CloneIn::clone_in(it, allocator)),
+            Self::TSTupleType(it) => TSTupleElement::TSTupleType(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeLiteral(it) => {
+                TSTupleElement::TSTypeLiteral(CloneIn::clone_in(it, allocator))
+            }
             Self::TSTypeOperatorType(it) => {
-                TSTupleElement::TSTypeOperatorType(it.clone_in(allocator))
+                TSTupleElement::TSTypeOperatorType(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypePredicate(it) => TSTupleElement::TSTypePredicate(it.clone_in(allocator)),
-            Self::TSTypeQuery(it) => TSTupleElement::TSTypeQuery(it.clone_in(allocator)),
-            Self::TSTypeReference(it) => TSTupleElement::TSTypeReference(it.clone_in(allocator)),
-            Self::TSUnionType(it) => TSTupleElement::TSUnionType(it.clone_in(allocator)),
+            Self::TSTypePredicate(it) => {
+                TSTupleElement::TSTypePredicate(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSTypeQuery(it) => TSTupleElement::TSTypeQuery(CloneIn::clone_in(it, allocator)),
+            Self::TSTypeReference(it) => {
+                TSTupleElement::TSTypeReference(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSUnionType(it) => TSTupleElement::TSUnionType(CloneIn::clone_in(it, allocator)),
             Self::TSParenthesizedType(it) => {
-                TSTupleElement::TSParenthesizedType(it.clone_in(allocator))
+                TSTupleElement::TSParenthesizedType(CloneIn::clone_in(it, allocator))
             }
             Self::JSDocNullableType(it) => {
-                TSTupleElement::JSDocNullableType(it.clone_in(allocator))
+                TSTupleElement::JSDocNullableType(CloneIn::clone_in(it, allocator))
             }
             Self::JSDocNonNullableType(it) => {
-                TSTupleElement::JSDocNonNullableType(it.clone_in(allocator))
+                TSTupleElement::JSDocNonNullableType(CloneIn::clone_in(it, allocator))
             }
-            Self::JSDocUnknownType(it) => TSTupleElement::JSDocUnknownType(it.clone_in(allocator)),
+            Self::JSDocUnknownType(it) => {
+                TSTupleElement::JSDocUnknownType(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2694,98 +3099,98 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'old_alloc> 
 impl<'alloc> CloneIn<'alloc> for TSAnyKeyword {
     type Cloned = TSAnyKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSAnyKeyword { span: self.span.clone_in(allocator) }
+        TSAnyKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSStringKeyword {
     type Cloned = TSStringKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSStringKeyword { span: self.span.clone_in(allocator) }
+        TSStringKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSBooleanKeyword {
     type Cloned = TSBooleanKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSBooleanKeyword { span: self.span.clone_in(allocator) }
+        TSBooleanKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNumberKeyword {
     type Cloned = TSNumberKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNumberKeyword { span: self.span.clone_in(allocator) }
+        TSNumberKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNeverKeyword {
     type Cloned = TSNeverKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNeverKeyword { span: self.span.clone_in(allocator) }
+        TSNeverKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSIntrinsicKeyword {
     type Cloned = TSIntrinsicKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSIntrinsicKeyword { span: self.span.clone_in(allocator) }
+        TSIntrinsicKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSUnknownKeyword {
     type Cloned = TSUnknownKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSUnknownKeyword { span: self.span.clone_in(allocator) }
+        TSUnknownKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNullKeyword {
     type Cloned = TSNullKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNullKeyword { span: self.span.clone_in(allocator) }
+        TSNullKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSUndefinedKeyword {
     type Cloned = TSUndefinedKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSUndefinedKeyword { span: self.span.clone_in(allocator) }
+        TSUndefinedKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSVoidKeyword {
     type Cloned = TSVoidKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSVoidKeyword { span: self.span.clone_in(allocator) }
+        TSVoidKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSSymbolKeyword {
     type Cloned = TSSymbolKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSSymbolKeyword { span: self.span.clone_in(allocator) }
+        TSSymbolKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSThisType {
     type Cloned = TSThisType;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSThisType { span: self.span.clone_in(allocator) }
+        TSThisType { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSObjectKeyword {
     type Cloned = TSObjectKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSObjectKeyword { span: self.span.clone_in(allocator) }
+        TSObjectKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSBigIntKeyword {
     type Cloned = TSBigIntKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSBigIntKeyword { span: self.span.clone_in(allocator) }
+        TSBigIntKeyword { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -2793,9 +3198,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'old_alloc>
     type Cloned = TSTypeReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeReference {
-            span: self.span.clone_in(allocator),
-            type_name: self.type_name.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_name: CloneIn::clone_in(&self.type_name, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -2805,9 +3210,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeName<'old_alloc> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::IdentifierReference(it) => {
-                TSTypeName::IdentifierReference(it.clone_in(allocator))
+                TSTypeName::IdentifierReference(CloneIn::clone_in(it, allocator))
             }
-            Self::QualifiedName(it) => TSTypeName::QualifiedName(it.clone_in(allocator)),
+            Self::QualifiedName(it) => TSTypeName::QualifiedName(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -2816,9 +3221,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'old_alloc>
     type Cloned = TSQualifiedName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSQualifiedName {
-            span: self.span.clone_in(allocator),
-            left: self.left.clone_in(allocator),
-            right: self.right.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            left: CloneIn::clone_in(&self.left, allocator),
+            right: CloneIn::clone_in(&self.right, allocator),
         }
     }
 }
@@ -2827,8 +3232,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiatio
     type Cloned = TSTypeParameterInstantiation<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterInstantiation {
-            span: self.span.clone_in(allocator),
-            params: self.params.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
         }
     }
 }
@@ -2837,13 +3242,13 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'old_alloc>
     type Cloned = TSTypeParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameter {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            constraint: self.constraint.clone_in(allocator),
-            default: self.default.clone_in(allocator),
-            r#in: self.r#in.clone_in(allocator),
-            out: self.out.clone_in(allocator),
-            r#const: self.r#const.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            constraint: CloneIn::clone_in(&self.constraint, allocator),
+            default: CloneIn::clone_in(&self.default, allocator),
+            r#in: CloneIn::clone_in(&self.r#in, allocator),
+            out: CloneIn::clone_in(&self.out, allocator),
+            r#const: CloneIn::clone_in(&self.r#const, allocator),
         }
     }
 }
@@ -2852,8 +3257,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<
     type Cloned = TSTypeParameterDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterDeclaration {
-            span: self.span.clone_in(allocator),
-            params: self.params.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
         }
     }
 }
@@ -2862,11 +3267,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'old
     type Cloned = TSTypeAliasDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAliasDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
         }
     }
@@ -2887,9 +3292,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'old_allo
     type Cloned = TSClassImplements<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSClassImplements {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -2898,12 +3303,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'old
     type Cloned = TSInterfaceDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            extends: self.extends.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
-            body: self.body.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            extends: CloneIn::clone_in(&self.extends, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
         }
     }
@@ -2912,7 +3317,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'old
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'old_alloc> {
     type Cloned = TSInterfaceBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSInterfaceBody { span: self.span.clone_in(allocator), body: self.body.clone_in(allocator) }
+        TSInterfaceBody {
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+        }
     }
 }
 
@@ -2920,12 +3328,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'old_al
     type Cloned = TSPropertySignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSPropertySignature {
-            span: self.span.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
-            readonly: self.readonly.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
+            readonly: CloneIn::clone_in(&self.readonly, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -2934,17 +3342,21 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSSignature<'old_alloc> {
     type Cloned = TSSignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::TSIndexSignature(it) => TSSignature::TSIndexSignature(it.clone_in(allocator)),
+            Self::TSIndexSignature(it) => {
+                TSSignature::TSIndexSignature(CloneIn::clone_in(it, allocator))
+            }
             Self::TSPropertySignature(it) => {
-                TSSignature::TSPropertySignature(it.clone_in(allocator))
+                TSSignature::TSPropertySignature(CloneIn::clone_in(it, allocator))
             }
             Self::TSCallSignatureDeclaration(it) => {
-                TSSignature::TSCallSignatureDeclaration(it.clone_in(allocator))
+                TSSignature::TSCallSignatureDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSConstructSignatureDeclaration(it) => {
-                TSSignature::TSConstructSignatureDeclaration(it.clone_in(allocator))
+                TSSignature::TSConstructSignatureDeclaration(CloneIn::clone_in(it, allocator))
             }
-            Self::TSMethodSignature(it) => TSSignature::TSMethodSignature(it.clone_in(allocator)),
+            Self::TSMethodSignature(it) => {
+                TSSignature::TSMethodSignature(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -2953,10 +3365,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'old_alloc
     type Cloned = TSIndexSignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignature {
-            span: self.span.clone_in(allocator),
-            parameters: self.parameters.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            readonly: self.readonly.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            parameters: CloneIn::clone_in(&self.parameters, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            readonly: CloneIn::clone_in(&self.readonly, allocator),
         }
     }
 }
@@ -2965,11 +3377,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<
     type Cloned = TSCallSignatureDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSCallSignatureDeclaration {
-            span: self.span.clone_in(allocator),
-            this_param: self.this_param.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            this_param: CloneIn::clone_in(&self.this_param, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -2989,15 +3401,15 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'old_allo
     type Cloned = TSMethodSignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMethodSignature {
-            span: self.span.clone_in(allocator),
-            key: self.key.clone_in(allocator),
-            computed: self.computed.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            this_param: self.this_param.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            key: CloneIn::clone_in(&self.key, allocator),
+            computed: CloneIn::clone_in(&self.computed, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            this_param: CloneIn::clone_in(&self.this_param, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3007,10 +3419,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclara
     type Cloned = TSConstructSignatureDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructSignatureDeclaration {
-            span: self.span.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3020,9 +3432,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'old_a
     type Cloned = TSIndexSignatureName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignatureName {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -3031,9 +3443,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'old_al
     type Cloned = TSInterfaceHeritage<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceHeritage {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3042,10 +3454,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'old_alloc>
     type Cloned = TSTypePredicate<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypePredicate {
-            span: self.span.clone_in(allocator),
-            parameter_name: self.parameter_name.clone_in(allocator),
-            asserts: self.asserts.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            parameter_name: CloneIn::clone_in(&self.parameter_name, allocator),
+            asserts: CloneIn::clone_in(&self.asserts, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -3054,8 +3466,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypePredicateName<'old_al
     type Cloned = TSTypePredicateName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => TSTypePredicateName::Identifier(it.clone_in(allocator)),
-            Self::This(it) => TSTypePredicateName::This(it.clone_in(allocator)),
+            Self::Identifier(it) => {
+                TSTypePredicateName::Identifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::This(it) => TSTypePredicateName::This(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -3064,11 +3478,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'old_al
     type Cloned = TSModuleDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            body: self.body.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            declare: self.declare.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3089,9 +3503,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationName<'ol
     type Cloned = TSModuleDeclarationName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => TSModuleDeclarationName::Identifier(it.clone_in(allocator)),
+            Self::Identifier(it) => {
+                TSModuleDeclarationName::Identifier(CloneIn::clone_in(it, allocator))
+            }
             Self::StringLiteral(it) => {
-                TSModuleDeclarationName::StringLiteral(it.clone_in(allocator))
+                TSModuleDeclarationName::StringLiteral(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -3102,10 +3518,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationBody<'ol
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::TSModuleDeclaration(it) => {
-                TSModuleDeclarationBody::TSModuleDeclaration(it.clone_in(allocator))
+                TSModuleDeclarationBody::TSModuleDeclaration(CloneIn::clone_in(it, allocator))
             }
             Self::TSModuleBlock(it) => {
-                TSModuleDeclarationBody::TSModuleBlock(it.clone_in(allocator))
+                TSModuleDeclarationBody::TSModuleBlock(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -3115,9 +3531,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'old_alloc> {
     type Cloned = TSModuleBlock<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleBlock {
-            span: self.span.clone_in(allocator),
-            directives: self.directives.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            directives: CloneIn::clone_in(&self.directives, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -3126,8 +3542,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'old_alloc> {
     type Cloned = TSTypeLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeLiteral {
-            span: self.span.clone_in(allocator),
-            members: self.members.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            members: CloneIn::clone_in(&self.members, allocator),
         }
     }
 }
@@ -3136,8 +3552,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInferType<'old_alloc> {
     type Cloned = TSInferType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInferType {
-            span: self.span.clone_in(allocator),
-            type_parameter: self.type_parameter.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
         }
     }
 }
@@ -3146,9 +3562,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'old_alloc> {
     type Cloned = TSTypeQuery<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeQuery {
-            span: self.span.clone_in(allocator),
-            expr_name: self.expr_name.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expr_name: CloneIn::clone_in(&self.expr_name, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3157,11 +3573,15 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeQueryExprName<'old_al
     type Cloned = TSTypeQueryExprName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::TSImportType(it) => TSTypeQueryExprName::TSImportType(it.clone_in(allocator)),
-            Self::IdentifierReference(it) => {
-                TSTypeQueryExprName::IdentifierReference(it.clone_in(allocator))
+            Self::TSImportType(it) => {
+                TSTypeQueryExprName::TSImportType(CloneIn::clone_in(it, allocator))
             }
-            Self::QualifiedName(it) => TSTypeQueryExprName::QualifiedName(it.clone_in(allocator)),
+            Self::IdentifierReference(it) => {
+                TSTypeQueryExprName::IdentifierReference(CloneIn::clone_in(it, allocator))
+            }
+            Self::QualifiedName(it) => {
+                TSTypeQueryExprName::QualifiedName(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3170,12 +3590,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportType<'old_alloc> {
     type Cloned = TSImportType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
-            span: self.span.clone_in(allocator),
-            is_type_of: self.is_type_of.clone_in(allocator),
-            parameter: self.parameter.clone_in(allocator),
-            qualifier: self.qualifier.clone_in(allocator),
-            attributes: self.attributes.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            is_type_of: CloneIn::clone_in(&self.is_type_of, allocator),
+            parameter: CloneIn::clone_in(&self.parameter, allocator),
+            qualifier: CloneIn::clone_in(&self.qualifier, allocator),
+            attributes: CloneIn::clone_in(&self.attributes, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3184,9 +3604,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttributes<'old_all
     type Cloned = TSImportAttributes<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportAttributes {
-            span: self.span.clone_in(allocator),
-            attributes_keyword: self.attributes_keyword.clone_in(allocator),
-            elements: self.elements.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            attributes_keyword: CloneIn::clone_in(&self.attributes_keyword, allocator),
+            elements: CloneIn::clone_in(&self.elements, allocator),
         }
     }
 }
@@ -3195,9 +3615,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttribute<'old_allo
     type Cloned = TSImportAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportAttribute {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -3206,8 +3626,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttributeName<'old_
     type Cloned = TSImportAttributeName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => TSImportAttributeName::Identifier(it.clone_in(allocator)),
-            Self::StringLiteral(it) => TSImportAttributeName::StringLiteral(it.clone_in(allocator)),
+            Self::Identifier(it) => {
+                TSImportAttributeName::Identifier(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                TSImportAttributeName::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3216,11 +3640,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'old_alloc> 
     type Cloned = TSFunctionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSFunctionType {
-            span: self.span.clone_in(allocator),
-            this_param: self.this_param.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            this_param: CloneIn::clone_in(&self.this_param, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3229,11 +3653,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'old_allo
     type Cloned = TSConstructorType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructorType {
-            span: self.span.clone_in(allocator),
-            r#abstract: self.r#abstract.clone_in(allocator),
-            params: self.params.clone_in(allocator),
-            return_type: self.return_type.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
+            params: CloneIn::clone_in(&self.params, allocator),
+            return_type: CloneIn::clone_in(&self.return_type, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3242,12 +3666,12 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSMappedType<'old_alloc> {
     type Cloned = TSMappedType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
-            span: self.span.clone_in(allocator),
-            type_parameter: self.type_parameter.clone_in(allocator),
-            name_type: self.name_type.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            optional: self.optional.clone_in(allocator),
-            readonly: self.readonly.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
+            name_type: CloneIn::clone_in(&self.name_type, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            optional: CloneIn::clone_in(&self.optional, allocator),
+            readonly: CloneIn::clone_in(&self.readonly, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3269,9 +3693,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'old_
     type Cloned = TSTemplateLiteralType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTemplateLiteralType {
-            span: self.span.clone_in(allocator),
-            quasis: self.quasis.clone_in(allocator),
-            types: self.types.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            quasis: CloneIn::clone_in(&self.quasis, allocator),
+            types: CloneIn::clone_in(&self.types, allocator),
         }
     }
 }
@@ -3280,9 +3704,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'old_alloc> 
     type Cloned = TSAsExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSAsExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -3291,9 +3715,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'old_
     type Cloned = TSSatisfiesExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSatisfiesExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -3302,9 +3726,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'old_alloc>
     type Cloned = TSTypeAssertion<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
     }
 }
@@ -3313,10 +3737,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'
     type Cloned = TSImportEqualsDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportEqualsDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
-            module_reference: self.module_reference.clone_in(allocator),
-            import_kind: self.import_kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
+            module_reference: CloneIn::clone_in(&self.module_reference, allocator),
+            import_kind: CloneIn::clone_in(&self.import_kind, allocator),
         }
     }
 }
@@ -3326,12 +3750,14 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'old_allo
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::ExternalModuleReference(it) => {
-                TSModuleReference::ExternalModuleReference(it.clone_in(allocator))
+                TSModuleReference::ExternalModuleReference(CloneIn::clone_in(it, allocator))
             }
             Self::IdentifierReference(it) => {
-                TSModuleReference::IdentifierReference(it.clone_in(allocator))
+                TSModuleReference::IdentifierReference(CloneIn::clone_in(it, allocator))
             }
-            Self::QualifiedName(it) => TSModuleReference::QualifiedName(it.clone_in(allocator)),
+            Self::QualifiedName(it) => {
+                TSModuleReference::QualifiedName(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3340,8 +3766,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'
     type Cloned = TSExternalModuleReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExternalModuleReference {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3350,8 +3776,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'old_al
     type Cloned = TSNonNullExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNonNullExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3360,8 +3786,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Decorator<'old_alloc> {
     type Cloned = Decorator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Decorator {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3370,8 +3796,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'old_all
     type Cloned = TSExportAssignment<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExportAssignment {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3380,8 +3806,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaratio
     type Cloned = TSNamespaceExportDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamespaceExportDeclaration {
-            span: self.span.clone_in(allocator),
-            id: self.id.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            id: CloneIn::clone_in(&self.id, allocator),
         }
     }
 }
@@ -3390,9 +3816,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'
     type Cloned = TSInstantiationExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInstantiationExpression {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3411,9 +3837,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'old_allo
     type Cloned = JSDocNullableType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNullableType {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            postfix: self.postfix.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            postfix: CloneIn::clone_in(&self.postfix, allocator),
         }
     }
 }
@@ -3422,9 +3848,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'old_a
     type Cloned = JSDocNonNullableType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNonNullableType {
-            span: self.span.clone_in(allocator),
-            type_annotation: self.type_annotation.clone_in(allocator),
-            postfix: self.postfix.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
+            postfix: CloneIn::clone_in(&self.postfix, allocator),
         }
     }
 }
@@ -3432,7 +3858,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'old_a
 impl<'alloc> CloneIn<'alloc> for JSDocUnknownType {
     type Cloned = JSDocUnknownType;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSDocUnknownType { span: self.span.clone_in(allocator) }
+        JSDocUnknownType { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -3440,10 +3866,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXElement<'old_alloc> {
     type Cloned = JSXElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXElement {
-            span: self.span.clone_in(allocator),
-            opening_element: self.opening_element.clone_in(allocator),
-            closing_element: self.closing_element.clone_in(allocator),
-            children: self.children.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            opening_element: CloneIn::clone_in(&self.opening_element, allocator),
+            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
+            children: CloneIn::clone_in(&self.children, allocator),
         }
     }
 }
@@ -3452,11 +3878,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'old_allo
     type Cloned = JSXOpeningElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
-            span: self.span.clone_in(allocator),
-            self_closing: self.self_closing.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            attributes: self.attributes.clone_in(allocator),
-            type_parameters: self.type_parameters.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            self_closing: CloneIn::clone_in(&self.self_closing, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            attributes: CloneIn::clone_in(&self.attributes, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3465,8 +3891,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'old_allo
     type Cloned = JSXClosingElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingElement {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
         }
     }
 }
@@ -3475,10 +3901,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXFragment<'old_alloc> {
     type Cloned = JSXFragment<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXFragment {
-            span: self.span.clone_in(allocator),
-            opening_fragment: self.opening_fragment.clone_in(allocator),
-            closing_fragment: self.closing_fragment.clone_in(allocator),
-            children: self.children.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
+            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
+            children: CloneIn::clone_in(&self.children, allocator),
         }
     }
 }
@@ -3486,14 +3912,14 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXFragment<'old_alloc> {
 impl<'alloc> CloneIn<'alloc> for JSXOpeningFragment {
     type Cloned = JSXOpeningFragment;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXOpeningFragment { span: self.span.clone_in(allocator) }
+        JSXOpeningFragment { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for JSXClosingFragment {
     type Cloned = JSXClosingFragment;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXClosingFragment { span: self.span.clone_in(allocator) }
+        JSXClosingFragment { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -3501,13 +3927,19 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXElementName<'old_alloc> 
     type Cloned = JSXElementName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => JSXElementName::Identifier(it.clone_in(allocator)),
+            Self::Identifier(it) => JSXElementName::Identifier(CloneIn::clone_in(it, allocator)),
             Self::IdentifierReference(it) => {
-                JSXElementName::IdentifierReference(it.clone_in(allocator))
+                JSXElementName::IdentifierReference(CloneIn::clone_in(it, allocator))
             }
-            Self::NamespacedName(it) => JSXElementName::NamespacedName(it.clone_in(allocator)),
-            Self::MemberExpression(it) => JSXElementName::MemberExpression(it.clone_in(allocator)),
-            Self::ThisExpression(it) => JSXElementName::ThisExpression(it.clone_in(allocator)),
+            Self::NamespacedName(it) => {
+                JSXElementName::NamespacedName(CloneIn::clone_in(it, allocator))
+            }
+            Self::MemberExpression(it) => {
+                JSXElementName::MemberExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ThisExpression(it) => {
+                JSXElementName::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3516,9 +3948,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'old_allo
     type Cloned = JSXNamespacedName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXNamespacedName {
-            span: self.span.clone_in(allocator),
-            namespace: self.namespace.clone_in(allocator),
-            property: self.property.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            namespace: CloneIn::clone_in(&self.namespace, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
         }
     }
 }
@@ -3527,9 +3959,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'old_al
     type Cloned = JSXMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXMemberExpression {
-            span: self.span.clone_in(allocator),
-            object: self.object.clone_in(allocator),
-            property: self.property.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
         }
     }
 }
@@ -3539,13 +3971,13 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::IdentifierReference(it) => {
-                JSXMemberExpressionObject::IdentifierReference(it.clone_in(allocator))
+                JSXMemberExpressionObject::IdentifierReference(CloneIn::clone_in(it, allocator))
             }
             Self::MemberExpression(it) => {
-                JSXMemberExpressionObject::MemberExpression(it.clone_in(allocator))
+                JSXMemberExpressionObject::MemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ThisExpression(it) => {
-                JSXMemberExpressionObject::ThisExpression(it.clone_in(allocator))
+                JSXMemberExpressionObject::ThisExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -3555,8 +3987,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'old
     type Cloned = JSXExpressionContainer<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXExpressionContainer {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3565,76 +3997,122 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXExpression<'old_alloc> {
     type Cloned = JSXExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::EmptyExpression(it) => JSXExpression::EmptyExpression(it.clone_in(allocator)),
-            Self::BooleanLiteral(it) => JSXExpression::BooleanLiteral(it.clone_in(allocator)),
-            Self::NullLiteral(it) => JSXExpression::NullLiteral(it.clone_in(allocator)),
-            Self::NumericLiteral(it) => JSXExpression::NumericLiteral(it.clone_in(allocator)),
-            Self::BigIntLiteral(it) => JSXExpression::BigIntLiteral(it.clone_in(allocator)),
-            Self::RegExpLiteral(it) => JSXExpression::RegExpLiteral(it.clone_in(allocator)),
-            Self::StringLiteral(it) => JSXExpression::StringLiteral(it.clone_in(allocator)),
-            Self::TemplateLiteral(it) => JSXExpression::TemplateLiteral(it.clone_in(allocator)),
-            Self::Identifier(it) => JSXExpression::Identifier(it.clone_in(allocator)),
-            Self::MetaProperty(it) => JSXExpression::MetaProperty(it.clone_in(allocator)),
-            Self::Super(it) => JSXExpression::Super(it.clone_in(allocator)),
-            Self::ArrayExpression(it) => JSXExpression::ArrayExpression(it.clone_in(allocator)),
+            Self::EmptyExpression(it) => {
+                JSXExpression::EmptyExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BooleanLiteral(it) => {
+                JSXExpression::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => JSXExpression::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => {
+                JSXExpression::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => {
+                JSXExpression::BigIntLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::RegExpLiteral(it) => {
+                JSXExpression::RegExpLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                JSXExpression::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::TemplateLiteral(it) => {
+                JSXExpression::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => JSXExpression::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => JSXExpression::MetaProperty(CloneIn::clone_in(it, allocator)),
+            Self::Super(it) => JSXExpression::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                JSXExpression::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ArrowFunctionExpression(it) => {
-                JSXExpression::ArrowFunctionExpression(it.clone_in(allocator))
+                JSXExpression::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
             }
             Self::AssignmentExpression(it) => {
-                JSXExpression::AssignmentExpression(it.clone_in(allocator))
+                JSXExpression::AssignmentExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::AwaitExpression(it) => JSXExpression::AwaitExpression(it.clone_in(allocator)),
-            Self::BinaryExpression(it) => JSXExpression::BinaryExpression(it.clone_in(allocator)),
-            Self::CallExpression(it) => JSXExpression::CallExpression(it.clone_in(allocator)),
-            Self::ChainExpression(it) => JSXExpression::ChainExpression(it.clone_in(allocator)),
-            Self::ClassExpression(it) => JSXExpression::ClassExpression(it.clone_in(allocator)),
+            Self::AwaitExpression(it) => {
+                JSXExpression::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BinaryExpression(it) => {
+                JSXExpression::BinaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::CallExpression(it) => {
+                JSXExpression::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                JSXExpression::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                JSXExpression::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ConditionalExpression(it) => {
-                JSXExpression::ConditionalExpression(it.clone_in(allocator))
+                JSXExpression::ConditionalExpression(CloneIn::clone_in(it, allocator))
             }
             Self::FunctionExpression(it) => {
-                JSXExpression::FunctionExpression(it.clone_in(allocator))
+                JSXExpression::FunctionExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ImportExpression(it) => JSXExpression::ImportExpression(it.clone_in(allocator)),
-            Self::LogicalExpression(it) => JSXExpression::LogicalExpression(it.clone_in(allocator)),
-            Self::NewExpression(it) => JSXExpression::NewExpression(it.clone_in(allocator)),
-            Self::ObjectExpression(it) => JSXExpression::ObjectExpression(it.clone_in(allocator)),
+            Self::ImportExpression(it) => {
+                JSXExpression::ImportExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::LogicalExpression(it) => {
+                JSXExpression::LogicalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::NewExpression(it) => {
+                JSXExpression::NewExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ObjectExpression(it) => {
+                JSXExpression::ObjectExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::ParenthesizedExpression(it) => {
-                JSXExpression::ParenthesizedExpression(it.clone_in(allocator))
+                JSXExpression::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
             }
             Self::SequenceExpression(it) => {
-                JSXExpression::SequenceExpression(it.clone_in(allocator))
+                JSXExpression::SequenceExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TaggedTemplateExpression(it) => {
-                JSXExpression::TaggedTemplateExpression(it.clone_in(allocator))
+                JSXExpression::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::ThisExpression(it) => JSXExpression::ThisExpression(it.clone_in(allocator)),
-            Self::UnaryExpression(it) => JSXExpression::UnaryExpression(it.clone_in(allocator)),
-            Self::UpdateExpression(it) => JSXExpression::UpdateExpression(it.clone_in(allocator)),
-            Self::YieldExpression(it) => JSXExpression::YieldExpression(it.clone_in(allocator)),
+            Self::ThisExpression(it) => {
+                JSXExpression::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                JSXExpression::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UpdateExpression(it) => {
+                JSXExpression::UpdateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::YieldExpression(it) => {
+                JSXExpression::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::PrivateInExpression(it) => {
-                JSXExpression::PrivateInExpression(it.clone_in(allocator))
+                JSXExpression::PrivateInExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::JSXElement(it) => JSXExpression::JSXElement(it.clone_in(allocator)),
-            Self::JSXFragment(it) => JSXExpression::JSXFragment(it.clone_in(allocator)),
-            Self::TSAsExpression(it) => JSXExpression::TSAsExpression(it.clone_in(allocator)),
+            Self::JSXElement(it) => JSXExpression::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => JSXExpression::JSXFragment(CloneIn::clone_in(it, allocator)),
+            Self::TSAsExpression(it) => {
+                JSXExpression::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
             Self::TSSatisfiesExpression(it) => {
-                JSXExpression::TSSatisfiesExpression(it.clone_in(allocator))
+                JSXExpression::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
             }
-            Self::TSTypeAssertion(it) => JSXExpression::TSTypeAssertion(it.clone_in(allocator)),
+            Self::TSTypeAssertion(it) => {
+                JSXExpression::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
             Self::TSNonNullExpression(it) => {
-                JSXExpression::TSNonNullExpression(it.clone_in(allocator))
+                JSXExpression::TSNonNullExpression(CloneIn::clone_in(it, allocator))
             }
             Self::TSInstantiationExpression(it) => {
-                JSXExpression::TSInstantiationExpression(it.clone_in(allocator))
+                JSXExpression::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
             }
             Self::ComputedMemberExpression(it) => {
-                JSXExpression::ComputedMemberExpression(it.clone_in(allocator))
+                JSXExpression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::StaticMemberExpression(it) => {
-                JSXExpression::StaticMemberExpression(it.clone_in(allocator))
+                JSXExpression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
             }
             Self::PrivateFieldExpression(it) => {
-                JSXExpression::PrivateFieldExpression(it.clone_in(allocator))
+                JSXExpression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -3643,7 +4121,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXExpression<'old_alloc> {
 impl<'alloc> CloneIn<'alloc> for JSXEmptyExpression {
     type Cloned = JSXEmptyExpression;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXEmptyExpression { span: self.span.clone_in(allocator) }
+        JSXEmptyExpression { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -3651,8 +4129,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'old_alloc
     type Cloned = JSXAttributeItem<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Attribute(it) => JSXAttributeItem::Attribute(it.clone_in(allocator)),
-            Self::SpreadAttribute(it) => JSXAttributeItem::SpreadAttribute(it.clone_in(allocator)),
+            Self::Attribute(it) => JSXAttributeItem::Attribute(CloneIn::clone_in(it, allocator)),
+            Self::SpreadAttribute(it) => {
+                JSXAttributeItem::SpreadAttribute(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3661,9 +4141,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'old_alloc> {
     type Cloned = JSXAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXAttribute {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -3672,8 +4152,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'old_all
     type Cloned = JSXSpreadAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadAttribute {
-            span: self.span.clone_in(allocator),
-            argument: self.argument.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
         }
     }
 }
@@ -3682,8 +4162,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'old_alloc
     type Cloned = JSXAttributeName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => JSXAttributeName::Identifier(it.clone_in(allocator)),
-            Self::NamespacedName(it) => JSXAttributeName::NamespacedName(it.clone_in(allocator)),
+            Self::Identifier(it) => JSXAttributeName::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::NamespacedName(it) => {
+                JSXAttributeName::NamespacedName(CloneIn::clone_in(it, allocator))
+            }
         }
     }
 }
@@ -3692,12 +4174,14 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'old_allo
     type Cloned = JSXAttributeValue<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::StringLiteral(it) => JSXAttributeValue::StringLiteral(it.clone_in(allocator)),
-            Self::ExpressionContainer(it) => {
-                JSXAttributeValue::ExpressionContainer(it.clone_in(allocator))
+            Self::StringLiteral(it) => {
+                JSXAttributeValue::StringLiteral(CloneIn::clone_in(it, allocator))
             }
-            Self::Element(it) => JSXAttributeValue::Element(it.clone_in(allocator)),
-            Self::Fragment(it) => JSXAttributeValue::Fragment(it.clone_in(allocator)),
+            Self::ExpressionContainer(it) => {
+                JSXAttributeValue::ExpressionContainer(CloneIn::clone_in(it, allocator))
+            }
+            Self::Element(it) => JSXAttributeValue::Element(CloneIn::clone_in(it, allocator)),
+            Self::Fragment(it) => JSXAttributeValue::Fragment(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -3705,7 +4189,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'old_allo
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'old_alloc> {
     type Cloned = JSXIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXIdentifier { span: self.span.clone_in(allocator), name: self.name.clone_in(allocator) }
+        JSXIdentifier {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
     }
 }
 
@@ -3713,11 +4200,13 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXChild<'old_alloc> {
     type Cloned = JSXChild<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Text(it) => JSXChild::Text(it.clone_in(allocator)),
-            Self::Element(it) => JSXChild::Element(it.clone_in(allocator)),
-            Self::Fragment(it) => JSXChild::Fragment(it.clone_in(allocator)),
-            Self::ExpressionContainer(it) => JSXChild::ExpressionContainer(it.clone_in(allocator)),
-            Self::Spread(it) => JSXChild::Spread(it.clone_in(allocator)),
+            Self::Text(it) => JSXChild::Text(CloneIn::clone_in(it, allocator)),
+            Self::Element(it) => JSXChild::Element(CloneIn::clone_in(it, allocator)),
+            Self::Fragment(it) => JSXChild::Fragment(CloneIn::clone_in(it, allocator)),
+            Self::ExpressionContainer(it) => {
+                JSXChild::ExpressionContainer(CloneIn::clone_in(it, allocator))
+            }
+            Self::Spread(it) => JSXChild::Spread(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -3726,8 +4215,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'old_alloc> 
     type Cloned = JSXSpreadChild<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadChild {
-            span: self.span.clone_in(allocator),
-            expression: self.expression.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
         }
     }
 }
@@ -3735,6 +4224,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'old_alloc> 
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXText<'old_alloc> {
     type Cloned = JSXText<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXText { span: self.span.clone_in(allocator), value: self.value.clone_in(allocator) }
+        JSXText {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1,6 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
+#![allow(clippy::match_like_matches_macro)]
+
 use oxc_span::cmp::ContentEq;
 
 #[allow(clippy::wildcard_imports)]
@@ -17,7 +19,7 @@ use crate::ast::ts::*;
 
 impl ContentEq for BooleanLiteral {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
@@ -29,40 +31,48 @@ impl ContentEq for NullLiteral {
 
 impl<'a> ContentEq for NumericLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value)
-            && self.raw.content_eq(&other.raw)
-            && self.base.content_eq(&other.base)
+        ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.raw, &other.raw)
+            && ContentEq::content_eq(&self.base, &other.base)
     }
 }
 
 impl<'a> ContentEq for BigIntLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.raw.content_eq(&other.raw) && self.base.content_eq(&other.base)
+        ContentEq::content_eq(&self.raw, &other.raw)
+            && ContentEq::content_eq(&self.base, &other.base)
     }
 }
 
 impl<'a> ContentEq for RegExpLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value) && self.regex.content_eq(&other.regex)
+        ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.regex, &other.regex)
     }
 }
 
 impl<'a> ContentEq for RegExp<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.pattern.content_eq(&other.pattern) && self.flags.content_eq(&other.flags)
+        ContentEq::content_eq(&self.pattern, &other.pattern)
+            && ContentEq::content_eq(&self.flags, &other.flags)
     }
 }
 
 impl<'a> ContentEq for RegExpPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Raw(it) => matches!(other, Self::Raw(other) if it.content_eq(other)),
-            Self::Invalid(it) => {
-                matches!(other, Self::Invalid(other) if it.content_eq(other))
-            }
-            Self::Pattern(it) => {
-                matches!(other, Self::Pattern(other) if it.content_eq(other))
-            }
+            Self::Raw(it) => match other {
+                Self::Raw(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Invalid(it) => match other {
+                Self::Invalid(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Pattern(it) => match other {
+                Self::Pattern(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -75,193 +85,215 @@ impl ContentEq for EmptyObject {
 
 impl<'a> ContentEq for StringLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for Program<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.source_type.content_eq(&other.source_type)
-            && self.hashbang.content_eq(&other.hashbang)
-            && self.directives.content_eq(&other.directives)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.source_type, &other.source_type)
+            && ContentEq::content_eq(&self.hashbang, &other.hashbang)
+            && ContentEq::content_eq(&self.directives, &other.directives)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for Expression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for IdentifierName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for IdentifierReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for BindingIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for LabelIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
@@ -273,165 +305,189 @@ impl ContentEq for ThisExpression {
 
 impl<'a> ContentEq for ArrayExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.elements.content_eq(&other.elements)
+        ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
 impl<'a> ContentEq for ArrayExpressionElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::SpreadElement(it) => {
-                matches!(other, Self::SpreadElement(other) if it.content_eq(other))
-            }
-            Self::Elision(it) => {
-                matches!(other, Self::Elision(other) if it.content_eq(other))
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::SpreadElement(it) => match other {
+                Self::SpreadElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Elision(it) => match other {
+                Self::Elision(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -444,190 +500,216 @@ impl ContentEq for Elision {
 
 impl<'a> ContentEq for ObjectExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.properties.content_eq(&other.properties)
+        ContentEq::content_eq(&self.properties, &other.properties)
     }
 }
 
 impl<'a> ContentEq for ObjectPropertyKind<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ObjectProperty(it) => {
-                matches!(other, Self::ObjectProperty(other) if it.content_eq(other))
-            }
-            Self::SpreadProperty(it) => {
-                matches!(other, Self::SpreadProperty(other) if it.content_eq(other))
-            }
+            Self::ObjectProperty(it) => match other {
+                Self::ObjectProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SpreadProperty(it) => match other {
+                Self::SpreadProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ObjectProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
-            && self.key.content_eq(&other.key)
-            && self.value.content_eq(&other.value)
-            && self.init.content_eq(&other.init)
-            && self.method.content_eq(&other.method)
-            && self.shorthand.content_eq(&other.shorthand)
-            && self.computed.content_eq(&other.computed)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.init, &other.init)
+            && ContentEq::content_eq(&self.method, &other.method)
+            && ContentEq::content_eq(&self.shorthand, &other.shorthand)
+            && ContentEq::content_eq(&self.computed, &other.computed)
     }
 }
 
 impl<'a> ContentEq for PropertyKey<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::StaticIdentifier(it) => {
-                matches!(other, Self::StaticIdentifier(other) if it.content_eq(other))
-            }
-            Self::PrivateIdentifier(it) => {
-                matches!(other, Self::PrivateIdentifier(other) if it.content_eq(other))
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::StaticIdentifier(it) => match other {
+                Self::StaticIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateIdentifier(it) => match other {
+                Self::PrivateIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -640,368 +722,387 @@ impl ContentEq for PropertyKind {
 
 impl<'a> ContentEq for TemplateLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.quasis.content_eq(&other.quasis) && self.expressions.content_eq(&other.expressions)
+        ContentEq::content_eq(&self.quasis, &other.quasis)
+            && ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
 impl<'a> ContentEq for TaggedTemplateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.tag.content_eq(&other.tag)
-            && self.quasi.content_eq(&other.quasi)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.tag, &other.tag)
+            && ContentEq::content_eq(&self.quasi, &other.quasi)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TemplateElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.tail.content_eq(&other.tail) && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.tail, &other.tail)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for TemplateElementValue<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.raw.content_eq(&other.raw) && self.cooked.content_eq(&other.cooked)
+        ContentEq::content_eq(&self.raw, &other.raw)
+            && ContentEq::content_eq(&self.cooked, &other.cooked)
     }
 }
 
 impl<'a> ContentEq for MemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ComputedMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object.content_eq(&other.object)
-            && self.expression.content_eq(&other.expression)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for StaticMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object.content_eq(&other.object)
-            && self.property.content_eq(&other.property)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.property, &other.property)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for PrivateFieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object.content_eq(&other.object)
-            && self.field.content_eq(&other.field)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.field, &other.field)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for CallExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.callee.content_eq(&other.callee)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.arguments.content_eq(&other.arguments)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.callee, &other.callee)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.arguments, &other.arguments)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for NewExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.callee.content_eq(&other.callee)
-            && self.arguments.content_eq(&other.arguments)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.callee, &other.callee)
+            && ContentEq::content_eq(&self.arguments, &other.arguments)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for MetaProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.meta.content_eq(&other.meta) && self.property.content_eq(&other.property)
+        ContentEq::content_eq(&self.meta, &other.meta)
+            && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for SpreadElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Argument<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::SpreadElement(it) => {
-                matches!(other, Self::SpreadElement(other) if it.content_eq(other))
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::SpreadElement(it) => match other {
+                Self::SpreadElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for UpdateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.operator.content_eq(&other.operator)
-            && self.prefix.content_eq(&other.prefix)
-            && self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.prefix, &other.prefix)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for UnaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.operator.content_eq(&other.operator) && self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for BinaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left)
-            && self.operator.content_eq(&other.operator)
-            && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for PrivateInExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left)
-            && self.operator.content_eq(&other.operator)
-            && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for LogicalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left)
-            && self.operator.content_eq(&other.operator)
-            && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for ConditionalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.test.content_eq(&other.test)
-            && self.consequent.content_eq(&other.consequent)
-            && self.alternate.content_eq(&other.alternate)
+        ContentEq::content_eq(&self.test, &other.test)
+            && ContentEq::content_eq(&self.consequent, &other.consequent)
+            && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
 }
 
 impl<'a> ContentEq for AssignmentExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.operator.content_eq(&other.operator)
-            && self.left.content_eq(&other.left)
-            && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for AssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::AssignmentTargetIdentifier(it) => {
-                matches!(
-                    other, Self::AssignmentTargetIdentifier(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ArrayAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ArrayAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
-            Self::ObjectAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ObjectAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
+            Self::AssignmentTargetIdentifier(it) => match other {
+                Self::AssignmentTargetIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayAssignmentTarget(it) => match other {
+                Self::ArrayAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectAssignmentTarget(it) => match other {
+                Self::ObjectAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -1009,46 +1110,42 @@ impl<'a> ContentEq for AssignmentTarget<'a> {
 impl<'a> ContentEq for SimpleAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::AssignmentTargetIdentifier(it) => {
-                matches!(
-                    other, Self::AssignmentTargetIdentifier(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::AssignmentTargetIdentifier(it) => match other {
+                Self::AssignmentTargetIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -1056,141 +1153,142 @@ impl<'a> ContentEq for SimpleAssignmentTarget<'a> {
 impl<'a> ContentEq for AssignmentTargetPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ArrayAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ArrayAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
-            Self::ObjectAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ObjectAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
+            Self::ArrayAssignmentTarget(it) => match other {
+                Self::ArrayAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectAssignmentTarget(it) => match other {
+                Self::ObjectAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ArrayAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.elements.content_eq(&other.elements) && self.rest.content_eq(&other.rest)
+        ContentEq::content_eq(&self.elements, &other.elements)
+            && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for ObjectAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.properties.content_eq(&other.properties) && self.rest.content_eq(&other.rest)
+        ContentEq::content_eq(&self.properties, &other.properties)
+            && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetRest<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.target.content_eq(&other.target)
+        ContentEq::content_eq(&self.target, &other.target)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetMaybeDefault<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::AssignmentTargetWithDefault(it) => {
-                matches!(
-                    other, Self::AssignmentTargetWithDefault(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::AssignmentTargetIdentifier(it) => {
-                matches!(
-                    other, Self::AssignmentTargetIdentifier(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ArrayAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ArrayAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
-            Self::ObjectAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ObjectAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
+            Self::AssignmentTargetWithDefault(it) => match other {
+                Self::AssignmentTargetWithDefault(other) if ContentEq::content_eq(it, other) => {
+                    true
+                }
+                _ => false,
+            },
+            Self::AssignmentTargetIdentifier(it) => match other {
+                Self::AssignmentTargetIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayAssignmentTarget(it) => match other {
+                Self::ArrayAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectAssignmentTarget(it) => match other {
+                Self::ObjectAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetWithDefault<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.binding.content_eq(&other.binding) && self.init.content_eq(&other.init)
+        ContentEq::content_eq(&self.binding, &other.binding)
+            && ContentEq::content_eq(&self.init, &other.init)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => {
-                matches!(
-                    other, Self::AssignmentTargetPropertyIdentifier(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::AssignmentTargetPropertyProperty(it) => {
-                matches!(
-                    other, Self::AssignmentTargetPropertyProperty(other) if it
-                    .content_eq(other)
-                )
-            }
+            Self::AssignmentTargetPropertyIdentifier(it) => match other {
+                Self::AssignmentTargetPropertyIdentifier(other)
+                    if ContentEq::content_eq(it, other) =>
+                {
+                    true
+                }
+                _ => false,
+            },
+            Self::AssignmentTargetPropertyProperty(it) => match other {
+                Self::AssignmentTargetPropertyProperty(other)
+                    if ContentEq::content_eq(it, other) =>
+                {
+                    true
+                }
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetPropertyIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.binding.content_eq(&other.binding) && self.init.content_eq(&other.init)
+        ContentEq::content_eq(&self.binding, &other.binding)
+            && ContentEq::content_eq(&self.init, &other.init)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetPropertyProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name) && self.binding.content_eq(&other.binding)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.binding, &other.binding)
     }
 }
 
 impl<'a> ContentEq for SequenceExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expressions.content_eq(&other.expressions)
+        ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
@@ -1202,225 +1300,245 @@ impl ContentEq for Super {
 
 impl<'a> ContentEq for AwaitExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for ChainExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for ChainElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ParenthesizedExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for Statement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::BlockStatement(it) => {
-                matches!(other, Self::BlockStatement(other) if it.content_eq(other))
-            }
-            Self::BreakStatement(it) => {
-                matches!(other, Self::BreakStatement(other) if it.content_eq(other))
-            }
-            Self::ContinueStatement(it) => {
-                matches!(other, Self::ContinueStatement(other) if it.content_eq(other))
-            }
-            Self::DebuggerStatement(it) => {
-                matches!(other, Self::DebuggerStatement(other) if it.content_eq(other))
-            }
-            Self::DoWhileStatement(it) => {
-                matches!(other, Self::DoWhileStatement(other) if it.content_eq(other))
-            }
-            Self::EmptyStatement(it) => {
-                matches!(other, Self::EmptyStatement(other) if it.content_eq(other))
-            }
-            Self::ExpressionStatement(it) => {
-                matches!(other, Self::ExpressionStatement(other) if it.content_eq(other))
-            }
-            Self::ForInStatement(it) => {
-                matches!(other, Self::ForInStatement(other) if it.content_eq(other))
-            }
-            Self::ForOfStatement(it) => {
-                matches!(other, Self::ForOfStatement(other) if it.content_eq(other))
-            }
-            Self::ForStatement(it) => {
-                matches!(other, Self::ForStatement(other) if it.content_eq(other))
-            }
-            Self::IfStatement(it) => {
-                matches!(other, Self::IfStatement(other) if it.content_eq(other))
-            }
-            Self::LabeledStatement(it) => {
-                matches!(other, Self::LabeledStatement(other) if it.content_eq(other))
-            }
-            Self::ReturnStatement(it) => {
-                matches!(other, Self::ReturnStatement(other) if it.content_eq(other))
-            }
-            Self::SwitchStatement(it) => {
-                matches!(other, Self::SwitchStatement(other) if it.content_eq(other))
-            }
-            Self::ThrowStatement(it) => {
-                matches!(other, Self::ThrowStatement(other) if it.content_eq(other))
-            }
-            Self::TryStatement(it) => {
-                matches!(other, Self::TryStatement(other) if it.content_eq(other))
-            }
-            Self::WhileStatement(it) => {
-                matches!(other, Self::WhileStatement(other) if it.content_eq(other))
-            }
-            Self::WithStatement(it) => {
-                matches!(other, Self::WithStatement(other) if it.content_eq(other))
-            }
-            Self::VariableDeclaration(it) => {
-                matches!(other, Self::VariableDeclaration(other) if it.content_eq(other))
-            }
-            Self::FunctionDeclaration(it) => {
-                matches!(other, Self::FunctionDeclaration(other) if it.content_eq(other))
-            }
-            Self::ClassDeclaration(it) => {
-                matches!(other, Self::ClassDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSTypeAliasDeclaration(it) => {
-                matches!(
-                    other, Self::TSTypeAliasDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSInterfaceDeclaration(it) => {
-                matches!(
-                    other, Self::TSInterfaceDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSEnumDeclaration(it) => {
-                matches!(other, Self::TSEnumDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSModuleDeclaration(it) => {
-                matches!(other, Self::TSModuleDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSImportEqualsDeclaration(it) => {
-                matches!(
-                    other, Self::TSImportEqualsDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::ImportDeclaration(it) => {
-                matches!(other, Self::ImportDeclaration(other) if it.content_eq(other))
-            }
-            Self::ExportAllDeclaration(it) => {
-                matches!(
-                    other, Self::ExportAllDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::ExportDefaultDeclaration(it) => {
-                matches!(
-                    other, Self::ExportDefaultDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::ExportNamedDeclaration(it) => {
-                matches!(
-                    other, Self::ExportNamedDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSExportAssignment(it) => {
-                matches!(other, Self::TSExportAssignment(other) if it.content_eq(other))
-            }
-            Self::TSNamespaceExportDeclaration(it) => {
-                matches!(
-                    other, Self::TSNamespaceExportDeclaration(other) if it
-                    .content_eq(other)
-                )
-            }
+            Self::BlockStatement(it) => match other {
+                Self::BlockStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BreakStatement(it) => match other {
+                Self::BreakStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ContinueStatement(it) => match other {
+                Self::ContinueStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::DebuggerStatement(it) => match other {
+                Self::DebuggerStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::DoWhileStatement(it) => match other {
+                Self::DoWhileStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::EmptyStatement(it) => match other {
+                Self::EmptyStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExpressionStatement(it) => match other {
+                Self::ExpressionStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ForInStatement(it) => match other {
+                Self::ForInStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ForOfStatement(it) => match other {
+                Self::ForOfStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ForStatement(it) => match other {
+                Self::ForStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IfStatement(it) => match other {
+                Self::IfStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LabeledStatement(it) => match other {
+                Self::LabeledStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ReturnStatement(it) => match other {
+                Self::ReturnStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SwitchStatement(it) => match other {
+                Self::SwitchStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThrowStatement(it) => match other {
+                Self::ThrowStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TryStatement(it) => match other {
+                Self::TryStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::WhileStatement(it) => match other {
+                Self::WhileStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::WithStatement(it) => match other {
+                Self::WithStatement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::VariableDeclaration(it) => match other {
+                Self::VariableDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionDeclaration(it) => match other {
+                Self::FunctionDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassDeclaration(it) => match other {
+                Self::ClassDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAliasDeclaration(it) => match other {
+                Self::TSTypeAliasDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInterfaceDeclaration(it) => match other {
+                Self::TSInterfaceDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSEnumDeclaration(it) => match other {
+                Self::TSEnumDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSModuleDeclaration(it) => match other {
+                Self::TSModuleDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSImportEqualsDeclaration(it) => match other {
+                Self::TSImportEqualsDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportDeclaration(it) => match other {
+                Self::ImportDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportAllDeclaration(it) => match other {
+                Self::ExportAllDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportDefaultDeclaration(it) => match other {
+                Self::ExportDefaultDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportNamedDeclaration(it) => match other {
+                Self::ExportNamedDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSExportAssignment(it) => match other {
+                Self::TSExportAssignment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNamespaceExportDeclaration(it) => match other {
+                Self::TSNamespaceExportDeclaration(other) if ContentEq::content_eq(it, other) => {
+                    true
+                }
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for Directive<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression) && self.directive.content_eq(&other.directive)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.directive, &other.directive)
     }
 }
 
 impl<'a> ContentEq for Hashbang<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for BlockStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for Declaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::VariableDeclaration(it) => {
-                matches!(other, Self::VariableDeclaration(other) if it.content_eq(other))
-            }
-            Self::FunctionDeclaration(it) => {
-                matches!(other, Self::FunctionDeclaration(other) if it.content_eq(other))
-            }
-            Self::ClassDeclaration(it) => {
-                matches!(other, Self::ClassDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSTypeAliasDeclaration(it) => {
-                matches!(
-                    other, Self::TSTypeAliasDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSInterfaceDeclaration(it) => {
-                matches!(
-                    other, Self::TSInterfaceDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSEnumDeclaration(it) => {
-                matches!(other, Self::TSEnumDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSModuleDeclaration(it) => {
-                matches!(other, Self::TSModuleDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSImportEqualsDeclaration(it) => {
-                matches!(
-                    other, Self::TSImportEqualsDeclaration(other) if it.content_eq(other)
-                )
-            }
+            Self::VariableDeclaration(it) => match other {
+                Self::VariableDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionDeclaration(it) => match other {
+                Self::FunctionDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassDeclaration(it) => match other {
+                Self::ClassDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAliasDeclaration(it) => match other {
+                Self::TSTypeAliasDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInterfaceDeclaration(it) => match other {
+                Self::TSInterfaceDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSEnumDeclaration(it) => match other {
+                Self::TSEnumDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSModuleDeclaration(it) => match other {
+                Self::TSModuleDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSImportEqualsDeclaration(it) => match other {
+                Self::TSImportEqualsDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for VariableDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
-            && self.declarations.content_eq(&other.declarations)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.declarations, &other.declarations)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
@@ -1432,10 +1550,10 @@ impl ContentEq for VariableDeclarationKind {
 
 impl<'a> ContentEq for VariableDeclarator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
-            && self.id.content_eq(&other.id)
-            && self.init.content_eq(&other.init)
-            && self.definite.content_eq(&other.definite)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.init, &other.init)
+            && ContentEq::content_eq(&self.definite, &other.definite)
     }
 }
 
@@ -1447,337 +1565,362 @@ impl ContentEq for EmptyStatement {
 
 impl<'a> ContentEq for ExpressionStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for IfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.test.content_eq(&other.test)
-            && self.consequent.content_eq(&other.consequent)
-            && self.alternate.content_eq(&other.alternate)
+        ContentEq::content_eq(&self.test, &other.test)
+            && ContentEq::content_eq(&self.consequent, &other.consequent)
+            && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
 }
 
 impl<'a> ContentEq for DoWhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body) && self.test.content_eq(&other.test)
+        ContentEq::content_eq(&self.body, &other.body)
+            && ContentEq::content_eq(&self.test, &other.test)
     }
 }
 
 impl<'a> ContentEq for WhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.test.content_eq(&other.test) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.test, &other.test)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ForStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.init.content_eq(&other.init)
-            && self.test.content_eq(&other.test)
-            && self.update.content_eq(&other.update)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.init, &other.init)
+            && ContentEq::content_eq(&self.test, &other.test)
+            && ContentEq::content_eq(&self.update, &other.update)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ForStatementInit<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::VariableDeclaration(it) => {
-                matches!(other, Self::VariableDeclaration(other) if it.content_eq(other))
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::VariableDeclaration(it) => match other {
+                Self::VariableDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ForInStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left)
-            && self.right.content_eq(&other.right)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.right, &other.right)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ForStatementLeft<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::VariableDeclaration(it) => {
-                matches!(other, Self::VariableDeclaration(other) if it.content_eq(other))
-            }
-            Self::AssignmentTargetIdentifier(it) => {
-                matches!(
-                    other, Self::AssignmentTargetIdentifier(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ArrayAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ArrayAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
-            Self::ObjectAssignmentTarget(it) => {
-                matches!(
-                    other, Self::ObjectAssignmentTarget(other) if it.content_eq(other)
-                )
-            }
+            Self::VariableDeclaration(it) => match other {
+                Self::VariableDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentTargetIdentifier(it) => match other {
+                Self::AssignmentTargetIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayAssignmentTarget(it) => match other {
+                Self::ArrayAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectAssignmentTarget(it) => match other {
+                Self::ObjectAssignmentTarget(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ForOfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#await.content_eq(&other.r#await)
-            && self.left.content_eq(&other.left)
-            && self.right.content_eq(&other.right)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.r#await, &other.r#await)
+            && ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.right, &other.right)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ContinueStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.label.content_eq(&other.label)
+        ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for BreakStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.label.content_eq(&other.label)
+        ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for ReturnStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for WithStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object.content_eq(&other.object) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for SwitchStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.discriminant.content_eq(&other.discriminant) && self.cases.content_eq(&other.cases)
+        ContentEq::content_eq(&self.discriminant, &other.discriminant)
+            && ContentEq::content_eq(&self.cases, &other.cases)
     }
 }
 
 impl<'a> ContentEq for SwitchCase<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.test.content_eq(&other.test) && self.consequent.content_eq(&other.consequent)
+        ContentEq::content_eq(&self.test, &other.test)
+            && ContentEq::content_eq(&self.consequent, &other.consequent)
     }
 }
 
 impl<'a> ContentEq for LabeledStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.label.content_eq(&other.label) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.label, &other.label)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ThrowStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for TryStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.block.content_eq(&other.block)
-            && self.handler.content_eq(&other.handler)
-            && self.finalizer.content_eq(&other.finalizer)
+        ContentEq::content_eq(&self.block, &other.block)
+            && ContentEq::content_eq(&self.handler, &other.handler)
+            && ContentEq::content_eq(&self.finalizer, &other.finalizer)
     }
 }
 
 impl<'a> ContentEq for CatchClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.param.content_eq(&other.param) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.param, &other.param)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for CatchParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.pattern.content_eq(&other.pattern)
+        ContentEq::content_eq(&self.pattern, &other.pattern)
     }
 }
 
@@ -1789,76 +1932,83 @@ impl ContentEq for DebuggerStatement {
 
 impl<'a> ContentEq for BindingPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for BindingPatternKind<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::BindingIdentifier(it) => {
-                matches!(other, Self::BindingIdentifier(other) if it.content_eq(other))
-            }
-            Self::ObjectPattern(it) => {
-                matches!(other, Self::ObjectPattern(other) if it.content_eq(other))
-            }
-            Self::ArrayPattern(it) => {
-                matches!(other, Self::ArrayPattern(other) if it.content_eq(other))
-            }
-            Self::AssignmentPattern(it) => {
-                matches!(other, Self::AssignmentPattern(other) if it.content_eq(other))
-            }
+            Self::BindingIdentifier(it) => match other {
+                Self::BindingIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectPattern(it) => match other {
+                Self::ObjectPattern(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayPattern(it) => match other {
+                Self::ArrayPattern(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentPattern(it) => match other {
+                Self::AssignmentPattern(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for AssignmentPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left) && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for ObjectPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.properties.content_eq(&other.properties) && self.rest.content_eq(&other.rest)
+        ContentEq::content_eq(&self.properties, &other.properties)
+            && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.key.content_eq(&other.key)
-            && self.value.content_eq(&other.value)
-            && self.shorthand.content_eq(&other.shorthand)
-            && self.computed.content_eq(&other.computed)
+        ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.shorthand, &other.shorthand)
+            && ContentEq::content_eq(&self.computed, &other.computed)
     }
 }
 
 impl<'a> ContentEq for ArrayPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.elements.content_eq(&other.elements) && self.rest.content_eq(&other.rest)
+        ContentEq::content_eq(&self.elements, &other.elements)
+            && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingRestElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Function<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#type.content_eq(&other.r#type)
-            && self.id.content_eq(&other.id)
-            && self.generator.content_eq(&other.generator)
-            && self.r#async.content_eq(&other.r#async)
-            && self.declare.content_eq(&other.declare)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.this_param.content_eq(&other.this_param)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
+            && ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.generator, &other.generator)
+            && ContentEq::content_eq(&self.r#async, &other.r#async)
+            && ContentEq::content_eq(&self.declare, &other.declare)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -1870,19 +2020,19 @@ impl ContentEq for FunctionType {
 
 impl<'a> ContentEq for FormalParameters<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
-            && self.items.content_eq(&other.items)
-            && self.rest.content_eq(&other.rest)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.items, &other.items)
+            && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for FormalParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.decorators.content_eq(&other.decorators)
-            && self.pattern.content_eq(&other.pattern)
-            && self.accessibility.content_eq(&other.accessibility)
-            && self.readonly.content_eq(&other.readonly)
-            && self.r#override.content_eq(&other.r#override)
+        ContentEq::content_eq(&self.decorators, &other.decorators)
+            && ContentEq::content_eq(&self.pattern, &other.pattern)
+            && ContentEq::content_eq(&self.accessibility, &other.accessibility)
+            && ContentEq::content_eq(&self.readonly, &other.readonly)
+            && ContentEq::content_eq(&self.r#override, &other.r#override)
     }
 }
 
@@ -1894,40 +2044,41 @@ impl ContentEq for FormalParameterKind {
 
 impl<'a> ContentEq for FunctionBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.directives.content_eq(&other.directives)
-            && self.statements.content_eq(&other.statements)
+        ContentEq::content_eq(&self.directives, &other.directives)
+            && ContentEq::content_eq(&self.statements, &other.statements)
     }
 }
 
 impl<'a> ContentEq for ArrowFunctionExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.r#async.content_eq(&other.r#async)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.r#async, &other.r#async)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for YieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.delegate.content_eq(&other.delegate) && self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.delegate, &other.delegate)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Class<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#type.content_eq(&other.r#type)
-            && self.decorators.content_eq(&other.decorators)
-            && self.id.content_eq(&other.id)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.super_class.content_eq(&other.super_class)
-            && self.super_type_parameters.content_eq(&other.super_type_parameters)
-            && self.implements.content_eq(&other.implements)
-            && self.body.content_eq(&other.body)
-            && self.r#abstract.content_eq(&other.r#abstract)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
+            && ContentEq::content_eq(&self.decorators, &other.decorators)
+            && ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.super_class, &other.super_class)
+            && ContentEq::content_eq(&self.super_type_parameters, &other.super_type_parameters)
+            && ContentEq::content_eq(&self.implements, &other.implements)
+            && ContentEq::content_eq(&self.body, &other.body)
+            && ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
@@ -1939,44 +2090,49 @@ impl ContentEq for ClassType {
 
 impl<'a> ContentEq for ClassBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ClassElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::StaticBlock(it) => {
-                matches!(other, Self::StaticBlock(other) if it.content_eq(other))
-            }
-            Self::MethodDefinition(it) => {
-                matches!(other, Self::MethodDefinition(other) if it.content_eq(other))
-            }
-            Self::PropertyDefinition(it) => {
-                matches!(other, Self::PropertyDefinition(other) if it.content_eq(other))
-            }
-            Self::AccessorProperty(it) => {
-                matches!(other, Self::AccessorProperty(other) if it.content_eq(other))
-            }
-            Self::TSIndexSignature(it) => {
-                matches!(other, Self::TSIndexSignature(other) if it.content_eq(other))
-            }
+            Self::StaticBlock(it) => match other {
+                Self::StaticBlock(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MethodDefinition(it) => match other {
+                Self::MethodDefinition(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PropertyDefinition(it) => match other {
+                Self::PropertyDefinition(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AccessorProperty(it) => match other {
+                Self::AccessorProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIndexSignature(it) => match other {
+                Self::TSIndexSignature(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for MethodDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#type.content_eq(&other.r#type)
-            && self.decorators.content_eq(&other.decorators)
-            && self.key.content_eq(&other.key)
-            && self.value.content_eq(&other.value)
-            && self.kind.content_eq(&other.kind)
-            && self.computed.content_eq(&other.computed)
-            && self.r#static.content_eq(&other.r#static)
-            && self.r#override.content_eq(&other.r#override)
-            && self.optional.content_eq(&other.optional)
-            && self.accessibility.content_eq(&other.accessibility)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
+            && ContentEq::content_eq(&self.decorators, &other.decorators)
+            && ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.computed, &other.computed)
+            && ContentEq::content_eq(&self.r#static, &other.r#static)
+            && ContentEq::content_eq(&self.r#override, &other.r#override)
+            && ContentEq::content_eq(&self.optional, &other.optional)
+            && ContentEq::content_eq(&self.accessibility, &other.accessibility)
     }
 }
 
@@ -1988,19 +2144,19 @@ impl ContentEq for MethodDefinitionType {
 
 impl<'a> ContentEq for PropertyDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#type.content_eq(&other.r#type)
-            && self.decorators.content_eq(&other.decorators)
-            && self.key.content_eq(&other.key)
-            && self.value.content_eq(&other.value)
-            && self.computed.content_eq(&other.computed)
-            && self.r#static.content_eq(&other.r#static)
-            && self.declare.content_eq(&other.declare)
-            && self.r#override.content_eq(&other.r#override)
-            && self.optional.content_eq(&other.optional)
-            && self.definite.content_eq(&other.definite)
-            && self.readonly.content_eq(&other.readonly)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.accessibility.content_eq(&other.accessibility)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
+            && ContentEq::content_eq(&self.decorators, &other.decorators)
+            && ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.computed, &other.computed)
+            && ContentEq::content_eq(&self.r#static, &other.r#static)
+            && ContentEq::content_eq(&self.declare, &other.declare)
+            && ContentEq::content_eq(&self.r#override, &other.r#override)
+            && ContentEq::content_eq(&self.optional, &other.optional)
+            && ContentEq::content_eq(&self.definite, &other.definite)
+            && ContentEq::content_eq(&self.readonly, &other.readonly)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.accessibility, &other.accessibility)
     }
 }
 
@@ -2018,46 +2174,45 @@ impl ContentEq for MethodDefinitionKind {
 
 impl<'a> ContentEq for PrivateIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for StaticBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ModuleDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ImportDeclaration(it) => {
-                matches!(other, Self::ImportDeclaration(other) if it.content_eq(other))
-            }
-            Self::ExportAllDeclaration(it) => {
-                matches!(
-                    other, Self::ExportAllDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::ExportDefaultDeclaration(it) => {
-                matches!(
-                    other, Self::ExportDefaultDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::ExportNamedDeclaration(it) => {
-                matches!(
-                    other, Self::ExportNamedDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::TSExportAssignment(it) => {
-                matches!(other, Self::TSExportAssignment(other) if it.content_eq(other))
-            }
-            Self::TSNamespaceExportDeclaration(it) => {
-                matches!(
-                    other, Self::TSNamespaceExportDeclaration(other) if it
-                    .content_eq(other)
-                )
-            }
+            Self::ImportDeclaration(it) => match other {
+                Self::ImportDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportAllDeclaration(it) => match other {
+                Self::ExportAllDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportDefaultDeclaration(it) => match other {
+                Self::ExportDefaultDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExportNamedDeclaration(it) => match other {
+                Self::ExportNamedDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSExportAssignment(it) => match other {
+                Self::TSExportAssignment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNamespaceExportDeclaration(it) => match other {
+                Self::TSNamespaceExportDeclaration(other) if ContentEq::content_eq(it, other) => {
+                    true
+                }
+                _ => false,
+            },
         }
     }
 }
@@ -2070,292 +2225,319 @@ impl ContentEq for AccessorPropertyType {
 
 impl<'a> ContentEq for AccessorProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#type.content_eq(&other.r#type)
-            && self.decorators.content_eq(&other.decorators)
-            && self.key.content_eq(&other.key)
-            && self.value.content_eq(&other.value)
-            && self.computed.content_eq(&other.computed)
-            && self.r#static.content_eq(&other.r#static)
-            && self.definite.content_eq(&other.definite)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.accessibility.content_eq(&other.accessibility)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
+            && ContentEq::content_eq(&self.decorators, &other.decorators)
+            && ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.computed, &other.computed)
+            && ContentEq::content_eq(&self.r#static, &other.r#static)
+            && ContentEq::content_eq(&self.definite, &other.definite)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.accessibility, &other.accessibility)
     }
 }
 
 impl<'a> ContentEq for ImportExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.source.content_eq(&other.source) && self.arguments.content_eq(&other.arguments)
+        ContentEq::content_eq(&self.source, &other.source)
+            && ContentEq::content_eq(&self.arguments, &other.arguments)
     }
 }
 
 impl<'a> ContentEq for ImportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.specifiers.content_eq(&other.specifiers)
-            && self.source.content_eq(&other.source)
-            && self.with_clause.content_eq(&other.with_clause)
-            && self.import_kind.content_eq(&other.import_kind)
+        ContentEq::content_eq(&self.specifiers, &other.specifiers)
+            && ContentEq::content_eq(&self.source, &other.source)
+            && ContentEq::content_eq(&self.with_clause, &other.with_clause)
+            && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
 }
 
 impl<'a> ContentEq for ImportDeclarationSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ImportSpecifier(it) => {
-                matches!(other, Self::ImportSpecifier(other) if it.content_eq(other))
-            }
-            Self::ImportDefaultSpecifier(it) => {
-                matches!(
-                    other, Self::ImportDefaultSpecifier(other) if it.content_eq(other)
-                )
-            }
-            Self::ImportNamespaceSpecifier(it) => {
-                matches!(
-                    other, Self::ImportNamespaceSpecifier(other) if it.content_eq(other)
-                )
-            }
+            Self::ImportSpecifier(it) => match other {
+                Self::ImportSpecifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportDefaultSpecifier(it) => match other {
+                Self::ImportDefaultSpecifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportNamespaceSpecifier(it) => match other {
+                Self::ImportNamespaceSpecifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ImportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.imported.content_eq(&other.imported)
-            && self.local.content_eq(&other.local)
-            && self.import_kind.content_eq(&other.import_kind)
+        ContentEq::content_eq(&self.imported, &other.imported)
+            && ContentEq::content_eq(&self.local, &other.local)
+            && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
 }
 
 impl<'a> ContentEq for ImportDefaultSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.local.content_eq(&other.local)
+        ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for ImportNamespaceSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.local.content_eq(&other.local)
+        ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for WithClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.attributes_keyword.content_eq(&other.attributes_keyword)
-            && self.with_entries.content_eq(&other.with_entries)
+        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+            && ContentEq::content_eq(&self.with_entries, &other.with_entries)
     }
 }
 
 impl<'a> ContentEq for ImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.key.content_eq(&other.key) && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for ImportAttributeKey<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for ExportNamedDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.declaration.content_eq(&other.declaration)
-            && self.specifiers.content_eq(&other.specifiers)
-            && self.source.content_eq(&other.source)
-            && self.export_kind.content_eq(&other.export_kind)
-            && self.with_clause.content_eq(&other.with_clause)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
+            && ContentEq::content_eq(&self.specifiers, &other.specifiers)
+            && ContentEq::content_eq(&self.source, &other.source)
+            && ContentEq::content_eq(&self.export_kind, &other.export_kind)
+            && ContentEq::content_eq(&self.with_clause, &other.with_clause)
     }
 }
 
 impl<'a> ContentEq for ExportDefaultDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.declaration.content_eq(&other.declaration) && self.exported.content_eq(&other.exported)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
+            && ContentEq::content_eq(&self.exported, &other.exported)
     }
 }
 
 impl<'a> ContentEq for ExportAllDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.exported.content_eq(&other.exported)
-            && self.source.content_eq(&other.source)
-            && self.with_clause.content_eq(&other.with_clause)
-            && self.export_kind.content_eq(&other.export_kind)
+        ContentEq::content_eq(&self.exported, &other.exported)
+            && ContentEq::content_eq(&self.source, &other.source)
+            && ContentEq::content_eq(&self.with_clause, &other.with_clause)
+            && ContentEq::content_eq(&self.export_kind, &other.export_kind)
     }
 }
 
 impl<'a> ContentEq for ExportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.local.content_eq(&other.local)
-            && self.exported.content_eq(&other.exported)
-            && self.export_kind.content_eq(&other.export_kind)
+        ContentEq::content_eq(&self.local, &other.local)
+            && ContentEq::content_eq(&self.exported, &other.exported)
+            && ContentEq::content_eq(&self.export_kind, &other.export_kind)
     }
 }
 
 impl<'a> ContentEq for ExportDefaultDeclarationKind<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::FunctionDeclaration(it) => {
-                matches!(other, Self::FunctionDeclaration(other) if it.content_eq(other))
-            }
-            Self::ClassDeclaration(it) => {
-                matches!(other, Self::ClassDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSInterfaceDeclaration(it) => {
-                matches!(
-                    other, Self::TSInterfaceDeclaration(other) if it.content_eq(other)
-                )
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::FunctionDeclaration(it) => match other {
+                Self::FunctionDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassDeclaration(it) => match other {
+                Self::ClassDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInterfaceDeclaration(it) => match other {
+                Self::TSInterfaceDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -2363,248 +2545,282 @@ impl<'a> ContentEq for ExportDefaultDeclarationKind<'a> {
 impl<'a> ContentEq for ModuleExportName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::IdentifierName(it) => {
-                matches!(other, Self::IdentifierName(other) if it.content_eq(other))
-            }
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
+            Self::IdentifierName(it) => match other {
+                Self::IdentifierName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSThisParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSEnumDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
-            && self.members.content_eq(&other.members)
-            && self.r#const.content_eq(&other.r#const)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.members, &other.members)
+            && ContentEq::content_eq(&self.r#const, &other.r#const)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
 impl<'a> ContentEq for TSEnumMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id) && self.initializer.content_eq(&other.initializer)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.initializer, &other.initializer)
     }
 }
 
 impl<'a> ContentEq for TSEnumMemberName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::StaticIdentifier(it) => {
-                matches!(other, Self::StaticIdentifier(other) if it.content_eq(other))
-            }
-            Self::StaticStringLiteral(it) => {
-                matches!(other, Self::StaticStringLiteral(other) if it.content_eq(other))
-            }
-            Self::StaticTemplateLiteral(it) => {
-                matches!(
-                    other, Self::StaticTemplateLiteral(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticNumericLiteral(it) => {
-                matches!(
-                    other, Self::StaticNumericLiteral(other) if it.content_eq(other)
-                )
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::StaticIdentifier(it) => match other {
+                Self::StaticIdentifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticStringLiteral(it) => match other {
+                Self::StaticStringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticTemplateLiteral(it) => match other {
+                Self::StaticTemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticNumericLiteral(it) => match other {
+                Self::StaticNumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSTypeAnnotation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.literal.content_eq(&other.literal)
+        ContentEq::content_eq(&self.literal, &other.literal)
     }
 }
 
 impl<'a> ContentEq for TSLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -2612,159 +2828,193 @@ impl<'a> ContentEq for TSLiteral<'a> {
 impl<'a> ContentEq for TSType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::TSAnyKeyword(it) => {
-                matches!(other, Self::TSAnyKeyword(other) if it.content_eq(other))
-            }
-            Self::TSBigIntKeyword(it) => {
-                matches!(other, Self::TSBigIntKeyword(other) if it.content_eq(other))
-            }
-            Self::TSBooleanKeyword(it) => {
-                matches!(other, Self::TSBooleanKeyword(other) if it.content_eq(other))
-            }
-            Self::TSIntrinsicKeyword(it) => {
-                matches!(other, Self::TSIntrinsicKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNeverKeyword(it) => {
-                matches!(other, Self::TSNeverKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNullKeyword(it) => {
-                matches!(other, Self::TSNullKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNumberKeyword(it) => {
-                matches!(other, Self::TSNumberKeyword(other) if it.content_eq(other))
-            }
-            Self::TSObjectKeyword(it) => {
-                matches!(other, Self::TSObjectKeyword(other) if it.content_eq(other))
-            }
-            Self::TSStringKeyword(it) => {
-                matches!(other, Self::TSStringKeyword(other) if it.content_eq(other))
-            }
-            Self::TSSymbolKeyword(it) => {
-                matches!(other, Self::TSSymbolKeyword(other) if it.content_eq(other))
-            }
-            Self::TSUndefinedKeyword(it) => {
-                matches!(other, Self::TSUndefinedKeyword(other) if it.content_eq(other))
-            }
-            Self::TSUnknownKeyword(it) => {
-                matches!(other, Self::TSUnknownKeyword(other) if it.content_eq(other))
-            }
-            Self::TSVoidKeyword(it) => {
-                matches!(other, Self::TSVoidKeyword(other) if it.content_eq(other))
-            }
-            Self::TSArrayType(it) => {
-                matches!(other, Self::TSArrayType(other) if it.content_eq(other))
-            }
-            Self::TSConditionalType(it) => {
-                matches!(other, Self::TSConditionalType(other) if it.content_eq(other))
-            }
-            Self::TSConstructorType(it) => {
-                matches!(other, Self::TSConstructorType(other) if it.content_eq(other))
-            }
-            Self::TSFunctionType(it) => {
-                matches!(other, Self::TSFunctionType(other) if it.content_eq(other))
-            }
-            Self::TSImportType(it) => {
-                matches!(other, Self::TSImportType(other) if it.content_eq(other))
-            }
-            Self::TSIndexedAccessType(it) => {
-                matches!(other, Self::TSIndexedAccessType(other) if it.content_eq(other))
-            }
-            Self::TSInferType(it) => {
-                matches!(other, Self::TSInferType(other) if it.content_eq(other))
-            }
-            Self::TSIntersectionType(it) => {
-                matches!(other, Self::TSIntersectionType(other) if it.content_eq(other))
-            }
-            Self::TSLiteralType(it) => {
-                matches!(other, Self::TSLiteralType(other) if it.content_eq(other))
-            }
-            Self::TSMappedType(it) => {
-                matches!(other, Self::TSMappedType(other) if it.content_eq(other))
-            }
-            Self::TSNamedTupleMember(it) => {
-                matches!(other, Self::TSNamedTupleMember(other) if it.content_eq(other))
-            }
-            Self::TSQualifiedName(it) => {
-                matches!(other, Self::TSQualifiedName(other) if it.content_eq(other))
-            }
-            Self::TSTemplateLiteralType(it) => {
-                matches!(
-                    other, Self::TSTemplateLiteralType(other) if it.content_eq(other)
-                )
-            }
-            Self::TSThisType(it) => {
-                matches!(other, Self::TSThisType(other) if it.content_eq(other))
-            }
-            Self::TSTupleType(it) => {
-                matches!(other, Self::TSTupleType(other) if it.content_eq(other))
-            }
-            Self::TSTypeLiteral(it) => {
-                matches!(other, Self::TSTypeLiteral(other) if it.content_eq(other))
-            }
-            Self::TSTypeOperatorType(it) => {
-                matches!(other, Self::TSTypeOperatorType(other) if it.content_eq(other))
-            }
-            Self::TSTypePredicate(it) => {
-                matches!(other, Self::TSTypePredicate(other) if it.content_eq(other))
-            }
-            Self::TSTypeQuery(it) => {
-                matches!(other, Self::TSTypeQuery(other) if it.content_eq(other))
-            }
-            Self::TSTypeReference(it) => {
-                matches!(other, Self::TSTypeReference(other) if it.content_eq(other))
-            }
-            Self::TSUnionType(it) => {
-                matches!(other, Self::TSUnionType(other) if it.content_eq(other))
-            }
-            Self::TSParenthesizedType(it) => {
-                matches!(other, Self::TSParenthesizedType(other) if it.content_eq(other))
-            }
-            Self::JSDocNullableType(it) => {
-                matches!(other, Self::JSDocNullableType(other) if it.content_eq(other))
-            }
-            Self::JSDocNonNullableType(it) => {
-                matches!(
-                    other, Self::JSDocNonNullableType(other) if it.content_eq(other)
-                )
-            }
-            Self::JSDocUnknownType(it) => {
-                matches!(other, Self::JSDocUnknownType(other) if it.content_eq(other))
-            }
+            Self::TSAnyKeyword(it) => match other {
+                Self::TSAnyKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSBigIntKeyword(it) => match other {
+                Self::TSBigIntKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSBooleanKeyword(it) => match other {
+                Self::TSBooleanKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIntrinsicKeyword(it) => match other {
+                Self::TSIntrinsicKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNeverKeyword(it) => match other {
+                Self::TSNeverKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNullKeyword(it) => match other {
+                Self::TSNullKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNumberKeyword(it) => match other {
+                Self::TSNumberKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSObjectKeyword(it) => match other {
+                Self::TSObjectKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSStringKeyword(it) => match other {
+                Self::TSStringKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSymbolKeyword(it) => match other {
+                Self::TSSymbolKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUndefinedKeyword(it) => match other {
+                Self::TSUndefinedKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUnknownKeyword(it) => match other {
+                Self::TSUnknownKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSVoidKeyword(it) => match other {
+                Self::TSVoidKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSArrayType(it) => match other {
+                Self::TSArrayType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSConditionalType(it) => match other {
+                Self::TSConditionalType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSConstructorType(it) => match other {
+                Self::TSConstructorType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSFunctionType(it) => match other {
+                Self::TSFunctionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSImportType(it) => match other {
+                Self::TSImportType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIndexedAccessType(it) => match other {
+                Self::TSIndexedAccessType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInferType(it) => match other {
+                Self::TSInferType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIntersectionType(it) => match other {
+                Self::TSIntersectionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSLiteralType(it) => match other {
+                Self::TSLiteralType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSMappedType(it) => match other {
+                Self::TSMappedType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNamedTupleMember(it) => match other {
+                Self::TSNamedTupleMember(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSQualifiedName(it) => match other {
+                Self::TSQualifiedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTemplateLiteralType(it) => match other {
+                Self::TSTemplateLiteralType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSThisType(it) => match other {
+                Self::TSThisType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTupleType(it) => match other {
+                Self::TSTupleType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeLiteral(it) => match other {
+                Self::TSTypeLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeOperatorType(it) => match other {
+                Self::TSTypeOperatorType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypePredicate(it) => match other {
+                Self::TSTypePredicate(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeQuery(it) => match other {
+                Self::TSTypeQuery(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeReference(it) => match other {
+                Self::TSTypeReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUnionType(it) => match other {
+                Self::TSUnionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSParenthesizedType(it) => match other {
+                Self::TSParenthesizedType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocNullableType(it) => match other {
+                Self::JSDocNullableType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocNonNullableType(it) => match other {
+                Self::JSDocNonNullableType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocUnknownType(it) => match other {
+                Self::JSDocUnknownType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSConditionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.check_type.content_eq(&other.check_type)
-            && self.extends_type.content_eq(&other.extends_type)
-            && self.true_type.content_eq(&other.true_type)
-            && self.false_type.content_eq(&other.false_type)
+        ContentEq::content_eq(&self.check_type, &other.check_type)
+            && ContentEq::content_eq(&self.extends_type, &other.extends_type)
+            && ContentEq::content_eq(&self.true_type, &other.true_type)
+            && ContentEq::content_eq(&self.false_type, &other.false_type)
     }
 }
 
 impl<'a> ContentEq for TSUnionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.types.content_eq(&other.types)
+        ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSIntersectionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.types.content_eq(&other.types)
+        ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSParenthesizedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeOperator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.operator.content_eq(&other.operator)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.operator, &other.operator)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
@@ -2776,170 +3026,206 @@ impl ContentEq for TSTypeOperatorOperator {
 
 impl<'a> ContentEq for TSArrayType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.element_type.content_eq(&other.element_type)
+        ContentEq::content_eq(&self.element_type, &other.element_type)
     }
 }
 
 impl<'a> ContentEq for TSIndexedAccessType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object_type.content_eq(&other.object_type)
-            && self.index_type.content_eq(&other.index_type)
+        ContentEq::content_eq(&self.object_type, &other.object_type)
+            && ContentEq::content_eq(&self.index_type, &other.index_type)
     }
 }
 
 impl<'a> ContentEq for TSTupleType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.element_types.content_eq(&other.element_types)
+        ContentEq::content_eq(&self.element_types, &other.element_types)
     }
 }
 
 impl<'a> ContentEq for TSNamedTupleMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.element_type.content_eq(&other.element_type)
-            && self.label.content_eq(&other.label)
-            && self.optional.content_eq(&other.optional)
+        ContentEq::content_eq(&self.element_type, &other.element_type)
+            && ContentEq::content_eq(&self.label, &other.label)
+            && ContentEq::content_eq(&self.optional, &other.optional)
     }
 }
 
 impl<'a> ContentEq for TSOptionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSRestType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTupleElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::TSOptionalType(it) => {
-                matches!(other, Self::TSOptionalType(other) if it.content_eq(other))
-            }
-            Self::TSRestType(it) => {
-                matches!(other, Self::TSRestType(other) if it.content_eq(other))
-            }
-            Self::TSAnyKeyword(it) => {
-                matches!(other, Self::TSAnyKeyword(other) if it.content_eq(other))
-            }
-            Self::TSBigIntKeyword(it) => {
-                matches!(other, Self::TSBigIntKeyword(other) if it.content_eq(other))
-            }
-            Self::TSBooleanKeyword(it) => {
-                matches!(other, Self::TSBooleanKeyword(other) if it.content_eq(other))
-            }
-            Self::TSIntrinsicKeyword(it) => {
-                matches!(other, Self::TSIntrinsicKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNeverKeyword(it) => {
-                matches!(other, Self::TSNeverKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNullKeyword(it) => {
-                matches!(other, Self::TSNullKeyword(other) if it.content_eq(other))
-            }
-            Self::TSNumberKeyword(it) => {
-                matches!(other, Self::TSNumberKeyword(other) if it.content_eq(other))
-            }
-            Self::TSObjectKeyword(it) => {
-                matches!(other, Self::TSObjectKeyword(other) if it.content_eq(other))
-            }
-            Self::TSStringKeyword(it) => {
-                matches!(other, Self::TSStringKeyword(other) if it.content_eq(other))
-            }
-            Self::TSSymbolKeyword(it) => {
-                matches!(other, Self::TSSymbolKeyword(other) if it.content_eq(other))
-            }
-            Self::TSUndefinedKeyword(it) => {
-                matches!(other, Self::TSUndefinedKeyword(other) if it.content_eq(other))
-            }
-            Self::TSUnknownKeyword(it) => {
-                matches!(other, Self::TSUnknownKeyword(other) if it.content_eq(other))
-            }
-            Self::TSVoidKeyword(it) => {
-                matches!(other, Self::TSVoidKeyword(other) if it.content_eq(other))
-            }
-            Self::TSArrayType(it) => {
-                matches!(other, Self::TSArrayType(other) if it.content_eq(other))
-            }
-            Self::TSConditionalType(it) => {
-                matches!(other, Self::TSConditionalType(other) if it.content_eq(other))
-            }
-            Self::TSConstructorType(it) => {
-                matches!(other, Self::TSConstructorType(other) if it.content_eq(other))
-            }
-            Self::TSFunctionType(it) => {
-                matches!(other, Self::TSFunctionType(other) if it.content_eq(other))
-            }
-            Self::TSImportType(it) => {
-                matches!(other, Self::TSImportType(other) if it.content_eq(other))
-            }
-            Self::TSIndexedAccessType(it) => {
-                matches!(other, Self::TSIndexedAccessType(other) if it.content_eq(other))
-            }
-            Self::TSInferType(it) => {
-                matches!(other, Self::TSInferType(other) if it.content_eq(other))
-            }
-            Self::TSIntersectionType(it) => {
-                matches!(other, Self::TSIntersectionType(other) if it.content_eq(other))
-            }
-            Self::TSLiteralType(it) => {
-                matches!(other, Self::TSLiteralType(other) if it.content_eq(other))
-            }
-            Self::TSMappedType(it) => {
-                matches!(other, Self::TSMappedType(other) if it.content_eq(other))
-            }
-            Self::TSNamedTupleMember(it) => {
-                matches!(other, Self::TSNamedTupleMember(other) if it.content_eq(other))
-            }
-            Self::TSQualifiedName(it) => {
-                matches!(other, Self::TSQualifiedName(other) if it.content_eq(other))
-            }
-            Self::TSTemplateLiteralType(it) => {
-                matches!(
-                    other, Self::TSTemplateLiteralType(other) if it.content_eq(other)
-                )
-            }
-            Self::TSThisType(it) => {
-                matches!(other, Self::TSThisType(other) if it.content_eq(other))
-            }
-            Self::TSTupleType(it) => {
-                matches!(other, Self::TSTupleType(other) if it.content_eq(other))
-            }
-            Self::TSTypeLiteral(it) => {
-                matches!(other, Self::TSTypeLiteral(other) if it.content_eq(other))
-            }
-            Self::TSTypeOperatorType(it) => {
-                matches!(other, Self::TSTypeOperatorType(other) if it.content_eq(other))
-            }
-            Self::TSTypePredicate(it) => {
-                matches!(other, Self::TSTypePredicate(other) if it.content_eq(other))
-            }
-            Self::TSTypeQuery(it) => {
-                matches!(other, Self::TSTypeQuery(other) if it.content_eq(other))
-            }
-            Self::TSTypeReference(it) => {
-                matches!(other, Self::TSTypeReference(other) if it.content_eq(other))
-            }
-            Self::TSUnionType(it) => {
-                matches!(other, Self::TSUnionType(other) if it.content_eq(other))
-            }
-            Self::TSParenthesizedType(it) => {
-                matches!(other, Self::TSParenthesizedType(other) if it.content_eq(other))
-            }
-            Self::JSDocNullableType(it) => {
-                matches!(other, Self::JSDocNullableType(other) if it.content_eq(other))
-            }
-            Self::JSDocNonNullableType(it) => {
-                matches!(
-                    other, Self::JSDocNonNullableType(other) if it.content_eq(other)
-                )
-            }
-            Self::JSDocUnknownType(it) => {
-                matches!(other, Self::JSDocUnknownType(other) if it.content_eq(other))
-            }
+            Self::TSOptionalType(it) => match other {
+                Self::TSOptionalType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSRestType(it) => match other {
+                Self::TSRestType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAnyKeyword(it) => match other {
+                Self::TSAnyKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSBigIntKeyword(it) => match other {
+                Self::TSBigIntKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSBooleanKeyword(it) => match other {
+                Self::TSBooleanKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIntrinsicKeyword(it) => match other {
+                Self::TSIntrinsicKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNeverKeyword(it) => match other {
+                Self::TSNeverKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNullKeyword(it) => match other {
+                Self::TSNullKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNumberKeyword(it) => match other {
+                Self::TSNumberKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSObjectKeyword(it) => match other {
+                Self::TSObjectKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSStringKeyword(it) => match other {
+                Self::TSStringKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSymbolKeyword(it) => match other {
+                Self::TSSymbolKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUndefinedKeyword(it) => match other {
+                Self::TSUndefinedKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUnknownKeyword(it) => match other {
+                Self::TSUnknownKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSVoidKeyword(it) => match other {
+                Self::TSVoidKeyword(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSArrayType(it) => match other {
+                Self::TSArrayType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSConditionalType(it) => match other {
+                Self::TSConditionalType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSConstructorType(it) => match other {
+                Self::TSConstructorType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSFunctionType(it) => match other {
+                Self::TSFunctionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSImportType(it) => match other {
+                Self::TSImportType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIndexedAccessType(it) => match other {
+                Self::TSIndexedAccessType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInferType(it) => match other {
+                Self::TSInferType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSIntersectionType(it) => match other {
+                Self::TSIntersectionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSLiteralType(it) => match other {
+                Self::TSLiteralType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSMappedType(it) => match other {
+                Self::TSMappedType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNamedTupleMember(it) => match other {
+                Self::TSNamedTupleMember(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSQualifiedName(it) => match other {
+                Self::TSQualifiedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTemplateLiteralType(it) => match other {
+                Self::TSTemplateLiteralType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSThisType(it) => match other {
+                Self::TSThisType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTupleType(it) => match other {
+                Self::TSTupleType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeLiteral(it) => match other {
+                Self::TSTypeLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeOperatorType(it) => match other {
+                Self::TSTypeOperatorType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypePredicate(it) => match other {
+                Self::TSTypePredicate(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeQuery(it) => match other {
+                Self::TSTypeQuery(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeReference(it) => match other {
+                Self::TSTypeReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSUnionType(it) => match other {
+                Self::TSUnionType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSParenthesizedType(it) => match other {
+                Self::TSParenthesizedType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocNullableType(it) => match other {
+                Self::JSDocNullableType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocNonNullableType(it) => match other {
+                Self::JSDocNonNullableType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSDocUnknownType(it) => match other {
+                Self::JSDocUnknownType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -3030,59 +3316,62 @@ impl ContentEq for TSBigIntKeyword {
 
 impl<'a> ContentEq for TSTypeReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_name.content_eq(&other.type_name)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.type_name, &other.type_name)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSTypeName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::QualifiedName(it) => {
-                matches!(other, Self::QualifiedName(other) if it.content_eq(other))
-            }
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::QualifiedName(it) => match other {
+                Self::QualifiedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSQualifiedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.left.content_eq(&other.left) && self.right.content_eq(&other.right)
+        ContentEq::content_eq(&self.left, &other.left)
+            && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameterInstantiation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.params.content_eq(&other.params)
+        ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
-            && self.constraint.content_eq(&other.constraint)
-            && self.default.content_eq(&other.default)
-            && self.r#in.content_eq(&other.r#in)
-            && self.out.content_eq(&other.out)
-            && self.r#const.content_eq(&other.r#const)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.constraint, &other.constraint)
+            && ContentEq::content_eq(&self.default, &other.default)
+            && ContentEq::content_eq(&self.r#in, &other.r#in)
+            && ContentEq::content_eq(&self.out, &other.out)
+            && ContentEq::content_eq(&self.r#const, &other.r#const)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameterDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.params.content_eq(&other.params)
+        ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeAliasDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
@@ -3094,79 +3383,82 @@ impl ContentEq for TSAccessibility {
 
 impl<'a> ContentEq for TSClassImplements<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
-            && self.extends.content_eq(&other.extends)
-            && self.type_parameters.content_eq(&other.type_parameters)
-            && self.body.content_eq(&other.body)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.extends, &other.extends)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.body, &other.body)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSPropertySignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.computed.content_eq(&other.computed)
-            && self.optional.content_eq(&other.optional)
-            && self.readonly.content_eq(&other.readonly)
-            && self.key.content_eq(&other.key)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.computed, &other.computed)
+            && ContentEq::content_eq(&self.optional, &other.optional)
+            && ContentEq::content_eq(&self.readonly, &other.readonly)
+            && ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::TSIndexSignature(it) => {
-                matches!(other, Self::TSIndexSignature(other) if it.content_eq(other))
-            }
-            Self::TSPropertySignature(it) => {
-                matches!(other, Self::TSPropertySignature(other) if it.content_eq(other))
-            }
-            Self::TSCallSignatureDeclaration(it) => {
-                matches!(
-                    other, Self::TSCallSignatureDeclaration(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSConstructSignatureDeclaration(it) => {
-                matches!(
-                    other, Self::TSConstructSignatureDeclaration(other) if it
-                    .content_eq(other)
-                )
-            }
-            Self::TSMethodSignature(it) => {
-                matches!(other, Self::TSMethodSignature(other) if it.content_eq(other))
-            }
+            Self::TSIndexSignature(it) => match other {
+                Self::TSIndexSignature(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSPropertySignature(it) => match other {
+                Self::TSPropertySignature(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSCallSignatureDeclaration(it) => match other {
+                Self::TSCallSignatureDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSConstructSignatureDeclaration(it) => match other {
+                Self::TSConstructSignatureDeclaration(other)
+                    if ContentEq::content_eq(it, other) =>
+                {
+                    true
+                }
+                _ => false,
+            },
+            Self::TSMethodSignature(it) => match other {
+                Self::TSMethodSignature(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSIndexSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.parameters.content_eq(&other.parameters)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.readonly.content_eq(&other.readonly)
+        ContentEq::content_eq(&self.parameters, &other.parameters)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.readonly, &other.readonly)
     }
 }
 
 impl<'a> ContentEq for TSCallSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.this_param.content_eq(&other.this_param)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.this_param, &other.this_param)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
@@ -3178,63 +3470,68 @@ impl ContentEq for TSMethodSignatureKind {
 
 impl<'a> ContentEq for TSMethodSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.key.content_eq(&other.key)
-            && self.computed.content_eq(&other.computed)
-            && self.optional.content_eq(&other.optional)
-            && self.kind.content_eq(&other.kind)
-            && self.this_param.content_eq(&other.this_param)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.key, &other.key)
+            && ContentEq::content_eq(&self.computed, &other.computed)
+            && ContentEq::content_eq(&self.optional, &other.optional)
+            && ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSIndexSignatureName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name) && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceHeritage<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSTypePredicate<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.parameter_name.content_eq(&other.parameter_name)
-            && self.asserts.content_eq(&other.asserts)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.parameter_name, &other.parameter_name)
+            && ContentEq::content_eq(&self.asserts, &other.asserts)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypePredicateName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::This(it) => matches!(other, Self::This(other) if it.content_eq(other)),
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::This(it) => match other {
+                Self::This(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSModuleDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
-            && self.body.content_eq(&other.body)
-            && self.kind.content_eq(&other.kind)
-            && self.declare.content_eq(&other.declare)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.body, &other.body)
+            && ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.declare, &other.declare)
     }
 }
 
@@ -3247,12 +3544,14 @@ impl ContentEq for TSModuleDeclarationKind {
 impl<'a> ContentEq for TSModuleDeclarationName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -3260,118 +3559,127 @@ impl<'a> ContentEq for TSModuleDeclarationName<'a> {
 impl<'a> ContentEq for TSModuleDeclarationBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::TSModuleDeclaration(it) => {
-                matches!(other, Self::TSModuleDeclaration(other) if it.content_eq(other))
-            }
-            Self::TSModuleBlock(it) => {
-                matches!(other, Self::TSModuleBlock(other) if it.content_eq(other))
-            }
+            Self::TSModuleDeclaration(it) => match other {
+                Self::TSModuleDeclaration(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSModuleBlock(it) => match other {
+                Self::TSModuleBlock(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSModuleBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.directives.content_eq(&other.directives) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.directives, &other.directives)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSTypeLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.members.content_eq(&other.members)
+        ContentEq::content_eq(&self.members, &other.members)
     }
 }
 
 impl<'a> ContentEq for TSInferType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_parameter.content_eq(&other.type_parameter)
+        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
     }
 }
 
 impl<'a> ContentEq for TSTypeQuery<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expr_name.content_eq(&other.expr_name)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.expr_name, &other.expr_name)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSTypeQueryExprName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::TSImportType(it) => {
-                matches!(other, Self::TSImportType(other) if it.content_eq(other))
-            }
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::QualifiedName(it) => {
-                matches!(other, Self::QualifiedName(other) if it.content_eq(other))
-            }
+            Self::TSImportType(it) => match other {
+                Self::TSImportType(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::QualifiedName(it) => match other {
+                Self::QualifiedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSImportType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.is_type_of.content_eq(&other.is_type_of)
-            && self.parameter.content_eq(&other.parameter)
-            && self.qualifier.content_eq(&other.qualifier)
-            && self.attributes.content_eq(&other.attributes)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
+            && ContentEq::content_eq(&self.parameter, &other.parameter)
+            && ContentEq::content_eq(&self.qualifier, &other.qualifier)
+            && ContentEq::content_eq(&self.attributes, &other.attributes)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSImportAttributes<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.attributes_keyword.content_eq(&other.attributes_keyword)
-            && self.elements.content_eq(&other.elements)
+        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+            && ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
 impl<'a> ContentEq for TSImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name) && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for TSImportAttributeName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSFunctionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.this_param.content_eq(&other.this_param)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.this_param, &other.this_param)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSConstructorType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.r#abstract.content_eq(&other.r#abstract)
-            && self.params.content_eq(&other.params)
-            && self.return_type.content_eq(&other.return_type)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
+            && ContentEq::content_eq(&self.params, &other.params)
+            && ContentEq::content_eq(&self.return_type, &other.return_type)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSMappedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_parameter.content_eq(&other.type_parameter)
-            && self.name_type.content_eq(&other.name_type)
-            && self.type_annotation.content_eq(&other.type_annotation)
-            && self.optional.content_eq(&other.optional)
-            && self.readonly.content_eq(&other.readonly)
+        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+            && ContentEq::content_eq(&self.name_type, &other.name_type)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.optional, &other.optional)
+            && ContentEq::content_eq(&self.readonly, &other.readonly)
     }
 }
 
@@ -3383,91 +3691,93 @@ impl ContentEq for TSMappedTypeModifierOperator {
 
 impl<'a> ContentEq for TSTemplateLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.quasis.content_eq(&other.quasis) && self.types.content_eq(&other.types)
+        ContentEq::content_eq(&self.quasis, &other.quasis)
+            && ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSAsExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSSatisfiesExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeAssertion<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_annotation.content_eq(&other.type_annotation)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSImportEqualsDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
-            && self.module_reference.content_eq(&other.module_reference)
-            && self.import_kind.content_eq(&other.import_kind)
+        ContentEq::content_eq(&self.id, &other.id)
+            && ContentEq::content_eq(&self.module_reference, &other.module_reference)
+            && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
 }
 
 impl<'a> ContentEq for TSModuleReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::ExternalModuleReference(it) => {
-                matches!(
-                    other, Self::ExternalModuleReference(other) if it.content_eq(other)
-                )
-            }
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::QualifiedName(it) => {
-                matches!(other, Self::QualifiedName(other) if it.content_eq(other))
-            }
+            Self::ExternalModuleReference(it) => match other {
+                Self::ExternalModuleReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::QualifiedName(it) => match other {
+                Self::QualifiedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for TSExternalModuleReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNonNullExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for Decorator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSExportAssignment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNamespaceExportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.id.content_eq(&other.id)
+        ContentEq::content_eq(&self.id, &other.id)
     }
 }
 
 impl<'a> ContentEq for TSInstantiationExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.expression, &other.expression)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
@@ -3479,15 +3789,15 @@ impl ContentEq for ImportOrExportKind {
 
 impl<'a> ContentEq for JSDocNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
-            && self.postfix.content_eq(&other.postfix)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
 impl<'a> ContentEq for JSDocNonNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.type_annotation.content_eq(&other.type_annotation)
-            && self.postfix.content_eq(&other.postfix)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+            && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
@@ -3499,32 +3809,32 @@ impl ContentEq for JSDocUnknownType {
 
 impl<'a> ContentEq for JSXElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.opening_element.content_eq(&other.opening_element)
-            && self.closing_element.content_eq(&other.closing_element)
-            && self.children.content_eq(&other.children)
+        ContentEq::content_eq(&self.opening_element, &other.opening_element)
+            && ContentEq::content_eq(&self.closing_element, &other.closing_element)
+            && ContentEq::content_eq(&self.children, &other.children)
     }
 }
 
 impl<'a> ContentEq for JSXOpeningElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.self_closing.content_eq(&other.self_closing)
-            && self.name.content_eq(&other.name)
-            && self.attributes.content_eq(&other.attributes)
-            && self.type_parameters.content_eq(&other.type_parameters)
+        ContentEq::content_eq(&self.self_closing, &other.self_closing)
+            && ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.attributes, &other.attributes)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for JSXClosingElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for JSXFragment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.opening_fragment.content_eq(&other.opening_fragment)
-            && self.closing_fragment.content_eq(&other.closing_fragment)
-            && self.children.content_eq(&other.children)
+        ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
+            && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
+            && ContentEq::content_eq(&self.children, &other.children)
     }
 }
 
@@ -3543,211 +3853,244 @@ impl ContentEq for JSXClosingFragment {
 impl<'a> ContentEq for JSXElementName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::NamespacedName(it) => {
-                matches!(other, Self::NamespacedName(other) if it.content_eq(other))
-            }
-            Self::MemberExpression(it) => {
-                matches!(other, Self::MemberExpression(other) if it.content_eq(other))
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NamespacedName(it) => match other {
+                Self::NamespacedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MemberExpression(it) => match other {
+                Self::MemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for JSXNamespacedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.namespace.content_eq(&other.namespace) && self.property.content_eq(&other.property)
+        ContentEq::content_eq(&self.namespace, &other.namespace)
+            && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for JSXMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.object.content_eq(&other.object) && self.property.content_eq(&other.property)
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for JSXMemberExpressionObject<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::IdentifierReference(it) => {
-                matches!(other, Self::IdentifierReference(other) if it.content_eq(other))
-            }
-            Self::MemberExpression(it) => {
-                matches!(other, Self::MemberExpression(other) if it.content_eq(other))
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
+            Self::IdentifierReference(it) => match other {
+                Self::IdentifierReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MemberExpression(it) => match other {
+                Self::MemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for JSXExpressionContainer<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for JSXExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::EmptyExpression(it) => {
-                matches!(other, Self::EmptyExpression(other) if it.content_eq(other))
-            }
-            Self::BooleanLiteral(it) => {
-                matches!(other, Self::BooleanLiteral(other) if it.content_eq(other))
-            }
-            Self::NullLiteral(it) => {
-                matches!(other, Self::NullLiteral(other) if it.content_eq(other))
-            }
-            Self::NumericLiteral(it) => {
-                matches!(other, Self::NumericLiteral(other) if it.content_eq(other))
-            }
-            Self::BigIntLiteral(it) => {
-                matches!(other, Self::BigIntLiteral(other) if it.content_eq(other))
-            }
-            Self::RegExpLiteral(it) => {
-                matches!(other, Self::RegExpLiteral(other) if it.content_eq(other))
-            }
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::TemplateLiteral(it) => {
-                matches!(other, Self::TemplateLiteral(other) if it.content_eq(other))
-            }
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::MetaProperty(it) => {
-                matches!(other, Self::MetaProperty(other) if it.content_eq(other))
-            }
-            Self::Super(it) => {
-                matches!(other, Self::Super(other) if it.content_eq(other))
-            }
-            Self::ArrayExpression(it) => {
-                matches!(other, Self::ArrayExpression(other) if it.content_eq(other))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                matches!(
-                    other, Self::ArrowFunctionExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AssignmentExpression(it) => {
-                matches!(
-                    other, Self::AssignmentExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::AwaitExpression(it) => {
-                matches!(other, Self::AwaitExpression(other) if it.content_eq(other))
-            }
-            Self::BinaryExpression(it) => {
-                matches!(other, Self::BinaryExpression(other) if it.content_eq(other))
-            }
-            Self::CallExpression(it) => {
-                matches!(other, Self::CallExpression(other) if it.content_eq(other))
-            }
-            Self::ChainExpression(it) => {
-                matches!(other, Self::ChainExpression(other) if it.content_eq(other))
-            }
-            Self::ClassExpression(it) => {
-                matches!(other, Self::ClassExpression(other) if it.content_eq(other))
-            }
-            Self::ConditionalExpression(it) => {
-                matches!(
-                    other, Self::ConditionalExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::FunctionExpression(it) => {
-                matches!(other, Self::FunctionExpression(other) if it.content_eq(other))
-            }
-            Self::ImportExpression(it) => {
-                matches!(other, Self::ImportExpression(other) if it.content_eq(other))
-            }
-            Self::LogicalExpression(it) => {
-                matches!(other, Self::LogicalExpression(other) if it.content_eq(other))
-            }
-            Self::NewExpression(it) => {
-                matches!(other, Self::NewExpression(other) if it.content_eq(other))
-            }
-            Self::ObjectExpression(it) => {
-                matches!(other, Self::ObjectExpression(other) if it.content_eq(other))
-            }
-            Self::ParenthesizedExpression(it) => {
-                matches!(
-                    other, Self::ParenthesizedExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::SequenceExpression(it) => {
-                matches!(other, Self::SequenceExpression(other) if it.content_eq(other))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                matches!(
-                    other, Self::TaggedTemplateExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ThisExpression(it) => {
-                matches!(other, Self::ThisExpression(other) if it.content_eq(other))
-            }
-            Self::UnaryExpression(it) => {
-                matches!(other, Self::UnaryExpression(other) if it.content_eq(other))
-            }
-            Self::UpdateExpression(it) => {
-                matches!(other, Self::UpdateExpression(other) if it.content_eq(other))
-            }
-            Self::YieldExpression(it) => {
-                matches!(other, Self::YieldExpression(other) if it.content_eq(other))
-            }
-            Self::PrivateInExpression(it) => {
-                matches!(other, Self::PrivateInExpression(other) if it.content_eq(other))
-            }
-            Self::JSXElement(it) => {
-                matches!(other, Self::JSXElement(other) if it.content_eq(other))
-            }
-            Self::JSXFragment(it) => {
-                matches!(other, Self::JSXFragment(other) if it.content_eq(other))
-            }
-            Self::TSAsExpression(it) => {
-                matches!(other, Self::TSAsExpression(other) if it.content_eq(other))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                matches!(
-                    other, Self::TSSatisfiesExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::TSTypeAssertion(it) => {
-                matches!(other, Self::TSTypeAssertion(other) if it.content_eq(other))
-            }
-            Self::TSNonNullExpression(it) => {
-                matches!(other, Self::TSNonNullExpression(other) if it.content_eq(other))
-            }
-            Self::TSInstantiationExpression(it) => {
-                matches!(
-                    other, Self::TSInstantiationExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::ComputedMemberExpression(it) => {
-                matches!(
-                    other, Self::ComputedMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::StaticMemberExpression(it) => {
-                matches!(
-                    other, Self::StaticMemberExpression(other) if it.content_eq(other)
-                )
-            }
-            Self::PrivateFieldExpression(it) => {
-                matches!(
-                    other, Self::PrivateFieldExpression(other) if it.content_eq(other)
-                )
-            }
+            Self::EmptyExpression(it) => match other {
+                Self::EmptyExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BooleanLiteral(it) => match other {
+                Self::BooleanLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NullLiteral(it) => match other {
+                Self::NullLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NumericLiteral(it) => match other {
+                Self::NumericLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BigIntLiteral(it) => match other {
+                Self::BigIntLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::RegExpLiteral(it) => match other {
+                Self::RegExpLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TemplateLiteral(it) => match other {
+                Self::TemplateLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::MetaProperty(it) => match other {
+                Self::MetaProperty(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Super(it) => match other {
+                Self::Super(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrayExpression(it) => match other {
+                Self::ArrayExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ArrowFunctionExpression(it) => match other {
+                Self::ArrowFunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AssignmentExpression(it) => match other {
+                Self::AssignmentExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::AwaitExpression(it) => match other {
+                Self::AwaitExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::BinaryExpression(it) => match other {
+                Self::BinaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CallExpression(it) => match other {
+                Self::CallExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ChainExpression(it) => match other {
+                Self::ChainExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassExpression(it) => match other {
+                Self::ClassExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ConditionalExpression(it) => match other {
+                Self::ConditionalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::FunctionExpression(it) => match other {
+                Self::FunctionExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ImportExpression(it) => match other {
+                Self::ImportExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LogicalExpression(it) => match other {
+                Self::LogicalExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NewExpression(it) => match other {
+                Self::NewExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ObjectExpression(it) => match other {
+                Self::ObjectExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ParenthesizedExpression(it) => match other {
+                Self::ParenthesizedExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SequenceExpression(it) => match other {
+                Self::SequenceExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TaggedTemplateExpression(it) => match other {
+                Self::TaggedTemplateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ThisExpression(it) => match other {
+                Self::ThisExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnaryExpression(it) => match other {
+                Self::UnaryExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UpdateExpression(it) => match other {
+                Self::UpdateExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::YieldExpression(it) => match other {
+                Self::YieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateInExpression(it) => match other {
+                Self::PrivateInExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXElement(it) => match other {
+                Self::JSXElement(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::JSXFragment(it) => match other {
+                Self::JSXFragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSAsExpression(it) => match other {
+                Self::TSAsExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSSatisfiesExpression(it) => match other {
+                Self::TSSatisfiesExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSTypeAssertion(it) => match other {
+                Self::TSTypeAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSNonNullExpression(it) => match other {
+                Self::TSNonNullExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::TSInstantiationExpression(it) => match other {
+                Self::TSInstantiationExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ComputedMemberExpression(it) => match other {
+                Self::ComputedMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::StaticMemberExpression(it) => match other {
+                Self::StaticMemberExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::PrivateFieldExpression(it) => match other {
+                Self::PrivateFieldExpression(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -3761,37 +4104,42 @@ impl ContentEq for JSXEmptyExpression {
 impl<'a> ContentEq for JSXAttributeItem<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Attribute(it) => {
-                matches!(other, Self::Attribute(other) if it.content_eq(other))
-            }
-            Self::SpreadAttribute(it) => {
-                matches!(other, Self::SpreadAttribute(other) if it.content_eq(other))
-            }
+            Self::Attribute(it) => match other {
+                Self::Attribute(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::SpreadAttribute(it) => match other {
+                Self::SpreadAttribute(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for JSXAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name) && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for JSXSpreadAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.argument.content_eq(&other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for JSXAttributeName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Identifier(it) => {
-                matches!(other, Self::Identifier(other) if it.content_eq(other))
-            }
-            Self::NamespacedName(it) => {
-                matches!(other, Self::NamespacedName(other) if it.content_eq(other))
-            }
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NamespacedName(it) => match other {
+                Self::NamespacedName(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
@@ -3799,56 +4147,67 @@ impl<'a> ContentEq for JSXAttributeName<'a> {
 impl<'a> ContentEq for JSXAttributeValue<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::StringLiteral(it) => {
-                matches!(other, Self::StringLiteral(other) if it.content_eq(other))
-            }
-            Self::ExpressionContainer(it) => {
-                matches!(other, Self::ExpressionContainer(other) if it.content_eq(other))
-            }
-            Self::Element(it) => {
-                matches!(other, Self::Element(other) if it.content_eq(other))
-            }
-            Self::Fragment(it) => {
-                matches!(other, Self::Fragment(other) if it.content_eq(other))
-            }
+            Self::StringLiteral(it) => match other {
+                Self::StringLiteral(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExpressionContainer(it) => match other {
+                Self::ExpressionContainer(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Element(it) => match other {
+                Self::Element(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Fragment(it) => match other {
+                Self::Fragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for JSXIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for JSXChild<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::Text(it) => matches!(other, Self::Text(other) if it.content_eq(other)),
-            Self::Element(it) => {
-                matches!(other, Self::Element(other) if it.content_eq(other))
-            }
-            Self::Fragment(it) => {
-                matches!(other, Self::Fragment(other) if it.content_eq(other))
-            }
-            Self::ExpressionContainer(it) => {
-                matches!(other, Self::ExpressionContainer(other) if it.content_eq(other))
-            }
-            Self::Spread(it) => {
-                matches!(other, Self::Spread(other) if it.content_eq(other))
-            }
+            Self::Text(it) => match other {
+                Self::Text(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Element(it) => match other {
+                Self::Element(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Fragment(it) => match other {
+                Self::Fragment(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ExpressionContainer(it) => match other {
+                Self::ExpressionContainer(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Spread(it) => match other {
+                Self::Spread(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl<'a> ContentEq for JSXSpreadChild<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.expression.content_eq(&other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for JSXText<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -21,28 +21,28 @@ use crate::ast::ts::*;
 
 impl ContentHash for BooleanLiteral {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BigIntLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.content_hash(state);
-        self.base.content_hash(state);
+        ContentHash::content_hash(&self.raw, state);
+        ContentHash::content_hash(&self.base, state);
     }
 }
 
 impl<'a> ContentHash for RegExpLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.value.content_hash(state);
-        self.regex.content_hash(state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.regex, state);
     }
 }
 
 impl<'a> ContentHash for RegExp<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.pattern.content_hash(state);
-        self.flags.content_hash(state);
+        ContentHash::content_hash(&self.pattern, state);
+        ContentHash::content_hash(&self.flags, state);
     }
 }
 
@@ -50,9 +50,9 @@ impl<'a> ContentHash for RegExpPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Raw(it) => it.content_hash(state),
-            Self::Invalid(it) => it.content_hash(state),
-            Self::Pattern(it) => it.content_hash(state),
+            Self::Raw(it) => ContentHash::content_hash(it, state),
+            Self::Invalid(it) => ContentHash::content_hash(it, state),
+            Self::Pattern(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -63,16 +63,16 @@ impl ContentHash for EmptyObject {
 
 impl<'a> ContentHash for StringLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for Program<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.source_type.content_hash(state);
-        self.hashbang.content_hash(state);
-        self.directives.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.source_type, state);
+        ContentHash::content_hash(&self.hashbang, state);
+        ContentHash::content_hash(&self.directives, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -80,73 +80,73 @@ impl<'a> ContentHash for Expression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for IdentifierName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for IdentifierReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for BindingIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for LabelIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
@@ -156,7 +156,7 @@ impl ContentHash for ThisExpression {
 
 impl<'a> ContentHash for ArrayExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.elements.content_hash(state);
+        ContentHash::content_hash(&self.elements, state);
     }
 }
 
@@ -164,50 +164,50 @@ impl<'a> ContentHash for ArrayExpressionElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::SpreadElement(it) => it.content_hash(state),
-            Self::Elision(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::SpreadElement(it) => ContentHash::content_hash(it, state),
+            Self::Elision(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -218,7 +218,7 @@ impl ContentHash for Elision {
 
 impl<'a> ContentHash for ObjectExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.properties.content_hash(state);
+        ContentHash::content_hash(&self.properties, state);
     }
 }
 
@@ -226,21 +226,21 @@ impl<'a> ContentHash for ObjectPropertyKind<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ObjectProperty(it) => it.content_hash(state),
-            Self::SpreadProperty(it) => it.content_hash(state),
+            Self::ObjectProperty(it) => ContentHash::content_hash(it, state),
+            Self::SpreadProperty(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ObjectProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.key.content_hash(state);
-        self.value.content_hash(state);
-        self.init.content_hash(state);
-        self.method.content_hash(state);
-        self.shorthand.content_hash(state);
-        self.computed.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.init, state);
+        ContentHash::content_hash(&self.method, state);
+        ContentHash::content_hash(&self.shorthand, state);
+        ContentHash::content_hash(&self.computed, state);
     }
 }
 
@@ -248,50 +248,50 @@ impl<'a> ContentHash for PropertyKey<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::StaticIdentifier(it) => it.content_hash(state),
-            Self::PrivateIdentifier(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::StaticIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::PrivateIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -304,30 +304,30 @@ impl ContentHash for PropertyKind {
 
 impl<'a> ContentHash for TemplateLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.quasis.content_hash(state);
-        self.expressions.content_hash(state);
+        ContentHash::content_hash(&self.quasis, state);
+        ContentHash::content_hash(&self.expressions, state);
     }
 }
 
 impl<'a> ContentHash for TaggedTemplateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.tag.content_hash(state);
-        self.quasi.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.tag, state);
+        ContentHash::content_hash(&self.quasi, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TemplateElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.tail.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.tail, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for TemplateElementValue<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.content_hash(state);
-        self.cooked.content_hash(state);
+        ContentHash::content_hash(&self.raw, state);
+        ContentHash::content_hash(&self.cooked, state);
     }
 }
 
@@ -335,64 +335,64 @@ impl<'a> ContentHash for MemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ComputedMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object.content_hash(state);
-        self.expression.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.object, state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
 impl<'a> ContentHash for StaticMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object.content_hash(state);
-        self.property.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.object, state);
+        ContentHash::content_hash(&self.property, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
 impl<'a> ContentHash for PrivateFieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object.content_hash(state);
-        self.field.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.object, state);
+        ContentHash::content_hash(&self.field, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
 impl<'a> ContentHash for CallExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.callee.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.arguments.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.callee, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.arguments, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
 impl<'a> ContentHash for NewExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.callee.content_hash(state);
-        self.arguments.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.callee, state);
+        ContentHash::content_hash(&self.arguments, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for MetaProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.meta.content_hash(state);
-        self.property.content_hash(state);
+        ContentHash::content_hash(&self.meta, state);
+        ContentHash::content_hash(&self.property, state);
     }
 }
 
 impl<'a> ContentHash for SpreadElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
@@ -400,105 +400,105 @@ impl<'a> ContentHash for Argument<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::SpreadElement(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::SpreadElement(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for UpdateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.operator.content_hash(state);
-        self.prefix.content_hash(state);
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.prefix, state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for UnaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.operator.content_hash(state);
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for BinaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.operator.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
 impl<'a> ContentHash for PrivateInExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.operator.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
 impl<'a> ContentHash for LogicalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.operator.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
 impl<'a> ContentHash for ConditionalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.test.content_hash(state);
-        self.consequent.content_hash(state);
-        self.alternate.content_hash(state);
+        ContentHash::content_hash(&self.test, state);
+        ContentHash::content_hash(&self.consequent, state);
+        ContentHash::content_hash(&self.alternate, state);
     }
 }
 
 impl<'a> ContentHash for AssignmentExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.operator.content_hash(state);
-        self.left.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
@@ -506,17 +506,17 @@ impl<'a> ContentHash for AssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
-            Self::ArrayAssignmentTarget(it) => it.content_hash(state),
-            Self::ObjectAssignmentTarget(it) => it.content_hash(state),
+            Self::AssignmentTargetIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrayAssignmentTarget(it) => ContentHash::content_hash(it, state),
+            Self::ObjectAssignmentTarget(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -525,15 +525,15 @@ impl<'a> ContentHash for SimpleAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::AssignmentTargetIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -542,29 +542,29 @@ impl<'a> ContentHash for AssignmentTargetPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ArrayAssignmentTarget(it) => it.content_hash(state),
-            Self::ObjectAssignmentTarget(it) => it.content_hash(state),
+            Self::ArrayAssignmentTarget(it) => ContentHash::content_hash(it, state),
+            Self::ObjectAssignmentTarget(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ArrayAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.elements.content_hash(state);
-        self.rest.content_hash(state);
+        ContentHash::content_hash(&self.elements, state);
+        ContentHash::content_hash(&self.rest, state);
     }
 }
 
 impl<'a> ContentHash for ObjectAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.properties.content_hash(state);
-        self.rest.content_hash(state);
+        ContentHash::content_hash(&self.properties, state);
+        ContentHash::content_hash(&self.rest, state);
     }
 }
 
 impl<'a> ContentHash for AssignmentTargetRest<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.target.content_hash(state);
+        ContentHash::content_hash(&self.target, state);
     }
 }
 
@@ -572,26 +572,26 @@ impl<'a> ContentHash for AssignmentTargetMaybeDefault<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::AssignmentTargetWithDefault(it) => it.content_hash(state),
-            Self::AssignmentTargetIdentifier(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
-            Self::ArrayAssignmentTarget(it) => it.content_hash(state),
-            Self::ObjectAssignmentTarget(it) => it.content_hash(state),
+            Self::AssignmentTargetWithDefault(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentTargetIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrayAssignmentTarget(it) => ContentHash::content_hash(it, state),
+            Self::ObjectAssignmentTarget(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for AssignmentTargetWithDefault<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.binding.content_hash(state);
-        self.init.content_hash(state);
+        ContentHash::content_hash(&self.binding, state);
+        ContentHash::content_hash(&self.init, state);
     }
 }
 
@@ -599,29 +599,29 @@ impl<'a> ContentHash for AssignmentTargetProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => it.content_hash(state),
-            Self::AssignmentTargetPropertyProperty(it) => it.content_hash(state),
+            Self::AssignmentTargetPropertyIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentTargetPropertyProperty(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for AssignmentTargetPropertyIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.binding.content_hash(state);
-        self.init.content_hash(state);
+        ContentHash::content_hash(&self.binding, state);
+        ContentHash::content_hash(&self.init, state);
     }
 }
 
 impl<'a> ContentHash for AssignmentTargetPropertyProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.binding.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.binding, state);
     }
 }
 
 impl<'a> ContentHash for SequenceExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expressions.content_hash(state);
+        ContentHash::content_hash(&self.expressions, state);
     }
 }
 
@@ -631,13 +631,13 @@ impl ContentHash for Super {
 
 impl<'a> ContentHash for AwaitExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for ChainExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
@@ -645,17 +645,17 @@ impl<'a> ContentHash for ChainElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ParenthesizedExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
@@ -663,58 +663,58 @@ impl<'a> ContentHash for Statement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::BlockStatement(it) => it.content_hash(state),
-            Self::BreakStatement(it) => it.content_hash(state),
-            Self::ContinueStatement(it) => it.content_hash(state),
-            Self::DebuggerStatement(it) => it.content_hash(state),
-            Self::DoWhileStatement(it) => it.content_hash(state),
-            Self::EmptyStatement(it) => it.content_hash(state),
-            Self::ExpressionStatement(it) => it.content_hash(state),
-            Self::ForInStatement(it) => it.content_hash(state),
-            Self::ForOfStatement(it) => it.content_hash(state),
-            Self::ForStatement(it) => it.content_hash(state),
-            Self::IfStatement(it) => it.content_hash(state),
-            Self::LabeledStatement(it) => it.content_hash(state),
-            Self::ReturnStatement(it) => it.content_hash(state),
-            Self::SwitchStatement(it) => it.content_hash(state),
-            Self::ThrowStatement(it) => it.content_hash(state),
-            Self::TryStatement(it) => it.content_hash(state),
-            Self::WhileStatement(it) => it.content_hash(state),
-            Self::WithStatement(it) => it.content_hash(state),
-            Self::VariableDeclaration(it) => it.content_hash(state),
-            Self::FunctionDeclaration(it) => it.content_hash(state),
-            Self::ClassDeclaration(it) => it.content_hash(state),
-            Self::TSTypeAliasDeclaration(it) => it.content_hash(state),
-            Self::TSInterfaceDeclaration(it) => it.content_hash(state),
-            Self::TSEnumDeclaration(it) => it.content_hash(state),
-            Self::TSModuleDeclaration(it) => it.content_hash(state),
-            Self::TSImportEqualsDeclaration(it) => it.content_hash(state),
-            Self::ImportDeclaration(it) => it.content_hash(state),
-            Self::ExportAllDeclaration(it) => it.content_hash(state),
-            Self::ExportDefaultDeclaration(it) => it.content_hash(state),
-            Self::ExportNamedDeclaration(it) => it.content_hash(state),
-            Self::TSExportAssignment(it) => it.content_hash(state),
-            Self::TSNamespaceExportDeclaration(it) => it.content_hash(state),
+            Self::BlockStatement(it) => ContentHash::content_hash(it, state),
+            Self::BreakStatement(it) => ContentHash::content_hash(it, state),
+            Self::ContinueStatement(it) => ContentHash::content_hash(it, state),
+            Self::DebuggerStatement(it) => ContentHash::content_hash(it, state),
+            Self::DoWhileStatement(it) => ContentHash::content_hash(it, state),
+            Self::EmptyStatement(it) => ContentHash::content_hash(it, state),
+            Self::ExpressionStatement(it) => ContentHash::content_hash(it, state),
+            Self::ForInStatement(it) => ContentHash::content_hash(it, state),
+            Self::ForOfStatement(it) => ContentHash::content_hash(it, state),
+            Self::ForStatement(it) => ContentHash::content_hash(it, state),
+            Self::IfStatement(it) => ContentHash::content_hash(it, state),
+            Self::LabeledStatement(it) => ContentHash::content_hash(it, state),
+            Self::ReturnStatement(it) => ContentHash::content_hash(it, state),
+            Self::SwitchStatement(it) => ContentHash::content_hash(it, state),
+            Self::ThrowStatement(it) => ContentHash::content_hash(it, state),
+            Self::TryStatement(it) => ContentHash::content_hash(it, state),
+            Self::WhileStatement(it) => ContentHash::content_hash(it, state),
+            Self::WithStatement(it) => ContentHash::content_hash(it, state),
+            Self::VariableDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::FunctionDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ClassDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAliasDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSInterfaceDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSEnumDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSModuleDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSImportEqualsDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ImportDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportAllDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportDefaultDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportNamedDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSExportAssignment(it) => ContentHash::content_hash(it, state),
+            Self::TSNamespaceExportDeclaration(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for Directive<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.directive.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.directive, state);
     }
 }
 
 impl<'a> ContentHash for Hashbang<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BlockStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -722,23 +722,23 @@ impl<'a> ContentHash for Declaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::VariableDeclaration(it) => it.content_hash(state),
-            Self::FunctionDeclaration(it) => it.content_hash(state),
-            Self::ClassDeclaration(it) => it.content_hash(state),
-            Self::TSTypeAliasDeclaration(it) => it.content_hash(state),
-            Self::TSInterfaceDeclaration(it) => it.content_hash(state),
-            Self::TSEnumDeclaration(it) => it.content_hash(state),
-            Self::TSModuleDeclaration(it) => it.content_hash(state),
-            Self::TSImportEqualsDeclaration(it) => it.content_hash(state),
+            Self::VariableDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::FunctionDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ClassDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAliasDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSInterfaceDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSEnumDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSModuleDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSImportEqualsDeclaration(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for VariableDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.declarations.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.declarations, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
@@ -750,10 +750,10 @@ impl ContentHash for VariableDeclarationKind {
 
 impl<'a> ContentHash for VariableDeclarator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.id.content_hash(state);
-        self.init.content_hash(state);
-        self.definite.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.init, state);
+        ContentHash::content_hash(&self.definite, state);
     }
 }
 
@@ -763,38 +763,38 @@ impl ContentHash for EmptyStatement {
 
 impl<'a> ContentHash for ExpressionStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for IfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.test.content_hash(state);
-        self.consequent.content_hash(state);
-        self.alternate.content_hash(state);
+        ContentHash::content_hash(&self.test, state);
+        ContentHash::content_hash(&self.consequent, state);
+        ContentHash::content_hash(&self.alternate, state);
     }
 }
 
 impl<'a> ContentHash for DoWhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
-        self.test.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
+        ContentHash::content_hash(&self.test, state);
     }
 }
 
 impl<'a> ContentHash for WhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.test.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.test, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for ForStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.init.content_hash(state);
-        self.test.content_hash(state);
-        self.update.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.init, state);
+        ContentHash::content_hash(&self.test, state);
+        ContentHash::content_hash(&self.update, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -802,58 +802,58 @@ impl<'a> ContentHash for ForStatementInit<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::VariableDeclaration(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::VariableDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ForInStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.right.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.right, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -861,101 +861,101 @@ impl<'a> ContentHash for ForStatementLeft<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::VariableDeclaration(it) => it.content_hash(state),
-            Self::AssignmentTargetIdentifier(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
-            Self::ArrayAssignmentTarget(it) => it.content_hash(state),
-            Self::ObjectAssignmentTarget(it) => it.content_hash(state),
+            Self::VariableDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentTargetIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrayAssignmentTarget(it) => ContentHash::content_hash(it, state),
+            Self::ObjectAssignmentTarget(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ForOfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#await.content_hash(state);
-        self.left.content_hash(state);
-        self.right.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.r#await, state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.right, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for ContinueStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.label.content_hash(state);
+        ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for BreakStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.label.content_hash(state);
+        ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for ReturnStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for WithStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.object, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for SwitchStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.discriminant.content_hash(state);
-        self.cases.content_hash(state);
+        ContentHash::content_hash(&self.discriminant, state);
+        ContentHash::content_hash(&self.cases, state);
     }
 }
 
 impl<'a> ContentHash for SwitchCase<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.test.content_hash(state);
-        self.consequent.content_hash(state);
+        ContentHash::content_hash(&self.test, state);
+        ContentHash::content_hash(&self.consequent, state);
     }
 }
 
 impl<'a> ContentHash for LabeledStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.label.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.label, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for ThrowStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for TryStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.block.content_hash(state);
-        self.handler.content_hash(state);
-        self.finalizer.content_hash(state);
+        ContentHash::content_hash(&self.block, state);
+        ContentHash::content_hash(&self.handler, state);
+        ContentHash::content_hash(&self.finalizer, state);
     }
 }
 
 impl<'a> ContentHash for CatchClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.param.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.param, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for CatchParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.pattern.content_hash(state);
+        ContentHash::content_hash(&self.pattern, state);
     }
 }
 
@@ -965,9 +965,9 @@ impl ContentHash for DebuggerStatement {
 
 impl<'a> ContentHash for BindingPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
@@ -975,62 +975,62 @@ impl<'a> ContentHash for BindingPatternKind<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::BindingIdentifier(it) => it.content_hash(state),
-            Self::ObjectPattern(it) => it.content_hash(state),
-            Self::ArrayPattern(it) => it.content_hash(state),
-            Self::AssignmentPattern(it) => it.content_hash(state),
+            Self::BindingIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::ObjectPattern(it) => ContentHash::content_hash(it, state),
+            Self::ArrayPattern(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentPattern(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for AssignmentPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
 impl<'a> ContentHash for ObjectPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.properties.content_hash(state);
-        self.rest.content_hash(state);
+        ContentHash::content_hash(&self.properties, state);
+        ContentHash::content_hash(&self.rest, state);
     }
 }
 
 impl<'a> ContentHash for BindingProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.key.content_hash(state);
-        self.value.content_hash(state);
-        self.shorthand.content_hash(state);
-        self.computed.content_hash(state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.shorthand, state);
+        ContentHash::content_hash(&self.computed, state);
     }
 }
 
 impl<'a> ContentHash for ArrayPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.elements.content_hash(state);
-        self.rest.content_hash(state);
+        ContentHash::content_hash(&self.elements, state);
+        ContentHash::content_hash(&self.rest, state);
     }
 }
 
 impl<'a> ContentHash for BindingRestElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for Function<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#type.content_hash(state);
-        self.id.content_hash(state);
-        self.generator.content_hash(state);
-        self.r#async.content_hash(state);
-        self.declare.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.this_param.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.r#type, state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.generator, state);
+        ContentHash::content_hash(&self.r#async, state);
+        ContentHash::content_hash(&self.declare, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.this_param, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -1042,19 +1042,19 @@ impl ContentHash for FunctionType {
 
 impl<'a> ContentHash for FormalParameters<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.items.content_hash(state);
-        self.rest.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.items, state);
+        ContentHash::content_hash(&self.rest, state);
     }
 }
 
 impl<'a> ContentHash for FormalParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.decorators.content_hash(state);
-        self.pattern.content_hash(state);
-        self.accessibility.content_hash(state);
-        self.readonly.content_hash(state);
-        self.r#override.content_hash(state);
+        ContentHash::content_hash(&self.decorators, state);
+        ContentHash::content_hash(&self.pattern, state);
+        ContentHash::content_hash(&self.accessibility, state);
+        ContentHash::content_hash(&self.readonly, state);
+        ContentHash::content_hash(&self.r#override, state);
     }
 }
 
@@ -1066,41 +1066,41 @@ impl ContentHash for FormalParameterKind {
 
 impl<'a> ContentHash for FunctionBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.directives.content_hash(state);
-        self.statements.content_hash(state);
+        ContentHash::content_hash(&self.directives, state);
+        ContentHash::content_hash(&self.statements, state);
     }
 }
 
 impl<'a> ContentHash for ArrowFunctionExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.r#async.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.r#async, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for YieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.delegate.content_hash(state);
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.delegate, state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for Class<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#type.content_hash(state);
-        self.decorators.content_hash(state);
-        self.id.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.super_class.content_hash(state);
-        self.super_type_parameters.content_hash(state);
-        self.implements.content_hash(state);
-        self.body.content_hash(state);
-        self.r#abstract.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.r#type, state);
+        ContentHash::content_hash(&self.decorators, state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.super_class, state);
+        ContentHash::content_hash(&self.super_type_parameters, state);
+        ContentHash::content_hash(&self.implements, state);
+        ContentHash::content_hash(&self.body, state);
+        ContentHash::content_hash(&self.r#abstract, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
@@ -1112,7 +1112,7 @@ impl ContentHash for ClassType {
 
 impl<'a> ContentHash for ClassBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -1120,27 +1120,27 @@ impl<'a> ContentHash for ClassElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::StaticBlock(it) => it.content_hash(state),
-            Self::MethodDefinition(it) => it.content_hash(state),
-            Self::PropertyDefinition(it) => it.content_hash(state),
-            Self::AccessorProperty(it) => it.content_hash(state),
-            Self::TSIndexSignature(it) => it.content_hash(state),
+            Self::StaticBlock(it) => ContentHash::content_hash(it, state),
+            Self::MethodDefinition(it) => ContentHash::content_hash(it, state),
+            Self::PropertyDefinition(it) => ContentHash::content_hash(it, state),
+            Self::AccessorProperty(it) => ContentHash::content_hash(it, state),
+            Self::TSIndexSignature(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for MethodDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#type.content_hash(state);
-        self.decorators.content_hash(state);
-        self.key.content_hash(state);
-        self.value.content_hash(state);
-        self.kind.content_hash(state);
-        self.computed.content_hash(state);
-        self.r#static.content_hash(state);
-        self.r#override.content_hash(state);
-        self.optional.content_hash(state);
-        self.accessibility.content_hash(state);
+        ContentHash::content_hash(&self.r#type, state);
+        ContentHash::content_hash(&self.decorators, state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.computed, state);
+        ContentHash::content_hash(&self.r#static, state);
+        ContentHash::content_hash(&self.r#override, state);
+        ContentHash::content_hash(&self.optional, state);
+        ContentHash::content_hash(&self.accessibility, state);
     }
 }
 
@@ -1152,19 +1152,19 @@ impl ContentHash for MethodDefinitionType {
 
 impl<'a> ContentHash for PropertyDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#type.content_hash(state);
-        self.decorators.content_hash(state);
-        self.key.content_hash(state);
-        self.value.content_hash(state);
-        self.computed.content_hash(state);
-        self.r#static.content_hash(state);
-        self.declare.content_hash(state);
-        self.r#override.content_hash(state);
-        self.optional.content_hash(state);
-        self.definite.content_hash(state);
-        self.readonly.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.accessibility.content_hash(state);
+        ContentHash::content_hash(&self.r#type, state);
+        ContentHash::content_hash(&self.decorators, state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.computed, state);
+        ContentHash::content_hash(&self.r#static, state);
+        ContentHash::content_hash(&self.declare, state);
+        ContentHash::content_hash(&self.r#override, state);
+        ContentHash::content_hash(&self.optional, state);
+        ContentHash::content_hash(&self.definite, state);
+        ContentHash::content_hash(&self.readonly, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.accessibility, state);
     }
 }
 
@@ -1182,13 +1182,13 @@ impl ContentHash for MethodDefinitionKind {
 
 impl<'a> ContentHash for PrivateIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for StaticBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -1196,12 +1196,12 @@ impl<'a> ContentHash for ModuleDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ImportDeclaration(it) => it.content_hash(state),
-            Self::ExportAllDeclaration(it) => it.content_hash(state),
-            Self::ExportDefaultDeclaration(it) => it.content_hash(state),
-            Self::ExportNamedDeclaration(it) => it.content_hash(state),
-            Self::TSExportAssignment(it) => it.content_hash(state),
-            Self::TSNamespaceExportDeclaration(it) => it.content_hash(state),
+            Self::ImportDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportAllDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportDefaultDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ExportNamedDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSExportAssignment(it) => ContentHash::content_hash(it, state),
+            Self::TSNamespaceExportDeclaration(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -1214,31 +1214,31 @@ impl ContentHash for AccessorPropertyType {
 
 impl<'a> ContentHash for AccessorProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#type.content_hash(state);
-        self.decorators.content_hash(state);
-        self.key.content_hash(state);
-        self.value.content_hash(state);
-        self.computed.content_hash(state);
-        self.r#static.content_hash(state);
-        self.definite.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.accessibility.content_hash(state);
+        ContentHash::content_hash(&self.r#type, state);
+        ContentHash::content_hash(&self.decorators, state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
+        ContentHash::content_hash(&self.computed, state);
+        ContentHash::content_hash(&self.r#static, state);
+        ContentHash::content_hash(&self.definite, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.accessibility, state);
     }
 }
 
 impl<'a> ContentHash for ImportExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.source.content_hash(state);
-        self.arguments.content_hash(state);
+        ContentHash::content_hash(&self.source, state);
+        ContentHash::content_hash(&self.arguments, state);
     }
 }
 
 impl<'a> ContentHash for ImportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.specifiers.content_hash(state);
-        self.source.content_hash(state);
-        self.with_clause.content_hash(state);
-        self.import_kind.content_hash(state);
+        ContentHash::content_hash(&self.specifiers, state);
+        ContentHash::content_hash(&self.source, state);
+        ContentHash::content_hash(&self.with_clause, state);
+        ContentHash::content_hash(&self.import_kind, state);
     }
 }
 
@@ -1246,44 +1246,44 @@ impl<'a> ContentHash for ImportDeclarationSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ImportSpecifier(it) => it.content_hash(state),
-            Self::ImportDefaultSpecifier(it) => it.content_hash(state),
-            Self::ImportNamespaceSpecifier(it) => it.content_hash(state),
+            Self::ImportSpecifier(it) => ContentHash::content_hash(it, state),
+            Self::ImportDefaultSpecifier(it) => ContentHash::content_hash(it, state),
+            Self::ImportNamespaceSpecifier(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ImportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.imported.content_hash(state);
-        self.local.content_hash(state);
-        self.import_kind.content_hash(state);
+        ContentHash::content_hash(&self.imported, state);
+        ContentHash::content_hash(&self.local, state);
+        ContentHash::content_hash(&self.import_kind, state);
     }
 }
 
 impl<'a> ContentHash for ImportDefaultSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.local.content_hash(state);
+        ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for ImportNamespaceSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.local.content_hash(state);
+        ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for WithClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.attributes_keyword.content_hash(state);
-        self.with_entries.content_hash(state);
+        ContentHash::content_hash(&self.attributes_keyword, state);
+        ContentHash::content_hash(&self.with_entries, state);
     }
 }
 
 impl<'a> ContentHash for ImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.key.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
@@ -1291,43 +1291,43 @@ impl<'a> ContentHash for ImportAttributeKey<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for ExportNamedDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.declaration.content_hash(state);
-        self.specifiers.content_hash(state);
-        self.source.content_hash(state);
-        self.export_kind.content_hash(state);
-        self.with_clause.content_hash(state);
+        ContentHash::content_hash(&self.declaration, state);
+        ContentHash::content_hash(&self.specifiers, state);
+        ContentHash::content_hash(&self.source, state);
+        ContentHash::content_hash(&self.export_kind, state);
+        ContentHash::content_hash(&self.with_clause, state);
     }
 }
 
 impl<'a> ContentHash for ExportDefaultDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.declaration.content_hash(state);
-        self.exported.content_hash(state);
+        ContentHash::content_hash(&self.declaration, state);
+        ContentHash::content_hash(&self.exported, state);
     }
 }
 
 impl<'a> ContentHash for ExportAllDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.exported.content_hash(state);
-        self.source.content_hash(state);
-        self.with_clause.content_hash(state);
-        self.export_kind.content_hash(state);
+        ContentHash::content_hash(&self.exported, state);
+        ContentHash::content_hash(&self.source, state);
+        ContentHash::content_hash(&self.with_clause, state);
+        ContentHash::content_hash(&self.export_kind, state);
     }
 }
 
 impl<'a> ContentHash for ExportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.local.content_hash(state);
-        self.exported.content_hash(state);
-        self.export_kind.content_hash(state);
+        ContentHash::content_hash(&self.local, state);
+        ContentHash::content_hash(&self.exported, state);
+        ContentHash::content_hash(&self.export_kind, state);
     }
 }
 
@@ -1335,51 +1335,51 @@ impl<'a> ContentHash for ExportDefaultDeclarationKind<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::FunctionDeclaration(it) => it.content_hash(state),
-            Self::ClassDeclaration(it) => it.content_hash(state),
-            Self::TSInterfaceDeclaration(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::FunctionDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::ClassDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSInterfaceDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -1388,32 +1388,32 @@ impl<'a> ContentHash for ModuleExportName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::IdentifierName(it) => it.content_hash(state),
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
+            Self::IdentifierName(it) => ContentHash::content_hash(it, state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSThisParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSEnumDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.members.content_hash(state);
-        self.r#const.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.members, state);
+        ContentHash::content_hash(&self.r#const, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
 impl<'a> ContentHash for TSEnumMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.initializer.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.initializer, state);
     }
 }
 
@@ -1421,65 +1421,65 @@ impl<'a> ContentHash for TSEnumMemberName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::StaticIdentifier(it) => it.content_hash(state),
-            Self::StaticStringLiteral(it) => it.content_hash(state),
-            Self::StaticTemplateLiteral(it) => it.content_hash(state),
-            Self::StaticNumericLiteral(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::StaticIdentifier(it) => ContentHash::content_hash(it, state),
+            Self::StaticStringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StaticTemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StaticNumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSTypeAnnotation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.literal.content_hash(state);
+        ContentHash::content_hash(&self.literal, state);
     }
 }
 
@@ -1487,14 +1487,14 @@ impl<'a> ContentHash for TSLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -1503,79 +1503,79 @@ impl<'a> ContentHash for TSType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::TSAnyKeyword(it) => it.content_hash(state),
-            Self::TSBigIntKeyword(it) => it.content_hash(state),
-            Self::TSBooleanKeyword(it) => it.content_hash(state),
-            Self::TSIntrinsicKeyword(it) => it.content_hash(state),
-            Self::TSNeverKeyword(it) => it.content_hash(state),
-            Self::TSNullKeyword(it) => it.content_hash(state),
-            Self::TSNumberKeyword(it) => it.content_hash(state),
-            Self::TSObjectKeyword(it) => it.content_hash(state),
-            Self::TSStringKeyword(it) => it.content_hash(state),
-            Self::TSSymbolKeyword(it) => it.content_hash(state),
-            Self::TSUndefinedKeyword(it) => it.content_hash(state),
-            Self::TSUnknownKeyword(it) => it.content_hash(state),
-            Self::TSVoidKeyword(it) => it.content_hash(state),
-            Self::TSArrayType(it) => it.content_hash(state),
-            Self::TSConditionalType(it) => it.content_hash(state),
-            Self::TSConstructorType(it) => it.content_hash(state),
-            Self::TSFunctionType(it) => it.content_hash(state),
-            Self::TSImportType(it) => it.content_hash(state),
-            Self::TSIndexedAccessType(it) => it.content_hash(state),
-            Self::TSInferType(it) => it.content_hash(state),
-            Self::TSIntersectionType(it) => it.content_hash(state),
-            Self::TSLiteralType(it) => it.content_hash(state),
-            Self::TSMappedType(it) => it.content_hash(state),
-            Self::TSNamedTupleMember(it) => it.content_hash(state),
-            Self::TSQualifiedName(it) => it.content_hash(state),
-            Self::TSTemplateLiteralType(it) => it.content_hash(state),
-            Self::TSThisType(it) => it.content_hash(state),
-            Self::TSTupleType(it) => it.content_hash(state),
-            Self::TSTypeLiteral(it) => it.content_hash(state),
-            Self::TSTypeOperatorType(it) => it.content_hash(state),
-            Self::TSTypePredicate(it) => it.content_hash(state),
-            Self::TSTypeQuery(it) => it.content_hash(state),
-            Self::TSTypeReference(it) => it.content_hash(state),
-            Self::TSUnionType(it) => it.content_hash(state),
-            Self::TSParenthesizedType(it) => it.content_hash(state),
-            Self::JSDocNullableType(it) => it.content_hash(state),
-            Self::JSDocNonNullableType(it) => it.content_hash(state),
-            Self::JSDocUnknownType(it) => it.content_hash(state),
+            Self::TSAnyKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSBigIntKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSBooleanKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSIntrinsicKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNeverKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNullKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNumberKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSObjectKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSStringKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSSymbolKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSUndefinedKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSUnknownKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSVoidKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSArrayType(it) => ContentHash::content_hash(it, state),
+            Self::TSConditionalType(it) => ContentHash::content_hash(it, state),
+            Self::TSConstructorType(it) => ContentHash::content_hash(it, state),
+            Self::TSFunctionType(it) => ContentHash::content_hash(it, state),
+            Self::TSImportType(it) => ContentHash::content_hash(it, state),
+            Self::TSIndexedAccessType(it) => ContentHash::content_hash(it, state),
+            Self::TSInferType(it) => ContentHash::content_hash(it, state),
+            Self::TSIntersectionType(it) => ContentHash::content_hash(it, state),
+            Self::TSLiteralType(it) => ContentHash::content_hash(it, state),
+            Self::TSMappedType(it) => ContentHash::content_hash(it, state),
+            Self::TSNamedTupleMember(it) => ContentHash::content_hash(it, state),
+            Self::TSQualifiedName(it) => ContentHash::content_hash(it, state),
+            Self::TSTemplateLiteralType(it) => ContentHash::content_hash(it, state),
+            Self::TSThisType(it) => ContentHash::content_hash(it, state),
+            Self::TSTupleType(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeOperatorType(it) => ContentHash::content_hash(it, state),
+            Self::TSTypePredicate(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeQuery(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeReference(it) => ContentHash::content_hash(it, state),
+            Self::TSUnionType(it) => ContentHash::content_hash(it, state),
+            Self::TSParenthesizedType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocNullableType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocNonNullableType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocUnknownType(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSConditionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.check_type.content_hash(state);
-        self.extends_type.content_hash(state);
-        self.true_type.content_hash(state);
-        self.false_type.content_hash(state);
+        ContentHash::content_hash(&self.check_type, state);
+        ContentHash::content_hash(&self.extends_type, state);
+        ContentHash::content_hash(&self.true_type, state);
+        ContentHash::content_hash(&self.false_type, state);
     }
 }
 
 impl<'a> ContentHash for TSUnionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.types.content_hash(state);
+        ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSIntersectionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.types.content_hash(state);
+        ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSParenthesizedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeOperator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.operator.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.operator, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
@@ -1587,40 +1587,40 @@ impl ContentHash for TSTypeOperatorOperator {
 
 impl<'a> ContentHash for TSArrayType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.element_type.content_hash(state);
+        ContentHash::content_hash(&self.element_type, state);
     }
 }
 
 impl<'a> ContentHash for TSIndexedAccessType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object_type.content_hash(state);
-        self.index_type.content_hash(state);
+        ContentHash::content_hash(&self.object_type, state);
+        ContentHash::content_hash(&self.index_type, state);
     }
 }
 
 impl<'a> ContentHash for TSTupleType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.element_types.content_hash(state);
+        ContentHash::content_hash(&self.element_types, state);
     }
 }
 
 impl<'a> ContentHash for TSNamedTupleMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.element_type.content_hash(state);
-        self.label.content_hash(state);
-        self.optional.content_hash(state);
+        ContentHash::content_hash(&self.element_type, state);
+        ContentHash::content_hash(&self.label, state);
+        ContentHash::content_hash(&self.optional, state);
     }
 }
 
 impl<'a> ContentHash for TSOptionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSRestType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
@@ -1628,46 +1628,46 @@ impl<'a> ContentHash for TSTupleElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::TSOptionalType(it) => it.content_hash(state),
-            Self::TSRestType(it) => it.content_hash(state),
-            Self::TSAnyKeyword(it) => it.content_hash(state),
-            Self::TSBigIntKeyword(it) => it.content_hash(state),
-            Self::TSBooleanKeyword(it) => it.content_hash(state),
-            Self::TSIntrinsicKeyword(it) => it.content_hash(state),
-            Self::TSNeverKeyword(it) => it.content_hash(state),
-            Self::TSNullKeyword(it) => it.content_hash(state),
-            Self::TSNumberKeyword(it) => it.content_hash(state),
-            Self::TSObjectKeyword(it) => it.content_hash(state),
-            Self::TSStringKeyword(it) => it.content_hash(state),
-            Self::TSSymbolKeyword(it) => it.content_hash(state),
-            Self::TSUndefinedKeyword(it) => it.content_hash(state),
-            Self::TSUnknownKeyword(it) => it.content_hash(state),
-            Self::TSVoidKeyword(it) => it.content_hash(state),
-            Self::TSArrayType(it) => it.content_hash(state),
-            Self::TSConditionalType(it) => it.content_hash(state),
-            Self::TSConstructorType(it) => it.content_hash(state),
-            Self::TSFunctionType(it) => it.content_hash(state),
-            Self::TSImportType(it) => it.content_hash(state),
-            Self::TSIndexedAccessType(it) => it.content_hash(state),
-            Self::TSInferType(it) => it.content_hash(state),
-            Self::TSIntersectionType(it) => it.content_hash(state),
-            Self::TSLiteralType(it) => it.content_hash(state),
-            Self::TSMappedType(it) => it.content_hash(state),
-            Self::TSNamedTupleMember(it) => it.content_hash(state),
-            Self::TSQualifiedName(it) => it.content_hash(state),
-            Self::TSTemplateLiteralType(it) => it.content_hash(state),
-            Self::TSThisType(it) => it.content_hash(state),
-            Self::TSTupleType(it) => it.content_hash(state),
-            Self::TSTypeLiteral(it) => it.content_hash(state),
-            Self::TSTypeOperatorType(it) => it.content_hash(state),
-            Self::TSTypePredicate(it) => it.content_hash(state),
-            Self::TSTypeQuery(it) => it.content_hash(state),
-            Self::TSTypeReference(it) => it.content_hash(state),
-            Self::TSUnionType(it) => it.content_hash(state),
-            Self::TSParenthesizedType(it) => it.content_hash(state),
-            Self::JSDocNullableType(it) => it.content_hash(state),
-            Self::JSDocNonNullableType(it) => it.content_hash(state),
-            Self::JSDocUnknownType(it) => it.content_hash(state),
+            Self::TSOptionalType(it) => ContentHash::content_hash(it, state),
+            Self::TSRestType(it) => ContentHash::content_hash(it, state),
+            Self::TSAnyKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSBigIntKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSBooleanKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSIntrinsicKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNeverKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNullKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSNumberKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSObjectKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSStringKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSSymbolKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSUndefinedKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSUnknownKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSVoidKeyword(it) => ContentHash::content_hash(it, state),
+            Self::TSArrayType(it) => ContentHash::content_hash(it, state),
+            Self::TSConditionalType(it) => ContentHash::content_hash(it, state),
+            Self::TSConstructorType(it) => ContentHash::content_hash(it, state),
+            Self::TSFunctionType(it) => ContentHash::content_hash(it, state),
+            Self::TSImportType(it) => ContentHash::content_hash(it, state),
+            Self::TSIndexedAccessType(it) => ContentHash::content_hash(it, state),
+            Self::TSInferType(it) => ContentHash::content_hash(it, state),
+            Self::TSIntersectionType(it) => ContentHash::content_hash(it, state),
+            Self::TSLiteralType(it) => ContentHash::content_hash(it, state),
+            Self::TSMappedType(it) => ContentHash::content_hash(it, state),
+            Self::TSNamedTupleMember(it) => ContentHash::content_hash(it, state),
+            Self::TSQualifiedName(it) => ContentHash::content_hash(it, state),
+            Self::TSTemplateLiteralType(it) => ContentHash::content_hash(it, state),
+            Self::TSThisType(it) => ContentHash::content_hash(it, state),
+            Self::TSTupleType(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeOperatorType(it) => ContentHash::content_hash(it, state),
+            Self::TSTypePredicate(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeQuery(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeReference(it) => ContentHash::content_hash(it, state),
+            Self::TSUnionType(it) => ContentHash::content_hash(it, state),
+            Self::TSParenthesizedType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocNullableType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocNonNullableType(it) => ContentHash::content_hash(it, state),
+            Self::JSDocUnknownType(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -1730,8 +1730,8 @@ impl ContentHash for TSBigIntKeyword {
 
 impl<'a> ContentHash for TSTypeReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_name.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.type_name, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -1739,48 +1739,48 @@ impl<'a> ContentHash for TSTypeName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::QualifiedName(it) => it.content_hash(state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::QualifiedName(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSQualifiedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.left.content_hash(state);
-        self.right.content_hash(state);
+        ContentHash::content_hash(&self.left, state);
+        ContentHash::content_hash(&self.right, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeParameterInstantiation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.params.content_hash(state);
+        ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.constraint.content_hash(state);
-        self.default.content_hash(state);
-        self.r#in.content_hash(state);
-        self.out.content_hash(state);
-        self.r#const.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.constraint, state);
+        ContentHash::content_hash(&self.default, state);
+        ContentHash::content_hash(&self.r#in, state);
+        ContentHash::content_hash(&self.out, state);
+        ContentHash::content_hash(&self.r#const, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeParameterDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.params.content_hash(state);
+        ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeAliasDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
@@ -1792,34 +1792,34 @@ impl ContentHash for TSAccessibility {
 
 impl<'a> ContentHash for TSClassImplements<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSInterfaceDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.extends.content_hash(state);
-        self.type_parameters.content_hash(state);
-        self.body.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.extends, state);
+        ContentHash::content_hash(&self.type_parameters, state);
+        ContentHash::content_hash(&self.body, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
 impl<'a> ContentHash for TSInterfaceBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for TSPropertySignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.computed.content_hash(state);
-        self.optional.content_hash(state);
-        self.readonly.content_hash(state);
-        self.key.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.computed, state);
+        ContentHash::content_hash(&self.optional, state);
+        ContentHash::content_hash(&self.readonly, state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
@@ -1827,29 +1827,29 @@ impl<'a> ContentHash for TSSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::TSIndexSignature(it) => it.content_hash(state),
-            Self::TSPropertySignature(it) => it.content_hash(state),
-            Self::TSCallSignatureDeclaration(it) => it.content_hash(state),
-            Self::TSConstructSignatureDeclaration(it) => it.content_hash(state),
-            Self::TSMethodSignature(it) => it.content_hash(state),
+            Self::TSIndexSignature(it) => ContentHash::content_hash(it, state),
+            Self::TSPropertySignature(it) => ContentHash::content_hash(it, state),
+            Self::TSCallSignatureDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSConstructSignatureDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSMethodSignature(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSIndexSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.parameters.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.readonly.content_hash(state);
+        ContentHash::content_hash(&self.parameters, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.readonly, state);
     }
 }
 
 impl<'a> ContentHash for TSCallSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.this_param.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.this_param, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -1861,44 +1861,44 @@ impl ContentHash for TSMethodSignatureKind {
 
 impl<'a> ContentHash for TSMethodSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.key.content_hash(state);
-        self.computed.content_hash(state);
-        self.optional.content_hash(state);
-        self.kind.content_hash(state);
-        self.this_param.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.key, state);
+        ContentHash::content_hash(&self.computed, state);
+        ContentHash::content_hash(&self.optional, state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.this_param, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSIndexSignatureName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSInterfaceHeritage<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSTypePredicate<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.parameter_name.content_hash(state);
-        self.asserts.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.parameter_name, state);
+        ContentHash::content_hash(&self.asserts, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
@@ -1906,18 +1906,18 @@ impl<'a> ContentHash for TSTypePredicateName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::This(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::This(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSModuleDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.body.content_hash(state);
-        self.kind.content_hash(state);
-        self.declare.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.body, state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.declare, state);
     }
 }
 
@@ -1931,8 +1931,8 @@ impl<'a> ContentHash for TSModuleDeclarationName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -1941,35 +1941,35 @@ impl<'a> ContentHash for TSModuleDeclarationBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::TSModuleDeclaration(it) => it.content_hash(state),
-            Self::TSModuleBlock(it) => it.content_hash(state),
+            Self::TSModuleDeclaration(it) => ContentHash::content_hash(it, state),
+            Self::TSModuleBlock(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSModuleBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.directives.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.directives, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.members.content_hash(state);
+        ContentHash::content_hash(&self.members, state);
     }
 }
 
 impl<'a> ContentHash for TSInferType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_parameter.content_hash(state);
+        ContentHash::content_hash(&self.type_parameter, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeQuery<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expr_name.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.expr_name, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -1977,34 +1977,34 @@ impl<'a> ContentHash for TSTypeQueryExprName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::TSImportType(it) => it.content_hash(state),
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::QualifiedName(it) => it.content_hash(state),
+            Self::TSImportType(it) => ContentHash::content_hash(it, state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::QualifiedName(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSImportType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.is_type_of.content_hash(state);
-        self.parameter.content_hash(state);
-        self.qualifier.content_hash(state);
-        self.attributes.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.is_type_of, state);
+        ContentHash::content_hash(&self.parameter, state);
+        ContentHash::content_hash(&self.qualifier, state);
+        ContentHash::content_hash(&self.attributes, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSImportAttributes<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.attributes_keyword.content_hash(state);
-        self.elements.content_hash(state);
+        ContentHash::content_hash(&self.attributes_keyword, state);
+        ContentHash::content_hash(&self.elements, state);
     }
 }
 
 impl<'a> ContentHash for TSImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
@@ -2012,37 +2012,37 @@ impl<'a> ContentHash for TSImportAttributeName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSFunctionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.this_param.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.this_param, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSConstructorType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.r#abstract.content_hash(state);
-        self.params.content_hash(state);
-        self.return_type.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.r#abstract, state);
+        ContentHash::content_hash(&self.params, state);
+        ContentHash::content_hash(&self.return_type, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSMappedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_parameter.content_hash(state);
-        self.name_type.content_hash(state);
-        self.type_annotation.content_hash(state);
-        self.optional.content_hash(state);
-        self.readonly.content_hash(state);
+        ContentHash::content_hash(&self.type_parameter, state);
+        ContentHash::content_hash(&self.name_type, state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.optional, state);
+        ContentHash::content_hash(&self.readonly, state);
     }
 }
 
@@ -2054,37 +2054,37 @@ impl ContentHash for TSMappedTypeModifierOperator {
 
 impl<'a> ContentHash for TSTemplateLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.quasis.content_hash(state);
-        self.types.content_hash(state);
+        ContentHash::content_hash(&self.quasis, state);
+        ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSAsExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSSatisfiesExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeAssertion<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_annotation.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSImportEqualsDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
-        self.module_reference.content_hash(state);
-        self.import_kind.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
+        ContentHash::content_hash(&self.module_reference, state);
+        ContentHash::content_hash(&self.import_kind, state);
     }
 }
 
@@ -2092,47 +2092,47 @@ impl<'a> ContentHash for TSModuleReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::ExternalModuleReference(it) => it.content_hash(state),
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::QualifiedName(it) => it.content_hash(state),
+            Self::ExternalModuleReference(it) => ContentHash::content_hash(it, state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::QualifiedName(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for TSExternalModuleReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNonNullExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for Decorator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSExportAssignment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNamespaceExportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.id.content_hash(state);
+        ContentHash::content_hash(&self.id, state);
     }
 }
 
 impl<'a> ContentHash for TSInstantiationExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -2144,15 +2144,15 @@ impl ContentHash for ImportOrExportKind {
 
 impl<'a> ContentHash for JSDocNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
-        self.postfix.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.postfix, state);
     }
 }
 
 impl<'a> ContentHash for JSDocNonNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.type_annotation.content_hash(state);
-        self.postfix.content_hash(state);
+        ContentHash::content_hash(&self.type_annotation, state);
+        ContentHash::content_hash(&self.postfix, state);
     }
 }
 
@@ -2162,32 +2162,32 @@ impl ContentHash for JSDocUnknownType {
 
 impl<'a> ContentHash for JSXElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.opening_element.content_hash(state);
-        self.closing_element.content_hash(state);
-        self.children.content_hash(state);
+        ContentHash::content_hash(&self.opening_element, state);
+        ContentHash::content_hash(&self.closing_element, state);
+        ContentHash::content_hash(&self.children, state);
     }
 }
 
 impl<'a> ContentHash for JSXOpeningElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.self_closing.content_hash(state);
-        self.name.content_hash(state);
-        self.attributes.content_hash(state);
-        self.type_parameters.content_hash(state);
+        ContentHash::content_hash(&self.self_closing, state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.attributes, state);
+        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for JSXClosingElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for JSXFragment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.opening_fragment.content_hash(state);
-        self.closing_fragment.content_hash(state);
-        self.children.content_hash(state);
+        ContentHash::content_hash(&self.opening_fragment, state);
+        ContentHash::content_hash(&self.closing_fragment, state);
+        ContentHash::content_hash(&self.children, state);
     }
 }
 
@@ -2203,26 +2203,26 @@ impl<'a> ContentHash for JSXElementName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::NamespacedName(it) => it.content_hash(state),
-            Self::MemberExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::NamespacedName(it) => ContentHash::content_hash(it, state),
+            Self::MemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for JSXNamespacedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.namespace.content_hash(state);
-        self.property.content_hash(state);
+        ContentHash::content_hash(&self.namespace, state);
+        ContentHash::content_hash(&self.property, state);
     }
 }
 
 impl<'a> ContentHash for JSXMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.object.content_hash(state);
-        self.property.content_hash(state);
+        ContentHash::content_hash(&self.object, state);
+        ContentHash::content_hash(&self.property, state);
     }
 }
 
@@ -2230,16 +2230,16 @@ impl<'a> ContentHash for JSXMemberExpressionObject<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::IdentifierReference(it) => it.content_hash(state),
-            Self::MemberExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
+            Self::IdentifierReference(it) => ContentHash::content_hash(it, state),
+            Self::MemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for JSXExpressionContainer<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
@@ -2247,49 +2247,49 @@ impl<'a> ContentHash for JSXExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::EmptyExpression(it) => it.content_hash(state),
-            Self::BooleanLiteral(it) => it.content_hash(state),
-            Self::NullLiteral(it) => it.content_hash(state),
-            Self::NumericLiteral(it) => it.content_hash(state),
-            Self::BigIntLiteral(it) => it.content_hash(state),
-            Self::RegExpLiteral(it) => it.content_hash(state),
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::TemplateLiteral(it) => it.content_hash(state),
-            Self::Identifier(it) => it.content_hash(state),
-            Self::MetaProperty(it) => it.content_hash(state),
-            Self::Super(it) => it.content_hash(state),
-            Self::ArrayExpression(it) => it.content_hash(state),
-            Self::ArrowFunctionExpression(it) => it.content_hash(state),
-            Self::AssignmentExpression(it) => it.content_hash(state),
-            Self::AwaitExpression(it) => it.content_hash(state),
-            Self::BinaryExpression(it) => it.content_hash(state),
-            Self::CallExpression(it) => it.content_hash(state),
-            Self::ChainExpression(it) => it.content_hash(state),
-            Self::ClassExpression(it) => it.content_hash(state),
-            Self::ConditionalExpression(it) => it.content_hash(state),
-            Self::FunctionExpression(it) => it.content_hash(state),
-            Self::ImportExpression(it) => it.content_hash(state),
-            Self::LogicalExpression(it) => it.content_hash(state),
-            Self::NewExpression(it) => it.content_hash(state),
-            Self::ObjectExpression(it) => it.content_hash(state),
-            Self::ParenthesizedExpression(it) => it.content_hash(state),
-            Self::SequenceExpression(it) => it.content_hash(state),
-            Self::TaggedTemplateExpression(it) => it.content_hash(state),
-            Self::ThisExpression(it) => it.content_hash(state),
-            Self::UnaryExpression(it) => it.content_hash(state),
-            Self::UpdateExpression(it) => it.content_hash(state),
-            Self::YieldExpression(it) => it.content_hash(state),
-            Self::PrivateInExpression(it) => it.content_hash(state),
-            Self::JSXElement(it) => it.content_hash(state),
-            Self::JSXFragment(it) => it.content_hash(state),
-            Self::TSAsExpression(it) => it.content_hash(state),
-            Self::TSSatisfiesExpression(it) => it.content_hash(state),
-            Self::TSTypeAssertion(it) => it.content_hash(state),
-            Self::TSNonNullExpression(it) => it.content_hash(state),
-            Self::TSInstantiationExpression(it) => it.content_hash(state),
-            Self::ComputedMemberExpression(it) => it.content_hash(state),
-            Self::StaticMemberExpression(it) => it.content_hash(state),
-            Self::PrivateFieldExpression(it) => it.content_hash(state),
+            Self::EmptyExpression(it) => ContentHash::content_hash(it, state),
+            Self::BooleanLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NullLiteral(it) => ContentHash::content_hash(it, state),
+            Self::NumericLiteral(it) => ContentHash::content_hash(it, state),
+            Self::BigIntLiteral(it) => ContentHash::content_hash(it, state),
+            Self::RegExpLiteral(it) => ContentHash::content_hash(it, state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::TemplateLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::MetaProperty(it) => ContentHash::content_hash(it, state),
+            Self::Super(it) => ContentHash::content_hash(it, state),
+            Self::ArrayExpression(it) => ContentHash::content_hash(it, state),
+            Self::ArrowFunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::AssignmentExpression(it) => ContentHash::content_hash(it, state),
+            Self::AwaitExpression(it) => ContentHash::content_hash(it, state),
+            Self::BinaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::CallExpression(it) => ContentHash::content_hash(it, state),
+            Self::ChainExpression(it) => ContentHash::content_hash(it, state),
+            Self::ClassExpression(it) => ContentHash::content_hash(it, state),
+            Self::ConditionalExpression(it) => ContentHash::content_hash(it, state),
+            Self::FunctionExpression(it) => ContentHash::content_hash(it, state),
+            Self::ImportExpression(it) => ContentHash::content_hash(it, state),
+            Self::LogicalExpression(it) => ContentHash::content_hash(it, state),
+            Self::NewExpression(it) => ContentHash::content_hash(it, state),
+            Self::ObjectExpression(it) => ContentHash::content_hash(it, state),
+            Self::ParenthesizedExpression(it) => ContentHash::content_hash(it, state),
+            Self::SequenceExpression(it) => ContentHash::content_hash(it, state),
+            Self::TaggedTemplateExpression(it) => ContentHash::content_hash(it, state),
+            Self::ThisExpression(it) => ContentHash::content_hash(it, state),
+            Self::UnaryExpression(it) => ContentHash::content_hash(it, state),
+            Self::UpdateExpression(it) => ContentHash::content_hash(it, state),
+            Self::YieldExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateInExpression(it) => ContentHash::content_hash(it, state),
+            Self::JSXElement(it) => ContentHash::content_hash(it, state),
+            Self::JSXFragment(it) => ContentHash::content_hash(it, state),
+            Self::TSAsExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSSatisfiesExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSTypeAssertion(it) => ContentHash::content_hash(it, state),
+            Self::TSNonNullExpression(it) => ContentHash::content_hash(it, state),
+            Self::TSInstantiationExpression(it) => ContentHash::content_hash(it, state),
+            Self::ComputedMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::StaticMemberExpression(it) => ContentHash::content_hash(it, state),
+            Self::PrivateFieldExpression(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -2302,22 +2302,22 @@ impl<'a> ContentHash for JSXAttributeItem<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Attribute(it) => it.content_hash(state),
-            Self::SpreadAttribute(it) => it.content_hash(state),
+            Self::Attribute(it) => ContentHash::content_hash(it, state),
+            Self::SpreadAttribute(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for JSXAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for JSXSpreadAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.argument.content_hash(state);
+        ContentHash::content_hash(&self.argument, state);
     }
 }
 
@@ -2325,8 +2325,8 @@ impl<'a> ContentHash for JSXAttributeName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Identifier(it) => it.content_hash(state),
-            Self::NamespacedName(it) => it.content_hash(state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::NamespacedName(it) => ContentHash::content_hash(it, state),
         }
     }
 }
@@ -2335,17 +2335,17 @@ impl<'a> ContentHash for JSXAttributeValue<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::StringLiteral(it) => it.content_hash(state),
-            Self::ExpressionContainer(it) => it.content_hash(state),
-            Self::Element(it) => it.content_hash(state),
-            Self::Fragment(it) => it.content_hash(state),
+            Self::StringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::ExpressionContainer(it) => ContentHash::content_hash(it, state),
+            Self::Element(it) => ContentHash::content_hash(it, state),
+            Self::Fragment(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for JSXIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }
 
@@ -2353,23 +2353,23 @@ impl<'a> ContentHash for JSXChild<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::Text(it) => it.content_hash(state),
-            Self::Element(it) => it.content_hash(state),
-            Self::Fragment(it) => it.content_hash(state),
-            Self::ExpressionContainer(it) => it.content_hash(state),
-            Self::Spread(it) => it.content_hash(state),
+            Self::Text(it) => ContentHash::content_hash(it, state),
+            Self::Element(it) => ContentHash::content_hash(it, state),
+            Self::Fragment(it) => ContentHash::content_hash(it, state),
+            Self::ExpressionContainer(it) => ContentHash::content_hash(it, state),
+            Self::Spread(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl<'a> ContentHash for JSXSpreadChild<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.expression.content_hash(state);
+        ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for JSXText<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.value, state);
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -69,48 +69,48 @@ impl<'a> GetSpan for Program<'a> {
 impl<'a> GetSpan for Expression<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -160,50 +160,50 @@ impl<'a> GetSpan for ArrayExpression<'a> {
 impl<'a> GetSpan for ArrayExpressionElement<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::SpreadElement(it) => it.span(),
-            Self::Elision(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::SpreadElement(it) => GetSpan::span(it.as_ref()),
+            Self::Elision(it) => GetSpan::span(it),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -225,8 +225,8 @@ impl<'a> GetSpan for ObjectExpression<'a> {
 impl<'a> GetSpan for ObjectPropertyKind<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ObjectProperty(it) => it.span(),
-            Self::SpreadProperty(it) => it.span(),
+            Self::ObjectProperty(it) => GetSpan::span(it.as_ref()),
+            Self::SpreadProperty(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -241,50 +241,50 @@ impl<'a> GetSpan for ObjectProperty<'a> {
 impl<'a> GetSpan for PropertyKey<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticIdentifier(it) => it.span(),
-            Self::PrivateIdentifier(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::StaticIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -313,9 +313,9 @@ impl<'a> GetSpan for TemplateElement<'a> {
 impl<'a> GetSpan for MemberExpression<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -372,49 +372,49 @@ impl<'a> GetSpan for SpreadElement<'a> {
 impl<'a> GetSpan for Argument<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::SpreadElement(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::SpreadElement(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -471,17 +471,17 @@ impl<'a> GetSpan for AssignmentExpression<'a> {
 impl<'a> GetSpan for AssignmentTarget<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
-            Self::ArrayAssignmentTarget(it) => it.span(),
-            Self::ObjectAssignmentTarget(it) => it.span(),
+            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -489,15 +489,15 @@ impl<'a> GetSpan for AssignmentTarget<'a> {
 impl<'a> GetSpan for SimpleAssignmentTarget<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -505,8 +505,8 @@ impl<'a> GetSpan for SimpleAssignmentTarget<'a> {
 impl<'a> GetSpan for AssignmentTargetPattern<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ArrayAssignmentTarget(it) => it.span(),
-            Self::ObjectAssignmentTarget(it) => it.span(),
+            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -535,18 +535,18 @@ impl<'a> GetSpan for AssignmentTargetRest<'a> {
 impl<'a> GetSpan for AssignmentTargetMaybeDefault<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetWithDefault(it) => it.span(),
-            Self::AssignmentTargetIdentifier(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
-            Self::ArrayAssignmentTarget(it) => it.span(),
-            Self::ObjectAssignmentTarget(it) => it.span(),
+            Self::AssignmentTargetWithDefault(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -561,8 +561,8 @@ impl<'a> GetSpan for AssignmentTargetWithDefault<'a> {
 impl<'a> GetSpan for AssignmentTargetProperty<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => it.span(),
-            Self::AssignmentTargetPropertyProperty(it) => it.span(),
+            Self::AssignmentTargetPropertyIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetPropertyProperty(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -612,10 +612,10 @@ impl<'a> GetSpan for ChainExpression<'a> {
 impl<'a> GetSpan for ChainElement<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::CallExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -630,38 +630,38 @@ impl<'a> GetSpan for ParenthesizedExpression<'a> {
 impl<'a> GetSpan for Statement<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::BlockStatement(it) => it.span(),
-            Self::BreakStatement(it) => it.span(),
-            Self::ContinueStatement(it) => it.span(),
-            Self::DebuggerStatement(it) => it.span(),
-            Self::DoWhileStatement(it) => it.span(),
-            Self::EmptyStatement(it) => it.span(),
-            Self::ExpressionStatement(it) => it.span(),
-            Self::ForInStatement(it) => it.span(),
-            Self::ForOfStatement(it) => it.span(),
-            Self::ForStatement(it) => it.span(),
-            Self::IfStatement(it) => it.span(),
-            Self::LabeledStatement(it) => it.span(),
-            Self::ReturnStatement(it) => it.span(),
-            Self::SwitchStatement(it) => it.span(),
-            Self::ThrowStatement(it) => it.span(),
-            Self::TryStatement(it) => it.span(),
-            Self::WhileStatement(it) => it.span(),
-            Self::WithStatement(it) => it.span(),
-            Self::VariableDeclaration(it) => it.span(),
-            Self::FunctionDeclaration(it) => it.span(),
-            Self::ClassDeclaration(it) => it.span(),
-            Self::TSTypeAliasDeclaration(it) => it.span(),
-            Self::TSInterfaceDeclaration(it) => it.span(),
-            Self::TSEnumDeclaration(it) => it.span(),
-            Self::TSModuleDeclaration(it) => it.span(),
-            Self::TSImportEqualsDeclaration(it) => it.span(),
-            Self::ImportDeclaration(it) => it.span(),
-            Self::ExportAllDeclaration(it) => it.span(),
-            Self::ExportDefaultDeclaration(it) => it.span(),
-            Self::ExportNamedDeclaration(it) => it.span(),
-            Self::TSExportAssignment(it) => it.span(),
-            Self::TSNamespaceExportDeclaration(it) => it.span(),
+            Self::BlockStatement(it) => GetSpan::span(it.as_ref()),
+            Self::BreakStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ContinueStatement(it) => GetSpan::span(it.as_ref()),
+            Self::DebuggerStatement(it) => GetSpan::span(it.as_ref()),
+            Self::DoWhileStatement(it) => GetSpan::span(it.as_ref()),
+            Self::EmptyStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ExpressionStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ForInStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ForOfStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ForStatement(it) => GetSpan::span(it.as_ref()),
+            Self::IfStatement(it) => GetSpan::span(it.as_ref()),
+            Self::LabeledStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ReturnStatement(it) => GetSpan::span(it.as_ref()),
+            Self::SwitchStatement(it) => GetSpan::span(it.as_ref()),
+            Self::ThrowStatement(it) => GetSpan::span(it.as_ref()),
+            Self::TryStatement(it) => GetSpan::span(it.as_ref()),
+            Self::WhileStatement(it) => GetSpan::span(it.as_ref()),
+            Self::WithStatement(it) => GetSpan::span(it.as_ref()),
+            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAliasDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSEnumDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSImportEqualsDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ImportDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportAllDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportDefaultDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportNamedDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSExportAssignment(it) => GetSpan::span(it.as_ref()),
+            Self::TSNamespaceExportDeclaration(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -690,14 +690,14 @@ impl<'a> GetSpan for BlockStatement<'a> {
 impl<'a> GetSpan for Declaration<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => it.span(),
-            Self::FunctionDeclaration(it) => it.span(),
-            Self::ClassDeclaration(it) => it.span(),
-            Self::TSTypeAliasDeclaration(it) => it.span(),
-            Self::TSInterfaceDeclaration(it) => it.span(),
-            Self::TSEnumDeclaration(it) => it.span(),
-            Self::TSModuleDeclaration(it) => it.span(),
-            Self::TSImportEqualsDeclaration(it) => it.span(),
+            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAliasDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSEnumDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSImportEqualsDeclaration(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -761,49 +761,49 @@ impl<'a> GetSpan for ForStatement<'a> {
 impl<'a> GetSpan for ForStatementInit<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -818,18 +818,18 @@ impl<'a> GetSpan for ForInStatement<'a> {
 impl<'a> GetSpan for ForStatementLeft<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => it.span(),
-            Self::AssignmentTargetIdentifier(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
-            Self::ArrayAssignmentTarget(it) => it.span(),
-            Self::ObjectAssignmentTarget(it) => it.span(),
+            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -928,17 +928,17 @@ impl GetSpan for DebuggerStatement {
 impl<'a> GetSpan for BindingPattern<'a> {
     #[inline]
     fn span(&self) -> Span {
-        self.kind.span()
+        GetSpan::span(&self.kind)
     }
 }
 
 impl<'a> GetSpan for BindingPatternKind<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::BindingIdentifier(it) => it.span(),
-            Self::ObjectPattern(it) => it.span(),
-            Self::ArrayPattern(it) => it.span(),
-            Self::AssignmentPattern(it) => it.span(),
+            Self::BindingIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectPattern(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayPattern(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentPattern(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1037,11 +1037,11 @@ impl<'a> GetSpan for ClassBody<'a> {
 impl<'a> GetSpan for ClassElement<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticBlock(it) => it.span(),
-            Self::MethodDefinition(it) => it.span(),
-            Self::PropertyDefinition(it) => it.span(),
-            Self::AccessorProperty(it) => it.span(),
-            Self::TSIndexSignature(it) => it.span(),
+            Self::StaticBlock(it) => GetSpan::span(it.as_ref()),
+            Self::MethodDefinition(it) => GetSpan::span(it.as_ref()),
+            Self::PropertyDefinition(it) => GetSpan::span(it.as_ref()),
+            Self::AccessorProperty(it) => GetSpan::span(it.as_ref()),
+            Self::TSIndexSignature(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1077,12 +1077,12 @@ impl<'a> GetSpan for StaticBlock<'a> {
 impl<'a> GetSpan for ModuleDeclaration<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ImportDeclaration(it) => it.span(),
-            Self::ExportAllDeclaration(it) => it.span(),
-            Self::ExportDefaultDeclaration(it) => it.span(),
-            Self::ExportNamedDeclaration(it) => it.span(),
-            Self::TSExportAssignment(it) => it.span(),
-            Self::TSNamespaceExportDeclaration(it) => it.span(),
+            Self::ImportDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportAllDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportDefaultDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ExportNamedDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSExportAssignment(it) => GetSpan::span(it.as_ref()),
+            Self::TSNamespaceExportDeclaration(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1111,9 +1111,9 @@ impl<'a> GetSpan for ImportDeclaration<'a> {
 impl<'a> GetSpan for ImportDeclarationSpecifier<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ImportSpecifier(it) => it.span(),
-            Self::ImportDefaultSpecifier(it) => it.span(),
-            Self::ImportNamespaceSpecifier(it) => it.span(),
+            Self::ImportSpecifier(it) => GetSpan::span(it.as_ref()),
+            Self::ImportDefaultSpecifier(it) => GetSpan::span(it.as_ref()),
+            Self::ImportNamespaceSpecifier(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1156,8 +1156,8 @@ impl<'a> GetSpan for ImportAttribute<'a> {
 impl<'a> GetSpan for ImportAttributeKey<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it),
+            Self::StringLiteral(it) => GetSpan::span(it),
         }
     }
 }
@@ -1193,51 +1193,51 @@ impl<'a> GetSpan for ExportSpecifier<'a> {
 impl<'a> GetSpan for ExportDefaultDeclarationKind<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::FunctionDeclaration(it) => it.span(),
-            Self::ClassDeclaration(it) => it.span(),
-            Self::TSInterfaceDeclaration(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1245,9 +1245,9 @@ impl<'a> GetSpan for ExportDefaultDeclarationKind<'a> {
 impl<'a> GetSpan for ModuleExportName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierName(it) => it.span(),
-            Self::IdentifierReference(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
+            Self::IdentifierName(it) => GetSpan::span(it),
+            Self::IdentifierReference(it) => GetSpan::span(it),
+            Self::StringLiteral(it) => GetSpan::span(it),
         }
     }
 }
@@ -1276,52 +1276,52 @@ impl<'a> GetSpan for TSEnumMember<'a> {
 impl<'a> GetSpan for TSEnumMemberName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticIdentifier(it) => it.span(),
-            Self::StaticStringLiteral(it) => it.span(),
-            Self::StaticTemplateLiteral(it) => it.span(),
-            Self::StaticNumericLiteral(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::StaticIdentifier(it) => GetSpan::span(it.as_ref()),
+            Self::StaticStringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StaticTemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StaticNumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1343,14 +1343,14 @@ impl<'a> GetSpan for TSLiteralType<'a> {
 impl<'a> GetSpan for TSLiteral<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1358,44 +1358,44 @@ impl<'a> GetSpan for TSLiteral<'a> {
 impl<'a> GetSpan for TSType<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::TSAnyKeyword(it) => it.span(),
-            Self::TSBigIntKeyword(it) => it.span(),
-            Self::TSBooleanKeyword(it) => it.span(),
-            Self::TSIntrinsicKeyword(it) => it.span(),
-            Self::TSNeverKeyword(it) => it.span(),
-            Self::TSNullKeyword(it) => it.span(),
-            Self::TSNumberKeyword(it) => it.span(),
-            Self::TSObjectKeyword(it) => it.span(),
-            Self::TSStringKeyword(it) => it.span(),
-            Self::TSSymbolKeyword(it) => it.span(),
-            Self::TSUndefinedKeyword(it) => it.span(),
-            Self::TSUnknownKeyword(it) => it.span(),
-            Self::TSVoidKeyword(it) => it.span(),
-            Self::TSArrayType(it) => it.span(),
-            Self::TSConditionalType(it) => it.span(),
-            Self::TSConstructorType(it) => it.span(),
-            Self::TSFunctionType(it) => it.span(),
-            Self::TSImportType(it) => it.span(),
-            Self::TSIndexedAccessType(it) => it.span(),
-            Self::TSInferType(it) => it.span(),
-            Self::TSIntersectionType(it) => it.span(),
-            Self::TSLiteralType(it) => it.span(),
-            Self::TSMappedType(it) => it.span(),
-            Self::TSNamedTupleMember(it) => it.span(),
-            Self::TSQualifiedName(it) => it.span(),
-            Self::TSTemplateLiteralType(it) => it.span(),
-            Self::TSThisType(it) => it.span(),
-            Self::TSTupleType(it) => it.span(),
-            Self::TSTypeLiteral(it) => it.span(),
-            Self::TSTypeOperatorType(it) => it.span(),
-            Self::TSTypePredicate(it) => it.span(),
-            Self::TSTypeQuery(it) => it.span(),
-            Self::TSTypeReference(it) => it.span(),
-            Self::TSUnionType(it) => it.span(),
-            Self::TSParenthesizedType(it) => it.span(),
-            Self::JSDocNullableType(it) => it.span(),
-            Self::JSDocNonNullableType(it) => it.span(),
-            Self::JSDocUnknownType(it) => it.span(),
+            Self::TSAnyKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSBigIntKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSBooleanKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSIntrinsicKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNeverKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNullKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNumberKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSObjectKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSStringKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSSymbolKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSUndefinedKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSUnknownKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSVoidKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSArrayType(it) => GetSpan::span(it.as_ref()),
+            Self::TSConditionalType(it) => GetSpan::span(it.as_ref()),
+            Self::TSConstructorType(it) => GetSpan::span(it.as_ref()),
+            Self::TSFunctionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
+            Self::TSIndexedAccessType(it) => GetSpan::span(it.as_ref()),
+            Self::TSInferType(it) => GetSpan::span(it.as_ref()),
+            Self::TSIntersectionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSLiteralType(it) => GetSpan::span(it.as_ref()),
+            Self::TSMappedType(it) => GetSpan::span(it.as_ref()),
+            Self::TSNamedTupleMember(it) => GetSpan::span(it.as_ref()),
+            Self::TSQualifiedName(it) => GetSpan::span(it.as_ref()),
+            Self::TSTemplateLiteralType(it) => GetSpan::span(it.as_ref()),
+            Self::TSThisType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTupleType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeOperatorType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypePredicate(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeQuery(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeReference(it) => GetSpan::span(it.as_ref()),
+            Self::TSUnionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSParenthesizedType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocNullableType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocNonNullableType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocUnknownType(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1480,46 +1480,46 @@ impl<'a> GetSpan for TSRestType<'a> {
 impl<'a> GetSpan for TSTupleElement<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::TSOptionalType(it) => it.span(),
-            Self::TSRestType(it) => it.span(),
-            Self::TSAnyKeyword(it) => it.span(),
-            Self::TSBigIntKeyword(it) => it.span(),
-            Self::TSBooleanKeyword(it) => it.span(),
-            Self::TSIntrinsicKeyword(it) => it.span(),
-            Self::TSNeverKeyword(it) => it.span(),
-            Self::TSNullKeyword(it) => it.span(),
-            Self::TSNumberKeyword(it) => it.span(),
-            Self::TSObjectKeyword(it) => it.span(),
-            Self::TSStringKeyword(it) => it.span(),
-            Self::TSSymbolKeyword(it) => it.span(),
-            Self::TSUndefinedKeyword(it) => it.span(),
-            Self::TSUnknownKeyword(it) => it.span(),
-            Self::TSVoidKeyword(it) => it.span(),
-            Self::TSArrayType(it) => it.span(),
-            Self::TSConditionalType(it) => it.span(),
-            Self::TSConstructorType(it) => it.span(),
-            Self::TSFunctionType(it) => it.span(),
-            Self::TSImportType(it) => it.span(),
-            Self::TSIndexedAccessType(it) => it.span(),
-            Self::TSInferType(it) => it.span(),
-            Self::TSIntersectionType(it) => it.span(),
-            Self::TSLiteralType(it) => it.span(),
-            Self::TSMappedType(it) => it.span(),
-            Self::TSNamedTupleMember(it) => it.span(),
-            Self::TSQualifiedName(it) => it.span(),
-            Self::TSTemplateLiteralType(it) => it.span(),
-            Self::TSThisType(it) => it.span(),
-            Self::TSTupleType(it) => it.span(),
-            Self::TSTypeLiteral(it) => it.span(),
-            Self::TSTypeOperatorType(it) => it.span(),
-            Self::TSTypePredicate(it) => it.span(),
-            Self::TSTypeQuery(it) => it.span(),
-            Self::TSTypeReference(it) => it.span(),
-            Self::TSUnionType(it) => it.span(),
-            Self::TSParenthesizedType(it) => it.span(),
-            Self::JSDocNullableType(it) => it.span(),
-            Self::JSDocNonNullableType(it) => it.span(),
-            Self::JSDocUnknownType(it) => it.span(),
+            Self::TSOptionalType(it) => GetSpan::span(it.as_ref()),
+            Self::TSRestType(it) => GetSpan::span(it.as_ref()),
+            Self::TSAnyKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSBigIntKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSBooleanKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSIntrinsicKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNeverKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNullKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSNumberKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSObjectKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSStringKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSSymbolKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSUndefinedKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSUnknownKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSVoidKeyword(it) => GetSpan::span(it.as_ref()),
+            Self::TSArrayType(it) => GetSpan::span(it.as_ref()),
+            Self::TSConditionalType(it) => GetSpan::span(it.as_ref()),
+            Self::TSConstructorType(it) => GetSpan::span(it.as_ref()),
+            Self::TSFunctionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
+            Self::TSIndexedAccessType(it) => GetSpan::span(it.as_ref()),
+            Self::TSInferType(it) => GetSpan::span(it.as_ref()),
+            Self::TSIntersectionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSLiteralType(it) => GetSpan::span(it.as_ref()),
+            Self::TSMappedType(it) => GetSpan::span(it.as_ref()),
+            Self::TSNamedTupleMember(it) => GetSpan::span(it.as_ref()),
+            Self::TSQualifiedName(it) => GetSpan::span(it.as_ref()),
+            Self::TSTemplateLiteralType(it) => GetSpan::span(it.as_ref()),
+            Self::TSThisType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTupleType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeOperatorType(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypePredicate(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeQuery(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeReference(it) => GetSpan::span(it.as_ref()),
+            Self::TSUnionType(it) => GetSpan::span(it.as_ref()),
+            Self::TSParenthesizedType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocNullableType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocNonNullableType(it) => GetSpan::span(it.as_ref()),
+            Self::JSDocUnknownType(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1632,8 +1632,8 @@ impl<'a> GetSpan for TSTypeReference<'a> {
 impl<'a> GetSpan for TSTypeName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierReference(it) => it.span(),
-            Self::QualifiedName(it) => it.span(),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1704,11 +1704,11 @@ impl<'a> GetSpan for TSPropertySignature<'a> {
 impl<'a> GetSpan for TSSignature<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::TSIndexSignature(it) => it.span(),
-            Self::TSPropertySignature(it) => it.span(),
-            Self::TSCallSignatureDeclaration(it) => it.span(),
-            Self::TSConstructSignatureDeclaration(it) => it.span(),
-            Self::TSMethodSignature(it) => it.span(),
+            Self::TSIndexSignature(it) => GetSpan::span(it.as_ref()),
+            Self::TSPropertySignature(it) => GetSpan::span(it.as_ref()),
+            Self::TSCallSignatureDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSConstructSignatureDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSMethodSignature(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1765,8 +1765,8 @@ impl<'a> GetSpan for TSTypePredicate<'a> {
 impl<'a> GetSpan for TSTypePredicateName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::This(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::This(it) => GetSpan::span(it),
         }
     }
 }
@@ -1781,8 +1781,8 @@ impl<'a> GetSpan for TSModuleDeclaration<'a> {
 impl<'a> GetSpan for TSModuleDeclarationName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it),
+            Self::StringLiteral(it) => GetSpan::span(it),
         }
     }
 }
@@ -1790,8 +1790,8 @@ impl<'a> GetSpan for TSModuleDeclarationName<'a> {
 impl<'a> GetSpan for TSModuleDeclarationBody<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::TSModuleDeclaration(it) => it.span(),
-            Self::TSModuleBlock(it) => it.span(),
+            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::TSModuleBlock(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1827,9 +1827,9 @@ impl<'a> GetSpan for TSTypeQuery<'a> {
 impl<'a> GetSpan for TSTypeQueryExprName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::TSImportType(it) => it.span(),
-            Self::IdentifierReference(it) => it.span(),
-            Self::QualifiedName(it) => it.span(),
+            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -1858,8 +1858,8 @@ impl<'a> GetSpan for TSImportAttribute<'a> {
 impl<'a> GetSpan for TSImportAttributeName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it),
+            Self::StringLiteral(it) => GetSpan::span(it),
         }
     }
 }
@@ -1923,9 +1923,9 @@ impl<'a> GetSpan for TSImportEqualsDeclaration<'a> {
 impl<'a> GetSpan for TSModuleReference<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::ExternalModuleReference(it) => it.span(),
-            Self::IdentifierReference(it) => it.span(),
-            Self::QualifiedName(it) => it.span(),
+            Self::ExternalModuleReference(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2038,11 +2038,11 @@ impl GetSpan for JSXClosingFragment {
 impl<'a> GetSpan for JSXElementName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::IdentifierReference(it) => it.span(),
-            Self::NamespacedName(it) => it.span(),
-            Self::MemberExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
+            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2064,9 +2064,9 @@ impl<'a> GetSpan for JSXMemberExpression<'a> {
 impl<'a> GetSpan for JSXMemberExpressionObject<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierReference(it) => it.span(),
-            Self::MemberExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2081,49 +2081,49 @@ impl<'a> GetSpan for JSXExpressionContainer<'a> {
 impl<'a> GetSpan for JSXExpression<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::EmptyExpression(it) => it.span(),
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::TemplateLiteral(it) => it.span(),
-            Self::Identifier(it) => it.span(),
-            Self::MetaProperty(it) => it.span(),
-            Self::Super(it) => it.span(),
-            Self::ArrayExpression(it) => it.span(),
-            Self::ArrowFunctionExpression(it) => it.span(),
-            Self::AssignmentExpression(it) => it.span(),
-            Self::AwaitExpression(it) => it.span(),
-            Self::BinaryExpression(it) => it.span(),
-            Self::CallExpression(it) => it.span(),
-            Self::ChainExpression(it) => it.span(),
-            Self::ClassExpression(it) => it.span(),
-            Self::ConditionalExpression(it) => it.span(),
-            Self::FunctionExpression(it) => it.span(),
-            Self::ImportExpression(it) => it.span(),
-            Self::LogicalExpression(it) => it.span(),
-            Self::NewExpression(it) => it.span(),
-            Self::ObjectExpression(it) => it.span(),
-            Self::ParenthesizedExpression(it) => it.span(),
-            Self::SequenceExpression(it) => it.span(),
-            Self::TaggedTemplateExpression(it) => it.span(),
-            Self::ThisExpression(it) => it.span(),
-            Self::UnaryExpression(it) => it.span(),
-            Self::UpdateExpression(it) => it.span(),
-            Self::YieldExpression(it) => it.span(),
-            Self::PrivateInExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::TSAsExpression(it) => it.span(),
-            Self::TSSatisfiesExpression(it) => it.span(),
-            Self::TSTypeAssertion(it) => it.span(),
-            Self::TSNonNullExpression(it) => it.span(),
-            Self::TSInstantiationExpression(it) => it.span(),
-            Self::ComputedMemberExpression(it) => it.span(),
-            Self::StaticMemberExpression(it) => it.span(),
-            Self::PrivateFieldExpression(it) => it.span(),
+            Self::EmptyExpression(it) => GetSpan::span(it),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2138,8 +2138,8 @@ impl GetSpan for JSXEmptyExpression {
 impl<'a> GetSpan for JSXAttributeItem<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Attribute(it) => it.span(),
-            Self::SpreadAttribute(it) => it.span(),
+            Self::Attribute(it) => GetSpan::span(it.as_ref()),
+            Self::SpreadAttribute(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2161,8 +2161,8 @@ impl<'a> GetSpan for JSXSpreadAttribute<'a> {
 impl<'a> GetSpan for JSXAttributeName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
-            Self::NamespacedName(it) => it.span(),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2170,10 +2170,10 @@ impl<'a> GetSpan for JSXAttributeName<'a> {
 impl<'a> GetSpan for JSXAttributeValue<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::StringLiteral(it) => it.span(),
-            Self::ExpressionContainer(it) => it.span(),
-            Self::Element(it) => it.span(),
-            Self::Fragment(it) => it.span(),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
+            Self::Element(it) => GetSpan::span(it.as_ref()),
+            Self::Fragment(it) => GetSpan::span(it.as_ref()),
         }
     }
 }
@@ -2188,11 +2188,11 @@ impl<'a> GetSpan for JSXIdentifier<'a> {
 impl<'a> GetSpan for JSXChild<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Text(it) => it.span(),
-            Self::Element(it) => it.span(),
-            Self::Fragment(it) => it.span(),
-            Self::ExpressionContainer(it) => it.span(),
-            Self::Spread(it) => it.span(),
+            Self::Text(it) => GetSpan::span(it.as_ref()),
+            Self::Element(it) => GetSpan::span(it.as_ref()),
+            Self::Fragment(it) => GetSpan::span(it.as_ref()),
+            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
+            Self::Spread(it) => GetSpan::span(it.as_ref()),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -69,48 +69,48 @@ impl<'a> GetSpanMut for Program<'a> {
 impl<'a> GetSpanMut for Expression<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -160,50 +160,50 @@ impl<'a> GetSpanMut for ArrayExpression<'a> {
 impl<'a> GetSpanMut for ArrayExpressionElement<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::SpreadElement(it) => it.span_mut(),
-            Self::Elision(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::SpreadElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Elision(it) => GetSpanMut::span_mut(it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -225,8 +225,8 @@ impl<'a> GetSpanMut for ObjectExpression<'a> {
 impl<'a> GetSpanMut for ObjectPropertyKind<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ObjectProperty(it) => it.span_mut(),
-            Self::SpreadProperty(it) => it.span_mut(),
+            Self::ObjectProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SpreadProperty(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -241,50 +241,50 @@ impl<'a> GetSpanMut for ObjectProperty<'a> {
 impl<'a> GetSpanMut for PropertyKey<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticIdentifier(it) => it.span_mut(),
-            Self::PrivateIdentifier(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::StaticIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -313,9 +313,9 @@ impl<'a> GetSpanMut for TemplateElement<'a> {
 impl<'a> GetSpanMut for MemberExpression<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -372,49 +372,49 @@ impl<'a> GetSpanMut for SpreadElement<'a> {
 impl<'a> GetSpanMut for Argument<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::SpreadElement(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::SpreadElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -471,17 +471,17 @@ impl<'a> GetSpanMut for AssignmentExpression<'a> {
 impl<'a> GetSpanMut for AssignmentTarget<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
-            Self::ArrayAssignmentTarget(it) => it.span_mut(),
-            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -489,15 +489,15 @@ impl<'a> GetSpanMut for AssignmentTarget<'a> {
 impl<'a> GetSpanMut for SimpleAssignmentTarget<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -505,8 +505,8 @@ impl<'a> GetSpanMut for SimpleAssignmentTarget<'a> {
 impl<'a> GetSpanMut for AssignmentTargetPattern<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ArrayAssignmentTarget(it) => it.span_mut(),
-            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -535,18 +535,18 @@ impl<'a> GetSpanMut for AssignmentTargetRest<'a> {
 impl<'a> GetSpanMut for AssignmentTargetMaybeDefault<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetWithDefault(it) => it.span_mut(),
-            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
-            Self::ArrayAssignmentTarget(it) => it.span_mut(),
-            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+            Self::AssignmentTargetWithDefault(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -561,8 +561,8 @@ impl<'a> GetSpanMut for AssignmentTargetWithDefault<'a> {
 impl<'a> GetSpanMut for AssignmentTargetProperty<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => it.span_mut(),
-            Self::AssignmentTargetPropertyProperty(it) => it.span_mut(),
+            Self::AssignmentTargetPropertyIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetPropertyProperty(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -612,10 +612,10 @@ impl<'a> GetSpanMut for ChainExpression<'a> {
 impl<'a> GetSpanMut for ChainElement<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -630,38 +630,38 @@ impl<'a> GetSpanMut for ParenthesizedExpression<'a> {
 impl<'a> GetSpanMut for Statement<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BlockStatement(it) => it.span_mut(),
-            Self::BreakStatement(it) => it.span_mut(),
-            Self::ContinueStatement(it) => it.span_mut(),
-            Self::DebuggerStatement(it) => it.span_mut(),
-            Self::DoWhileStatement(it) => it.span_mut(),
-            Self::EmptyStatement(it) => it.span_mut(),
-            Self::ExpressionStatement(it) => it.span_mut(),
-            Self::ForInStatement(it) => it.span_mut(),
-            Self::ForOfStatement(it) => it.span_mut(),
-            Self::ForStatement(it) => it.span_mut(),
-            Self::IfStatement(it) => it.span_mut(),
-            Self::LabeledStatement(it) => it.span_mut(),
-            Self::ReturnStatement(it) => it.span_mut(),
-            Self::SwitchStatement(it) => it.span_mut(),
-            Self::ThrowStatement(it) => it.span_mut(),
-            Self::TryStatement(it) => it.span_mut(),
-            Self::WhileStatement(it) => it.span_mut(),
-            Self::WithStatement(it) => it.span_mut(),
-            Self::VariableDeclaration(it) => it.span_mut(),
-            Self::FunctionDeclaration(it) => it.span_mut(),
-            Self::ClassDeclaration(it) => it.span_mut(),
-            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
-            Self::TSInterfaceDeclaration(it) => it.span_mut(),
-            Self::TSEnumDeclaration(it) => it.span_mut(),
-            Self::TSModuleDeclaration(it) => it.span_mut(),
-            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
-            Self::ImportDeclaration(it) => it.span_mut(),
-            Self::ExportAllDeclaration(it) => it.span_mut(),
-            Self::ExportDefaultDeclaration(it) => it.span_mut(),
-            Self::ExportNamedDeclaration(it) => it.span_mut(),
-            Self::TSExportAssignment(it) => it.span_mut(),
-            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
+            Self::BlockStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BreakStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ContinueStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::DebuggerStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::DoWhileStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::EmptyStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExpressionStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ForInStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ForOfStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ForStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IfStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LabeledStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ReturnStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SwitchStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThrowStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TryStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::WhileStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::WithStatement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAliasDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSEnumDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSImportEqualsDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportAllDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportDefaultDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportNamedDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSExportAssignment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNamespaceExportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -690,14 +690,14 @@ impl<'a> GetSpanMut for BlockStatement<'a> {
 impl<'a> GetSpanMut for Declaration<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => it.span_mut(),
-            Self::FunctionDeclaration(it) => it.span_mut(),
-            Self::ClassDeclaration(it) => it.span_mut(),
-            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
-            Self::TSInterfaceDeclaration(it) => it.span_mut(),
-            Self::TSEnumDeclaration(it) => it.span_mut(),
-            Self::TSModuleDeclaration(it) => it.span_mut(),
-            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
+            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAliasDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSEnumDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSImportEqualsDeclaration(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -761,49 +761,49 @@ impl<'a> GetSpanMut for ForStatement<'a> {
 impl<'a> GetSpanMut for ForStatementInit<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -818,18 +818,18 @@ impl<'a> GetSpanMut for ForInStatement<'a> {
 impl<'a> GetSpanMut for ForStatementLeft<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => it.span_mut(),
-            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
-            Self::ArrayAssignmentTarget(it) => it.span_mut(),
-            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -928,17 +928,17 @@ impl GetSpanMut for DebuggerStatement {
 impl<'a> GetSpanMut for BindingPattern<'a> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
-        self.kind.span_mut()
+        GetSpanMut::span_mut(&mut self.kind)
     }
 }
 
 impl<'a> GetSpanMut for BindingPatternKind<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BindingIdentifier(it) => it.span_mut(),
-            Self::ObjectPattern(it) => it.span_mut(),
-            Self::ArrayPattern(it) => it.span_mut(),
-            Self::AssignmentPattern(it) => it.span_mut(),
+            Self::BindingIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectPattern(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayPattern(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentPattern(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1037,11 +1037,11 @@ impl<'a> GetSpanMut for ClassBody<'a> {
 impl<'a> GetSpanMut for ClassElement<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticBlock(it) => it.span_mut(),
-            Self::MethodDefinition(it) => it.span_mut(),
-            Self::PropertyDefinition(it) => it.span_mut(),
-            Self::AccessorProperty(it) => it.span_mut(),
-            Self::TSIndexSignature(it) => it.span_mut(),
+            Self::StaticBlock(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MethodDefinition(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PropertyDefinition(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AccessorProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIndexSignature(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1077,12 +1077,12 @@ impl<'a> GetSpanMut for StaticBlock<'a> {
 impl<'a> GetSpanMut for ModuleDeclaration<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ImportDeclaration(it) => it.span_mut(),
-            Self::ExportAllDeclaration(it) => it.span_mut(),
-            Self::ExportDefaultDeclaration(it) => it.span_mut(),
-            Self::ExportNamedDeclaration(it) => it.span_mut(),
-            Self::TSExportAssignment(it) => it.span_mut(),
-            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
+            Self::ImportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportAllDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportDefaultDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExportNamedDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSExportAssignment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNamespaceExportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1111,9 +1111,9 @@ impl<'a> GetSpanMut for ImportDeclaration<'a> {
 impl<'a> GetSpanMut for ImportDeclarationSpecifier<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ImportSpecifier(it) => it.span_mut(),
-            Self::ImportDefaultSpecifier(it) => it.span_mut(),
-            Self::ImportNamespaceSpecifier(it) => it.span_mut(),
+            Self::ImportSpecifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportDefaultSpecifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportNamespaceSpecifier(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1156,8 +1156,8 @@ impl<'a> GetSpanMut for ImportAttribute<'a> {
 impl<'a> GetSpanMut for ImportAttributeKey<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
         }
     }
 }
@@ -1193,51 +1193,51 @@ impl<'a> GetSpanMut for ExportSpecifier<'a> {
 impl<'a> GetSpanMut for ExportDefaultDeclarationKind<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::FunctionDeclaration(it) => it.span_mut(),
-            Self::ClassDeclaration(it) => it.span_mut(),
-            Self::TSInterfaceDeclaration(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1245,9 +1245,9 @@ impl<'a> GetSpanMut for ExportDefaultDeclarationKind<'a> {
 impl<'a> GetSpanMut for ModuleExportName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierName(it) => it.span_mut(),
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
+            Self::IdentifierName(it) => GetSpanMut::span_mut(it),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
         }
     }
 }
@@ -1276,52 +1276,52 @@ impl<'a> GetSpanMut for TSEnumMember<'a> {
 impl<'a> GetSpanMut for TSEnumMemberName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticIdentifier(it) => it.span_mut(),
-            Self::StaticStringLiteral(it) => it.span_mut(),
-            Self::StaticTemplateLiteral(it) => it.span_mut(),
-            Self::StaticNumericLiteral(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::StaticIdentifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticStringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticTemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticNumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1343,14 +1343,14 @@ impl<'a> GetSpanMut for TSLiteralType<'a> {
 impl<'a> GetSpanMut for TSLiteral<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1358,44 +1358,44 @@ impl<'a> GetSpanMut for TSLiteral<'a> {
 impl<'a> GetSpanMut for TSType<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSAnyKeyword(it) => it.span_mut(),
-            Self::TSBigIntKeyword(it) => it.span_mut(),
-            Self::TSBooleanKeyword(it) => it.span_mut(),
-            Self::TSIntrinsicKeyword(it) => it.span_mut(),
-            Self::TSNeverKeyword(it) => it.span_mut(),
-            Self::TSNullKeyword(it) => it.span_mut(),
-            Self::TSNumberKeyword(it) => it.span_mut(),
-            Self::TSObjectKeyword(it) => it.span_mut(),
-            Self::TSStringKeyword(it) => it.span_mut(),
-            Self::TSSymbolKeyword(it) => it.span_mut(),
-            Self::TSUndefinedKeyword(it) => it.span_mut(),
-            Self::TSUnknownKeyword(it) => it.span_mut(),
-            Self::TSVoidKeyword(it) => it.span_mut(),
-            Self::TSArrayType(it) => it.span_mut(),
-            Self::TSConditionalType(it) => it.span_mut(),
-            Self::TSConstructorType(it) => it.span_mut(),
-            Self::TSFunctionType(it) => it.span_mut(),
-            Self::TSImportType(it) => it.span_mut(),
-            Self::TSIndexedAccessType(it) => it.span_mut(),
-            Self::TSInferType(it) => it.span_mut(),
-            Self::TSIntersectionType(it) => it.span_mut(),
-            Self::TSLiteralType(it) => it.span_mut(),
-            Self::TSMappedType(it) => it.span_mut(),
-            Self::TSNamedTupleMember(it) => it.span_mut(),
-            Self::TSQualifiedName(it) => it.span_mut(),
-            Self::TSTemplateLiteralType(it) => it.span_mut(),
-            Self::TSThisType(it) => it.span_mut(),
-            Self::TSTupleType(it) => it.span_mut(),
-            Self::TSTypeLiteral(it) => it.span_mut(),
-            Self::TSTypeOperatorType(it) => it.span_mut(),
-            Self::TSTypePredicate(it) => it.span_mut(),
-            Self::TSTypeQuery(it) => it.span_mut(),
-            Self::TSTypeReference(it) => it.span_mut(),
-            Self::TSUnionType(it) => it.span_mut(),
-            Self::TSParenthesizedType(it) => it.span_mut(),
-            Self::JSDocNullableType(it) => it.span_mut(),
-            Self::JSDocNonNullableType(it) => it.span_mut(),
-            Self::JSDocUnknownType(it) => it.span_mut(),
+            Self::TSAnyKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSBigIntKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSBooleanKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIntrinsicKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNeverKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNullKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNumberKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSObjectKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSStringKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSymbolKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUndefinedKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUnknownKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSVoidKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSArrayType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSConditionalType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSConstructorType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSFunctionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIndexedAccessType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInferType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIntersectionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSLiteralType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSMappedType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNamedTupleMember(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSQualifiedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTemplateLiteralType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSThisType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTupleType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeOperatorType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypePredicate(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeQuery(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUnionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSParenthesizedType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocNullableType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocNonNullableType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocUnknownType(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1480,46 +1480,46 @@ impl<'a> GetSpanMut for TSRestType<'a> {
 impl<'a> GetSpanMut for TSTupleElement<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSOptionalType(it) => it.span_mut(),
-            Self::TSRestType(it) => it.span_mut(),
-            Self::TSAnyKeyword(it) => it.span_mut(),
-            Self::TSBigIntKeyword(it) => it.span_mut(),
-            Self::TSBooleanKeyword(it) => it.span_mut(),
-            Self::TSIntrinsicKeyword(it) => it.span_mut(),
-            Self::TSNeverKeyword(it) => it.span_mut(),
-            Self::TSNullKeyword(it) => it.span_mut(),
-            Self::TSNumberKeyword(it) => it.span_mut(),
-            Self::TSObjectKeyword(it) => it.span_mut(),
-            Self::TSStringKeyword(it) => it.span_mut(),
-            Self::TSSymbolKeyword(it) => it.span_mut(),
-            Self::TSUndefinedKeyword(it) => it.span_mut(),
-            Self::TSUnknownKeyword(it) => it.span_mut(),
-            Self::TSVoidKeyword(it) => it.span_mut(),
-            Self::TSArrayType(it) => it.span_mut(),
-            Self::TSConditionalType(it) => it.span_mut(),
-            Self::TSConstructorType(it) => it.span_mut(),
-            Self::TSFunctionType(it) => it.span_mut(),
-            Self::TSImportType(it) => it.span_mut(),
-            Self::TSIndexedAccessType(it) => it.span_mut(),
-            Self::TSInferType(it) => it.span_mut(),
-            Self::TSIntersectionType(it) => it.span_mut(),
-            Self::TSLiteralType(it) => it.span_mut(),
-            Self::TSMappedType(it) => it.span_mut(),
-            Self::TSNamedTupleMember(it) => it.span_mut(),
-            Self::TSQualifiedName(it) => it.span_mut(),
-            Self::TSTemplateLiteralType(it) => it.span_mut(),
-            Self::TSThisType(it) => it.span_mut(),
-            Self::TSTupleType(it) => it.span_mut(),
-            Self::TSTypeLiteral(it) => it.span_mut(),
-            Self::TSTypeOperatorType(it) => it.span_mut(),
-            Self::TSTypePredicate(it) => it.span_mut(),
-            Self::TSTypeQuery(it) => it.span_mut(),
-            Self::TSTypeReference(it) => it.span_mut(),
-            Self::TSUnionType(it) => it.span_mut(),
-            Self::TSParenthesizedType(it) => it.span_mut(),
-            Self::JSDocNullableType(it) => it.span_mut(),
-            Self::JSDocNonNullableType(it) => it.span_mut(),
-            Self::JSDocUnknownType(it) => it.span_mut(),
+            Self::TSOptionalType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSRestType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAnyKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSBigIntKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSBooleanKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIntrinsicKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNeverKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNullKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNumberKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSObjectKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSStringKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSymbolKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUndefinedKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUnknownKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSVoidKeyword(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSArrayType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSConditionalType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSConstructorType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSFunctionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIndexedAccessType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInferType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIntersectionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSLiteralType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSMappedType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNamedTupleMember(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSQualifiedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTemplateLiteralType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSThisType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTupleType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeOperatorType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypePredicate(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeQuery(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSUnionType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSParenthesizedType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocNullableType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocNonNullableType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSDocUnknownType(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1632,8 +1632,8 @@ impl<'a> GetSpanMut for TSTypeReference<'a> {
 impl<'a> GetSpanMut for TSTypeName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::QualifiedName(it) => it.span_mut(),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1704,11 +1704,11 @@ impl<'a> GetSpanMut for TSPropertySignature<'a> {
 impl<'a> GetSpanMut for TSSignature<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSIndexSignature(it) => it.span_mut(),
-            Self::TSPropertySignature(it) => it.span_mut(),
-            Self::TSCallSignatureDeclaration(it) => it.span_mut(),
-            Self::TSConstructSignatureDeclaration(it) => it.span_mut(),
-            Self::TSMethodSignature(it) => it.span_mut(),
+            Self::TSIndexSignature(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSPropertySignature(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSCallSignatureDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSConstructSignatureDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSMethodSignature(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1765,8 +1765,8 @@ impl<'a> GetSpanMut for TSTypePredicate<'a> {
 impl<'a> GetSpanMut for TSTypePredicateName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::This(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::This(it) => GetSpanMut::span_mut(it),
         }
     }
 }
@@ -1781,8 +1781,8 @@ impl<'a> GetSpanMut for TSModuleDeclaration<'a> {
 impl<'a> GetSpanMut for TSModuleDeclarationName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
         }
     }
 }
@@ -1790,8 +1790,8 @@ impl<'a> GetSpanMut for TSModuleDeclarationName<'a> {
 impl<'a> GetSpanMut for TSModuleDeclarationBody<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSModuleDeclaration(it) => it.span_mut(),
-            Self::TSModuleBlock(it) => it.span_mut(),
+            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSModuleBlock(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1827,9 +1827,9 @@ impl<'a> GetSpanMut for TSTypeQuery<'a> {
 impl<'a> GetSpanMut for TSTypeQueryExprName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSImportType(it) => it.span_mut(),
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::QualifiedName(it) => it.span_mut(),
+            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -1858,8 +1858,8 @@ impl<'a> GetSpanMut for TSImportAttribute<'a> {
 impl<'a> GetSpanMut for TSImportAttributeName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
         }
     }
 }
@@ -1923,9 +1923,9 @@ impl<'a> GetSpanMut for TSImportEqualsDeclaration<'a> {
 impl<'a> GetSpanMut for TSModuleReference<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ExternalModuleReference(it) => it.span_mut(),
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::QualifiedName(it) => it.span_mut(),
+            Self::ExternalModuleReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2038,11 +2038,11 @@ impl GetSpanMut for JSXClosingFragment {
 impl<'a> GetSpanMut for JSXElementName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::NamespacedName(it) => it.span_mut(),
-            Self::MemberExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2064,9 +2064,9 @@ impl<'a> GetSpanMut for JSXMemberExpression<'a> {
 impl<'a> GetSpanMut for JSXMemberExpressionObject<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierReference(it) => it.span_mut(),
-            Self::MemberExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2081,49 +2081,49 @@ impl<'a> GetSpanMut for JSXExpressionContainer<'a> {
 impl<'a> GetSpanMut for JSXExpression<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::EmptyExpression(it) => it.span_mut(),
-            Self::BooleanLiteral(it) => it.span_mut(),
-            Self::NullLiteral(it) => it.span_mut(),
-            Self::NumericLiteral(it) => it.span_mut(),
-            Self::BigIntLiteral(it) => it.span_mut(),
-            Self::RegExpLiteral(it) => it.span_mut(),
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::TemplateLiteral(it) => it.span_mut(),
-            Self::Identifier(it) => it.span_mut(),
-            Self::MetaProperty(it) => it.span_mut(),
-            Self::Super(it) => it.span_mut(),
-            Self::ArrayExpression(it) => it.span_mut(),
-            Self::ArrowFunctionExpression(it) => it.span_mut(),
-            Self::AssignmentExpression(it) => it.span_mut(),
-            Self::AwaitExpression(it) => it.span_mut(),
-            Self::BinaryExpression(it) => it.span_mut(),
-            Self::CallExpression(it) => it.span_mut(),
-            Self::ChainExpression(it) => it.span_mut(),
-            Self::ClassExpression(it) => it.span_mut(),
-            Self::ConditionalExpression(it) => it.span_mut(),
-            Self::FunctionExpression(it) => it.span_mut(),
-            Self::ImportExpression(it) => it.span_mut(),
-            Self::LogicalExpression(it) => it.span_mut(),
-            Self::NewExpression(it) => it.span_mut(),
-            Self::ObjectExpression(it) => it.span_mut(),
-            Self::ParenthesizedExpression(it) => it.span_mut(),
-            Self::SequenceExpression(it) => it.span_mut(),
-            Self::TaggedTemplateExpression(it) => it.span_mut(),
-            Self::ThisExpression(it) => it.span_mut(),
-            Self::UnaryExpression(it) => it.span_mut(),
-            Self::UpdateExpression(it) => it.span_mut(),
-            Self::YieldExpression(it) => it.span_mut(),
-            Self::PrivateInExpression(it) => it.span_mut(),
-            Self::JSXElement(it) => it.span_mut(),
-            Self::JSXFragment(it) => it.span_mut(),
-            Self::TSAsExpression(it) => it.span_mut(),
-            Self::TSSatisfiesExpression(it) => it.span_mut(),
-            Self::TSTypeAssertion(it) => it.span_mut(),
-            Self::TSNonNullExpression(it) => it.span_mut(),
-            Self::TSInstantiationExpression(it) => it.span_mut(),
-            Self::ComputedMemberExpression(it) => it.span_mut(),
-            Self::StaticMemberExpression(it) => it.span_mut(),
-            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::EmptyExpression(it) => GetSpanMut::span_mut(it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2138,8 +2138,8 @@ impl GetSpanMut for JSXEmptyExpression {
 impl<'a> GetSpanMut for JSXAttributeItem<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Attribute(it) => it.span_mut(),
-            Self::SpreadAttribute(it) => it.span_mut(),
+            Self::Attribute(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SpreadAttribute(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2161,8 +2161,8 @@ impl<'a> GetSpanMut for JSXSpreadAttribute<'a> {
 impl<'a> GetSpanMut for JSXAttributeName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
-            Self::NamespacedName(it) => it.span_mut(),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2170,10 +2170,10 @@ impl<'a> GetSpanMut for JSXAttributeName<'a> {
 impl<'a> GetSpanMut for JSXAttributeValue<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StringLiteral(it) => it.span_mut(),
-            Self::ExpressionContainer(it) => it.span_mut(),
-            Self::Element(it) => it.span_mut(),
-            Self::Fragment(it) => it.span_mut(),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }
@@ -2188,11 +2188,11 @@ impl<'a> GetSpanMut for JSXIdentifier<'a> {
 impl<'a> GetSpanMut for JSXChild<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Text(it) => it.span_mut(),
-            Self::Element(it) => it.span_mut(),
-            Self::Fragment(it) => it.span_mut(),
-            Self::ExpressionContainer(it) => it.span_mut(),
-            Self::Spread(it) => it.span_mut(),
+            Self::Text(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Spread(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }

--- a/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
@@ -12,9 +12,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegularExpression<'old_allo
     type Cloned = RegularExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         RegularExpression {
-            span: self.span.clone_in(allocator),
-            pattern: self.pattern.clone_in(allocator),
-            flags: self.flags.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            pattern: CloneIn::clone_in(&self.pattern, allocator),
+            flags: CloneIn::clone_in(&self.flags, allocator),
         }
     }
 }
@@ -23,15 +23,15 @@ impl<'alloc> CloneIn<'alloc> for Flags {
     type Cloned = Flags;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         Flags {
-            span: self.span.clone_in(allocator),
-            global: self.global.clone_in(allocator),
-            ignore_case: self.ignore_case.clone_in(allocator),
-            multiline: self.multiline.clone_in(allocator),
-            unicode: self.unicode.clone_in(allocator),
-            sticky: self.sticky.clone_in(allocator),
-            dot_all: self.dot_all.clone_in(allocator),
-            has_indices: self.has_indices.clone_in(allocator),
-            unicode_sets: self.unicode_sets.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            global: CloneIn::clone_in(&self.global, allocator),
+            ignore_case: CloneIn::clone_in(&self.ignore_case, allocator),
+            multiline: CloneIn::clone_in(&self.multiline, allocator),
+            unicode: CloneIn::clone_in(&self.unicode, allocator),
+            sticky: CloneIn::clone_in(&self.sticky, allocator),
+            dot_all: CloneIn::clone_in(&self.dot_all, allocator),
+            has_indices: CloneIn::clone_in(&self.has_indices, allocator),
+            unicode_sets: CloneIn::clone_in(&self.unicode_sets, allocator),
         }
     }
 }
@@ -39,21 +39,30 @@ impl<'alloc> CloneIn<'alloc> for Flags {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Pattern<'old_alloc> {
     type Cloned = Pattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Pattern { span: self.span.clone_in(allocator), body: self.body.clone_in(allocator) }
+        Pattern {
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+        }
     }
 }
 
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Disjunction<'old_alloc> {
     type Cloned = Disjunction<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Disjunction { span: self.span.clone_in(allocator), body: self.body.clone_in(allocator) }
+        Disjunction {
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+        }
     }
 }
 
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Alternative<'old_alloc> {
     type Cloned = Alternative<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Alternative { span: self.span.clone_in(allocator), body: self.body.clone_in(allocator) }
+        Alternative {
+            span: CloneIn::clone_in(&self.span, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
+        }
     }
 }
 
@@ -61,18 +70,26 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Term<'old_alloc> {
     type Cloned = Term<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::BoundaryAssertion(it) => Term::BoundaryAssertion(it.clone_in(allocator)),
-            Self::LookAroundAssertion(it) => Term::LookAroundAssertion(it.clone_in(allocator)),
-            Self::Quantifier(it) => Term::Quantifier(it.clone_in(allocator)),
-            Self::Character(it) => Term::Character(it.clone_in(allocator)),
-            Self::Dot(it) => Term::Dot(it.clone_in(allocator)),
-            Self::CharacterClassEscape(it) => Term::CharacterClassEscape(it.clone_in(allocator)),
-            Self::UnicodePropertyEscape(it) => Term::UnicodePropertyEscape(it.clone_in(allocator)),
-            Self::CharacterClass(it) => Term::CharacterClass(it.clone_in(allocator)),
-            Self::CapturingGroup(it) => Term::CapturingGroup(it.clone_in(allocator)),
-            Self::IgnoreGroup(it) => Term::IgnoreGroup(it.clone_in(allocator)),
-            Self::IndexedReference(it) => Term::IndexedReference(it.clone_in(allocator)),
-            Self::NamedReference(it) => Term::NamedReference(it.clone_in(allocator)),
+            Self::BoundaryAssertion(it) => {
+                Term::BoundaryAssertion(CloneIn::clone_in(it, allocator))
+            }
+            Self::LookAroundAssertion(it) => {
+                Term::LookAroundAssertion(CloneIn::clone_in(it, allocator))
+            }
+            Self::Quantifier(it) => Term::Quantifier(CloneIn::clone_in(it, allocator)),
+            Self::Character(it) => Term::Character(CloneIn::clone_in(it, allocator)),
+            Self::Dot(it) => Term::Dot(CloneIn::clone_in(it, allocator)),
+            Self::CharacterClassEscape(it) => {
+                Term::CharacterClassEscape(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnicodePropertyEscape(it) => {
+                Term::UnicodePropertyEscape(CloneIn::clone_in(it, allocator))
+            }
+            Self::CharacterClass(it) => Term::CharacterClass(CloneIn::clone_in(it, allocator)),
+            Self::CapturingGroup(it) => Term::CapturingGroup(CloneIn::clone_in(it, allocator)),
+            Self::IgnoreGroup(it) => Term::IgnoreGroup(CloneIn::clone_in(it, allocator)),
+            Self::IndexedReference(it) => Term::IndexedReference(CloneIn::clone_in(it, allocator)),
+            Self::NamedReference(it) => Term::NamedReference(CloneIn::clone_in(it, allocator)),
         }
     }
 }
@@ -81,8 +98,8 @@ impl<'alloc> CloneIn<'alloc> for BoundaryAssertion {
     type Cloned = BoundaryAssertion;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         BoundaryAssertion {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
         }
     }
 }
@@ -103,9 +120,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LookAroundAssertion<'old_al
     type Cloned = LookAroundAssertion<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LookAroundAssertion {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -126,11 +143,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Quantifier<'old_alloc> {
     type Cloned = Quantifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Quantifier {
-            span: self.span.clone_in(allocator),
-            min: self.min.clone_in(allocator),
-            max: self.max.clone_in(allocator),
-            greedy: self.greedy.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            min: CloneIn::clone_in(&self.min, allocator),
+            max: CloneIn::clone_in(&self.max, allocator),
+            greedy: CloneIn::clone_in(&self.greedy, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -139,9 +156,9 @@ impl<'alloc> CloneIn<'alloc> for Character {
     type Cloned = Character;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         Character {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -166,8 +183,8 @@ impl<'alloc> CloneIn<'alloc> for CharacterClassEscape {
     type Cloned = CharacterClassEscape;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         CharacterClassEscape {
-            span: self.span.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
         }
     }
 }
@@ -190,11 +207,11 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UnicodePropertyEscape<'old_
     type Cloned = UnicodePropertyEscape<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UnicodePropertyEscape {
-            span: self.span.clone_in(allocator),
-            negative: self.negative.clone_in(allocator),
-            strings: self.strings.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            value: self.value.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            negative: CloneIn::clone_in(&self.negative, allocator),
+            strings: CloneIn::clone_in(&self.strings, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }
@@ -202,7 +219,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UnicodePropertyEscape<'old_
 impl<'alloc> CloneIn<'alloc> for Dot {
     type Cloned = Dot;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        Dot { span: self.span.clone_in(allocator) }
+        Dot { span: CloneIn::clone_in(&self.span, allocator) }
     }
 }
 
@@ -210,10 +227,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CharacterClass<'old_alloc> 
     type Cloned = CharacterClass<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CharacterClass {
-            span: self.span.clone_in(allocator),
-            negative: self.negative.clone_in(allocator),
-            kind: self.kind.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            negative: CloneIn::clone_in(&self.negative, allocator),
+            kind: CloneIn::clone_in(&self.kind, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -234,20 +251,22 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CharacterClassContents<'old
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
             Self::CharacterClassRange(it) => {
-                CharacterClassContents::CharacterClassRange(it.clone_in(allocator))
+                CharacterClassContents::CharacterClassRange(CloneIn::clone_in(it, allocator))
             }
             Self::CharacterClassEscape(it) => {
-                CharacterClassContents::CharacterClassEscape(it.clone_in(allocator))
+                CharacterClassContents::CharacterClassEscape(CloneIn::clone_in(it, allocator))
             }
             Self::UnicodePropertyEscape(it) => {
-                CharacterClassContents::UnicodePropertyEscape(it.clone_in(allocator))
+                CharacterClassContents::UnicodePropertyEscape(CloneIn::clone_in(it, allocator))
             }
-            Self::Character(it) => CharacterClassContents::Character(it.clone_in(allocator)),
+            Self::Character(it) => {
+                CharacterClassContents::Character(CloneIn::clone_in(it, allocator))
+            }
             Self::NestedCharacterClass(it) => {
-                CharacterClassContents::NestedCharacterClass(it.clone_in(allocator))
+                CharacterClassContents::NestedCharacterClass(CloneIn::clone_in(it, allocator))
             }
             Self::ClassStringDisjunction(it) => {
-                CharacterClassContents::ClassStringDisjunction(it.clone_in(allocator))
+                CharacterClassContents::ClassStringDisjunction(CloneIn::clone_in(it, allocator))
             }
         }
     }
@@ -257,9 +276,9 @@ impl<'alloc> CloneIn<'alloc> for CharacterClassRange {
     type Cloned = CharacterClassRange;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         CharacterClassRange {
-            span: self.span.clone_in(allocator),
-            min: self.min.clone_in(allocator),
-            max: self.max.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            min: CloneIn::clone_in(&self.min, allocator),
+            max: CloneIn::clone_in(&self.max, allocator),
         }
     }
 }
@@ -268,9 +287,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ClassStringDisjunction<'old
     type Cloned = ClassStringDisjunction<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ClassStringDisjunction {
-            span: self.span.clone_in(allocator),
-            strings: self.strings.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            strings: CloneIn::clone_in(&self.strings, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -279,9 +298,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ClassString<'old_alloc> {
     type Cloned = ClassString<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ClassString {
-            span: self.span.clone_in(allocator),
-            strings: self.strings.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            strings: CloneIn::clone_in(&self.strings, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -290,9 +309,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CapturingGroup<'old_alloc> 
     type Cloned = CapturingGroup<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CapturingGroup {
-            span: self.span.clone_in(allocator),
-            name: self.name.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -301,10 +320,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IgnoreGroup<'old_alloc> {
     type Cloned = IgnoreGroup<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IgnoreGroup {
-            span: self.span.clone_in(allocator),
-            enabling_modifiers: self.enabling_modifiers.clone_in(allocator),
-            disabling_modifiers: self.disabling_modifiers.clone_in(allocator),
-            body: self.body.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            enabling_modifiers: CloneIn::clone_in(&self.enabling_modifiers, allocator),
+            disabling_modifiers: CloneIn::clone_in(&self.disabling_modifiers, allocator),
+            body: CloneIn::clone_in(&self.body, allocator),
         }
     }
 }
@@ -313,9 +332,9 @@ impl<'alloc> CloneIn<'alloc> for ModifierFlags {
     type Cloned = ModifierFlags;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         ModifierFlags {
-            ignore_case: self.ignore_case.clone_in(allocator),
-            sticky: self.sticky.clone_in(allocator),
-            multiline: self.multiline.clone_in(allocator),
+            ignore_case: CloneIn::clone_in(&self.ignore_case, allocator),
+            sticky: CloneIn::clone_in(&self.sticky, allocator),
+            multiline: CloneIn::clone_in(&self.multiline, allocator),
         }
     }
 }
@@ -324,8 +343,8 @@ impl<'alloc> CloneIn<'alloc> for IndexedReference {
     type Cloned = IndexedReference;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         IndexedReference {
-            span: self.span.clone_in(allocator),
-            index: self.index.clone_in(allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+            index: CloneIn::clone_in(&self.index, allocator),
         }
     }
 }
@@ -333,6 +352,9 @@ impl<'alloc> CloneIn<'alloc> for IndexedReference {
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NamedReference<'old_alloc> {
     type Cloned = NamedReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NamedReference { span: self.span.clone_in(allocator), name: self.name.clone_in(allocator) }
+        NamedReference {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
     }
 }

--- a/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
@@ -1,6 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
+#![allow(clippy::match_like_matches_macro)]
+
 use oxc_span::cmp::ContentEq;
 
 #[allow(clippy::wildcard_imports)]
@@ -8,89 +10,100 @@ use crate::ast::*;
 
 impl<'a> ContentEq for RegularExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.pattern.content_eq(&other.pattern) && self.flags.content_eq(&other.flags)
+        ContentEq::content_eq(&self.pattern, &other.pattern)
+            && ContentEq::content_eq(&self.flags, &other.flags)
     }
 }
 
 impl ContentEq for Flags {
     fn content_eq(&self, other: &Self) -> bool {
-        self.global.content_eq(&other.global)
-            && self.ignore_case.content_eq(&other.ignore_case)
-            && self.multiline.content_eq(&other.multiline)
-            && self.unicode.content_eq(&other.unicode)
-            && self.sticky.content_eq(&other.sticky)
-            && self.dot_all.content_eq(&other.dot_all)
-            && self.has_indices.content_eq(&other.has_indices)
-            && self.unicode_sets.content_eq(&other.unicode_sets)
+        ContentEq::content_eq(&self.global, &other.global)
+            && ContentEq::content_eq(&self.ignore_case, &other.ignore_case)
+            && ContentEq::content_eq(&self.multiline, &other.multiline)
+            && ContentEq::content_eq(&self.unicode, &other.unicode)
+            && ContentEq::content_eq(&self.sticky, &other.sticky)
+            && ContentEq::content_eq(&self.dot_all, &other.dot_all)
+            && ContentEq::content_eq(&self.has_indices, &other.has_indices)
+            && ContentEq::content_eq(&self.unicode_sets, &other.unicode_sets)
     }
 }
 
 impl<'a> ContentEq for Pattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for Disjunction<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for Alternative<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for Term<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::BoundaryAssertion(it) => {
-                matches!(other, Self::BoundaryAssertion(other) if it.content_eq(other))
-            }
-            Self::LookAroundAssertion(it) => {
-                matches!(other, Self::LookAroundAssertion(other) if it.content_eq(other))
-            }
-            Self::Quantifier(it) => {
-                matches!(other, Self::Quantifier(other) if it.content_eq(other))
-            }
-            Self::Character(it) => {
-                matches!(other, Self::Character(other) if it.content_eq(other))
-            }
-            Self::Dot(it) => matches!(other, Self::Dot(other) if it.content_eq(other)),
-            Self::CharacterClassEscape(it) => {
-                matches!(
-                    other, Self::CharacterClassEscape(other) if it.content_eq(other)
-                )
-            }
-            Self::UnicodePropertyEscape(it) => {
-                matches!(
-                    other, Self::UnicodePropertyEscape(other) if it.content_eq(other)
-                )
-            }
-            Self::CharacterClass(it) => {
-                matches!(other, Self::CharacterClass(other) if it.content_eq(other))
-            }
-            Self::CapturingGroup(it) => {
-                matches!(other, Self::CapturingGroup(other) if it.content_eq(other))
-            }
-            Self::IgnoreGroup(it) => {
-                matches!(other, Self::IgnoreGroup(other) if it.content_eq(other))
-            }
-            Self::IndexedReference(it) => {
-                matches!(other, Self::IndexedReference(other) if it.content_eq(other))
-            }
-            Self::NamedReference(it) => {
-                matches!(other, Self::NamedReference(other) if it.content_eq(other))
-            }
+            Self::BoundaryAssertion(it) => match other {
+                Self::BoundaryAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::LookAroundAssertion(it) => match other {
+                Self::LookAroundAssertion(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Quantifier(it) => match other {
+                Self::Quantifier(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Character(it) => match other {
+                Self::Character(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Dot(it) => match other {
+                Self::Dot(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CharacterClassEscape(it) => match other {
+                Self::CharacterClassEscape(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnicodePropertyEscape(it) => match other {
+                Self::UnicodePropertyEscape(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CharacterClass(it) => match other {
+                Self::CharacterClass(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CapturingGroup(it) => match other {
+                Self::CapturingGroup(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IgnoreGroup(it) => match other {
+                Self::IgnoreGroup(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::IndexedReference(it) => match other {
+                Self::IndexedReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NamedReference(it) => match other {
+                Self::NamedReference(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl ContentEq for BoundaryAssertion {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
     }
 }
 
@@ -102,7 +115,8 @@ impl ContentEq for BoundaryAssertionKind {
 
 impl<'a> ContentEq for LookAroundAssertion<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -114,16 +128,17 @@ impl ContentEq for LookAroundAssertionKind {
 
 impl<'a> ContentEq for Quantifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.min.content_eq(&other.min)
-            && self.max.content_eq(&other.max)
-            && self.greedy.content_eq(&other.greedy)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.min, &other.min)
+            && ContentEq::content_eq(&self.max, &other.max)
+            && ContentEq::content_eq(&self.greedy, &other.greedy)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl ContentEq for Character {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind) && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
@@ -135,7 +150,7 @@ impl ContentEq for CharacterKind {
 
 impl ContentEq for CharacterClassEscape {
     fn content_eq(&self, other: &Self) -> bool {
-        self.kind.content_eq(&other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
     }
 }
 
@@ -147,10 +162,10 @@ impl ContentEq for CharacterClassEscapeKind {
 
 impl<'a> ContentEq for UnicodePropertyEscape<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.negative.content_eq(&other.negative)
-            && self.strings.content_eq(&other.strings)
-            && self.name.content_eq(&other.name)
-            && self.value.content_eq(&other.value)
+        ContentEq::content_eq(&self.negative, &other.negative)
+            && ContentEq::content_eq(&self.strings, &other.strings)
+            && ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
@@ -162,9 +177,9 @@ impl ContentEq for Dot {
 
 impl<'a> ContentEq for CharacterClass<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.negative.content_eq(&other.negative)
-            && self.kind.content_eq(&other.kind)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.negative, &other.negative)
+            && ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -177,84 +192,85 @@ impl ContentEq for CharacterClassContentsKind {
 impl<'a> ContentEq for CharacterClassContents<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::CharacterClassRange(it) => {
-                matches!(other, Self::CharacterClassRange(other) if it.content_eq(other))
-            }
-            Self::CharacterClassEscape(it) => {
-                matches!(
-                    other, Self::CharacterClassEscape(other) if it.content_eq(other)
-                )
-            }
-            Self::UnicodePropertyEscape(it) => {
-                matches!(
-                    other, Self::UnicodePropertyEscape(other) if it.content_eq(other)
-                )
-            }
-            Self::Character(it) => {
-                matches!(other, Self::Character(other) if it.content_eq(other))
-            }
-            Self::NestedCharacterClass(it) => {
-                matches!(
-                    other, Self::NestedCharacterClass(other) if it.content_eq(other)
-                )
-            }
-            Self::ClassStringDisjunction(it) => {
-                matches!(
-                    other, Self::ClassStringDisjunction(other) if it.content_eq(other)
-                )
-            }
+            Self::CharacterClassRange(it) => match other {
+                Self::CharacterClassRange(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::CharacterClassEscape(it) => match other {
+                Self::CharacterClassEscape(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::UnicodePropertyEscape(it) => match other {
+                Self::UnicodePropertyEscape(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::Character(it) => match other {
+                Self::Character(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::NestedCharacterClass(it) => match other {
+                Self::NestedCharacterClass(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
+            Self::ClassStringDisjunction(it) => match other {
+                Self::ClassStringDisjunction(other) if ContentEq::content_eq(it, other) => true,
+                _ => false,
+            },
         }
     }
 }
 
 impl ContentEq for CharacterClassRange {
     fn content_eq(&self, other: &Self) -> bool {
-        self.min.content_eq(&other.min) && self.max.content_eq(&other.max)
+        ContentEq::content_eq(&self.min, &other.min) && ContentEq::content_eq(&self.max, &other.max)
     }
 }
 
 impl<'a> ContentEq for ClassStringDisjunction<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.strings.content_eq(&other.strings) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.strings, &other.strings)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ClassString<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.strings.content_eq(&other.strings) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.strings, &other.strings)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for CapturingGroup<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name) && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for IgnoreGroup<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.enabling_modifiers.content_eq(&other.enabling_modifiers)
-            && self.disabling_modifiers.content_eq(&other.disabling_modifiers)
-            && self.body.content_eq(&other.body)
+        ContentEq::content_eq(&self.enabling_modifiers, &other.enabling_modifiers)
+            && ContentEq::content_eq(&self.disabling_modifiers, &other.disabling_modifiers)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl ContentEq for ModifierFlags {
     fn content_eq(&self, other: &Self) -> bool {
-        self.ignore_case.content_eq(&other.ignore_case)
-            && self.sticky.content_eq(&other.sticky)
-            && self.multiline.content_eq(&other.multiline)
+        ContentEq::content_eq(&self.ignore_case, &other.ignore_case)
+            && ContentEq::content_eq(&self.sticky, &other.sticky)
+            && ContentEq::content_eq(&self.multiline, &other.multiline)
     }
 }
 
 impl ContentEq for IndexedReference {
     fn content_eq(&self, other: &Self) -> bool {
-        self.index.content_eq(&other.index)
+        ContentEq::content_eq(&self.index, &other.index)
     }
 }
 
 impl<'a> ContentEq for NamedReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.name.content_eq(&other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }

--- a/crates/oxc_regular_expression/src/generated/derive_content_hash.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_content_hash.rs
@@ -12,39 +12,39 @@ use crate::ast::*;
 
 impl<'a> ContentHash for RegularExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.pattern.content_hash(state);
-        self.flags.content_hash(state);
+        ContentHash::content_hash(&self.pattern, state);
+        ContentHash::content_hash(&self.flags, state);
     }
 }
 
 impl ContentHash for Flags {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.global.content_hash(state);
-        self.ignore_case.content_hash(state);
-        self.multiline.content_hash(state);
-        self.unicode.content_hash(state);
-        self.sticky.content_hash(state);
-        self.dot_all.content_hash(state);
-        self.has_indices.content_hash(state);
-        self.unicode_sets.content_hash(state);
+        ContentHash::content_hash(&self.global, state);
+        ContentHash::content_hash(&self.ignore_case, state);
+        ContentHash::content_hash(&self.multiline, state);
+        ContentHash::content_hash(&self.unicode, state);
+        ContentHash::content_hash(&self.sticky, state);
+        ContentHash::content_hash(&self.dot_all, state);
+        ContentHash::content_hash(&self.has_indices, state);
+        ContentHash::content_hash(&self.unicode_sets, state);
     }
 }
 
 impl<'a> ContentHash for Pattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for Disjunction<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for Alternative<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -52,25 +52,25 @@ impl<'a> ContentHash for Term<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::BoundaryAssertion(it) => it.content_hash(state),
-            Self::LookAroundAssertion(it) => it.content_hash(state),
-            Self::Quantifier(it) => it.content_hash(state),
-            Self::Character(it) => it.content_hash(state),
-            Self::Dot(it) => it.content_hash(state),
-            Self::CharacterClassEscape(it) => it.content_hash(state),
-            Self::UnicodePropertyEscape(it) => it.content_hash(state),
-            Self::CharacterClass(it) => it.content_hash(state),
-            Self::CapturingGroup(it) => it.content_hash(state),
-            Self::IgnoreGroup(it) => it.content_hash(state),
-            Self::IndexedReference(it) => it.content_hash(state),
-            Self::NamedReference(it) => it.content_hash(state),
+            Self::BoundaryAssertion(it) => ContentHash::content_hash(it, state),
+            Self::LookAroundAssertion(it) => ContentHash::content_hash(it, state),
+            Self::Quantifier(it) => ContentHash::content_hash(it, state),
+            Self::Character(it) => ContentHash::content_hash(it, state),
+            Self::Dot(it) => ContentHash::content_hash(it, state),
+            Self::CharacterClassEscape(it) => ContentHash::content_hash(it, state),
+            Self::UnicodePropertyEscape(it) => ContentHash::content_hash(it, state),
+            Self::CharacterClass(it) => ContentHash::content_hash(it, state),
+            Self::CapturingGroup(it) => ContentHash::content_hash(it, state),
+            Self::IgnoreGroup(it) => ContentHash::content_hash(it, state),
+            Self::IndexedReference(it) => ContentHash::content_hash(it, state),
+            Self::NamedReference(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl ContentHash for BoundaryAssertion {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
     }
 }
 
@@ -82,8 +82,8 @@ impl ContentHash for BoundaryAssertionKind {
 
 impl<'a> ContentHash for LookAroundAssertion<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -95,17 +95,17 @@ impl ContentHash for LookAroundAssertionKind {
 
 impl<'a> ContentHash for Quantifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.min.content_hash(state);
-        self.max.content_hash(state);
-        self.greedy.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.min, state);
+        ContentHash::content_hash(&self.max, state);
+        ContentHash::content_hash(&self.greedy, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl ContentHash for Character {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
@@ -117,7 +117,7 @@ impl ContentHash for CharacterKind {
 
 impl ContentHash for CharacterClassEscape {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.kind.content_hash(state);
+        ContentHash::content_hash(&self.kind, state);
     }
 }
 
@@ -129,10 +129,10 @@ impl ContentHash for CharacterClassEscapeKind {
 
 impl<'a> ContentHash for UnicodePropertyEscape<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.negative.content_hash(state);
-        self.strings.content_hash(state);
-        self.name.content_hash(state);
-        self.value.content_hash(state);
+        ContentHash::content_hash(&self.negative, state);
+        ContentHash::content_hash(&self.strings, state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.value, state);
     }
 }
 
@@ -142,9 +142,9 @@ impl ContentHash for Dot {
 
 impl<'a> ContentHash for CharacterClass<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.negative.content_hash(state);
-        self.kind.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.negative, state);
+        ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
@@ -158,68 +158,68 @@ impl<'a> ContentHash for CharacterClassContents<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::CharacterClassRange(it) => it.content_hash(state),
-            Self::CharacterClassEscape(it) => it.content_hash(state),
-            Self::UnicodePropertyEscape(it) => it.content_hash(state),
-            Self::Character(it) => it.content_hash(state),
-            Self::NestedCharacterClass(it) => it.content_hash(state),
-            Self::ClassStringDisjunction(it) => it.content_hash(state),
+            Self::CharacterClassRange(it) => ContentHash::content_hash(it, state),
+            Self::CharacterClassEscape(it) => ContentHash::content_hash(it, state),
+            Self::UnicodePropertyEscape(it) => ContentHash::content_hash(it, state),
+            Self::Character(it) => ContentHash::content_hash(it, state),
+            Self::NestedCharacterClass(it) => ContentHash::content_hash(it, state),
+            Self::ClassStringDisjunction(it) => ContentHash::content_hash(it, state),
         }
     }
 }
 
 impl ContentHash for CharacterClassRange {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.min.content_hash(state);
-        self.max.content_hash(state);
+        ContentHash::content_hash(&self.min, state);
+        ContentHash::content_hash(&self.max, state);
     }
 }
 
 impl<'a> ContentHash for ClassStringDisjunction<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.strings.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.strings, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for ClassString<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.strings.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.strings, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for CapturingGroup<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for IgnoreGroup<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.enabling_modifiers.content_hash(state);
-        self.disabling_modifiers.content_hash(state);
-        self.body.content_hash(state);
+        ContentHash::content_hash(&self.enabling_modifiers, state);
+        ContentHash::content_hash(&self.disabling_modifiers, state);
+        ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl ContentHash for ModifierFlags {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.ignore_case.content_hash(state);
-        self.sticky.content_hash(state);
-        self.multiline.content_hash(state);
+        ContentHash::content_hash(&self.ignore_case, state);
+        ContentHash::content_hash(&self.sticky, state);
+        ContentHash::content_hash(&self.multiline, state);
     }
 }
 
 impl ContentHash for IndexedReference {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.index.content_hash(state);
+        ContentHash::content_hash(&self.index, state);
     }
 }
 
 impl<'a> ContentHash for NamedReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        self.name.content_hash(state);
+        ContentHash::content_hash(&self.name, state);
     }
 }

--- a/crates/oxc_syntax/src/generated/derive_content_eq.rs
+++ b/crates/oxc_syntax/src/generated/derive_content_eq.rs
@@ -1,6 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
+#![allow(clippy::match_like_matches_macro)]
+
 use oxc_span::cmp::ContentEq;
 
 #[allow(clippy::wildcard_imports)]

--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -49,7 +49,7 @@ fn derive_enum(def: &EnumDef) -> TokenStream {
                 quote!(Self :: #ident => #ty_ident :: #ident)
             } else {
                 used_alloc = true;
-                quote!(Self :: #ident(it) => #ty_ident :: #ident(it.clone_in(allocator)))
+                quote!(Self :: #ident(it) => #ty_ident :: #ident(CloneIn::clone_in(it, allocator)))
             }
         })
         .collect_vec();
@@ -74,7 +74,9 @@ fn derive_struct(def: &StructDef) -> TokenStream {
             let ident = field.ident();
             match field.markers.derive_attributes.clone_in {
                 CloneInAttribute::Default => quote!(#ident: Default::default()),
-                CloneInAttribute::None => quote!(#ident: self.#ident.clone_in(allocator)),
+                CloneInAttribute::None => {
+                    quote!(#ident: CloneIn::clone_in(&self.#ident, allocator))
+                }
             }
         });
         (format_ident!("allocator"), quote!(#ty_ident { #(#fields),* }))

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -39,6 +39,9 @@ impl Derive for DeriveContentEq {
 
     fn prelude() -> TokenStream {
         quote! {
+            // NOTE: writing long match expressions formats better than using `matches` macro.
+            #![allow(clippy::match_like_matches_macro)]
+
             ///@@line_break
             use oxc_span::cmp::ContentEq;
         }
@@ -57,7 +60,11 @@ fn derive_enum(def: &EnumDef) -> (&str, TokenStream) {
             } else {
                 quote! {
                     Self :: #ident(it) => {
-                        matches!(other, Self :: #ident (other) if it.content_eq(other))
+                        // NOTE: writing the match expression formats better than using `matches` macro.
+                        match other {
+                            Self :: #ident (other) if ContentEq::content_eq(it, other) => true,
+                            _ => false,
+                        }
                     }
                 }
             }
@@ -87,7 +94,7 @@ fn derive_struct(def: &StructDef) -> (&str, TokenStream) {
             })
             .map(|field| {
                 let ident = field.ident();
-                quote!(self.#ident.content_eq(&other.#ident))
+                quote!(ContentEq::content_eq(&self.#ident, &other.#ident))
             })
             .collect_vec();
         if fields.is_empty() {

--- a/tasks/ast_tools/src/derives/content_hash.rs
+++ b/tasks/ast_tools/src/derives/content_hash.rs
@@ -67,7 +67,7 @@ fn derive_enum(def: &EnumDef) -> (&str, TokenStream) {
                     non_exhaustive = true;
                     None
                 } else {
-                    Some(quote!(Self :: #ident(it) => it.content_hash(state)))
+                    Some(quote!(Self :: #ident(it) => ContentHash::content_hash(it, state)))
                 }
             })
             .collect_vec();
@@ -98,7 +98,7 @@ fn derive_struct(def: &StructDef) -> (&str, TokenStream) {
             })
             .map(|field| {
                 let ident = field.ident();
-                quote!(self.#ident.content_hash(state);)
+                quote!(ContentHash::content_hash(&self.#ident, state);)
             })
             .collect_vec();
         if fields.is_empty() {

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -5,7 +5,7 @@ use syn::Ident;
 use crate::{
     codegen::LateCtx,
     schema::{EnumDef, GetGenerics, StructDef, ToType, TypeDef},
-    util::ToIdent,
+    util::{ToIdent, TypeWrapper},
 };
 
 use super::{define_derive, Derive, DeriveOutput};
@@ -23,8 +23,19 @@ impl Derive for DeriveGetSpan {
         let self_type = quote!(&self);
         let result_type = quote!(Span);
         let result_expr = quote!(self.span);
+        let unbox = |it| quote!(#it.as_ref());
+        let reference = |it| quote!(&#it);
 
-        derive(Self::trait_name(), "span", &self_type, &result_type, &result_expr, def)
+        derive(
+            Self::trait_name(),
+            "span",
+            &self_type,
+            &result_type,
+            &result_expr,
+            def,
+            unbox,
+            reference,
+        )
     }
 
     fn prelude() -> TokenStream {
@@ -50,8 +61,19 @@ impl Derive for DeriveGetSpanMut {
         let self_type = quote!(&mut self);
         let result_type = quote!(&mut Span);
         let result_expr = quote!(&mut self.span);
+        let unbox = |it| quote!(&mut **#it);
+        let reference = |it| quote!(&mut #it);
 
-        derive(Self::trait_name(), "span_mut", &self_type, &result_type, &result_expr, def)
+        derive(
+            Self::trait_name(),
+            "span_mut",
+            &self_type,
+            &result_type,
+            &result_expr,
+            def,
+            unbox,
+            reference,
+        )
     }
 
     fn prelude() -> TokenStream {
@@ -64,37 +86,60 @@ impl Derive for DeriveGetSpanMut {
     }
 }
 
-fn derive(
+#[allow(clippy::too_many_arguments)]
+fn derive<U, R>(
     trait_name: &str,
     method_name: &str,
     self_type: &TokenStream,
     result_type: &TokenStream,
     result_expr: &TokenStream,
     def: &TypeDef,
-) -> TokenStream {
+    unbox: U,
+    reference: R,
+) -> TokenStream
+where
+    U: Fn(TokenStream) -> TokenStream,
+    R: Fn(TokenStream) -> TokenStream,
+{
     let trait_ident = trait_name.to_ident();
     let method_ident = method_name.to_ident();
     match &def {
-        TypeDef::Enum(def) => derive_enum(def, &trait_ident, &method_ident, self_type, result_type),
-        TypeDef::Struct(def) => {
-            derive_struct(def, &trait_ident, &method_ident, self_type, result_type, result_expr)
+        TypeDef::Enum(def) => {
+            derive_enum(def, &trait_ident, &method_ident, self_type, result_type, unbox)
         }
+        TypeDef::Struct(def) => derive_struct(
+            def,
+            &trait_ident,
+            &method_ident,
+            self_type,
+            result_type,
+            result_expr,
+            reference,
+        ),
     }
 }
 
-fn derive_enum(
+fn derive_enum<U>(
     def: &EnumDef,
     trait_name: &Ident,
     method_name: &Ident,
     self_type: &TokenStream,
     result_type: &TokenStream,
-) -> TokenStream {
+    unbox: U,
+) -> TokenStream
+where
+    U: Fn(TokenStream) -> TokenStream,
+{
     let target_type = def.to_type();
     let generics = def.generics();
 
     let matches = def.all_variants().map(|var| {
         let ident = var.ident();
-        quote!(Self :: #ident(it) => it.#method_name())
+        let mut it = quote!(it);
+        if var.fields.first().is_some_and(|it| it.typ.analysis().wrapper == TypeWrapper::Box) {
+            it = unbox(it);
+        }
+        quote!(Self :: #ident(it) => #trait_name :: #method_name(#it))
     });
 
     quote! {
@@ -108,21 +153,26 @@ fn derive_enum(
     }
 }
 
-fn derive_struct(
+fn derive_struct<R>(
     def: &StructDef,
     trait_name: &Ident,
     method_name: &Ident,
     self_type: &TokenStream,
     result_type: &TokenStream,
     result_expr: &TokenStream,
-) -> TokenStream {
+    reference: R,
+) -> TokenStream
+where
+    R: Fn(TokenStream) -> TokenStream,
+{
     let target_type = def.to_type();
     let generics = def.generics();
 
     let span_field = def.fields.iter().find(|field| field.markers.span);
     let result_expr = if let Some(span_field) = span_field {
         let ident = span_field.name.as_ref().map(ToIdent::to_ident).unwrap();
-        quote!(self.#ident.#method_name())
+        let reference = reference(quote!(self.#ident));
+        quote!(#trait_name :: #method_name (#reference))
     } else {
         result_expr.clone()
     };


### PR DESCRIPTION
As of now if we remove the implementation of a trait for a type and implement the method on that type directly it wouldn't break while it isn't the original trait anymore so that method might do something entirely different.
This change is more explicit on trait calls so we hit compile errors on these kinds of changes.