### PR TITLE
fix(linter/tree-shaking): detect the correct export symbol resolution

### DIFF
--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -8,10 +8,10 @@ use oxc_ast::{
         FormalParameter, Function, IdentifierReference, JSXAttribute, JSXAttributeItem,
         JSXAttributeValue, JSXChild, JSXElement, JSXElementName, JSXExpression,
         JSXExpressionContainer, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
-        JSXOpeningElement, LogicalExpression, MemberExpression, NewExpression, ObjectExpression,
-        ObjectPropertyKind, ParenthesizedExpression, PrivateFieldExpression, Program, PropertyKey,
-        SequenceExpression, SimpleAssignmentTarget, Statement, StaticMemberExpression, SwitchCase,
-        ThisExpression, UnaryExpression, VariableDeclarator,
+        JSXOpeningElement, LogicalExpression, MemberExpression, ModuleExportName, NewExpression,
+        ObjectExpression, ObjectPropertyKind, ParenthesizedExpression, PrivateFieldExpression,
+        Program, PropertyKey, SequenceExpression, SimpleAssignmentTarget, Statement,
+        StaticMemberExpression, SwitchCase, ThisExpression, UnaryExpression, VariableDeclarator,
     },
     AstKind,
 };
@@ -195,9 +195,10 @@ impl<'a> ListenerMap for ExportSpecifier<'a> {
         let ctx = options.ctx;
         let symbol_table = ctx.symbols();
         if has_comment_about_side_effect_check(self.exported.span(), ctx) {
-            let Some(name) = self.exported.identifier_name() else { return };
-            let Some(symbol_id) = options.ctx.symbols().get_symbol_id_from_name(name.as_str())
-            else {
+            let ModuleExportName::IdentifierReference(ident) = &self.local else {
+                return;
+            };
+            let Some(symbol_id) = get_symbol_id_of_variable(ident, ctx) else {
                 return;
             };
 

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -346,6 +346,11 @@ fn test() {
         r#"export {x as default} from "import""#,
         "export const /* tree-shaking no-side-effects-when-called */ x = function(){}",
         "export function /* tree-shaking no-side-effects-when-called */ x(){}",
+        "
+            { let x = ext; }
+            let x =  () => {}
+            export {/* tree-shaking no-side-effects-when-called */ x}
+        ",
         "const x = function(){}; export {/* tree-shaking no-side-effects-when-called */ x}",
         // ExpressionStatement
         "const x = 1",
@@ -632,6 +637,11 @@ fn test() {
         "export const /* tree-shaking no-side-effects-when-called */ x = ext",
         "export function /* tree-shaking no-side-effects-when-called */ x(){ext()}",
         "const x = ext; export {/* tree-shaking no-side-effects-when-called */ x}",
+        "
+            { let x = () => {}; }
+            let x = ext 
+            export {/* tree-shaking no-side-effects-when-called */ x}
+        ", 
         // ExpressionStatement
         "ext()",
         // ForInStatement

--- a/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
+++ b/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
@@ -410,6 +410,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:3:21]
+ 2 │             { let x = () => {}; }
+ 3 │             let x = ext 
+   ·                     ───
+ 4 │             export {/* tree-shaking no-side-effects-when-called */ x}
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
    ╭─[no_side_effects_in_initialization.tsx:1:1]
  1 │ ext()
    · ───


### PR DESCRIPTION
fixes: #5455
