### PR TITLE
refactor(ast): simplify `ContentEq` trait definition.

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -58,7 +58,7 @@ fn assert_generated_derives(attrs: &[syn::Attribute]) -> TokenStream2 {
         } else if ident == "GetSpanMut" {
             (quote!(::oxc_span::GetSpanMut), TokenStream2::default())
         } else if ident == "ContentEq" {
-            (quote!(::oxc_span::cmp::ContentEq), quote!(<()>))
+            (quote!(::oxc_span::cmp::ContentEq), TokenStream2::default())
         } else if ident == "ContentHash" {
             (quote!(::oxc_span::hash::ContentHash), TokenStream2::default())
         } else {

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -180,30 +180,6 @@ impl<'a> ContentEq for Atom<'a> {
     }
 }
 
-impl<'a> ContentEq<Atom<'a>> for &str {
-    fn content_eq(&self, other: &Atom<'a>) -> bool {
-        self == other
-    }
-}
-
-impl<'a> ContentEq<str> for Atom<'a> {
-    fn content_eq(&self, other: &str) -> bool {
-        self == other
-    }
-}
-
-impl<'a> ContentEq<Atom<'a>> for Cow<'_, str> {
-    fn content_eq(&self, other: &Atom<'a>) -> bool {
-        self == other
-    }
-}
-
-impl<'a> ContentEq<&Atom<'a>> for Cow<'_, str> {
-    fn content_eq(&self, other: &&Atom<'a>) -> bool {
-        self == other
-    }
-}
-
 impl<'a> ContentHash for Atom<'a> {
     fn content_hash<H: hash::Hasher>(&self, state: &mut H) {
         hash::Hash::hash(self, state);

--- a/crates/oxc_span/src/cmp.rs
+++ b/crates/oxc_span/src/cmp.rs
@@ -5,17 +5,17 @@
 ///
 /// One should always prefer using the [PartialEq] over this since implementations of this trait
 /// inherently are slower or in the best-case scenario as fast as the [PartialEq] comparison.
-pub trait ContentEq<Rhs: ?Sized = Self> {
+pub trait ContentEq {
     /// This method tests for contents of `self` and `other` to be equal.
     #[must_use]
-    fn content_eq(&self, other: &Rhs) -> bool;
+    fn content_eq(&self, other: &Self) -> bool;
 
     /// This method tests for contents of `self` and `other` not to be equal.
     /// The default implementation is almost always
     /// sufficient, and should not be overridden without very good reason.
     #[inline]
     #[must_use]
-    fn content_ne(&self, other: &Rhs) -> bool {
+    fn content_ne(&self, other: &Self) -> bool {
         !self.content_eq(other)
     }
 }
@@ -29,66 +29,6 @@ impl ContentEq for () {
     #[inline]
     fn content_ne(&self, _other: &()) -> bool {
         false
-    }
-}
-
-/// Blanket implementation for references
-impl<A: ?Sized, B: ?Sized> ContentEq<&B> for &A
-where
-    A: ContentEq<B>,
-{
-    #[inline]
-    fn content_eq(&self, other: &&B) -> bool {
-        ContentEq::content_eq(*self, *other)
-    }
-    #[inline]
-    fn content_ne(&self, other: &&B) -> bool {
-        ContentEq::content_ne(*self, *other)
-    }
-}
-
-/// Blanket implementation for mutable references
-impl<A: ?Sized, B: ?Sized> ContentEq<&mut B> for &mut A
-where
-    A: ContentEq<B>,
-{
-    #[inline]
-    fn content_eq(&self, other: &&mut B) -> bool {
-        ContentEq::content_eq(*self, *other)
-    }
-    #[inline]
-    fn content_ne(&self, other: &&mut B) -> bool {
-        ContentEq::content_ne(*self, *other)
-    }
-}
-
-/// Blanket implementation for mixed references
-impl<A: ?Sized, B: ?Sized> ContentEq<&mut B> for &A
-where
-    A: ContentEq<B>,
-{
-    #[inline]
-    fn content_eq(&self, other: &&mut B) -> bool {
-        ContentEq::content_eq(*self, *other)
-    }
-    #[inline]
-    fn content_ne(&self, other: &&mut B) -> bool {
-        ContentEq::content_ne(*self, *other)
-    }
-}
-
-/// Blanket implementation for mixed references
-impl<A: ?Sized, B: ?Sized> ContentEq<&B> for &mut A
-where
-    A: ContentEq<B>,
-{
-    #[inline]
-    fn content_eq(&self, other: &&B) -> bool {
-        ContentEq::content_eq(*self, *other)
-    }
-    #[inline]
-    fn content_ne(&self, other: &&B) -> bool {
-        ContentEq::content_ne(*self, *other)
     }
 }
 


### PR DESCRIPTION
Addresses the concerns brought up in #5427 