### PR TITLE
feat(oxc_diagnostic):  impl DerefMut for OxcDiagnostic

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -9,7 +9,7 @@ mod service;
 use std::{
     borrow::Cow,
     fmt::{self, Display},
-    ops::Deref,
+    ops::{Deref, DerefMut},
 };
 
 pub use crate::{
@@ -39,6 +39,12 @@ impl Deref for OxcDiagnostic {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl DerefMut for OxcDiagnostic {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
     }
 }
 


### PR DESCRIPTION
1. Impl `DerefMut` for `OxcDiagnositc` so downstream user could move `OxcDiagnostic` rather clone it, 
https://github.com/rolldown/rolldown/blob/40ae24d59711599e8fb23ae5f3619144eb001cec/crates/rolldown_ecmascript/src/ecma_compiler.rs#L36-L48