### PR TITLE
docs(span): update docs about `ContentEq` `Vec` comparison speed

### DIFF
--- a/crates/oxc_span/src/cmp.rs
+++ b/crates/oxc_span/src/cmp.rs
@@ -59,10 +59,10 @@ impl<'a, T: ContentEq> ContentEq for oxc_allocator::Box<'a, T> {
 
 /// Blanket implementation for [oxc_allocator::Vec] types
 ///
-/// # WARNING
-///
-/// This implementation is slow compared to `[PartialEq]`, Consider comparing the 2 vectors using
-/// that when one is implemented. This implementation takes triple the time the `PartialEq` would take.
+/// # Warning
+/// This implementation is slow compared to [PartialEq] for native types which are [Copy] (e.g. `u32`).
+/// Prefer comparing the 2 vectors using `==` if they contain such native types (e.g. `Vec<u32>`).
+/// <https://godbolt.org/z/54on5sMWc>
 impl<'a, T: ContentEq> ContentEq for oxc_allocator::Vec<'a, T> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
Update the docs for `impl ContentEq for Vec` to state in what circumstances `PartialEq` is faster. See https://github.com/oxc-project/oxc/pull/5427#discussion_r1744290058.
