### PR TITLE
refactor(semantic)!: remove `SymbolTable::get_symbol_id_from_name` and `SymbolTable::get_scope_id_from_name`

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -71,16 +71,6 @@ impl SymbolTable {
             .find_map(|(symbol, &inner_span)| if inner_span == span { Some(symbol) } else { None })
     }
 
-    pub fn get_symbol_id_from_name(&self, name: &str) -> Option<SymbolId> {
-        self.names.iter_enumerated().find_map(|(symbol, inner_name)| {
-            if inner_name.as_str() == name {
-                Some(symbol)
-            } else {
-                None
-            }
-        })
-    }
-
     #[inline]
     pub fn get_span(&self, symbol_id: SymbolId) -> Span {
         self.spans[symbol_id]
@@ -133,10 +123,6 @@ impl SymbolTable {
 
     pub fn get_scope_id_from_span(&self, span: Span) -> Option<ScopeId> {
         self.get_symbol_id_from_span(span).map(|symbol_id| self.get_scope_id(symbol_id))
-    }
-
-    pub fn get_scope_id_from_name(&self, name: &str) -> Option<ScopeId> {
-        self.get_symbol_id_from_name(name).map(|symbol_id| self.get_scope_id(symbol_id))
     }
 
     #[inline]


### PR DESCRIPTION
Close #5456.