### PR TITLE
fix(transformer): RegExp transform don't transform all RegExps

### DIFF
--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -120,7 +120,13 @@ impl<'a> Traverse<'a> for RegExp<'a> {
         };
 
         let has_unsupported_flags = regexp.regex.flags.intersects(self.unsupported_flags);
-        if !has_unsupported_flags && self.some_unsupported_patterns {
+        if !has_unsupported_flags {
+            if !self.some_unsupported_patterns {
+                // This RegExp has no unsupported flags, and there are no patterns which may need transforming,
+                // so there's nothing to do
+                return;
+            }
+
             match try_parse_pattern(regexp, ctx) {
                 Ok(pattern) => {
                     let is_unsupported = self.has_unsupported_regular_expression_pattern(&pattern);
@@ -134,7 +140,7 @@ impl<'a> Traverse<'a> for RegExp<'a> {
                     return;
                 }
             }
-        };
+        }
 
         let pattern_source: Cow<'_, str> = match &regexp.regex.pattern {
             RegExpPattern::Raw(raw) | RegExpPattern::Invalid(raw) => Cow::Borrowed(raw),

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -46,10 +46,10 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(9), ScopeId(14), S
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(13), ScopeId(19), ScopeId(22), ScopeId(23)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(20), ReferenceId(22), ReferenceId(26), ReferenceId(34), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(80), ReferenceId(81), ReferenceId(83), ReferenceId(86), ReferenceId(89), ReferenceId(91), ReferenceId(97)]
-rebuilt        : SymbolId(0): [ReferenceId(39), ReferenceId(40), ReferenceId(43), ReferenceId(45), ReferenceId(48), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(61), ReferenceId(63), ReferenceId(66), ReferenceId(69), ReferenceId(72), ReferenceId(74), ReferenceId(80)]
+rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
 Unresolved references mismatch:
-after transform: ["Object", "RegExp", "true", "undefined"]
-rebuilt        : ["Object", "RegExp", "undefined"]
+after transform: ["Object", "true", "undefined"]
+rebuilt        : ["Object", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
 semantic error: Bindings mismatch:
@@ -1496,43 +1496,43 @@ after transform: ScopeId(1): ["Tany"]
 rebuilt        : ScopeId(1): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("a")
-rebuilt        : ReferenceId(1): None
+rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("a")
-rebuilt        : ReferenceId(2): None
+rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("a")
-rebuilt        : ReferenceId(3): None
+rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
-rebuilt        : ReferenceId(4): None
+rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
-rebuilt        : ReferenceId(5): None
+rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("A")
-rebuilt        : ReferenceId(6): None
+rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("A")
-rebuilt        : ReferenceId(7): None
+rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("A")
-rebuilt        : ReferenceId(8): None
+rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("A")
-rebuilt        : ReferenceId(9): None
+rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("A")
-rebuilt        : ReferenceId(10): None
+rebuilt        : ReferenceId(9): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("A")
-rebuilt        : ReferenceId(11): None
+rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("A")
-rebuilt        : ReferenceId(12): None
+rebuilt        : ReferenceId(11): None
 Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : ["A", "RegExp", "a"]
+after transform: []
+rebuilt        : ["A", "a"]
 
 tasks/coverage/typescript/tests/cases/compiler/castNewObjectBug.ts
 semantic error: Bindings mismatch:
@@ -5108,8 +5108,8 @@ Reference symbol mismatch:
 after transform: ReferenceId(0): Some("require")
 rebuilt        : ReferenceId(0): None
 Unresolved references mismatch:
-after transform: ["Error", "JSON", "RegExp"]
-rebuilt        : ["Error", "JSON", "RegExp", "require"]
+after transform: ["Error", "JSON"]
+rebuilt        : ["Error", "JSON", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
 semantic error: Bindings mismatch:
@@ -31707,10 +31707,7 @@ rebuilt        : ["undefined"]
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDoWhileStatement.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Function", "RegExp", "undefined"]
-rebuilt        : ["RegExp", "undefined"]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(23), ReferenceId(33), ReferenceId(42), ReferenceId(43)]
-rebuilt        : [ReferenceId(29), ReferenceId(38)]
+rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
 semantic error: Bindings mismatch:
@@ -31749,10 +31746,7 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Function", "RegExp"]
-rebuilt        : ["RegExp"]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(0), ReferenceId(11)]
-rebuilt        : [ReferenceId(1)]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
 semantic error: Bindings mismatch:
@@ -31815,10 +31809,10 @@ after transform: ScopeId(12): ["T", "data"]
 rebuilt        : ScopeId(12): ["data"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(15): [ReferenceId(29), ReferenceId(30)]
-rebuilt        : SymbolId(11): [ReferenceId(24)]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(0), ReferenceId(31)]
-rebuilt        : [ReferenceId(1)]
+rebuilt        : SymbolId(11): [ReferenceId(23)]
+Unresolved references mismatch:
+after transform: ["Error", "JSON", "RegExp"]
+rebuilt        : ["Error", "JSON"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
 semantic error: Bindings mismatch:
@@ -31977,8 +31971,8 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(16)]
 rebuilt        : SymbolId(0): [ReferenceId(11)]
 Unresolved references mismatch:
-after transform: ["Object", "RegExp", "RegExpExecArray", "getFooOrNull", "getStringOrNumberOrNull"]
-rebuilt        : ["RegExp", "getFooOrNull", "getStringOrNumberOrNull"]
+after transform: ["Object", "RegExpExecArray", "getFooOrNull", "getStringOrNumberOrNull"]
+rebuilt        : ["getFooOrNull", "getStringOrNumberOrNull"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts
 semantic error: Bindings mismatch:
@@ -35674,9 +35668,9 @@ rebuilt        : ScopeId(0): ["a", "arr", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(0), ReferenceId(22)]
-rebuilt        : [ReferenceId(13)]
+Unresolved references mismatch:
+after transform: ["RegExp"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -42474,8 +42468,8 @@ Reference symbol mismatch:
 after transform: ReferenceId(1): Some("a")
 rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : ["RegExp", "a"]
+after transform: []
+rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolIndexer1.ts
 semantic error: Bindings mismatch:
@@ -43200,7 +43194,7 @@ after transform: ScopeId(10): ["T", "x"]
 rebuilt        : ScopeId(9): ["x"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(21), ReferenceId(42)]
-rebuilt        : SymbolId(1): [ReferenceId(20), ReferenceId(41)]
+rebuilt        : SymbolId(1): [ReferenceId(20), ReferenceId(40)]
 Symbol flags mismatch:
 after transform: SymbolId(7): SymbolFlags(Export | Class)
 rebuilt        : SymbolId(6): SymbolFlags(Class)


### PR DESCRIPTION
Previously `RegExp` transform would transform every `RegExp`, even if it had no unsupported flags/patterns.