### PR TITLE
fix(transformer): RegExp transform do not transform invalid regexps

### DIFF
--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -150,8 +150,9 @@ impl<'a> Traverse<'a> for RegExp<'a> {
         }
 
         let pattern_source: Cow<'_, str> = match &regexp.regex.pattern {
-            RegExpPattern::Raw(raw) | RegExpPattern::Invalid(raw) => Cow::Borrowed(raw),
+            RegExpPattern::Raw(raw) => Cow::Borrowed(raw),
             RegExpPattern::Pattern(p) => Cow::Owned(p.to_string()),
+            RegExpPattern::Invalid(_) => return,
         };
 
         let callee = {


### PR DESCRIPTION
Treat invalid regexps the same regardless of whether they have unsupported flags or not - don't transform them.