### PR TITLE
feat(transformer): add `TransformOptions::enable_all` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_traverse",
+ "pico-args",
  "ropey",
  "rustc-hash",
  "serde",

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -41,6 +41,7 @@ oxc-browserslist = { workspace = true }
 [dev-dependencies]
 oxc_parser  = { workspace = true }
 oxc_codegen = { workspace = true }
+pico-args   = { workspace = true }
 
 [features]
 default = []

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -55,6 +55,35 @@ pub struct TransformOptions {
 }
 
 impl TransformOptions {
+    /// Explicitly enable all plugins that are ready, mainly for testing purposes.
+    pub fn enable_all() -> Self {
+        Self {
+            cwd: PathBuf::new(),
+            assumptions: CompilerAssumptions::default(),
+            typescript: TypeScriptOptions::default(),
+            react: ReactOptions { development: true, ..ReactOptions::default() },
+            regexp: RegExpOptions {
+                sticky_flag: true,
+                unicode_flag: true,
+                dot_all_flag: true,
+                look_behind_assertions: true,
+                named_capture_groups: true,
+                unicode_property_escapes: true,
+                match_indices: true,
+                set_notation: true,
+            },
+            es2015: ES2015Options {
+                // Turned off because it is not ready.
+                arrow_function: None,
+            },
+            es2016: ES2016Options { exponentiation_operator: true },
+            es2018: ES2018Options { object_rest_spread: Some(ObjectRestSpreadOptions::default()) },
+            es2019: ES2019Options { optional_catch_binding: true },
+            es2020: ES2020Options { nullish_coalescing_operator: true },
+            es2021: ES2021Options { logical_assignment_operators: true },
+        }
+    }
+
     fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
         Self {
             es2015: ES2015Options::from_targets_and_bugfixes(targets, bugfixes),

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -6,7 +6,7 @@ use oxc_parser::{Parser, ParserReturn};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
-use oxc_transformer::{EnvOptions, Targets, TransformOptions, Transformer};
+use oxc_transformer::{TransformOptions, Transformer};
 
 fn bench_transformer(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("transformer");
@@ -40,17 +40,6 @@ fn bench_transformer(criterion: &mut Criterion) {
                 // in measure.
                 let trivias_copy = trivias.clone();
 
-                let env_options = EnvOptions {
-                    // >= ES2016
-                    targets: Targets::from_query("chrome 51"),
-                    ..Default::default()
-                };
-                let mut transform_options =
-                    TransformOptions::from_preset_env(&env_options).unwrap();
-
-                // Enable React related plugins
-                transform_options.react.development = true;
-
                 runner.run(|| {
                     let ret = Transformer::new(
                         &allocator,
@@ -58,7 +47,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                         source_type,
                         source_text,
                         trivias,
-                        transform_options,
+                        TransformOptions::enable_all(),
                     )
                     .build_with_symbols_and_scopes(symbols, scopes, program);
 


### PR DESCRIPTION
Make it **really** explicit about which transformer options are being turned on. I also need this in monitor-oxc.