### PR TITLE
test(linter/no-unused-vars): arrow functions in tagged templates

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -19,6 +19,23 @@ fn test_vars_simple() {
               });",
             None,
         ),
+        // https://github.com/oxc-project/oxc/issues/5391
+        (
+            "
+            import styled from 'styled-components';
+
+            import { Prose, ProseProps } from './prose';
+
+            interface Props extends ProseProps {
+              density?: number;
+            }
+
+            export const HandMarkedPaperBallotProse = styled(Prose)<Props>`
+            line-height: ${({ density }) => (density !== 0 ? '1.1' : '1.3')};
+            `;
+            ",
+            None,
+        ),
     ];
     let fail = vec![
         ("let a = 1", None),

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -426,3 +426,26 @@ fn test_arrow_explicit_return() {
         .has_number_of_writes(1)
         .test();
 }
+
+#[test]
+fn test_tagged_templates() {
+    // https://github.com/oxc-project/oxc/issues/5391
+    SemanticTester::tsx(
+        "
+        import styled from 'styled-components';
+
+        import { Prose, ProseProps } from './prose';
+        
+        interface Props extends ProseProps {
+          density?: number;
+        }
+        export const HandMarkedPaperBallotProse = styled(Prose)<Props>`
+          line-height: ${({ density }) => (density !== 0 ? '1.1' : '1.3')};
+        `;
+    ",
+    )
+    .has_some_symbol("density")
+    .has_number_of_reads(1)
+    .has_number_of_writes(0)
+    .test();
+}


### PR DESCRIPTION
Closes  #5391