### PR TITLE
refactor(transformer): break up RegExp transform into multiple functions

### DIFF
--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -48,7 +48,7 @@ use oxc_regular_expression::ast::{
     CharacterClass, CharacterClassContents, LookAroundAssertionKind, Pattern, Term,
 };
 use oxc_semantic::ReferenceFlags;
-use oxc_span::Atom;
+use oxc_span::{Atom, SPAN};
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::context::Ctx;
@@ -164,7 +164,7 @@ impl<'a> Traverse<'a> for RegExp<'a> {
         let callee = {
             let symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), "RegExp");
             let ident = ctx.create_reference_id(
-                regexp.span,
+                SPAN,
                 Atom::from("RegExp"),
                 symbol_id,
                 ReferenceFlags::read(),
@@ -174,14 +174,11 @@ impl<'a> Traverse<'a> for RegExp<'a> {
 
         let mut arguments = ctx.ast.vec_with_capacity(2);
         arguments.push(
-            ctx.ast.argument_expression(
-                ctx.ast.expression_string_literal(regexp.span, pattern_source),
-            ),
+            ctx.ast.argument_expression(ctx.ast.expression_string_literal(SPAN, pattern_source)),
         );
 
         let flags = regexp.regex.flags.to_string();
-        let flags =
-            ctx.ast.argument_expression(ctx.ast.expression_string_literal(regexp.span, flags));
+        let flags = ctx.ast.argument_expression(ctx.ast.expression_string_literal(SPAN, flags));
         arguments.push(flags);
 
         *expr = ctx.ast.expression_new(

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -120,7 +120,6 @@ impl<'a> Traverse<'a> for RegExp<'a> {
 }
 
 impl<'a> RegExp<'a> {
-    /// Transform RegExp if it contains unsupported flags or unsupported patterns
     fn transform_regexp(
         &mut self,
         expr: &mut Expression<'a>,
@@ -131,7 +130,8 @@ impl<'a> RegExp<'a> {
             _ => unreachable!(),
         };
 
-        let has_unsupported_flags = regexp.regex.flags.intersects(self.unsupported_flags);
+        let flags = regexp.regex.flags;
+        let has_unsupported_flags = flags.intersects(self.unsupported_flags);
         if !has_unsupported_flags {
             if !self.some_unsupported_patterns {
                 // This RegExp has no unsupported flags, and there are no patterns which may need transforming,
@@ -139,31 +139,38 @@ impl<'a> RegExp<'a> {
                 return;
             }
 
-            if !self.has_unsuppported_pattern(regexp, ctx) {
+            let span = regexp.span;
+            let pattern = match &mut regexp.regex.pattern {
+                RegExpPattern::Raw(raw) => {
+                    // Try to parse pattern
+                    match try_parse_pattern(raw, span, flags, ctx) {
+                        Ok(pattern) => {
+                            regexp.regex.pattern = RegExpPattern::Pattern(ctx.alloc(pattern));
+                            let RegExpPattern::Pattern(pattern) = &regexp.regex.pattern else {
+                                unreachable!()
+                            };
+                            pattern
+                        }
+                        Err(error) => {
+                            regexp.regex.pattern = RegExpPattern::Invalid(raw);
+                            self.ctx.error(error);
+                            return;
+                        }
+                    }
+                }
+                RegExpPattern::Invalid(_) => return,
+                RegExpPattern::Pattern(pattern) => &**pattern,
+            };
+
+            if !self.has_unsupported_regular_expression_pattern(pattern) {
                 return;
             }
-        } else if matches!(&regexp.regex.pattern, RegExpPattern::Invalid(_)) {
-            return;
         }
 
-        *expr = Self::transform_regexp_if_required(regexp, ctx);
-    }
-
-    /// Convert `RegExpLiteral` to `new RegExp(...)`.
-    /// Caller should have already checked for unsupported flags and unsupported patterns.
-    /// Caller must ensure pattern is not `RegExpPattern::Invalid` before calling this.
-    ///
-    /// This heavy logic is broken out into a separate function from `transform_regexp`, so that
-    /// `transform_regexp` remains small, and maybe compiler will be able to inline `transform_regexp`.
-    /// That would create a fast path for common case where RegExp has no unsupported features.
-    fn transform_regexp_if_required(
-        regexp: &mut RegExpLiteral<'a>,
-        ctx: &mut oxc_traverse::TraverseCtx<'a>,
-    ) -> Expression<'a> {
         let pattern_source: Cow<'_, str> = match &regexp.regex.pattern {
             RegExpPattern::Raw(raw) => Cow::Borrowed(raw),
             RegExpPattern::Pattern(p) => Cow::Owned(p.to_string()),
-            RegExpPattern::Invalid(_) => unreachable!(),
+            RegExpPattern::Invalid(_) => return,
         };
 
         let callee = {
@@ -186,48 +193,23 @@ impl<'a> RegExp<'a> {
         let flags = ctx.ast.argument_expression(ctx.ast.expression_string_literal(SPAN, flags));
         arguments.push(flags);
 
-        ctx.ast.expression_new(regexp.span, callee, arguments, None::<TSTypeParameterInstantiation>)
+        *expr = ctx.ast.expression_new(
+            regexp.span,
+            callee,
+            arguments,
+            None::<TSTypeParameterInstantiation>,
+        );
     }
 
-    /// Check if RegExp's pattern contains unsupported syntax.
-    /// Returns `true` if it does.
-    /// If pattern was not already parsed, parse it here.
-    fn has_unsuppported_pattern(
-        &mut self,
-        regexp: &mut RegExpLiteral<'a>,
-        ctx: &mut oxc_traverse::TraverseCtx<'a>,
-    ) -> bool {
-        let span = regexp.span;
-        let flags = regexp.regex.flags;
-        let pattern = match &mut regexp.regex.pattern {
-            RegExpPattern::Raw(raw) => {
-                // Try to parse pattern
-                match try_parse_pattern(raw, span, flags, ctx) {
-                    Ok(pattern) => {
-                        regexp.regex.pattern = RegExpPattern::Pattern(ctx.alloc(pattern));
-                        let RegExpPattern::Pattern(pattern) = &regexp.regex.pattern else {
-                            unreachable!()
-                        };
-                        pattern
-                    }
-                    Err(error) => {
-                        regexp.regex.pattern = RegExpPattern::Invalid(raw);
-                        self.ctx.error(error);
-                        return false;
-                    }
-                }
-            }
-            RegExpPattern::Invalid(_) => return false,
-            RegExpPattern::Pattern(pattern) => &**pattern,
-        };
-
-        // Check if pattern contains any unsupported syntax
+    /// Check if the regular expression contains any unsupported syntax.
+    ///
+    /// Based on parsed regular expression pattern.
+    fn has_unsupported_regular_expression_pattern(&self, pattern: &Pattern<'a>) -> bool {
         pattern.body.body.iter().any(|alternative| {
             alternative.body.iter().any(|term| self.term_contains_unsupported(term))
         })
     }
 
-    /// Check if a `Term` contains unsupported syntax
     fn term_contains_unsupported(&self, mut term: &Term) -> bool {
         // Loop because `Term::Quantifier` contains a nested `Term`
         loop {

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -113,9 +113,10 @@ impl<'a> Traverse<'a> for RegExp<'a> {
         expr: &mut Expression<'a>,
         ctx: &mut oxc_traverse::TraverseCtx<'a>,
     ) {
-        let Expression::RegExpLiteral(ref mut regexp) = expr else {
+        let Expression::RegExpLiteral(regexp) = expr else {
             return;
         };
+        let regexp = &mut **regexp;
 
         let flags = regexp.regex.flags;
         let has_unsupported_flags = flags.intersects(self.unsupported_flags);


### PR DESCRIPTION
Experiment. Idea is to split up the transform, with the heavy logic in separate functions, so potentially the compiler can inline the smaller "entry" functions.

`enter_expression` is now tiny, and `transform_regexp` also quite short as it's all simple comparisons. `transform_regexp` contains all the logic for bailing out quickly, so potentially the fast path for doing nothing could all get inlined.