### PR TITLE
fix(linter): handle loops in `getter-return` rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -353,8 +353,7 @@ fn test() {
         };
         ", None),
         // adapted from: https://github.com/1024pix/pix/blob/1352bd8d7f6070f1ff8da79867f543c1c1926e59/mon-pix/app/components/progress-bar.js#L29-L43
-        (
-            "
+        ("
         export default class ProgressBar extends Component {
             get steps() {
                 const steps = [];
@@ -367,42 +366,31 @@ fn test() {
 
                 return steps;
             }
-        }
-        ",
-            None,
-        ),
-        (
-            "
-            var foo = {
-                get bar() {
-                    for (let i = 0; i<10; i++) {
-                        if (i === 5) {
-                            return i;
-                        }
+        }", None),
+        ("
+        var foo = {
+            get bar() {
+                for (let i = 0; i<10; i++) {
+                    if (i === 5) {
+                        return i;
                     }
-                    return 0;
                 }
+                return 0;
             }
-            ",
-            None,
-        ),
-        (
-            "
-            var foo = {
-                get bar() {
-                    let i = 0;
-                    while (i < 10) {
-                        if (i === 5) {
-                            return i;
-                        }
-                        i++;
+        }", None),
+        ("
+        var foo = {
+            get bar() {
+                let i = 0;
+                while (i < 10) {
+                    if (i === 5) {
+                        return i;
                     }
-                    return 0;
+                    i++;
                 }
+                return 0;
             }
-            ",
-            None,
-        ),
+        }", None),
     ];
 
     let fail = vec![
@@ -478,31 +466,23 @@ fn test() {
         ),
         ("var foo = { get bar() { try { return a(); } catch {} } };", None),
         ("var foo = { get bar() { try { return a(); } catch {  } finally {  } } };", None),
-        (
-            "
-            var foo = {
-                get bar() {
-                    for (let i = 0; i<10; i++) {
-                        return i;
-                    }
+        ("
+        var foo = {
+            get bar() {
+                for (let i = 0; i<10; i++) {
+                    return i;
                 }
             }
-            ",
-            None,
-        ),
-        (
-            "
-            var foo = {
-                get bar() {
-                    let i = 0;
-                    while (i < 10) {
-                        return i;
-                    }
+        }", None),
+        ("
+        var foo = {
+            get bar() {
+                let i = 0;
+                while (i < 10) {
+                    return i;
                 }
             }
-            ",
-            None,
-        ),
+        }", None),
     ];
 
     Tester::new(GetterReturn::NAME, pass, fail)

--- a/crates/oxc_linter/src/snapshots/getter_return.snap
+++ b/crates/oxc_linter/src/snapshots/getter_return.snap
@@ -256,26 +256,26 @@ source: crates/oxc_linter/src/tester.rs
   help: Return a value from all code paths in getter.
 
   ⚠ eslint(getter-return): Expected to always return a value in getter.
-   ╭─[getter_return.js:3:24]
- 2 │                 var foo = {
- 3 │ ╭─▶                 get bar() {
- 4 │ │                       for (let i = 0; i<10; i++) {
- 5 │ │                           return i;
- 6 │ │                       }
- 7 │ ╰─▶                 }
- 8 │                 }
+   ╭─[getter_return.js:3:20]
+ 2 │             var foo = {
+ 3 │ ╭─▶             get bar() {
+ 4 │ │                   for (let i = 0; i<10; i++) {
+ 5 │ │                       return i;
+ 6 │ │                   }
+ 7 │ ╰─▶             }
+ 8 │             }
    ╰────
   help: Return a value from all code paths in getter.
 
   ⚠ eslint(getter-return): Expected to always return a value in getter.
-   ╭─[getter_return.js:3:24]
- 2 │                 var foo = {
- 3 │ ╭─▶                 get bar() {
- 4 │ │                       let i = 0;
- 5 │ │                       while (i < 10) {
- 6 │ │                           return i;
- 7 │ │                       }
- 8 │ ╰─▶                 }
- 9 │                 }
+   ╭─[getter_return.js:3:20]
+ 2 │             var foo = {
+ 3 │ ╭─▶             get bar() {
+ 4 │ │                   let i = 0;
+ 5 │ │                   while (i < 10) {
+ 6 │ │                       return i;
+ 7 │ │                   }
+ 8 │ ╰─▶             }
+ 9 │             }
    ╰────
   help: Return a value from all code paths in getter.

--- a/crates/oxc_linter/src/snapshots/getter_return.snap
+++ b/crates/oxc_linter/src/snapshots/getter_return.snap
@@ -254,3 +254,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ──────────────────────────────────────────────────
    ╰────
   help: Return a value from all code paths in getter.
+
+  ⚠ eslint(getter-return): Expected to always return a value in getter.
+   ╭─[getter_return.js:3:24]
+ 2 │                 var foo = {
+ 3 │ ╭─▶                 get bar() {
+ 4 │ │                       for (let i = 0; i<10; i++) {
+ 5 │ │                           return i;
+ 6 │ │                       }
+ 7 │ ╰─▶                 }
+ 8 │                 }
+   ╰────
+  help: Return a value from all code paths in getter.
+
+  ⚠ eslint(getter-return): Expected to always return a value in getter.
+   ╭─[getter_return.js:3:24]
+ 2 │                 var foo = {
+ 3 │ ╭─▶                 get bar() {
+ 4 │ │                       let i = 0;
+ 5 │ │                       while (i < 10) {
+ 6 │ │                           return i;
+ 7 │ │                       }
+ 8 │ ╰─▶                 }
+ 9 │                 }
+   ╰────
+  help: Return a value from all code paths in getter.


### PR DESCRIPTION
- Fixes https://github.com/oxc-project/oxc/issues/3935

Prior to this, it didn't seem like we were correctly continuing to search the graph after we encountered a backedge (loop). Now, when encountering a cycle, we will not automatically break or prune the search.