### PR TITLE
fix(regular_expression): Handle unterminated character class

### DIFF
--- a/crates/oxc_regular_expression/src/body_parser/mod.rs
+++ b/crates/oxc_regular_expression/src/body_parser/mod.rs
@@ -171,6 +171,10 @@ mod test {
             ("(?=a){1}", ParserOptions::default().with_unicode_mode()),
             ("(?!a){1}", ParserOptions::default().with_unicode_mode()),
             (r"[\d-\D]", ParserOptions::default().with_unicode_mode()),
+            ("[", ParserOptions::default()),
+            ("[", ParserOptions::default().with_unicode_sets_mode()),
+            ("[[", ParserOptions::default().with_unicode_sets_mode()),
+            ("[[]", ParserOptions::default().with_unicode_sets_mode()),
             ("[z-a]", ParserOptions::default()),
             (r"[a-c]]", ParserOptions::default().with_unicode_mode()),
             (

--- a/crates/oxc_regular_expression/src/body_parser/parser.rs
+++ b/crates/oxc_regular_expression/src/body_parser/parser.rs
@@ -771,7 +771,10 @@ impl<'a> PatternParser<'a> {
         &mut self,
     ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
         // [empty]
-        if self.reader.peek().filter(|&cp| cp == ']' as u32).is_some() {
+        if self.reader.peek().filter(|&cp| cp == ']' as u32).is_some()
+            // Unterminated
+            || self.reader.peek().is_none()
+        {
             return Ok((ast::CharacterClassContentsKind::Union, Vec::new_in(self.allocator)));
         }
 


### PR DESCRIPTION
`/[/` is reported by `debug_assert!`, but should not.