### PR TITLE
feat(oxc):  conditional expose `oxc_cfg` in `oxc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ version = "0.26.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
+ "oxc_cfg",
  "oxc_codegen",
  "oxc_diagnostics",
  "oxc_index",

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -40,6 +40,7 @@ oxc_mangler               = { workspace = true, optional = true }
 oxc_codegen               = { workspace = true, optional = true }
 oxc_sourcemap             = { workspace = true, optional = true }
 oxc_isolated_declarations = { workspace = true, optional = true }
+oxc_cfg                   = { workspace = true, optional = true }
 
 [features]
 full = ["codegen", "mangler", "minifier", "semantic", "transformer"]
@@ -49,6 +50,7 @@ transformer = ["oxc_transformer"]
 minifier    = ["oxc_mangler", "oxc_minifier"]
 codegen     = ["oxc_codegen"]
 mangler     = ["oxc_mangler"]
+cfg         = ["oxc_cfg"]
 
 serialize = ["oxc_ast/serialize", "oxc_semantic?/serialize", "oxc_span/serialize", "oxc_syntax/serialize"]
 

--- a/crates/oxc/src/lib.rs
+++ b/crates/oxc/src/lib.rs
@@ -84,3 +84,9 @@ pub mod sourcemap {
     #[doc(inline)]
     pub use oxc_sourcemap::*;
 }
+
+#[cfg(feature = "cfg")]
+pub mod cfg {
+    #[doc(inline)]
+    pub use oxc_cfg::*;
+}


### PR DESCRIPTION
This is useful when the downside user wants to use `oxc_cfg`, and easy to reuse `petgraph` in `oxc_cfg`