### PR TITLE
fix(semantic): incorrect reference when `MemberExpression` used in `TSPropertySignature`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1891,9 +1891,9 @@ impl<'a> SemanticBuilder<'a> {
                 }
             }
             AstKind::MemberExpression(_) => {
-                if !self.current_reference_flags.is_type() {
-                    self.current_reference_flags = ReferenceFlags::Read;
-                }
+                // A.B = 1;
+                // ^^^ we can't treat A as Write reference, because it's the property(B) of A that change
+                self.current_reference_flags -= ReferenceFlags::Write;
             }
             AstKind::AssignmentTarget(_) => {
                 self.current_reference_flags |= ReferenceFlags::Write;
@@ -1966,8 +1966,7 @@ impl<'a> SemanticBuilder<'a> {
                     self.current_reference_flags -= ReferenceFlags::Read;
                 }
             }
-            AstKind::MemberExpression(_)
-            | AstKind::ExportNamedDeclaration(_)
+            AstKind::ExportNamedDeclaration(_)
             | AstKind::TSTypeQuery(_)
             // Clear the reference flags that are set in AstKind::PropertySignature
             | AstKind::PropertyKey(_) => {

--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
@@ -18,6 +18,13 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/
         "id": 2,
         "node": "TSInterfaceDeclaration",
         "symbols": []
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 3,
+        "node": "TSInterfaceDeclaration",
+        "symbols": []
       }
     ],
     "flags": "ScopeFlags(StrictMode | Top)",
@@ -35,6 +42,12 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/
             "id": 0,
             "name": "X",
             "node_id": 15
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 2,
+            "name": "X",
+            "node_id": 27
           }
         ]
       },
@@ -49,6 +62,12 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/
             "id": 1,
             "name": "B",
             "node_id": 19
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 3,
+            "name": "B",
+            "node_id": 32
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
@@ -1,7 +1,11 @@
-import type X from 'mod';
+import type X from "mod";
 
 type B = number;
 
 export interface A {
-  [X]: B
+  [X]: B;
+}
+
+export interface A {
+  [X.X]: B;
 }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -16756,6 +16756,9 @@ rebuilt        : SymbolId(20): [ReferenceId(14), ReferenceId(15), ReferenceId(17
 Symbol reference IDs mismatch:
 after transform: SymbolId(25): [ReferenceId(13)]
 rebuilt        : SymbolId(21): []
+Reference flags mismatch:
+after transform: ReferenceId(12): ReferenceFlags(Write)
+rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
 
 tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
 semantic error: Bindings mismatch:


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/issues/5435#issuecomment-2333032168
