### PR TITLE
ci: Passthrough OXC_VERSION and JEMALLOC_SYS_WITH_LG_PAGE to build container

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,6 @@
 [build.env]
-passthrough = ["CI"] # for crates/oxc_traverse/build.rs
+passthrough = [
+  "CI", # for crates/oxc_traverse/build.rs
+  "OXC_VERSION",
+  "JEMALLOC_SYS_WITH_LG_PAGE",
+] 


### PR DESCRIPTION
Fixes:
- https://github.com/oxc-project/oxc/issues/4891

Currently only Mac OS and Windows versions return correct version. Linux versions still returns `dev`. This is caused by Mac OS and Windows building on the host ([logs](https://github.com/oxc-project/oxc/actions/runs/10667173657/job/29564299213#step:6:16)), while Linux is building inside a container. Container builds do not have access to host env variables by default.