### PR TITLE
refactor(regular_expression): Align diagnostics

### DIFF
--- a/crates/oxc_regular_expression/src/body_parser/mod.rs
+++ b/crates/oxc_regular_expression/src/body_parser/mod.rs
@@ -1,4 +1,3 @@
-mod diagnostics;
 mod parser;
 mod reader;
 mod state;

--- a/crates/oxc_regular_expression/src/body_parser/parser.rs
+++ b/crates/oxc_regular_expression/src/body_parser/parser.rs
@@ -4,7 +4,8 @@ use oxc_span::Atom as SpanAtom;
 
 use crate::{
     ast,
-    body_parser::{diagnostics, reader::Reader, state::State, unicode, unicode_property},
+    body_parser::{reader::Reader, state::State, unicode, unicode_property},
+    diagnostics,
     options::ParserOptions,
     span::SpanFactory,
     surrogate_pair,

--- a/crates/oxc_regular_expression/src/diagnostics.rs
+++ b/crates/oxc_regular_expression/src/diagnostics.rs
@@ -3,6 +3,43 @@ use oxc_span::Span;
 
 const PREFIX: &str = "Invalid regular expression:";
 
+// For (Literal)Parser ---
+
+#[cold]
+pub fn unexpected_literal_char(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unexpected literal character")).with_label(span0)
+}
+
+#[cold]
+pub fn unterminated_literal(span0: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unterminated {kind}")).with_label(span0)
+}
+
+#[cold]
+pub fn empty_literal(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Empty literal")).with_label(span0)
+}
+
+// For FlagsParser ---
+
+#[cold]
+pub fn duplicated_flag(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Duplicated flag")).with_label(span0)
+}
+
+#[cold]
+pub fn unknown_flag(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unknown flag")).with_label(span0)
+}
+
+#[cold]
+pub fn invalid_unicode_flags(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid flags, `u` and `v` should be used alone"))
+        .with_label(span0)
+}
+
+// For PatternParser ---
+
 #[cold]
 pub fn duplicated_capturing_group_names(spans: Vec<Span>) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Duplicated capturing group names")).with_labels(spans)

--- a/crates/oxc_regular_expression/src/lib.rs
+++ b/crates/oxc_regular_expression/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod ast;
 mod body_parser;
+mod diagnostics;
 mod display;
 mod flag_parser;
 mod literal_parser;


### PR DESCRIPTION
Manage all diagnostics for LiteralParser, FlagsParser, PatternParser in one place, same message format.