### PR TITLE
refactor(ast): inline `AstKind::as_*` methods

### DIFF
--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -528,6 +528,7 @@ impl<'a> GetSpan for AstKind<'a> {
 }
 
 impl<'a> AstKind<'a> {
+    #[inline]
     pub fn as_boolean_literal(&self) -> Option<&'a BooleanLiteral> {
         if let Self::BooleanLiteral(v) = self {
             Some(*v)
@@ -536,6 +537,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_null_literal(&self) -> Option<&'a NullLiteral> {
         if let Self::NullLiteral(v) = self {
             Some(*v)
@@ -544,6 +546,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_numeric_literal(&self) -> Option<&'a NumericLiteral<'a>> {
         if let Self::NumericLiteral(v) = self {
             Some(*v)
@@ -552,6 +555,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_big_int_literal(&self) -> Option<&'a BigIntLiteral<'a>> {
         if let Self::BigIntLiteral(v) = self {
             Some(*v)
@@ -560,6 +564,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_reg_exp_literal(&self) -> Option<&'a RegExpLiteral<'a>> {
         if let Self::RegExpLiteral(v) = self {
             Some(*v)
@@ -568,6 +573,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_string_literal(&self) -> Option<&'a StringLiteral<'a>> {
         if let Self::StringLiteral(v) = self {
             Some(*v)
@@ -576,6 +582,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_program(&self) -> Option<&'a Program<'a>> {
         if let Self::Program(v) = self {
             Some(*v)
@@ -584,6 +591,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_identifier_name(&self) -> Option<&'a IdentifierName<'a>> {
         if let Self::IdentifierName(v) = self {
             Some(*v)
@@ -592,6 +600,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_identifier_reference(&self) -> Option<&'a IdentifierReference<'a>> {
         if let Self::IdentifierReference(v) = self {
             Some(*v)
@@ -600,6 +609,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_binding_identifier(&self) -> Option<&'a BindingIdentifier<'a>> {
         if let Self::BindingIdentifier(v) = self {
             Some(*v)
@@ -608,6 +618,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_label_identifier(&self) -> Option<&'a LabelIdentifier<'a>> {
         if let Self::LabelIdentifier(v) = self {
             Some(*v)
@@ -616,6 +627,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_this_expression(&self) -> Option<&'a ThisExpression> {
         if let Self::ThisExpression(v) = self {
             Some(*v)
@@ -624,6 +636,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_array_expression(&self) -> Option<&'a ArrayExpression<'a>> {
         if let Self::ArrayExpression(v) = self {
             Some(*v)
@@ -632,6 +645,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_array_expression_element(&self) -> Option<&'a ArrayExpressionElement<'a>> {
         if let Self::ArrayExpressionElement(v) = self {
             Some(*v)
@@ -640,6 +654,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_elision(&self) -> Option<&'a Elision> {
         if let Self::Elision(v) = self {
             Some(*v)
@@ -648,6 +663,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_object_expression(&self) -> Option<&'a ObjectExpression<'a>> {
         if let Self::ObjectExpression(v) = self {
             Some(*v)
@@ -656,6 +672,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_object_property(&self) -> Option<&'a ObjectProperty<'a>> {
         if let Self::ObjectProperty(v) = self {
             Some(*v)
@@ -664,6 +681,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_property_key(&self) -> Option<&'a PropertyKey<'a>> {
         if let Self::PropertyKey(v) = self {
             Some(*v)
@@ -672,6 +690,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_template_literal(&self) -> Option<&'a TemplateLiteral<'a>> {
         if let Self::TemplateLiteral(v) = self {
             Some(*v)
@@ -680,6 +699,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_tagged_template_expression(&self) -> Option<&'a TaggedTemplateExpression<'a>> {
         if let Self::TaggedTemplateExpression(v) = self {
             Some(*v)
@@ -688,6 +708,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_member_expression(&self) -> Option<&'a MemberExpression<'a>> {
         if let Self::MemberExpression(v) = self {
             Some(*v)
@@ -696,6 +717,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_call_expression(&self) -> Option<&'a CallExpression<'a>> {
         if let Self::CallExpression(v) = self {
             Some(*v)
@@ -704,6 +726,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_new_expression(&self) -> Option<&'a NewExpression<'a>> {
         if let Self::NewExpression(v) = self {
             Some(*v)
@@ -712,6 +735,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_meta_property(&self) -> Option<&'a MetaProperty<'a>> {
         if let Self::MetaProperty(v) = self {
             Some(*v)
@@ -720,6 +744,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_spread_element(&self) -> Option<&'a SpreadElement<'a>> {
         if let Self::SpreadElement(v) = self {
             Some(*v)
@@ -728,6 +753,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_argument(&self) -> Option<&'a Argument<'a>> {
         if let Self::Argument(v) = self {
             Some(*v)
@@ -736,6 +762,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_update_expression(&self) -> Option<&'a UpdateExpression<'a>> {
         if let Self::UpdateExpression(v) = self {
             Some(*v)
@@ -744,6 +771,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_unary_expression(&self) -> Option<&'a UnaryExpression<'a>> {
         if let Self::UnaryExpression(v) = self {
             Some(*v)
@@ -752,6 +780,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_binary_expression(&self) -> Option<&'a BinaryExpression<'a>> {
         if let Self::BinaryExpression(v) = self {
             Some(*v)
@@ -760,6 +789,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_private_in_expression(&self) -> Option<&'a PrivateInExpression<'a>> {
         if let Self::PrivateInExpression(v) = self {
             Some(*v)
@@ -768,6 +798,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_logical_expression(&self) -> Option<&'a LogicalExpression<'a>> {
         if let Self::LogicalExpression(v) = self {
             Some(*v)
@@ -776,6 +807,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_conditional_expression(&self) -> Option<&'a ConditionalExpression<'a>> {
         if let Self::ConditionalExpression(v) = self {
             Some(*v)
@@ -784,6 +816,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_assignment_expression(&self) -> Option<&'a AssignmentExpression<'a>> {
         if let Self::AssignmentExpression(v) = self {
             Some(*v)
@@ -792,6 +825,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_assignment_target(&self) -> Option<&'a AssignmentTarget<'a>> {
         if let Self::AssignmentTarget(v) = self {
             Some(*v)
@@ -800,6 +834,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_simple_assignment_target(&self) -> Option<&'a SimpleAssignmentTarget<'a>> {
         if let Self::SimpleAssignmentTarget(v) = self {
             Some(*v)
@@ -808,6 +843,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_assignment_target_pattern(&self) -> Option<&'a AssignmentTargetPattern<'a>> {
         if let Self::AssignmentTargetPattern(v) = self {
             Some(*v)
@@ -816,6 +852,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_array_assignment_target(&self) -> Option<&'a ArrayAssignmentTarget<'a>> {
         if let Self::ArrayAssignmentTarget(v) = self {
             Some(*v)
@@ -824,6 +861,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_object_assignment_target(&self) -> Option<&'a ObjectAssignmentTarget<'a>> {
         if let Self::ObjectAssignmentTarget(v) = self {
             Some(*v)
@@ -832,6 +870,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_assignment_target_with_default(&self) -> Option<&'a AssignmentTargetWithDefault<'a>> {
         if let Self::AssignmentTargetWithDefault(v) = self {
             Some(*v)
@@ -840,6 +879,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_sequence_expression(&self) -> Option<&'a SequenceExpression<'a>> {
         if let Self::SequenceExpression(v) = self {
             Some(*v)
@@ -848,6 +888,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_super(&self) -> Option<&'a Super> {
         if let Self::Super(v) = self {
             Some(*v)
@@ -856,6 +897,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_await_expression(&self) -> Option<&'a AwaitExpression<'a>> {
         if let Self::AwaitExpression(v) = self {
             Some(*v)
@@ -864,6 +906,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_chain_expression(&self) -> Option<&'a ChainExpression<'a>> {
         if let Self::ChainExpression(v) = self {
             Some(*v)
@@ -872,6 +915,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_parenthesized_expression(&self) -> Option<&'a ParenthesizedExpression<'a>> {
         if let Self::ParenthesizedExpression(v) = self {
             Some(*v)
@@ -880,6 +924,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_directive(&self) -> Option<&'a Directive<'a>> {
         if let Self::Directive(v) = self {
             Some(*v)
@@ -888,6 +933,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_hashbang(&self) -> Option<&'a Hashbang<'a>> {
         if let Self::Hashbang(v) = self {
             Some(*v)
@@ -896,6 +942,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_block_statement(&self) -> Option<&'a BlockStatement<'a>> {
         if let Self::BlockStatement(v) = self {
             Some(*v)
@@ -904,6 +951,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_variable_declaration(&self) -> Option<&'a VariableDeclaration<'a>> {
         if let Self::VariableDeclaration(v) = self {
             Some(*v)
@@ -912,6 +960,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_variable_declarator(&self) -> Option<&'a VariableDeclarator<'a>> {
         if let Self::VariableDeclarator(v) = self {
             Some(*v)
@@ -920,6 +969,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_empty_statement(&self) -> Option<&'a EmptyStatement> {
         if let Self::EmptyStatement(v) = self {
             Some(*v)
@@ -928,6 +978,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_expression_statement(&self) -> Option<&'a ExpressionStatement<'a>> {
         if let Self::ExpressionStatement(v) = self {
             Some(*v)
@@ -936,6 +987,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_if_statement(&self) -> Option<&'a IfStatement<'a>> {
         if let Self::IfStatement(v) = self {
             Some(*v)
@@ -944,6 +996,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_do_while_statement(&self) -> Option<&'a DoWhileStatement<'a>> {
         if let Self::DoWhileStatement(v) = self {
             Some(*v)
@@ -952,6 +1005,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_while_statement(&self) -> Option<&'a WhileStatement<'a>> {
         if let Self::WhileStatement(v) = self {
             Some(*v)
@@ -960,6 +1014,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_for_statement(&self) -> Option<&'a ForStatement<'a>> {
         if let Self::ForStatement(v) = self {
             Some(*v)
@@ -968,6 +1023,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_for_statement_init(&self) -> Option<&'a ForStatementInit<'a>> {
         if let Self::ForStatementInit(v) = self {
             Some(*v)
@@ -976,6 +1032,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_for_in_statement(&self) -> Option<&'a ForInStatement<'a>> {
         if let Self::ForInStatement(v) = self {
             Some(*v)
@@ -984,6 +1041,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_for_of_statement(&self) -> Option<&'a ForOfStatement<'a>> {
         if let Self::ForOfStatement(v) = self {
             Some(*v)
@@ -992,6 +1050,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_continue_statement(&self) -> Option<&'a ContinueStatement<'a>> {
         if let Self::ContinueStatement(v) = self {
             Some(*v)
@@ -1000,6 +1059,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_break_statement(&self) -> Option<&'a BreakStatement<'a>> {
         if let Self::BreakStatement(v) = self {
             Some(*v)
@@ -1008,6 +1068,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_return_statement(&self) -> Option<&'a ReturnStatement<'a>> {
         if let Self::ReturnStatement(v) = self {
             Some(*v)
@@ -1016,6 +1077,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_with_statement(&self) -> Option<&'a WithStatement<'a>> {
         if let Self::WithStatement(v) = self {
             Some(*v)
@@ -1024,6 +1086,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_switch_statement(&self) -> Option<&'a SwitchStatement<'a>> {
         if let Self::SwitchStatement(v) = self {
             Some(*v)
@@ -1032,6 +1095,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_switch_case(&self) -> Option<&'a SwitchCase<'a>> {
         if let Self::SwitchCase(v) = self {
             Some(*v)
@@ -1040,6 +1104,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_labeled_statement(&self) -> Option<&'a LabeledStatement<'a>> {
         if let Self::LabeledStatement(v) = self {
             Some(*v)
@@ -1048,6 +1113,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_throw_statement(&self) -> Option<&'a ThrowStatement<'a>> {
         if let Self::ThrowStatement(v) = self {
             Some(*v)
@@ -1056,6 +1122,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_try_statement(&self) -> Option<&'a TryStatement<'a>> {
         if let Self::TryStatement(v) = self {
             Some(*v)
@@ -1064,6 +1131,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_finally_clause(&self) -> Option<&'a BlockStatement<'a>> {
         if let Self::FinallyClause(v) = self {
             Some(*v)
@@ -1072,6 +1140,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_catch_clause(&self) -> Option<&'a CatchClause<'a>> {
         if let Self::CatchClause(v) = self {
             Some(*v)
@@ -1080,6 +1149,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_catch_parameter(&self) -> Option<&'a CatchParameter<'a>> {
         if let Self::CatchParameter(v) = self {
             Some(*v)
@@ -1088,6 +1158,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_debugger_statement(&self) -> Option<&'a DebuggerStatement> {
         if let Self::DebuggerStatement(v) = self {
             Some(*v)
@@ -1096,6 +1167,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_assignment_pattern(&self) -> Option<&'a AssignmentPattern<'a>> {
         if let Self::AssignmentPattern(v) = self {
             Some(*v)
@@ -1104,6 +1176,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_object_pattern(&self) -> Option<&'a ObjectPattern<'a>> {
         if let Self::ObjectPattern(v) = self {
             Some(*v)
@@ -1112,6 +1185,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_array_pattern(&self) -> Option<&'a ArrayPattern<'a>> {
         if let Self::ArrayPattern(v) = self {
             Some(*v)
@@ -1120,6 +1194,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_binding_rest_element(&self) -> Option<&'a BindingRestElement<'a>> {
         if let Self::BindingRestElement(v) = self {
             Some(*v)
@@ -1128,6 +1203,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_function(&self) -> Option<&'a Function<'a>> {
         if let Self::Function(v) = self {
             Some(*v)
@@ -1136,6 +1212,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_formal_parameters(&self) -> Option<&'a FormalParameters<'a>> {
         if let Self::FormalParameters(v) = self {
             Some(*v)
@@ -1144,6 +1221,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_formal_parameter(&self) -> Option<&'a FormalParameter<'a>> {
         if let Self::FormalParameter(v) = self {
             Some(*v)
@@ -1152,6 +1230,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_function_body(&self) -> Option<&'a FunctionBody<'a>> {
         if let Self::FunctionBody(v) = self {
             Some(*v)
@@ -1160,6 +1239,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_arrow_function_expression(&self) -> Option<&'a ArrowFunctionExpression<'a>> {
         if let Self::ArrowFunctionExpression(v) = self {
             Some(*v)
@@ -1168,6 +1248,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_yield_expression(&self) -> Option<&'a YieldExpression<'a>> {
         if let Self::YieldExpression(v) = self {
             Some(*v)
@@ -1176,6 +1257,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_class(&self) -> Option<&'a Class<'a>> {
         if let Self::Class(v) = self {
             Some(*v)
@@ -1184,6 +1266,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_class_heritage(&self) -> Option<&'a Expression<'a>> {
         if let Self::ClassHeritage(v) = self {
             Some(*v)
@@ -1192,6 +1275,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_class_body(&self) -> Option<&'a ClassBody<'a>> {
         if let Self::ClassBody(v) = self {
             Some(*v)
@@ -1200,6 +1284,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_method_definition(&self) -> Option<&'a MethodDefinition<'a>> {
         if let Self::MethodDefinition(v) = self {
             Some(*v)
@@ -1208,6 +1293,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_property_definition(&self) -> Option<&'a PropertyDefinition<'a>> {
         if let Self::PropertyDefinition(v) = self {
             Some(*v)
@@ -1216,6 +1302,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_private_identifier(&self) -> Option<&'a PrivateIdentifier<'a>> {
         if let Self::PrivateIdentifier(v) = self {
             Some(*v)
@@ -1224,6 +1311,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_static_block(&self) -> Option<&'a StaticBlock<'a>> {
         if let Self::StaticBlock(v) = self {
             Some(*v)
@@ -1232,6 +1320,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_module_declaration(&self) -> Option<&'a ModuleDeclaration<'a>> {
         if let Self::ModuleDeclaration(v) = self {
             Some(*v)
@@ -1240,6 +1329,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_import_expression(&self) -> Option<&'a ImportExpression<'a>> {
         if let Self::ImportExpression(v) = self {
             Some(*v)
@@ -1248,6 +1338,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_import_declaration(&self) -> Option<&'a ImportDeclaration<'a>> {
         if let Self::ImportDeclaration(v) = self {
             Some(*v)
@@ -1256,6 +1347,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_import_specifier(&self) -> Option<&'a ImportSpecifier<'a>> {
         if let Self::ImportSpecifier(v) = self {
             Some(*v)
@@ -1264,6 +1356,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_import_default_specifier(&self) -> Option<&'a ImportDefaultSpecifier<'a>> {
         if let Self::ImportDefaultSpecifier(v) = self {
             Some(*v)
@@ -1272,6 +1365,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_import_namespace_specifier(&self) -> Option<&'a ImportNamespaceSpecifier<'a>> {
         if let Self::ImportNamespaceSpecifier(v) = self {
             Some(*v)
@@ -1280,6 +1374,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_export_named_declaration(&self) -> Option<&'a ExportNamedDeclaration<'a>> {
         if let Self::ExportNamedDeclaration(v) = self {
             Some(*v)
@@ -1288,6 +1383,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_export_default_declaration(&self) -> Option<&'a ExportDefaultDeclaration<'a>> {
         if let Self::ExportDefaultDeclaration(v) = self {
             Some(*v)
@@ -1296,6 +1392,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_export_all_declaration(&self) -> Option<&'a ExportAllDeclaration<'a>> {
         if let Self::ExportAllDeclaration(v) = self {
             Some(*v)
@@ -1304,6 +1401,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_export_specifier(&self) -> Option<&'a ExportSpecifier<'a>> {
         if let Self::ExportSpecifier(v) = self {
             Some(*v)
@@ -1312,6 +1410,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_this_parameter(&self) -> Option<&'a TSThisParameter<'a>> {
         if let Self::TSThisParameter(v) = self {
             Some(*v)
@@ -1320,6 +1419,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_enum_declaration(&self) -> Option<&'a TSEnumDeclaration<'a>> {
         if let Self::TSEnumDeclaration(v) = self {
             Some(*v)
@@ -1328,6 +1428,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_enum_member(&self) -> Option<&'a TSEnumMember<'a>> {
         if let Self::TSEnumMember(v) = self {
             Some(*v)
@@ -1336,6 +1437,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_annotation(&self) -> Option<&'a TSTypeAnnotation<'a>> {
         if let Self::TSTypeAnnotation(v) = self {
             Some(*v)
@@ -1344,6 +1446,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_literal_type(&self) -> Option<&'a TSLiteralType<'a>> {
         if let Self::TSLiteralType(v) = self {
             Some(*v)
@@ -1352,6 +1455,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_conditional_type(&self) -> Option<&'a TSConditionalType<'a>> {
         if let Self::TSConditionalType(v) = self {
             Some(*v)
@@ -1360,6 +1464,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_union_type(&self) -> Option<&'a TSUnionType<'a>> {
         if let Self::TSUnionType(v) = self {
             Some(*v)
@@ -1368,6 +1473,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_intersection_type(&self) -> Option<&'a TSIntersectionType<'a>> {
         if let Self::TSIntersectionType(v) = self {
             Some(*v)
@@ -1376,6 +1482,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_parenthesized_type(&self) -> Option<&'a TSParenthesizedType<'a>> {
         if let Self::TSParenthesizedType(v) = self {
             Some(*v)
@@ -1384,6 +1491,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_indexed_access_type(&self) -> Option<&'a TSIndexedAccessType<'a>> {
         if let Self::TSIndexedAccessType(v) = self {
             Some(*v)
@@ -1392,6 +1500,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_named_tuple_member(&self) -> Option<&'a TSNamedTupleMember<'a>> {
         if let Self::TSNamedTupleMember(v) = self {
             Some(*v)
@@ -1400,6 +1509,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_any_keyword(&self) -> Option<&'a TSAnyKeyword> {
         if let Self::TSAnyKeyword(v) = self {
             Some(*v)
@@ -1408,6 +1518,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_string_keyword(&self) -> Option<&'a TSStringKeyword> {
         if let Self::TSStringKeyword(v) = self {
             Some(*v)
@@ -1416,6 +1527,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_boolean_keyword(&self) -> Option<&'a TSBooleanKeyword> {
         if let Self::TSBooleanKeyword(v) = self {
             Some(*v)
@@ -1424,6 +1536,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_number_keyword(&self) -> Option<&'a TSNumberKeyword> {
         if let Self::TSNumberKeyword(v) = self {
             Some(*v)
@@ -1432,6 +1545,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_never_keyword(&self) -> Option<&'a TSNeverKeyword> {
         if let Self::TSNeverKeyword(v) = self {
             Some(*v)
@@ -1440,6 +1554,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_intrinsic_keyword(&self) -> Option<&'a TSIntrinsicKeyword> {
         if let Self::TSIntrinsicKeyword(v) = self {
             Some(*v)
@@ -1448,6 +1563,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_unknown_keyword(&self) -> Option<&'a TSUnknownKeyword> {
         if let Self::TSUnknownKeyword(v) = self {
             Some(*v)
@@ -1456,6 +1572,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_null_keyword(&self) -> Option<&'a TSNullKeyword> {
         if let Self::TSNullKeyword(v) = self {
             Some(*v)
@@ -1464,6 +1581,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_undefined_keyword(&self) -> Option<&'a TSUndefinedKeyword> {
         if let Self::TSUndefinedKeyword(v) = self {
             Some(*v)
@@ -1472,6 +1590,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_void_keyword(&self) -> Option<&'a TSVoidKeyword> {
         if let Self::TSVoidKeyword(v) = self {
             Some(*v)
@@ -1480,6 +1599,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_symbol_keyword(&self) -> Option<&'a TSSymbolKeyword> {
         if let Self::TSSymbolKeyword(v) = self {
             Some(*v)
@@ -1488,6 +1608,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_this_type(&self) -> Option<&'a TSThisType> {
         if let Self::TSThisType(v) = self {
             Some(*v)
@@ -1496,6 +1617,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_object_keyword(&self) -> Option<&'a TSObjectKeyword> {
         if let Self::TSObjectKeyword(v) = self {
             Some(*v)
@@ -1504,6 +1626,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_big_int_keyword(&self) -> Option<&'a TSBigIntKeyword> {
         if let Self::TSBigIntKeyword(v) = self {
             Some(*v)
@@ -1512,6 +1635,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_reference(&self) -> Option<&'a TSTypeReference<'a>> {
         if let Self::TSTypeReference(v) = self {
             Some(*v)
@@ -1520,6 +1644,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_name(&self) -> Option<&'a TSTypeName<'a>> {
         if let Self::TSTypeName(v) = self {
             Some(*v)
@@ -1528,6 +1653,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_qualified_name(&self) -> Option<&'a TSQualifiedName<'a>> {
         if let Self::TSQualifiedName(v) = self {
             Some(*v)
@@ -1536,6 +1662,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_parameter_instantiation(
         &self,
     ) -> Option<&'a TSTypeParameterInstantiation<'a>> {
@@ -1546,6 +1673,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_parameter(&self) -> Option<&'a TSTypeParameter<'a>> {
         if let Self::TSTypeParameter(v) = self {
             Some(*v)
@@ -1554,6 +1682,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_parameter_declaration(&self) -> Option<&'a TSTypeParameterDeclaration<'a>> {
         if let Self::TSTypeParameterDeclaration(v) = self {
             Some(*v)
@@ -1562,6 +1691,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_alias_declaration(&self) -> Option<&'a TSTypeAliasDeclaration<'a>> {
         if let Self::TSTypeAliasDeclaration(v) = self {
             Some(*v)
@@ -1570,6 +1700,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_class_implements(&self) -> Option<&'a TSClassImplements<'a>> {
         if let Self::TSClassImplements(v) = self {
             Some(*v)
@@ -1578,6 +1709,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_interface_declaration(&self) -> Option<&'a TSInterfaceDeclaration<'a>> {
         if let Self::TSInterfaceDeclaration(v) = self {
             Some(*v)
@@ -1586,6 +1718,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_property_signature(&self) -> Option<&'a TSPropertySignature<'a>> {
         if let Self::TSPropertySignature(v) = self {
             Some(*v)
@@ -1594,6 +1727,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_method_signature(&self) -> Option<&'a TSMethodSignature<'a>> {
         if let Self::TSMethodSignature(v) = self {
             Some(*v)
@@ -1602,6 +1736,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_construct_signature_declaration(
         &self,
     ) -> Option<&'a TSConstructSignatureDeclaration<'a>> {
@@ -1612,6 +1747,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_interface_heritage(&self) -> Option<&'a TSInterfaceHeritage<'a>> {
         if let Self::TSInterfaceHeritage(v) = self {
             Some(*v)
@@ -1620,6 +1756,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_module_declaration(&self) -> Option<&'a TSModuleDeclaration<'a>> {
         if let Self::TSModuleDeclaration(v) = self {
             Some(*v)
@@ -1628,6 +1765,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_module_block(&self) -> Option<&'a TSModuleBlock<'a>> {
         if let Self::TSModuleBlock(v) = self {
             Some(*v)
@@ -1636,6 +1774,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_literal(&self) -> Option<&'a TSTypeLiteral<'a>> {
         if let Self::TSTypeLiteral(v) = self {
             Some(*v)
@@ -1644,6 +1783,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_infer_type(&self) -> Option<&'a TSInferType<'a>> {
         if let Self::TSInferType(v) = self {
             Some(*v)
@@ -1652,6 +1792,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_query(&self) -> Option<&'a TSTypeQuery<'a>> {
         if let Self::TSTypeQuery(v) = self {
             Some(*v)
@@ -1660,6 +1801,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_import_type(&self) -> Option<&'a TSImportType<'a>> {
         if let Self::TSImportType(v) = self {
             Some(*v)
@@ -1668,6 +1810,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_mapped_type(&self) -> Option<&'a TSMappedType<'a>> {
         if let Self::TSMappedType(v) = self {
             Some(*v)
@@ -1676,6 +1819,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_template_literal_type(&self) -> Option<&'a TSTemplateLiteralType<'a>> {
         if let Self::TSTemplateLiteralType(v) = self {
             Some(*v)
@@ -1684,6 +1828,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_as_expression(&self) -> Option<&'a TSAsExpression<'a>> {
         if let Self::TSAsExpression(v) = self {
             Some(*v)
@@ -1692,6 +1837,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_satisfies_expression(&self) -> Option<&'a TSSatisfiesExpression<'a>> {
         if let Self::TSSatisfiesExpression(v) = self {
             Some(*v)
@@ -1700,6 +1846,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_type_assertion(&self) -> Option<&'a TSTypeAssertion<'a>> {
         if let Self::TSTypeAssertion(v) = self {
             Some(*v)
@@ -1708,6 +1855,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_import_equals_declaration(&self) -> Option<&'a TSImportEqualsDeclaration<'a>> {
         if let Self::TSImportEqualsDeclaration(v) = self {
             Some(*v)
@@ -1716,6 +1864,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_module_reference(&self) -> Option<&'a TSModuleReference<'a>> {
         if let Self::TSModuleReference(v) = self {
             Some(*v)
@@ -1724,6 +1873,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_external_module_reference(&self) -> Option<&'a TSExternalModuleReference<'a>> {
         if let Self::TSExternalModuleReference(v) = self {
             Some(*v)
@@ -1732,6 +1882,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_non_null_expression(&self) -> Option<&'a TSNonNullExpression<'a>> {
         if let Self::TSNonNullExpression(v) = self {
             Some(*v)
@@ -1740,6 +1891,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_decorator(&self) -> Option<&'a Decorator<'a>> {
         if let Self::Decorator(v) = self {
             Some(*v)
@@ -1748,6 +1900,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_export_assignment(&self) -> Option<&'a TSExportAssignment<'a>> {
         if let Self::TSExportAssignment(v) = self {
             Some(*v)
@@ -1756,6 +1909,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_ts_instantiation_expression(&self) -> Option<&'a TSInstantiationExpression<'a>> {
         if let Self::TSInstantiationExpression(v) = self {
             Some(*v)
@@ -1764,6 +1918,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_element(&self) -> Option<&'a JSXElement<'a>> {
         if let Self::JSXElement(v) = self {
             Some(*v)
@@ -1772,6 +1927,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_opening_element(&self) -> Option<&'a JSXOpeningElement<'a>> {
         if let Self::JSXOpeningElement(v) = self {
             Some(*v)
@@ -1780,6 +1936,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_closing_element(&self) -> Option<&'a JSXClosingElement<'a>> {
         if let Self::JSXClosingElement(v) = self {
             Some(*v)
@@ -1788,6 +1945,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_fragment(&self) -> Option<&'a JSXFragment<'a>> {
         if let Self::JSXFragment(v) = self {
             Some(*v)
@@ -1796,6 +1954,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_element_name(&self) -> Option<&'a JSXElementName<'a>> {
         if let Self::JSXElementName(v) = self {
             Some(*v)
@@ -1804,6 +1963,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_namespaced_name(&self) -> Option<&'a JSXNamespacedName<'a>> {
         if let Self::JSXNamespacedName(v) = self {
             Some(*v)
@@ -1812,6 +1972,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_member_expression(&self) -> Option<&'a JSXMemberExpression<'a>> {
         if let Self::JSXMemberExpression(v) = self {
             Some(*v)
@@ -1820,6 +1981,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_member_expression_object(&self) -> Option<&'a JSXMemberExpressionObject<'a>> {
         if let Self::JSXMemberExpressionObject(v) = self {
             Some(*v)
@@ -1828,6 +1990,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_expression_container(&self) -> Option<&'a JSXExpressionContainer<'a>> {
         if let Self::JSXExpressionContainer(v) = self {
             Some(*v)
@@ -1836,6 +1999,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_attribute_item(&self) -> Option<&'a JSXAttributeItem<'a>> {
         if let Self::JSXAttributeItem(v) = self {
             Some(*v)
@@ -1844,6 +2008,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_spread_attribute(&self) -> Option<&'a JSXSpreadAttribute<'a>> {
         if let Self::JSXSpreadAttribute(v) = self {
             Some(*v)
@@ -1852,6 +2017,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_identifier(&self) -> Option<&'a JSXIdentifier<'a>> {
         if let Self::JSXIdentifier(v) = self {
             Some(*v)
@@ -1860,6 +2026,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_jsx_text(&self) -> Option<&'a JSXText<'a>> {
         if let Self::JSXText(v) = self {
             Some(*v)
@@ -1868,6 +2035,7 @@ impl<'a> AstKind<'a> {
         }
     }
 
+    #[inline]
     pub fn as_expression_array_element(&self) -> Option<&'a Expression<'a>> {
         if let Self::ExpressionArrayElement(v) = self {
             Some(*v)

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -161,6 +161,7 @@ impl Generator for AstKindGenerator {
                     format_ident!("as_{}", ident.to_string().to_case(Case::Snake));
                 parse_quote!(
                     ///@@line_break
+                    #[inline]
                     pub fn #snake_case_name(&self) -> Option<&'a #typ> {
                         if let Self::#ident(v) = self {
                             Some(*v)


### PR DESCRIPTION
One would hope compiler will inline these trivial methods anyway, but mark them `#[inline]` to make sure.