### PR TITLE
fix(linter/tree-shaking): align JSXMemberExpression's report

### DIFF
--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -7,11 +7,11 @@ use oxc_ast::{
         ConditionalExpression, Declaration, ExportSpecifier, Expression, ForStatementInit,
         FormalParameter, Function, IdentifierReference, JSXAttribute, JSXAttributeItem,
         JSXAttributeValue, JSXChild, JSXElement, JSXElementName, JSXExpression,
-        JSXExpressionContainer, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
-        JSXOpeningElement, LogicalExpression, MemberExpression, ModuleExportName, NewExpression,
-        ObjectExpression, ObjectPropertyKind, ParenthesizedExpression, PrivateFieldExpression,
-        Program, PropertyKey, SequenceExpression, SimpleAssignmentTarget, Statement,
-        StaticMemberExpression, SwitchCase, ThisExpression, UnaryExpression, VariableDeclarator,
+        JSXExpressionContainer, JSXFragment, JSXMemberExpression, JSXOpeningElement,
+        LogicalExpression, MemberExpression, ModuleExportName, NewExpression, ObjectExpression,
+        ObjectPropertyKind, ParenthesizedExpression, PrivateFieldExpression, Program, PropertyKey,
+        SequenceExpression, SimpleAssignmentTarget, Statement, StaticMemberExpression, SwitchCase,
+        ThisExpression, UnaryExpression, VariableDeclarator,
     },
     AstKind,
 };
@@ -799,17 +799,7 @@ impl<'a> ListenerMap for JSXElementName<'a> {
 
 impl<'a> ListenerMap for JSXMemberExpression<'a> {
     fn report_effects_when_called(&self, options: &NodeListenerOptions) {
-        self.object.report_effects_when_called(options);
-    }
-}
-
-impl<'a> ListenerMap for JSXMemberExpressionObject<'a> {
-    fn report_effects_when_called(&self, options: &NodeListenerOptions) {
-        match self {
-            Self::IdentifierReference(ident) => ident.report_effects_when_called(options),
-            Self::MemberExpression(member) => member.report_effects_when_called(options),
-            Self::ThisExpression(expr) => expr.report_effects_when_called(options),
-        }
+        options.ctx.diagnostic(super::call_member(self.property.span()));
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
+++ b/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
@@ -825,10 +825,10 @@ source: crates/oxc_linter/src/tester.rs
    ·            ───
    ╰────
 
-  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling
-   ╭─[no_side_effects_in_initialization.tsx:1:11]
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling member function
+   ╭─[no_side_effects_in_initialization.tsx:1:34]
  1 │ const X = {Y: ext}; const x = <X.Y />
-   ·           ────────
+   ·                                  ─
    ╰────
 
   ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`


### PR DESCRIPTION
Follow up #5450.

[eslint-plugin-tree-shaking](https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/463fa1f0bef7caa2b231a38b9c3557051f506c92/src/rules/no-side-effects-in-initialization.ts#L673-L677) just report on `JSXMemberExpression.property`


![CleanShot 2024-09-06 at 22 34 55@2x](https://github.com/user-attachments/assets/a8dbfe43-daf8-4b96-b812-8afff5939b34)

