### PR TITLE
test(linter): add class method test cases for `oxc/no-async-await`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -82,6 +82,23 @@ fn test() {
                 async test() {}
             };
         ",
+        // FIXME: diagnostics on method `foo` have incorrect spans
+        "
+        class Foo {
+            async foo() {}
+        }
+        ",
+        "
+        class Foo {
+            public async foo() {}
+        }
+        ",
+        // this one is fine
+        "
+        const obj = {
+            async foo() {}
+        }
+        ",
     ];
 
     Tester::new(NoAsyncAwait::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_async_await.snap
+++ b/crates/oxc_linter/src/snapshots/no_async_await.snap
@@ -37,3 +37,30 @@ source: crates/oxc_linter/src/tester.rs
  4 │             };
    ╰────
   help: Async/await is not allowed
+
+  ⚠ oxc(no-async-await): Unexpected async/await
+   ╭─[no_async_await.tsx:3:22]
+ 2 │         class Foo {
+ 3 │             async foo() {}
+   ·                      ─────
+ 4 │         }
+   ╰────
+  help: Async/await is not allowed
+
+  ⚠ oxc(no-async-await): Unexpected async/await
+   ╭─[no_async_await.tsx:3:29]
+ 2 │         class Foo {
+ 3 │             public async foo() {}
+   ·                             ─────
+ 4 │         }
+   ╰────
+  help: Async/await is not allowed
+
+  ⚠ oxc(no-async-await): Unexpected async/await
+   ╭─[no_async_await.tsx:3:13]
+ 2 │         const obj = {
+ 3 │             async foo() {}
+   ·             ─────
+ 4 │         }
+   ╰────
+  help: Async/await is not allowed


### PR DESCRIPTION
Adds tests for class and object methods. Diagnostics for the former have incorrect spans.

```javascript
class Foo {
   // span covers `() {}`
  async foo() {}
}
```