### PR TITLE
feat(ast): add `JSXElementName::get_identifier` method

### DIFF
--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -28,11 +28,42 @@ impl<'a> fmt::Display for JSXNamespacedName<'a> {
 }
 
 impl<'a> JSXElementName<'a> {
+    pub fn get_identifier(&self) -> Option<&IdentifierReference<'a>> {
+        match self {
+            JSXElementName::Identifier(_)
+            | JSXElementName::NamespacedName(_)
+            | JSXElementName::ThisExpression(_) => None,
+            JSXElementName::IdentifierReference(ident) => Some(ident),
+            JSXElementName::MemberExpression(member_expr) => member_expr.get_identifier(),
+        }
+    }
+
     pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
         match self {
             Self::Identifier(id) => Some(id.as_ref().name.clone()),
             Self::IdentifierReference(id) => Some(id.as_ref().name.clone()),
             _ => None,
+        }
+    }
+}
+
+impl<'a> JSXMemberExpression<'a> {
+    pub fn get_identifier(&self) -> Option<&IdentifierReference<'a>> {
+        self.object.get_identifier()
+    }
+}
+
+impl<'a> JSXMemberExpressionObject<'a> {
+    pub fn get_identifier(&self) -> Option<&IdentifierReference<'a>> {
+        let mut object = self;
+        loop {
+            match object {
+                JSXMemberExpressionObject::IdentifierReference(ident) => return Some(ident),
+                JSXMemberExpressionObject::MemberExpression(member_expr) => {
+                    object = &member_expr.object;
+                }
+                JSXMemberExpressionObject::ThisExpression(_) => return None,
+            }
         }
     }
 }


### PR DESCRIPTION
Add `get_identifier` method for `JSXElementName`, `JSXMemberExpression` and `JSXMemberExpressionObject`, to get root object `IdentifierReference`. i.e. `Foo` in `<Foo>` or `<Foo.bar>`.