### PR TITLE
feat(oxc)!: add `SourceType::Unambiguous`; parse `.js` as unambiguous

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -548,7 +548,10 @@ impl<'a> ParserImpl<'a> {
     ) -> Result<Expression<'a>> {
         self.bump_any(); // bump `.`
         let property = match self.cur_kind() {
-            Kind::Meta => self.parse_keyword_identifier(Kind::Meta),
+            Kind::Meta => {
+                self.set_source_type_to_module_if_unambiguous();
+                self.parse_keyword_identifier(Kind::Meta)
+            }
             Kind::Target => self.parse_keyword_identifier(Kind::Target),
             _ => self.parse_identifier_name()?,
         };

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -41,6 +41,11 @@ impl<'a> ParserImpl<'a> {
                 break;
             }
             let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+
+            if is_top_level && stmt.is_module_declaration() {
+                self.set_source_type_to_module_if_unambiguous();
+            }
+
             // Section 11.2.1 Directive Prologue
             // The only way to get a correct directive is to parse the statement first and check if it is a string literal.
             // All other method are flawed, see test cases in [babel](https://github.com/babel/babel/blob/main/packages/babel-parser/test/fixtures/core/categorized/not-directive/input.js)

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -404,6 +404,10 @@ pub fn check_module_declaration<'a>(
     let start = decl.span().start;
     let span = Span::new(start, start + 6);
     match ctx.source_type.module_kind() {
+        ModuleKind::Unambiguous => {
+            #[cfg(debug_assertions)]
+            panic!("Technically unreachable, omit to avoid panic.");
+        }
         ModuleKind::Script => {
             ctx.error(module_code(text, span));
         }

--- a/crates/oxc_span/src/source_type/types.rs
+++ b/crates/oxc_span/src/source_type/types.rs
@@ -43,6 +43,14 @@ pub enum ModuleKind {
     Script = 0,
     /// ES6 Module
     Module = 1,
+    /// Consider the file a "module" if ESM syntax is present, or else consider it a "script".
+    ///
+    /// ESM syntax includes `import` statement, `export` statement and `import.meta`.
+    ///
+    /// Note: Dynamic import expression is not ESM syntax.
+    ///
+    /// See <https://babel.dev/docs/options#misc-options>
+    Unambiguous = 2,
 }
 
 /// JSX for JavaScript and TypeScript

--- a/tasks/coverage/misc/fail/oxc.js
+++ b/tasks/coverage/misc/fail/oxc.js
@@ -1,2 +1,4 @@
+'use strict';
+
 let.a = 1;
 let()[a] = 1;

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -245,15 +245,16 @@ Negative Passed: 17/17 (100.00%)
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/oxc.js:1:1]
- 1 │ let.a = 1;
+   ╭─[misc/fail/oxc.js:3:1]
+ 2 │ 
+ 3 │ let.a = 1;
    · ───
- 2 │ let()[a] = 1;
+ 4 │ let()[a] = 1;
    ╰────
 
   × The keyword 'let' is reserved
-   ╭─[misc/fail/oxc.js:2:1]
- 1 │ let.a = 1;
- 2 │ let()[a] = 1;
+   ╭─[misc/fail/oxc.js:4:1]
+ 3 │ let.a = 1;
+ 4 │ let()[a] = 1;
    · ───
    ╰────


### PR DESCRIPTION
See https://babel.dev/docs/options#misc-options for background on `unambiguous`

Once `SourceType::Unambiguous` is parsed, it will correctly set the returned `Program::source_type` to either `module` or `script`.