### PR TITLE
feat(traverse): add methods for deleting references

### DIFF
--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -425,6 +425,22 @@ impl<'a> TraverseCtx<'a> {
         self.scoping.create_reference_in_current_scope(name, flags)
     }
 
+    /// Delete a reference.
+    ///
+    /// Provided `name` must match `reference_id`.
+    ///
+    /// This is a shortcut for `ctx.scoping.delete_reference`.
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+        self.scoping.delete_reference(reference_id, name);
+    }
+
+    /// Delete reference for an `IdentifierReference`.
+    ///
+    /// This is a shortcut for `ctx.scoping.delete_reference_for_identifier`.
+    pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
+        self.scoping.delete_reference_for_identifier(ident);
+    }
+
     /// Clone `IdentifierReference` based on the original reference's `SymbolId` and name.
     ///
     /// This method makes a lookup of the `SymbolId` for the reference. If you need to create multiple

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -355,6 +355,25 @@ impl TraverseScoping {
         self.create_reference(name, symbol_id, flags)
     }
 
+    /// Delete a reference.
+    ///
+    /// Provided `name` must match `reference_id`.
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+        let symbol_id = self.symbols.get_reference(reference_id).symbol_id();
+        if let Some(symbol_id) = symbol_id {
+            self.symbols.delete_resolved_reference(symbol_id, reference_id);
+        } else {
+            self.scopes.delete_root_unresolved_reference(name, reference_id);
+        }
+    }
+
+    /// Delete reference for an `IdentifierReference`.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
+        // `unwrap` should never panic as `IdentifierReference`s should always have a `ReferenceId`
+        self.delete_reference(ident.reference_id().unwrap(), &ident.name);
+    }
+
     /// Clone `IdentifierReference` based on the original reference's `SymbolId` and name.
     ///
     /// This method makes a lookup of the `SymbolId` for the reference. If you need to create multiple


### PR DESCRIPTION
Add `TraverseCtx::delete_reference` and `TraverseCtx::delete_reference_for_identifier` methods for deleting references.

These methods can't go on `SymbolTable` as they need access to both `ScopeTree` and `SymbolTable`, and they can't go on `Semantic` as we need them in transformer where we don't have a complete `Semantic`.