### PR TITLE
refactor(linter): use meaningful names for diagnostic parameters

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -17,16 +17,20 @@ use crate::{
     AstNode,
 };
 
-fn expect_return(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Missing return on some path for array method {x0:?}"))
-        .with_help(format!("Array method {x0:?} needs to have valid return on all code paths"))
-        .with_label(span1)
+fn expect_return(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing return on some path for array method {method_name:?}"))
+        .with_help(format!(
+            "Array method {method_name:?} needs to have valid return on all code paths"
+        ))
+        .with_label(span)
 }
 
-fn expect_no_return(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected return for array method {x0:?}"))
-        .with_help(format!("Array method {x0:?} expects no useless return from the function"))
-        .with_label(span1)
+fn expect_no_return(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected return for array method {method_name:?}"))
+        .with_help(format!(
+            "Array method {method_name:?} expects no useless return from the function"
+        ))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -12,11 +12,11 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, Up
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn for_direction_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn for_direction_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The update clause in this loop moves the variable in the wrong direction")
         .with_help("Use while loop for intended infinite loop")
         .with_labels([
-            span0.label("This test moves in the wrong direction"),
+            span.label("This test moves in the wrong direction"),
             span1.label("with this update"),
         ])
 }

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_class_assign_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected re-assignment of class {x0}")).with_labels([
-        span1.label(format!("{x0} is declared as class here")),
-        span2.label(format!("{x0} is re-assigned here")),
+fn no_class_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of class {name}")).with_labels([
+        decl_span.label(format!("{name} is declared as class here")),
+        assign_span.label(format!("{name} is re-assigned here")),
     ])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_compare_neg_zero_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use the {x0} operator to compare against -0."))
+fn no_compare_neg_zero_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not use the {operator} operator to compare against -0."))
         .with_help("Use Object.is(x, -0) to test equality with -0 and use 0 for other cases")
-        .with_label(span1)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_const_assign_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected re-assignment of const variable {x0}")).with_labels([
-        span1.label(format!("{x0} is declared here as const")),
-        span2.label(format!("{x0} is re-assigned here")),
+fn no_const_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of const variable {name}")).with_labels([
+        decl_span.label(format!("{name} is declared here as const")),
+        assign_span.label(format!("{name} is re-assigned here")),
     ])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -48,18 +48,20 @@ declare_oxc_lint!(
     correctness
 );
 
-fn constant_short_circuit(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+fn constant_short_circuit(lhs_name: &str, expr_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Unexpected constant {x0:?} on the left-hand side of a {x1:?} expression"
+        "Unexpected constant {lhs_name:?} on the left-hand side of a {expr_name:?} expression"
     ))
     .with_help("This expression always evaluates to the constant on the left-hand side")
-    .with_label(span2)
+    .with_label(span)
 }
 
-fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+fn constant_binary_operand(left_or_right: &str, operator: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected constant binary expression")
-        .with_help(format!("This compares constantly with the {x0}-hand side of the {x1}"))
-        .with_label(span2)
+        .with_help(format!(
+            "This compares constantly with the {left_or_right}-hand side of the {operator}"
+        ))
+        .with_label(span)
 }
 
 fn constant_always_new(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -10,10 +10,10 @@ use regex::{Matches, Regex};
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
-fn no_control_regex_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_control_regex_diagnostic(regex: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected control character(s)")
-        .with_help(format!("Unexpected control character(s) in regular expression: \"{x0}\""))
-        .with_label(span1)
+        .with_help(format!("Unexpected control character(s) in regular expression: \"{regex}\""))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -6,15 +6,15 @@ use rustc_hash::FxHashMap;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_dupe_class_members_diagnostic(
-    x0: &str, /*Class member name */
-    span1: Span,
-    span2: Span,
+    member_name: &str, /*Class member name */
+    decl_span: Span,
+    re_decl_span: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Duplicate class member: {x0:?}"))
+    OxcDiagnostic::warn(format!("Duplicate class member: {member_name:?}"))
         .with_help("The last declaration overwrites previous ones, remove one of them or rename if both should be retained")
         .with_labels([
-            span1.label(format!("{x0:?} is previously declared here")),
-            span2.label(format!("{x0:?} is re-declared here")),
+            decl_span.label(format!("{member_name:?} is previously declared here")),
+            re_decl_span.label(format!("{member_name:?} is re-declared here")),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -9,10 +9,10 @@ use oxc_syntax::operator::LogicalOperator;
 
 use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
 
-fn no_dupe_else_if_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_dupe_else_if_diagnostic(first_test: Span, second_test: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("duplicate conditions in if-else-if chains")
         .with_help("This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain")
-        .with_labels([span0, span1])
+        .with_labels([first_test, second_test])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_empty_diagnostic(stmt_kind: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty block statements")
-        .with_help(format!("Add comment inside empty {x0} statement"))
-        .with_label(span1.label(format!("Empty {x0} statement")))
+        .with_help(format!("Add comment inside empty {stmt_kind} statement"))
+        .with_label(span.label(format!("Empty {stmt_kind} statement")))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -5,11 +5,11 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_pattern_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_empty_pattern_diagnostic(pattern_type: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty destructuring patterns.")
         .with_help("Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.")
         .with_label(
-            span1.label(format!("Empty {x0} binding pattern")),
+            span.label(format!("Empty {pattern_type} binding pattern")),
         )
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -6,9 +6,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_func_assign_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{x0}' is a function."))
-        .with_label(span1.label(format!("{x0} is re-assigned here")))
+fn no_func_assign_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{name}' is a function."))
+        .with_label(span.label(format!("{name} is re-assigned here")))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -4,9 +4,9 @@ use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_global_assign_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Read-only global '{x0}' should not be modified."))
-        .with_label(span1.label(format!("Read-only global '{x0}' should not be modified.")))
+fn no_global_assign_diagnostic(global_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Read-only global '{global_name}' should not be modified."))
+        .with_label(span.label(format!("Read-only global '{global_name}' should not be modified.")))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_inner_declarations_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
-        .with_help(format!("Move {x0} declaration to {x1} root"))
-        .with_label(span2)
+        .with_help(format!("Move {decl_type} declaration to {body} root"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -5,11 +5,11 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_label_var_diagnostic(x0: &str, span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Found identifier '{x0}' with the same name as a label."))
+fn no_label_var_diagnostic(name: &str, id_span: Span, label_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Found identifier '{name}' with the same name as a label."))
         .with_labels([
-            span0.label(format!("Identifier '{x0}' found here.")),
-            span1.label("Label with the same name."),
+            id_span.label(format!("Identifier '{name}' found here.")),
+            label_span.label("Label with the same name."),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_new_native_nonconstructor_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{x0}` cannot be called as a constructor.")).with_label(span1)
+fn no_new_native_nonconstructor_diagnostic(fn_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{fn_name}` cannot be called as a constructor.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -5,10 +5,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_new_wrappers_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_new_wrappers_diagnostic(builtin_name: &str, new_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow new operators with the String, Number, and Boolean objects")
-        .with_help(format!("do not use {x0} as a constructor, consider removing the new operator."))
-        .with_label(span1)
+        .with_help(format!(
+            "do not use {builtin_name} as a constructor, consider removing the new operator."
+        ))
+        .with_label(new_span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -7,16 +7,16 @@ use regex::{Captures, Regex};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn replacement(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Don't use '{x0}' escape sequence."))
-        .with_help(format!("Replace '{x0}' with '{x1}'. This maintains the current functionality."))
-        .with_label(span2)
+fn replacement(escape_sequence: &str, replacement: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Don't use '{escape_sequence}' escape sequence."))
+        .with_help(format!("Replace '{escape_sequence}' with '{replacement}'. This maintains the current functionality."))
+        .with_label(span)
 }
 
-fn escape_backslash(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Don't use '{x0}' escape sequence."))
-        .with_help(format!("Replace '{x0}' with '{x1}' to include the actual backslash character."))
-        .with_label(span2)
+fn escape_backslash(escape_sequence: &str, replacement: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Don't use '{escape_sequence}' escape sequence."))
+        .with_help(format!("Replace '{escape_sequence}' with '{replacement}' to include the actual backslash character."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -39,7 +39,8 @@ declare_oxc_lint!(
     /// "\\9"
     /// ```
     NoNonoctalDecimalEscape,
-    correctness
+    correctness,
+    pending
 );
 
 impl Rule for NoNonoctalDecimalEscape {

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -12,10 +12,10 @@ use crate::{context::LintContext, rule::Rule};
 const GLOBAL_THIS: &str = "globalThis";
 const NON_CALLABLE_GLOBALS: [&str; 5] = ["Atomics", "Intl", "JSON", "Math", "Reflect"];
 
-fn no_obj_calls_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_obj_calls_diagnostic(obj_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow calling some global objects as functions")
-        .with_help(format!("{x0} is not a function."))
-        .with_label(span1)
+        .with_help(format!("{obj_name} is not a function."))
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -5,12 +5,14 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_prototype_builtins_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("do not access Object.prototype method {x0:?} from target object"))
-        .with_help(format!(
-            "to avoid prototype pollution, use `Object.prototype.{x0}.call` instead"
-        ))
-        .with_label(span1)
+fn no_prototype_builtins_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "do not access Object.prototype method {method_name:?} from target object"
+    ))
+    .with_help(format!(
+        "to avoid prototype pollution, use `Object.prototype.{method_name}.call` instead"
+    ))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -9,18 +9,20 @@ use oxc_syntax::symbol::SymbolId;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_redeclare_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{x0}' is already defined.")).with_labels([
-        span1.label(format!("'{x0}' is already defined.")),
-        span2.label("It can not be redeclare here."),
+fn no_redeclare_diagnostic(id_name: &str, decl_span: Span, re_decl_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{id_name}' is already defined.")).with_labels([
+        decl_span.label(format!("'{id_name}' is already defined.")),
+        re_decl_span.label("It can not be redeclare here."),
     ])
 }
 
-fn no_redeclare_as_builti_in_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{x0}' is already defined as a built-in global variable."))
-        .with_label(
-            span1.label(format!("'{x0}' is already defined as a built-in global variable.")),
-        )
+fn no_redeclare_as_builtin_in_diagnostic(builtin_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "'{builtin_name}' is already defined as a built-in global variable."
+    ))
+    .with_label(
+        span.label(format!("'{builtin_name}' is already defined as a built-in global variable.")),
+    )
 }
 
 #[derive(Debug, Default, Clone)]
@@ -89,7 +91,7 @@ impl Rule for NoRedeclare {
 impl NoRedeclare {
     fn report_diagnostic(&self, ctx: &LintContext, span: Span, ident: &BindingIdentifier) {
         if self.built_in_globals && ctx.env_contains_var(&ident.name) {
-            ctx.diagnostic(no_redeclare_as_builti_in_diagnostic(ident.name.as_str(), ident.span));
+            ctx.diagnostic(no_redeclare_as_builtin_in_diagnostic(ident.name.as_str(), ident.span));
         } else {
             ctx.diagnostic(no_redeclare_diagnostic(ident.name.as_str(), ident.span, span));
         }

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -7,14 +7,14 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_restricted_globals(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    let warn_text = if x1.is_empty() {
-        format!("Unexpected use of '{x0}'.")
+fn no_restricted_globals(global_name: &str, suffix: &str, span: Span) -> OxcDiagnostic {
+    let warn_text = if suffix.is_empty() {
+        format!("Unexpected use of '{global_name}'.")
     } else {
-        format!("Unexpected use of '{x0}'. {x1}")
+        format!("Unexpected use of '{global_name}'. {suffix}")
     };
 
-    OxcDiagnostic::warn(warn_text).with_label(span2)
+    OxcDiagnostic::warn(warn_text).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
 
-fn no_self_compare_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_self_compare_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow comparisons where both sides are exactly the same")
         .with_help("If you are testing for NaN, you can use Number.isNaN function.")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, globals::PRE_DEFINE_VAR, rule::Rule};
 
-fn no_shadow_restricted_names_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Shadowing of global properties such as 'undefined' is not allowed.")
-        .with_help(format!("Shadowing of global properties '{x0}'."))
-        .with_label(span1)
+        .with_help(format!("Shadowing of global properties '{shadowed_name}'."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the use of undeclared variables.")
-        .with_help(format!("'{x0}' is not defined."))
-        .with_label(span1)
+        .with_help(format!("'{name}' is not defined."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -9,10 +9,10 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, AstNode};
 
-fn no_unsafe_negation_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected logical not in the left hand side of '{x0}' operator"))
-        .with_help(format!("use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '{x0}'"))
-        .with_label(span1)
+fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected logical not in the left hand side of '{operator}' operator"))
+        .with_help(format!("use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '{operator}'"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_unused_labels_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_unused_labels_diagnostic(label_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow unused labels")
-        .with_help(format!("'{x0}:' is defined but never used."))
-        .with_label(span1)
+        .with_help(format!("'{label_name}:' is defined but never used."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -8,8 +8,8 @@ use oxc_syntax::class::ElementKind;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_unused_private_class_members_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{x0}' is defined but never used.")).with_label(span1)
+fn no_unused_private_class_members_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{name}' is defined but never used.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -7,8 +7,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_useless_escape_diagnostic(x0: char, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unnecessary escape character {x0:?}")).with_label(span1)
+fn no_useless_escape_diagnostic(escape_char: char, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unnecessary escape character {escape_char:?}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -15,8 +15,9 @@ use crate::{
     AstNode,
 };
 
-fn prefer_numeric_literals_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use {x0} literals instead of parseInt().")).with_label(span)
+fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -16,20 +16,21 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn unexpected_syntax_order_diagnostic(
-    x0: &ImportKind,
-    x1: &ImportKind,
+    curr_kind: &ImportKind,
+    prev_kind: &ImportKind,
     span2: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Expected '{x0}' syntax before '{x1}' syntax.")).with_label(span2)
+    OxcDiagnostic::warn(format!("Expected '{curr_kind}' syntax before '{prev_kind}' syntax."))
+        .with_label(span2)
 }
 
 fn sort_imports_alphabetically_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span)
 }
 
-fn sort_members_alphabetically_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
+fn sort_members_alphabetically_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Member '{x0}' of the import declaration should be sorted alphabetically."
+        "Member '{name}' of the import declaration should be sorted alphabetically."
     ))
     .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -8,8 +8,8 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Default, Clone)]
 pub struct SymbolDescription;
 
-fn symbol_description_diagnostic(span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected Symbol to have a description.").with_label(span1)
+fn symbol_description_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expected Symbol to have a description.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -29,10 +29,10 @@ fn case_na_n(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn index_of_na_n(x0: &str, span1: Span) -> OxcDiagnostic {
+fn index_of_na_n(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
-        .with_help(format!("Array prototype method '{x0}' cannot find NaN."))
-        .with_label(span1)
+        .with_help(format!("Array prototype method '{method_name}' cannot find NaN."))
+        .with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -7,18 +7,18 @@ use phf::{phf_set, Set};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
+fn not_string(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
     let mut d =
-        OxcDiagnostic::warn("Typeof comparisons should be to string literals.").with_label(span1);
-    if let Some(x) = x0 {
+        OxcDiagnostic::warn("Typeof comparisons should be to string literals.").with_label(span);
+    if let Some(x) = help {
         d = d.with_help(x);
     }
     d
 }
 
-fn invalid_value(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn("Invalid typeof comparison value.").with_label(span1);
-    if let Some(x) = x0 {
+fn invalid_value(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
+    let mut d = OxcDiagnostic::warn("Invalid typeof comparison value.").with_label(span);
+    if let Some(x) = help {
         d = d.with_help(x);
     }
     d

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -5,10 +5,10 @@ use oxc_syntax::module_record::ImportImportName;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn default_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("No default export found in imported module {x0:?}"))
-        .with_help(format!("does {x0:?} have the default export?"))
-        .with_label(span1)
+fn default_diagnostic(imported_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("No default export found in imported module {imported_name:?}"))
+        .with_help(format!("does {imported_name:?} have the default export?"))
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md>

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -8,8 +8,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_export(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("No named exports found in module '{x1}'")).with_label(span)
+fn no_named_export(span: Span, module_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("No named exports found in module '{module_name}'"))
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -5,8 +7,11 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn max_dependencies_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0:?}"))
+fn max_dependencies_diagnostic<S: Into<Cow<'static, str>>>(
+    message: S,
+    span1: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(message)
         .with_help("Reduce the number of dependencies in this file")
         .with_label(span1)
 }
@@ -106,7 +111,7 @@ impl Rule for MaxDependencies {
             "File has too many dependencies ({}). Maximum allowed is {}.",
             module_count, self.max,
         );
-        ctx.diagnostic(max_dependencies_diagnostic(&error, entry.module_request.span()));
+        ctx.diagnostic(max_dependencies_diagnostic(error, entry.module_request.span()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -5,10 +5,10 @@ use oxc_syntax::module_record::{ExportImportName, ImportImportName};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn named_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("named import {x0:?} not found"))
-        .with_help(format!("does {x1:?} have the export {x0:?}?"))
-        .with_label(span2)
+fn named_diagnostic(imported_name: &str, module_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("named import {imported_name:?} not found"))
+        .with_help(format!("does {module_name:?} have the export {imported_name:?}?"))
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md>

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -12,24 +12,34 @@ use oxc_syntax::module_record::{ExportExportName, ExportImportName, ImportImport
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_export(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1:?} not found in imported namespace {x2:?}.")).with_label(span)
-}
-
-fn no_export_in_deeply_imported_namespace(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1:?} not found in deeply imported namespace {x2:?}."))
-        .with_label(span)
-}
-
-fn computed_reference(span: Span, x1: &str) -> OxcDiagnostic {
+fn no_export(span: Span, specifier_name: &str, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Unable to validate computed reference to imported namespace {x1:?}."
+        "{specifier_name:?} not found in imported namespace {namespace_name:?}."
     ))
     .with_label(span)
 }
 
-fn assignment(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Assignment to member of namespace {x1:?}.'")).with_label(span)
+fn no_export_in_deeply_imported_namespace(
+    span: Span,
+    specifier_name: &str,
+    namespace_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "{specifier_name:?} not found in deeply imported namespace {namespace_name:?}."
+    ))
+    .with_label(span)
+}
+
+fn computed_reference(span: Span, namespace_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Unable to validate computed reference to imported namespace {namespace_name:?}."
+    ))
+    .with_label(span)
+}
+
+fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Assignment to member of namespace {namespace_name:?}.'"))
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -8,9 +8,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_amd_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn no_amd_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use AMD `require` and `define` calls.")
-        .with_help(format!("Expected imports instead of AMD {x1}()"))
+        .with_help(format!("Expected imports instead of AMD {name}()"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -11,9 +11,9 @@ use oxc_syntax::{
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_cycle_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn no_cycle_diagnostic(span: Span, paths: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Dependency cycle detected")
-        .with_help(format!("These paths form a cycle: \n{x1}"))
+        .with_help(format!("These paths form a cycle: \n{paths}"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -5,9 +5,13 @@ use oxc_syntax::module_record::ImportImportName;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Module {x2:?} has named export {x1:?}"))
-        .with_help(format!("Using default import as {x1:?} can be confusing. Use another name for default import to avoid confusion."))
+fn no_named_as_default_diagnostic(
+    span: Span,
+    module_name: &str,
+    export_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Module {export_name:?} has named export {module_name:?}"))
+        .with_help(format!("Using default import as {module_name:?} can be confusing. Use another name for default import to avoid confusion."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -11,9 +11,14 @@ use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_member_dignostic(span: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1:?} also has a named export {x2:?}"))
-        .with_help(format!("Check if you meant to write `import {{{x2:}}} from {x3:?}`"))
+fn no_named_as_default_member_dignostic(
+    span: Span,
+    module_name: &str,
+    export_name: &str,
+    suggested_module_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{module_name:?} also has a named export {export_name:?}"))
+        .with_help(format!("Check if you meant to write `import {{ {export_name} }} from {suggested_module_name:?}`"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -9,8 +9,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected `!` in `{x0}`."))
+fn no_named_as_default_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected `!` in `{name}`."))
         .with_help("Do not use import syntax to configure webpack loaders")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -14,9 +14,11 @@ use crate::{
     AstNode,
 };
 
-fn aria_role_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn aria_role_diagnostic(span: Span, help_suffix: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Elements with ARIA roles must use a valid, non-abstract ARIA role.")
-        .with_help(format!("Set a valid, non-abstract ARIA role for element with ARIA{x1}"))
+        .with_help(format!(
+            "Set a valid, non-abstract ARIA role for element with ARIA{help_suffix}"
+        ))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -16,16 +16,16 @@ use crate::{
     AstNode,
 };
 
-fn label_has_associated_control_diagnostic(span0: Span) -> OxcDiagnostic {
+fn label_has_associated_control_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("A form label must be associated with a control.")
         .with_help("Either give the label a `htmlFor` attribute with the id of the associated control, or wrap the label around the control.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn label_has_associated_control_diagnostic_no_label(span0: Span) -> OxcDiagnostic {
+fn label_has_associated_control_diagnostic_no_label(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("A form label must have accessible text.")
         .with_help("Ensure the label either has text inside it or is accessibly labelled using an attribute such as `aria-label`, or `aria-labelledby`. You can mark more attributes as accessible labels by configuring the `labelAttributes` option.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -11,14 +11,14 @@ use crate::{
     AstNode,
 };
 
-fn miss_on_focus(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1} must be accompanied by onFocus for accessibility."))
+fn miss_on_focus(span: Span, attr_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{attr_name} must be accompanied by onFocus for accessibility."))
         .with_help("Try to add onFocus.")
         .with_label(span)
 }
 
-fn miss_on_blur(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1} must be accompanied by onBlur for accessibility."))
+fn miss_on_blur(span: Span, attr_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{attr_name} must be accompanied by onBlur for accessibility."))
         .with_help("Try to add onBlur.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -50,15 +50,15 @@ declare_oxc_lint!(
 #[derive(Debug, Default, Clone)]
 pub struct RoleSupportsAriaProps;
 
-fn default(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}."))
-        .with_help(format!("Try to remove invalid attribute {x1}."))
+fn default(span: Span, attr_name: &str, role: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("The attribute {attr_name} is not supported by the role {role}."))
+        .with_help(format!("Try to remove invalid attribute {attr_name}."))
         .with_label(span)
 }
 
-fn is_implicit_diagnostic(span: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}. This role is implicit on the element {x3}."))
-        .with_help(format!("Try to remove invalid attribute {x1}."))
+fn is_implicit_diagnostic(span: Span, attr_name: &str, role: &str, el_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("The attribute {attr_name} is not supported by the role {role}. This role is implicit on the element {el_name}."))
+        .with_help(format!("Try to remove invalid attribute {attr_name}."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -18,8 +18,8 @@ fn font_display_parameter_missing(span: Span) -> OxcDiagnostic {
     .with_label(span)
 }
 
-fn not_recommended_font_display_value(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{x1}` is not a recommended font-display value."))
+fn not_recommended_font_display_value(span: Span, font_display_value: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{font_display_value}` is not a recommended font-display value."))
         .with_help("See https://nextjs.org/docs/messages/google-font-display")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -5,6 +5,11 @@ use oxc_span::GetSpan;
 
 use crate::{context::LintContext, rule::Rule};
 
+fn no_duplicate_head(labels: Vec<LabeledSpan>) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not include multiple instances of `<Head/>`")
+        .with_help("Only use a single `<Head />` component in your custom document in `pages/_document.js`. See: https://nextjs.org/docs/messages/no-duplicate-head")
+        .with_labels(labels)
+}
 #[derive(Debug, Default, Clone)]
 pub struct NoDuplicateHead;
 
@@ -100,11 +105,7 @@ impl Rule for NoDuplicateHead {
             return;
         }
 
-        ctx.diagnostic(
-            OxcDiagnostic::warn("Do not include multiple instances of `<Head/>`")
-                .with_help("Only use a single `<Head />` component in your custom document in `pages/_document.js`. See: https://nextjs.org/docs/messages/no-duplicate-head")
-                .with_labels(labels),
-        );
+        ctx.diagnostic(no_duplicate_head(labels));
     }
 }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -9,10 +9,10 @@ use phf::phf_set;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_typos_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0} may be a typo. Did you mean {x1}?"))
+fn no_typos_diagnostic(typo: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{typo} may be a typo. Did you mean {suggestion}?"))
         .with_help("Prevent common typos in Next.js's data fetching functions")
-        .with_label(span2)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -33,7 +33,8 @@ declare_oxc_lint!(
     /// export async function getServurSideProps(){};
     /// ```
     NoTypos,
-    correctness
+    correctness,
+    pending
 );
 
 const NEXTJS_DATA_FETCHING_FUNCTIONS: phf::Set<&'static str> = phf_set! {

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -10,12 +10,12 @@ use phf::{phf_set, Set};
 
 use crate::{context::LintContext, rule::Rule, utils::get_next_script_import_local_name};
 
-fn no_unwanted_polyfillio_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn no_unwanted_polyfillio_diagnostic(polyfill_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "No duplicate polyfills from Polyfill.io are allowed. {x0} already shipped with Next.js."
+        "No duplicate polyfills from Polyfill.io are allowed. {polyfill_name} already shipped with Next.js."
     ))
     .with_help("See https://nextjs.org/docs/messages/no-unwanted-polyfillio")
-    .with_label(span1)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -9,9 +9,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn approx_constant_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Approximate value of `{x1}` found."))
-        .with_help(format!("Use `Math.{x1}` instead"))
+fn approx_constant_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Approximate value of `{method_name}` found."))
+        .with_help(format!("Use `Math.{method_name}` instead"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -8,12 +8,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn bad_array_method_on_arguments_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn bad_array_method_on_arguments_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad array method on arguments")
         .with_help(format!(
-            "The 'arguments' object does not have '{x0}()' method. If an array method was intended, consider converting the 'arguments' object to an array or using ES6 rest parameter instead."
+            "The 'arguments' object does not have '{method_name}()' method. If an array method was intended, consider converting the 'arguments' object to an array or using ES6 rest parameter instead."
         ))
-        .with_label(span1)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -9,10 +9,14 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn bad_bitwise_operator_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+fn bad_bitwise_operator_diagnostic(
+    bad_operator: &str,
+    suggestion: &str,
+    span2: Span,
+) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad bitwise operator")
         .with_help(format!(
-            "Bitwise operator '{x0}' seems unintended. Did you mean logical operator '{x1}'?"
+            "Bitwise operator '{bad_operator}' seems unintended. Did you mean logical operator '{suggestion}'?"
         ))
         .with_label(span2)
 }
@@ -52,6 +56,7 @@ declare_oxc_lint!(
     BadBitwiseOperator,
     restriction // Restricted because there are false positives for enum bitflags in TypeScript,
                 // e.g. in the vscode repo
+    pending
 );
 
 impl Rule for BadBitwiseOperator {

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -9,13 +9,13 @@ use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode}
 fn bad_char_at_comparison_diagnostic(
     char_at: Span,
     compared_string: Span,
-    x2: usize,
+    len: usize,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid comparison with `charAt` method")
         .with_help("`String.prototype.charAt` returns a string of length 1. If the return value is compared with a string of length greater than 1, the comparison will always be false.")
         .with_labels([
             char_at.label("`charAt` called here"),
-            compared_string.label(format!("And compared with a string of length {x2} here")),
+            compared_string.label(format!("And compared with a string of length {len} here")),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn bad_min_max_func_diagnostic(x0: f64, span1: Span) -> OxcDiagnostic {
+fn bad_min_max_func_diagnostic(constant_result: f64, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Math.min and Math.max combination leads to constant result")
         .with_help(format!(
-            "This evaluates to {x0:?} because of the incorrect `Math.min`/`Math.max` combination"
+            "This evaluates to {constant_result:?} because of the incorrect `Math.min`/`Math.max` combination"
         ))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -6,17 +6,17 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn object_comparison(span: Span, x1: bool) -> OxcDiagnostic {
+fn object_comparison(span: Span, const_result: bool) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected object literal comparison.")
         .with_help(format!(
-            "This comparison will always return {x1:?} as object literals are never equal to each other. Consider using `Object.entries()` of `Object.keys()` and comparing their lengths."
+            "This comparison will always return {const_result:?} as object literals are never equal to each other. Consider using `Object.entries()` of `Object.keys()` and comparing their lengths."
         ))
         .with_label(span)
 }
 
-fn array_comparison(span: Span, x1: bool) -> OxcDiagnostic {
+fn array_comparison(span: Span, const_result: bool) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected array literal comparison.")
-        .with_help(format!("This comparison will always return {x1:?} as array literals are never equal to each other. Consider using `Array.length` if empty checking was intended."))
+        .with_help(format!("This comparison will always return {const_result:?} as array literals are never equal to each other. Consider using `Array.length` if empty checking was intended."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -13,12 +13,12 @@ use crate::{
     AstNode,
 };
 
-fn bad_replace_all_arg_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn bad_replace_all_arg_diagnostic(replace_all_span: Span, regex_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.")
         .with_help("To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.")
         .with_labels([
-            span0.label("`replaceAll` called here"),
-            span1.label("RegExp supplied here"),
+            replace_all_span.label("`replaceAll` called here"),
+            regex_span.label("RegExp supplied here"),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -12,27 +12,27 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
-fn redundant_left_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnostic {
+fn redundant_left_hand_side(span: Span, span1: Span, help: String) -> OxcDiagnostic {
     OxcDiagnostic::warn("Left-hand side of `&&` operator has no effect.")
-        .with_help(x2.to_string())
+        .with_help(help)
         .with_labels([
-            span0.label("If this evaluates to `true`"),
+            span.label("If this evaluates to `true`"),
             span1.label("This will always evaluate to true."),
         ])
 }
 
-fn redundant_right_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnostic {
+fn redundant_right_hand_side(span: Span, span1: Span, help: String) -> OxcDiagnostic {
     OxcDiagnostic::warn("Right-hand side of `&&` operator has no effect.")
-        .with_help(x2.to_string())
+        .with_help(help)
         .with_labels([
-            span0.label("If this evaluates to `true`"),
+            span.label("If this evaluates to `true`"),
             span1.label("This will always evaluate to true."),
         ])
 }
 
-fn impossible(span0: Span, span1: Span, x2: &str, x3: &str, x4: &str) -> OxcDiagnostic {
+fn impossible(span: Span, span1: Span, x2: &str, x3: &str, x4: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected constant comparison").with_help(x4.to_string()).with_labels([
-        span0.label(format!("Requires that {x2}")),
+        span.label(format!("Requires that {x2}")),
         span1.label(format!("Requires that {x3}")),
     ])
 }
@@ -114,9 +114,9 @@ impl Rule for ConstComparisons {
                 // We already know that either side of `&&` has no effect,
                 // but emit a different error message depending on which side it is
                 if left_side_is_useless(left_cmp_op, ordering) {
-                    ctx.diagnostic(redundant_left_hand_side(left_span, logical_expr.right.span(), &format!("if `{rhs_str}` evaluates to true, `{lhs_str}` will always evaluate to true as well")));
+                    ctx.diagnostic(redundant_left_hand_side(left_span, logical_expr.right.span(), format!("if `{rhs_str}` evaluates to true, `{lhs_str}` will always evaluate to true as well")));
                 } else {
-                    ctx.diagnostic(redundant_right_hand_side(logical_expr.right.span(), left_span, &format!("if `{lhs_str}` evaluates to true, `{rhs_str}` will always evaluate to true as well")));
+                    ctx.diagnostic(redundant_right_hand_side(logical_expr.right.span(), left_span, format!("if `{lhs_str}` evaluates to true, `{rhs_str}` will always evaluate to true as well")));
                 }
             } else if !comparison_is_possible(left_cmp_op.direction(), ordering) {
                 let lhs_str = left_const_expr.span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
-fn double_comparisons_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn double_comparisons_diagnostic(span: Span, operator: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected double comparisons.")
         .with_help(format!(
-            "This logical expression can be simplified. Try using the `{x1}` operator instead."
+            "This logical expression can be simplified. Try using the `{operator}` operator instead."
         ))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -15,11 +15,11 @@ use crate::{
     AstNode,
 };
 
-fn misrefactored_assign_op_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn misrefactored_assign_op_diagnostic(span: Span, suggestion: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Misrefactored assign op. Variable appears on both sides of an assignment operation",
     )
-    .with_help(format!("Did you mean `{x1}`?"))
+    .with_help(format!("Did you mean `{suggestion}`?"))
     .with_label(span)
 }
 
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// ```
     MisrefactoredAssignOp,
     suspicious,
+    pending
 );
 
 impl Rule for MisrefactoredAssignOp {

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -5,12 +5,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_optional_chaining_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    if x1.is_empty() {
+fn no_optional_chaining_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
+    if help.is_empty() {
         OxcDiagnostic::warn("Optional chaining is not allowed.").with_label(span)
     } else {
         OxcDiagnostic::warn("Optional chaining is not allowed.")
-            .with_help(x1.to_owned())
+            .with_help(help.to_owned())
             .with_label(span)
     }
 }

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -5,8 +5,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_rest_spread_properties_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1} are not allowed. {x2}")).with_label(span)
+fn no_rest_spread_properties_diagnostic(
+    span: Span,
+    spread_kind: &str,
+    message_suffix: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{spread_kind} are not allowed. {message_suffix}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -6,18 +6,18 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn number_arg_out_of_range_diagnostic(
-    x0: &str,
-    x1: usize,
-    x2: usize,
-    span3: Span,
+    method_name: &str,
+    min: usize,
+    max: usize,
+    span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Radix or precision arguments of number-related functions should not exceed the limit",
     )
     .with_help(format!(
-        "The first argument of 'Number.prototype.{x0}' should be a number between {x1} and {x2}"
+        "The first argument of 'Number.prototype.{method_name}' should be a number between {min} and {max}"
     ))
-    .with_label(span3)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -10,9 +10,9 @@ use crate::{
     ast_util::get_function_like_declaration, context::LintContext, fixer::Fix, rule::Rule, AstNode,
 };
 
-fn only_used_in_recursion_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn only_used_in_recursion_diagnostic(span: Span, param_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Parameter `{x1}` is only used in recursive calls"
+        "Parameter `{param_name}` is only used in recursive calls"
     ))
     .with_help(
         "Remove the argument and its usage. Alternatively, use the argument in the function body.",

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -8,14 +8,14 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn uninvoked_array_callback_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn uninvoked_array_callback_diagnostic(cb_span: Span, arr_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Uninvoked array callback")
         .with_help(
             "consider filling the array with `undefined` values using `Array.prototype.fill()`",
         )
         .with_labels([
-            span0.label("this callback will not be invoked"),
-            span1.label("because this is an array with only empty slots"),
+            cb_span.label("this callback will not be invoked"),
+            arr_span.label("because this is an array with only empty slots"),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -10,10 +10,12 @@ use crate::{
     ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_promise, AstNode,
 };
 
-fn catch_or_return_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-promise(catch-or-return): Expected {x0} or return"))
-        .with_help(format!("Return the promise or chain a {x0}()"))
-        .with_label(span0)
+fn catch_or_return_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "eslint-plugin-promise(catch-or-return): Expected {method_name} or return"
+    ))
+    .with_help(format!("Return the promise or chain a {method_name}()"))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -5,8 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
 
-fn static_promise_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{x0}`")).with_label(span)
+fn static_promise_diagnostic(static_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{static_name}`"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -9,9 +9,11 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn param_names_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise constructor parameters must be named to match `{x0}`"))
-        .with_label(span)
+fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Promise constructor parameters must be named to match `{pattern}`"
+    ))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -1,10 +1,15 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
 use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
+
+fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}`"))
+        .with_label(member_span)
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct SpecOnly(Box<SpecOnlyConfig>);
@@ -82,10 +87,7 @@ impl Rule for SpecOnly {
             }
         }
 
-        ctx.diagnostic(
-            OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}`"))
-                .with_label(member_expr.span()),
-        );
+        ctx.diagnostic(spec_only(prop_name, member_expr.span()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -19,10 +19,10 @@ fn missing_property(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn exclusive_checked_attribute(span0: Span, span1: Span) -> OxcDiagnostic {
+fn exclusive_checked_attribute(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use either `checked` or `defaultChecked`, but not both.")
         .with_help("Remove either `checked` or `defaultChecked`.")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -10,17 +10,18 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::get_prop_value, AstNode};
 
-fn boolean_value_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Value must be omitted for boolean attribute {x0:?}"))
+fn boolean_value_diagnostic(attr: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Value must be omitted for boolean attribute {attr:?}"))
         .with_label(span)
 }
 
-fn boolean_value_always_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Value must be set for boolean attribute {x0:?}")).with_label(span)
+fn boolean_value_always_diagnostic(attr: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Value must be set for boolean attribute {attr:?}"))
+        .with_label(span)
 }
 
-fn boolean_value_undefined_false_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Value must be omitted for `false` attribute {x0:?}"))
+fn boolean_value_undefined_false_diagnostic(attr: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Value must be omitted for `false` attribute {attr:?}"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -12,12 +12,12 @@ fn missing_key_prop_for_element_in_array(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#).with_label(span)
 }
 
-fn missing_key_prop_for_element_in_iterator(span0: Span, span1: Span) -> OxcDiagnostic {
+fn missing_key_prop_for_element_in_iterator(iter_span: Span, el_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(r#"Missing "key" prop for element in iterator."#)
         .with_help(r#"Add a "key" prop to the element in the iterator (https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)."#)
         .with_labels([
-            span0.label("Iterator starts here."),
-            span1.label("Element generated here."),
+            iter_span.label("Iterator starts here."),
+            el_span.label("Element generated here."),
         ])
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -8,9 +8,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn jsx_no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn jsx_no_undef_diagnostic(ident_name: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow undeclared variables in JSX")
-        .with_help(format!("'{x0}' is not defined."))
+        .with_help(format!("'{ident_name}' is not defined."))
         .with_label(span1)
 }
 

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -6,8 +6,8 @@ use phf::{phf_map, Map};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unescaped_entities_diagnostic(span: Span, x1: char, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{x1}` can be escaped with {x2}")).with_label(span)
+fn no_unescaped_entities_diagnostic(span: Span, unescaped: char, escaped: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -16,17 +16,17 @@ use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, AstNode};
 
-fn invalid_prop_on_tag(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn invalid_prop_on_tag(span: Span, prop: &str, tag: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid property found")
-        .with_help(format!("Property '{x1}' is only allowed on: {x2}"))
+        .with_help(format!("Property '{prop}' is only allowed on: {tag}"))
         .with_label(span)
 }
 
-fn data_lowercase_required(span: Span, x1: &str) -> OxcDiagnostic {
+fn data_lowercase_required(span: Span, suggested_prop: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "React does not recognize data-* props with uppercase characters on a DOM element",
     )
-    .with_help(format!("Use '{x1}' instead"))
+    .with_help(format!("Use '{suggested_prop}' instead"))
     .with_label(span)
 }
 
@@ -71,7 +71,8 @@ declare_oxc_lint!(
     ///  const IconButton = <div aria-foo="bar" />;
     /// ```
     NoUnknownProperty,
-    restriction
+    restriction,
+    pending
 );
 
 const ATTRIBUTE_TAGS_MAP: Map<&'static str, Set<&'static str>> = phf_map! {

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -12,12 +12,13 @@ use phf::phf_set;
 
 use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
 
-fn void_dom_elements_no_children_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn void_dom_elements_no_children_diagnostic(tag: &str, span: Span) -> OxcDiagnostic {
+    // TODO: use imperative phrasing
     OxcDiagnostic::warn(
         "Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.",
     )
-    .with_help(format!("Void DOM element <{x0:?} /> cannot receive children."))
-    .with_label(span1)
+    .with_help(format!("Void DOM element <{tag:?} /> cannot receive children."))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -12,15 +12,15 @@ use oxc_span::{CompactStr, GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn adjacent_overload_signatures_diagnostic(
-    x0: &str,
-    span1: Option<Span>,
-    span2: Span,
+    fn_name: &str,
+    first: Option<Span>,
+    second: Span,
 ) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!("All {x0:?} signatures should be adjacent."));
-    if let Some(span) = span1 {
+    let mut d = OxcDiagnostic::warn(format!("All {fn_name:?} signatures should be adjacent."));
+    if let Some(span) = first {
         d = d.and_label(span);
     }
-    d.and_label(span2)
+    d.and_label(second)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -29,32 +29,37 @@ declare_oxc_lint!(
     fix
 );
 
-fn generic(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
+fn generic(readonly_prefix: &str, name: &str, type_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Array type using '{x0}{x2}[]' is forbidden. Use '{x1}<{x2}>' instead."
+        "Array type using '{readonly_prefix}{type_name}[]' is forbidden. Use '{name}<{type_name}>' instead."
     ))
-    .with_label(span3)
+    .with_label(span)
 }
 
-fn generic_simple(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
+fn generic_simple(readonly_prefix: &str, name: &str, type_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Array type using '{x0}{x2}[]' is forbidden for non-simple types. Use '{x1}<{x2}>' instead."
+        "Array type using '{readonly_prefix}{type_name}[]' is forbidden for non-simple types. Use '{name}<{type_name}>' instead."
     ))
-    .with_label(span3)
+    .with_label(span)
 }
 
-fn array(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
+fn array(readonly_prefix: &str, type_name: &str, generic_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Array type using '{x1}<{x2}>' is forbidden. Use '{x0}{x2}[]' instead."
+        "Array type using '{type_name}<{generic_name}>' is forbidden. Use '{readonly_prefix}{generic_name}[]' instead."
     ))
-    .with_label(span3)
+    .with_label(span)
 }
 
-fn array_simple(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
+fn array_simple(
+    readonly_prefix: &str,
+    type_name: &str,
+    generic_name: &str,
+    span: Span,
+) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Array type using '{x1}<{x2}>' is forbidden for simple types. Use '{x0}{x2}[]' instead."
+        "Array type using '{type_name}<{generic_name}>' is forbidden for simple types. Use '{readonly_prefix}{generic_name}[]' instead."
     ))
-    .with_label(span3)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -6,29 +6,35 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn comment(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use @ts-{x0} because it alters compilation errors."))
-        .with_label(span1)
+fn comment(ts_comment_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Do not use @ts-{ts_comment_name} because it alters compilation errors."
+    ))
+    .with_label(span)
 }
 
-fn ignore_instead_of_expect_error(span1: Span) -> OxcDiagnostic {
+fn ignore_instead_of_expect_error(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use \"@ts-expect-error\" instead of @ts-ignore, as \"@ts-ignore\" will do nothing if the following line is error-free.")
         .with_help("Replace \"@ts-ignore\" with \"@ts-expect-error\".")
-        .with_label(span1)
+        .with_label(span)
 }
 
-fn comment_requires_description(x0: &str, x1: u64, span2: Span) -> OxcDiagnostic {
+fn comment_requires_description(ts_comment_name: &str, min_len: u64, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Include a description after the @ts-{x0} directive to explain why the @ts-{x0} is necessary. The description must be {x1} characters or longer."
+        "Include a description after the @ts-{ts_comment_name} directive to explain why the @ts-{ts_comment_name} is necessary. The description must be {min_len} characters or longer."
     ))
-    .with_label(span2)
+    .with_label(span)
 }
 
-fn comment_description_not_match_pattern(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+fn comment_description_not_match_pattern(
+    ts_comment_name: &str,
+    pattern: &str,
+    span: Span,
+) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "The description for the @ts-{x0} directive must match the {x1} format."
+        "The description for the @ts-{ts_comment_name} directive must match the {pattern} format."
     ))
-    .with_label(span2)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -6,8 +6,8 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn ban_tslint_comment_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("tslint comment detected: \"{x0}\"")).with_label(span1)
+fn ban_tslint_comment_diagnostic(tslint_comment: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("tslint comment detected: \"{tslint_comment}\"")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -5,9 +5,11 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn type_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use {x0:?} as a type. Use \"{x1}\" instead"))
-        .with_label(span2)
+fn type_diagnostic(banned_type: &str, suggested_type: &str, span2: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Do not use {banned_type:?} as a type. Use \"{suggested_type}\" instead"
+    ))
+    .with_label(span2)
 }
 
 fn type_literal(span: Span) -> OxcDiagnostic {
@@ -46,7 +48,8 @@ declare_oxc_lint!(
     /// let bar: Boolean = true;
     /// ```
     BanTypes,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for BanTypes {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -8,10 +8,14 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn consistent_type_definitions_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use an `{x0}` instead of a `{x1}`"))
-        .with_help(format!("Use an `{x0}` instead of a `{x1}`"))
-        .with_label(span2)
+fn consistent_type_definitions_diagnostic(
+    preferred_type_kind: &str,
+    bad_type_kind: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use an `{preferred_type_kind}` instead of a `{bad_type_kind}`"))
+        .with_help(format!("Use an `{preferred_type_kind}` instead of a `{bad_type_kind}`"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -111,6 +111,7 @@ declare_oxc_lint!(
 
 fn explicit_function_return_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing return type on function.")
+        // TODO: actually provide a helpful message.
         .with_help("Require explicit return types on functions and class methods.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// ```
     NoConfusingNonNullAssertion,
     suspicious,
-    // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+    pending
 );
 
 fn not_need_no_confusing_non_null_assertion_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -6,10 +6,10 @@ use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_duplicate_enum_values_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_duplicate_enum_values_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow duplicate enum member values")
         .with_help("Duplicate values can lead to bugs that are hard to track down")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_non_null_asserted_optional_chain_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_non_null_asserted_optional_chain_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("non-null assertions after an optional chain expression")
         .with_help("Optional chain expressions can return undefined by design - using a non-null assertion is unsafe and wrong. You should remove the non-null assertion.")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -6,16 +6,16 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unnecessary_type_constraint_diagnostic(
-    x0: &str,
-    x1: &str,
-    span2: Span,
-    span3: Span,
+    generic_type: &str,
+    constraint: &str,
+    span: Span,
+    constraint_span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "constraining the generic type {x0:?} to {x1:?} does nothing and is unnecessary"
+        "constraining the generic type {generic_type:?} to {constraint:?} does nothing and is unnecessary"
     ))
-    .with_help(format!("Remove the unnecessary {x1:?} constraint"))
-    .with_labels([span2, span3])
+    .with_help(format!("Remove the unnecessary {constraint:?} constraint"))
+    .with_labels([span, constraint_span])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -6,10 +6,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unsafe_declaration_merging_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_unsafe_declaration_merging_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe declaration merging between classes and interfaces.")
         .with_help("The TypeScript compiler doesn't check whether properties are initialized, which can cause lead to TypeScript not detecting code that will cause runtime errors.")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -5,10 +5,16 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_enum_initializers_diagnostic(x0: &str, x1: usize, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The value of the member {x0:?} should be explicitly defined."))
-        .with_help(format!("Can be fixed to {x0:?} = {x1:?}."))
-        .with_label(span2)
+fn prefer_enum_initializers_diagnostic(
+    member_name: &str,
+    init: usize,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The value of the member {member_name:?} should be explicitly defined."
+    ))
+    .with_help(format!("Can be fixed to {member_name:?} = {init:?}."))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -30,7 +36,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferEnumInitializers,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for PreferEnumInitializers {

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -48,7 +48,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferForOf,
-    style
+    style,
+    pending
 );
 
 trait SpanExt {

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -8,10 +8,11 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
-fn prefer_function_type_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
+fn prefer_function_type_diagnostic(suggestion: &str, span: Span) -> OxcDiagnostic {
+    // FIXME: use imperative message phrasing
     OxcDiagnostic::warn("Enforce using function types instead of interfaces with call signatures.")
-        .with_help(format!("The function type form `{x0}` is generally preferred when possible for being more succinct."))
-        .with_label(span1)
+        .with_help(format!("The function type form `{suggestion}` is generally preferred when possible for being more succinct."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -10,10 +10,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn triple_slash_reference_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use a triple slash reference for {x0}, use `import` style instead."))
+fn triple_slash_reference_diagnostic(ref_kind: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not use a triple slash reference for {ref_kind}, use `import` style instead."))
         .with_help("Use of triple-slash reference type directives is generally discouraged in favor of ECMAScript Module imports.")
-        .with_label(span1)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -9,9 +9,15 @@ use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn catch_error_name_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The catch parameter {x0:?} should be named {x1:?}"))
-        .with_label(span2)
+fn catch_error_name_diagnostic(
+    caught_ident: &str,
+    expected_name: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The catch parameter {caught_ident:?} should be named {expected_name:?}"
+    ))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -56,7 +62,8 @@ declare_oxc_lint!(
     /// try { } catch (error) { }
     /// ```
     CatchErrorName,
-    style
+    style,
+    pending
 );
 
 impl Rule for CatchErrorName {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn consistent_function_scoping(x0: Span) -> OxcDiagnostic {
+fn consistent_function_scoping(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Function does not capture any variables from the outer scope.")
         .with_help("Move this function to the outer scope.")
-        .with_label(x0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -8,8 +8,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn missing_message(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Pass a message to the {x0:1} constructor.")).with_label(span1)
+fn missing_message(ctor_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Pass a message to the {ctor_name:1} constructor."))
+        .with_label(span)
 }
 
 fn empty_message(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -16,18 +16,22 @@ use crate::{
     AstNode,
 };
 
-fn none_zero(span: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is not zero."))
-        .with_label(span);
-    if let Some(x) = x3 {
+fn non_zero(span: Span, prop_name: &str, op_and_rhs: &str, help: Option<String>) -> OxcDiagnostic {
+    let mut d = OxcDiagnostic::warn(format!(
+        "Use `.{prop_name} {op_and_rhs}` when checking {prop_name} is not zero."
+    ))
+    .with_label(span);
+    if let Some(x) = help {
         d = d.with_help(x);
     }
     d
 }
 
-fn zero(span: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is zero."));
-    if let Some(x) = x3 {
+fn zero(span: Span, prop_name: &str, op_and_rhs: &str, help: Option<String>) -> OxcDiagnostic {
+    let mut d = OxcDiagnostic::warn(format!(
+        "Use `.{prop_name} {op_and_rhs}` when checking {prop_name} is zero."
+    ));
+    if let Some(x) = help {
         d = d.with_help(x);
     }
     d.with_label(span)
@@ -228,7 +232,7 @@ impl ExplicitLengthCheck {
         let diagnostic = if is_zero_length_check {
             zero(span, property.as_str(), check_code, help)
         } else {
-            none_zero(span, property.as_str(), check_code, help)
+            non_zero(span, property.as_str(), check_code, help)
         };
         if auto_fix {
             ctx.diagnostic_with_fix(diagnostic, |fixer| fixer.replace(span, fixed));

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn filename_case_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Filename should not be in {x1} case")).with_label(span)
+fn filename_case_diagnostic(span: Span, case_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Filename should not be in {case_name} case")).with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -10,12 +10,12 @@ use phf::phf_set;
 
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
-fn enforce(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `new {x1}()` instead of `{x1}()`")).with_label(span)
+fn enforce(span: Span, fn_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `new {fn_name}()` instead of `{fn_name}()`")).with_label(span)
 }
 
-fn disallow(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `{x1}()` instead of `new {x1}()`")).with_label(span)
+fn disallow(span: Span, fn_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `{fn_name}()` instead of `new {fn_name}()`")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use oxc_ast::{
     ast::{AssignmentExpression, AssignmentTarget, ExportDefaultDeclarationKind, Expression},
     AstKind,
@@ -8,9 +10,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_anonymous_default_export_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn no_anonymous_default_export_diagnostic(span: Span, kind: ErrorNodeKind) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow anonymous functions and classes as the default export")
-        .with_help(format!("The {x1} should be named."))
+        .with_help(format!("The {kind} should be named."))
         .with_label(span)
 }
 
@@ -104,7 +106,7 @@ impl Rule for NoAnonymousDefaultExport {
         };
 
         if let Some((span, error_kind)) = problem_node {
-            ctx.diagnostic(no_anonymous_default_export_diagnostic(span, error_kind.as_str()));
+            ctx.diagnostic(no_anonymous_default_export_diagnostic(span, error_kind));
         };
     }
 }
@@ -125,16 +127,17 @@ fn is_common_js_export(expr: &AssignmentExpression) -> bool {
     true
 }
 
+#[derive(Clone, Copy)]
 enum ErrorNodeKind {
     Function,
     Class,
 }
 
-impl ErrorNodeKind {
-    fn as_str(&self) -> &str {
+impl fmt::Display for ErrorNodeKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Function => "function",
-            Self::Class => "class",
+            Self::Function => "function".fmt(f),
+            Self::Class => "class".fmt(f),
         }
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// ```
     NoArrayForEach,
     restriction,
+    pending
 );
 
 impl Rule for NoArrayForEach {

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_await_in_promise_methods_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise in `Promise.{x1}()` should not be awaited."))
+fn no_await_in_promise_methods_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Promise in `Promise.{method_name}()` should not be awaited."))
         .with_help("Remove the `await`")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -12,10 +12,14 @@ use crate::{
     AstNode,
 };
 
-fn no_console_spaces_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use {x0} spaces with `console.{x1}` parameters"))
+fn no_console_spaces_diagnostic(
+    leading_or_trailing: &str,
+    method_name: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not use {leading_or_trailing} spaces with `console.{method_name}` parameters"))
         .with_help("The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.")
-        .with_label(span2)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_lonely_if_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
+fn no_lonely_if_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected `if` as the only statement in a `if` block without `else`.")
         .with_help("Move the inner `if` test to the outer `if` test.")
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// a ? doSomethingB() : doSomethingC()
     /// ```
     NoNegatedCondition,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoNegatedCondition {

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// ```
     NoNegationInEqualityCheck,
     pedantic,
+    pending
 );
 
 impl Rule for NoNegationInEqualityCheck {

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -36,7 +36,8 @@ declare_oxc_lint!(
     /// const array = [42];
     /// ```
     NoNewArray,
-    correctness
+    correctness,
+    pending
 );
 
 impl Rule for NoNewArray {

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -35,7 +35,8 @@ declare_oxc_lint!(
     /// const buffer = Buffer.alloc(10);
     /// ```
     NoNewBuffer,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoNewBuffer {

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn identifier(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{x1}`."))
+fn identifier(span: Span, param: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{param}`."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_this_assignment_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Do not assign `this` to `{x1}`"))
+fn no_this_assignment_diagnostic(span: Span, ident_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not assign `this` to `{ident_name}`"))
         .with_help("Reference `this` directly instead of assigning it to a variable.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -38,7 +38,8 @@ declare_oxc_lint!(
     /// foo === undefined;
     /// ```
     NoTypeofUndefined,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoTypeofUndefined {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUselessLengthCheck,
-    correctness
+    correctness,
+    pending
 );
 
 struct ConditionDTO<T: ToString> {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -14,14 +14,14 @@ use crate::{
     AstNode,
 };
 
-fn resolve(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `{x1} value` over `{x1} Promise.resolve(value)`."))
+fn resolve(span: Span, preferred: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{preferred} value` over `{preferred} Promise.resolve(value)`."))
         .with_help("Wrapping the return value in `Promise.Resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.")
         .with_label(span)
 }
 
-fn reject(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `throw error` over `{x1} Promise.reject(error)`."))
+fn reject(span: Span, preferred: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `throw error` over `{preferred} Promise.reject(error)`."))
         .with_help("Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -22,19 +22,21 @@ use crate::{
     AstNode,
 };
 
-fn spread_in_list(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Using a spread operator here creates a new {x1} unnecessarily."))
-        .with_help("Consider removing the spread operator.")
-        .with_label(span)
+fn spread_in_list(span: Span, arr_or_obj: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Using a spread operator here creates a new {arr_or_obj} unnecessarily."
+    ))
+    .with_help("Consider removing the spread operator.")
+    .with_label(span)
 }
 
 fn spread_in_arguments(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using a spread operator here creates a new array unnecessarily.").with_help("This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.\nFor example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.").with_label(span)
 }
 
-fn iterable_to_array(span: Span, x1: &str) -> OxcDiagnostic {
+fn iterable_to_array(span: Span, ctor_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "`{x1}` accepts an iterable, so it's unnecessary to convert the iterable to an array."
+        "`{ctor_name}` accepts an iterable, so it's unnecessary to convert the iterable to an array."
     ))
     .with_help("Consider removing the spread operator.")
     .with_label(span)
@@ -52,12 +54,12 @@ fn iterable_to_array_in_yield_star(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn clone(span: Span, is_array: bool, x1: Option<&str>) -> OxcDiagnostic {
+fn clone(span: Span, is_array: bool, method_name: Option<&str>) -> OxcDiagnostic {
     let noun = if is_array { "array" } else { "object" };
     OxcDiagnostic::warn(format!("Using a spread operator here creates a new {noun} unnecessarily."))
         .with_help(
-            if let Some(x1) = x1 {
-                format!("`{x1}` returns a new {noun}. Spreading it into an {noun} expression to create a new {noun} is redundant.")
+            if let Some(method_name) = method_name {
+                format!("`{method_name}` returns a new {noun}. Spreading it into an {noun} expression to create a new {noun} is redundant.")
             } else {
 
                 format!("This expression returns a new {noun}. Spreading it into an {noun} expression to create a new {noun} is redundant.")

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -45,7 +45,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUselessSwitchCase,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoUselessSwitchCase {

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -5,15 +5,15 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn zero_fraction(span: Span, x1: &str) -> OxcDiagnostic {
+fn zero_fraction(span: Span, lit: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use a zero fraction in the number.")
-        .with_help(format!("Replace the number literal with `{x1}`"))
+        .with_help(format!("Replace the number literal with `{lit}`"))
         .with_label(span)
 }
 
-fn dangling_dot(span: Span, x1: &str) -> OxcDiagnostic {
+fn dangling_dot(span: Span, lit: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use a dangling dot in the number.")
-        .with_help(format!("Replace the number literal with `{x1}`"))
+        .with_help(format!("Replace the number literal with `{lit}`"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn uppercase_prefix(span: Span, x1: &str) -> OxcDiagnostic {
+fn uppercase_prefix(span: Span, prefix: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected number literal prefix in uppercase.")
-        .with_help(format!("Use lowercase for the number literal prefix `{x1}`."))
+        .with_help(format!("Use lowercase for the number literal prefix `{prefix}`."))
         .with_label(span)
 }
 
@@ -23,12 +23,12 @@ fn lowercase_hexadecimal_digits(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn uppercase_prefix_and_lowercase_hexadecimal_digits(span: Span, x1: &str) -> OxcDiagnostic {
+fn uppercase_prefix_and_lowercase_hexadecimal_digits(span: Span, prefix: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Unexpected number literal prefix in uppercase and hexadecimal digits in lowercase.",
     )
     .with_help(format!(
-        "Use lowercase for the number literal prefix `{x1}` and uppercase for hexadecimal digits."
+        "Use lowercase for the number literal prefix `{prefix}` and uppercase for hexadecimal digits."
     ))
     .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -36,7 +36,8 @@ declare_oxc_lint!(
     /// foo.addEventListener('click', () => {});
     /// ```
     PreferAddEventListener,
-    suspicious
+    suspicious,
+    pending
 );
 
 impl Rule for PreferAddEventListener {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -5,9 +5,15 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_blob_reading_methods_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Blob#{x1}()` over `FileReader#{x2}(blob)`."))
-        .with_label(span)
+fn prefer_blob_reading_methods_diagnostic(
+    span: Span,
+    good_method: &str,
+    bad_method: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Prefer `Blob#{good_method}()` over `FileReader#{bad_method}(blob)`."
+    ))
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -42,7 +48,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferBlobReadingMethods,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for PreferBlobReadingMethods {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_code_point_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
-        .with_help(format!("Unicode is better supported in `{x1}` than `{x2}`"))
+fn prefer_code_point_diagnostic(span: Span, good_method: &str, bad_method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{good_method}` over `{bad_method}`"))
+        .with_help(format!("Unicode is better supported in `{good_method}` than `{bad_method}`"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -15,8 +15,8 @@ fn prefer_date_now(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn prefer_date_now_over_methods(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Date.now()` over `new Date().{x1}()`"))
+fn prefer_date_now_over_methods(span: Span, bad_method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `Date.now()` over `new Date().{bad_method}()`"))
         .with_help("Change to `Date.now()`.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -5,29 +5,35 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn set(span: Span, x1: &str) -> OxcDiagnostic {
+fn set(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `setAttribute`.")
-        .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1} = ...;`"))
-        .with_label(span)
-}
-
-fn get(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer using `dataset` over `getAttribute`.")
-        .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1}`"))
-        .with_label(span)
-}
-
-fn has(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer using `dataset` over `hasAttribute`.")
         .with_help(format!(
-            "Check the `dataset` object directly: `Object.hasOwn(element.dataset, '{x1}')"
+            "Access the `.dataset` object directly: `element.dataset.{method_name} = ...;`"
         ))
         .with_label(span)
 }
 
-fn remove(span: Span, x1: &str) -> OxcDiagnostic {
+fn get(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer using `dataset` over `getAttribute`.")
+        .with_help(format!(
+            "Access the `.dataset` object directly: `element.dataset.{method_name}`"
+        ))
+        .with_label(span)
+}
+
+fn has(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer using `dataset` over `hasAttribute`.")
+        .with_help(format!(
+            "Check the `dataset` object directly: `Object.hasOwn(element.dataset, '{method_name}')"
+        ))
+        .with_label(span)
+}
+
+fn remove(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `removeAttribute`.")
-        .with_help(format!("Access the `.dataset` object directly: `delete element.dataset.{x1};"))
+        .with_help(format!(
+            "Access the `.dataset` object directly: `delete element.dataset.{method_name};"
+        ))
         .with_label(span)
 }
 
@@ -55,7 +61,8 @@ declare_oxc_lint!(
     /// element.dataset.unicorn = '🦄';
     /// ```
     PreferDomNodeDataset,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for PreferDomNodeDataset {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -43,7 +43,8 @@ declare_oxc_lint!(
     /// if (str.includes('foo')) { }
     /// ```
     PreferIncludes,
-    style
+    style,
+    pending
 );
 
 impl Rule for PreferIncludes {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -39,7 +39,8 @@ declare_oxc_lint!(
     ///
     /// ```
     PreferLogicalOperatorOverTernary,
-    style
+    style,
+    pending
 );
 
 impl Rule for PreferLogicalOperatorOverTernary {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -6,8 +6,9 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_math_trunc_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{x1} 0`.")).with_label(span)
+fn prefer_math_trunc_diagnostic(span: Span, bad_op: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{bad_op} 0`."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -41,7 +42,8 @@ declare_oxc_lint!(
     /// const foo = Math.trunc(1.1);
     /// ```
     PreferMathTrunc,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for PreferMathTrunc {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -9,8 +9,13 @@ use phf::phf_map;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn prefer_modern_dom_apis_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer using `{x0}` over `{x1}`.")).with_label(span2)
+fn prefer_modern_dom_apis_diagnostic(
+    good_method: &str,
+    bad_method: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer using `{good_method}` over `{bad_method}`."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -56,7 +61,8 @@ declare_oxc_lint!(
     /// parentNode.replaceChild(newChildNode, oldChildNode);
     /// ```
     PreferModernDomApis,
-    style
+    style,
+    pending
 );
 
 impl Rule for PreferModernDomApis {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -19,8 +19,9 @@ fn prefer_math_hypot(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Math.hypot(…)` over alternatives").with_label(span)
 }
 
-fn prefer_math_log_n(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Math.{x1}(x)` over `{x2}`")).with_label(span)
+fn prefer_math_log_n(span: Span, good_method: &str, bad_method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `Math.{good_method}(x)` over `{bad_method}`"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -9,9 +9,11 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::get_first_parameter_name, AstNode};
 
-fn function(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("The function is equivalent to `{x1}`. Call `{x1}` directly."))
-        .with_label(span)
+fn function(span: Span, called_fn: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The function is equivalent to `{called_fn}`. Call `{called_fn}` directly."
+    ))
+    .with_label(span)
 }
 
 fn array_callback(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -9,9 +9,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_node_protocol_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+fn prefer_node_protocol_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using the `node:` protocol when importing Node.js builtin modules.")
-        .with_help(format!("Prefer `node:{x1}` over `{x1}`."))
+        .with_help(format!("Prefer `node:{module_name}` over `{module_name}`."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -8,9 +8,9 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
-fn prefer_number_properties_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `Number.{x1}` instead of the global `{x1}`"))
-        .with_help(format!("Replace it with `Number.{x1}`"))
+fn prefer_number_properties_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `Number.{method_name}` instead of the global `{method_name}`"))
+        .with_help(format!("Replace it with `Number.{method_name}`"))
         .with_label(span)
 }
 
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// ```
     PreferNumberProperties,
     restriction,
+    pending
 );
 
 impl Rule for PreferNumberProperties {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -11,12 +11,14 @@ use crate::{
     AstNode,
 };
 
-fn known_method(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer using `{x1}.prototype.{x2}`.")).with_label(span)
+fn known_method(span: Span, obj_name: &str, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer using `{obj_name}.prototype.{method_name}`."))
+        .with_label(span)
 }
 
-fn unknown_method(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer using method from `{x1}.prototype`.")).with_label(span)
+fn unknown_method(span: Span, obj_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer using method from `{obj_name}.prototype`."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -6,10 +6,14 @@ use phf::phf_map;
 
 use crate::{context::LintContext, rule::Rule, utils::is_node_value_not_dom_node, AstNode};
 
-fn prefer_query_selector_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `.{x0}()` over `.{x1}()`."))
+fn prefer_query_selector_diagnostic(
+    good_method: &str,
+    bad_method: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `.{good_method}()` over `.{bad_method}()`."))
         .with_help("It's better to use the same method to query DOM elements. This helps keep consistency and it lends itself to future improvements (e.g. more specific selectors).")
-        .with_label(span2)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -9,8 +9,8 @@ use phf::phf_set;
 
 use crate::{ast_util, context::LintContext, rule::Rule, AstNode};
 
-fn prefer_spread_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer the spread operator (`...`) over {x1}"))
+fn prefer_spread_diagnostic(span: Span, bad_method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer the spread operator (`...`) over {bad_method}"))
         .with_help("The spread operator (`...`) is more concise and readable.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -8,8 +8,9 @@ use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
-fn string_literal(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("This pattern can be replaced with `{x1}`.")).with_label(span)
+fn string_literal(span: Span, replacement: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("This pattern can be replaced with `{replacement}`."))
+        .with_label(span)
 }
 
 fn use_replace_all(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -5,8 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_string_slice_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer String#slice() over String#{x1}()")).with_label(span)
+fn prefer_string_slice_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer String#slice() over String#{method_name}()"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -5,9 +5,13 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_string_trim_start_end_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
-        .with_help(format!("Replace with `{x1}`"))
+fn prefer_string_trim_start_end_diagnostic(
+    span: Span,
+    good_trim: &str,
+    bad_trim: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{good_trim}` over `{bad_trim}`"))
+        .with_help(format!("Replace with `{good_trim}`"))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -9,8 +9,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn text_encoding_identifier_case_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`.")).with_label(span)
+fn text_encoding_identifier_case_diagnostic(
+    span: Span,
+    good_encoding: &str,
+    bad_encoding: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{good_encoding}` over `{bad_encoding}`.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -88,7 +88,8 @@ declare_oxc_lint!(
     /// })
     /// ```
     RequireLocalTestContextForConcurrentSnapshots,
-    correctness
+    correctness,
+    pending
 );
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {

--- a/crates/oxc_linter/src/snapshots/max_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/max_dependencies.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-import(max-dependencies): "File has too many dependencies (3). Maximum allowed is 1."
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 1.
    ╭─[index.ts:3:31]
  2 │             import { x } from './foo';
  3 │             import { y } from './foo';
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Reduce the number of dependencies in this file
 
-  ⚠ eslint-plugin-import(max-dependencies): "File has too many dependencies (3). Maximum allowed is 2."
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
    ╭─[index.ts:4:31]
  3 │             import { y } from './foo';
  4 │             import { z } from './baz';
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Reduce the number of dependencies in this file
 
-  ⚠ eslint-plugin-import(max-dependencies): "File has too many dependencies (2). Maximum allowed is 1."
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (2). Maximum allowed is 1.
    ╭─[index.ts:3:36]
  2 │             import type { x } from './foo';
  3 │             import type { y } from './foo';
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Reduce the number of dependencies in this file
 
-  ⚠ eslint-plugin-import(max-dependencies): "File has too many dependencies (3). Maximum allowed is 2."
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
    ╭─[index.ts:4:36]
  3 │             import type { y } from './foo';
  4 │             import type { z } from './baz';

--- a/crates/oxc_linter/src/snapshots/no_named_as_default_member.snap
+++ b/crates/oxc_linter/src/snapshots/no_named_as_default_member.snap
@@ -6,21 +6,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import baz from "./named-exports"; const a = baz.a;
    ·                                              ─────
    ╰────
-  help: Check if you meant to write `import {a} from "./named-exports"`
+  help: Check if you meant to write `import { a } from "./named-exports"`
 
   ⚠ eslint-plugin-import(no-named-as-default-member): "baz" also has a named export "a"
    ╭─[index.js:1:46]
  1 │ import baz from "./named-exports"; const a = baz["a"];
    ·                                              ────────
    ╰────
-  help: Check if you meant to write `import {a} from "./named-exports"`
+  help: Check if you meant to write `import { a } from "./named-exports"`
 
   ⚠ eslint-plugin-import(no-named-as-default-member): "baz" also has a named export "a"
    ╭─[index.js:1:36]
  1 │ import baz from "./named-exports"; baz.a();
    ·                                    ─────
    ╰────
-  help: Check if you meant to write `import {a} from "./named-exports"`
+  help: Check if you meant to write `import { a } from "./named-exports"`
 
   ⚠ eslint-plugin-import(no-named-as-default-member): "baz" also has a named export "a"
    ╭─[index.js:3:23]
@@ -29,18 +29,18 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────
  4 │         }
    ╰────
-  help: Check if you meant to write `import {a} from "./named-exports"`
+  help: Check if you meant to write `import { a } from "./named-exports"`
 
   ⚠ eslint-plugin-import(no-named-as-default-member): "baz" also has a named export "a"
    ╭─[index.js:1:51]
  1 │ import baz, { bar } from "./named-exports"; const {a} = baz
    ·                                                   ─────────
    ╰────
-  help: Check if you meant to write `import {a} from "./named-exports"`
+  help: Check if you meant to write `import { a } from "./named-exports"`
 
   ⚠ eslint-plugin-import(no-named-as-default-member): "baz" also has a named export "foo"
    ╭─[index.js:1:53]
  1 │ import baz from "./named-and-default-export"; const {foo: _foo} = baz
    ·                                                     ─────────────────
    ╰────
-  help: Check if you meant to write `import {foo} from "./named-and-default-export"`
+  help: Check if you meant to write `import { foo } from "./named-and-default-export"`

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -28,13 +28,13 @@ pub fn overlong_source() -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn flow(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Flow is not supported").with_label(span0)
+pub fn flow(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Flow is not supported").with_label(span)
 }
 
 #[cold]
-pub fn unexpected_token(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected token").with_label(span0)
+pub fn unexpected_token(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected token").with_label(span)
 }
 
 #[cold]
@@ -44,13 +44,13 @@ pub fn expect_token(x0: &str, x1: &str, span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn invalid_escape_sequence(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid escape sequence").with_label(span0)
+pub fn invalid_escape_sequence(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid escape sequence").with_label(span)
 }
 
 #[cold]
-pub fn unicode_escape_sequence(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid Unicode escape sequence").with_label(span0)
+pub fn unicode_escape_sequence(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid Unicode escape sequence").with_label(span)
 }
 
 #[cold]
@@ -59,18 +59,18 @@ pub fn invalid_character(x0: char, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn invalid_number_end(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid characters after number").with_label(span0)
+pub fn invalid_number_end(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid characters after number").with_label(span)
 }
 
 #[cold]
-pub fn unterminated_multi_line_comment(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unterminated multiline comment").with_label(span0)
+pub fn unterminated_multi_line_comment(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unterminated multiline comment").with_label(span)
 }
 
 #[cold]
-pub fn unterminated_string(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unterminated string").with_label(span0)
+pub fn unterminated_string(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unterminated string").with_label(span)
 }
 
 #[cold]
@@ -86,13 +86,13 @@ pub fn reg_exp_flag_twice(x0: char, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn unexpected_end(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected end of file").with_label(span0)
+pub fn unexpected_end(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected end of file").with_label(span)
 }
 
 #[cold]
-pub fn unterminated_reg_exp(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unterminated regular expression").with_label(span0)
+pub fn unterminated_reg_exp(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unterminated regular expression").with_label(span)
 }
 
 #[cold]
@@ -101,152 +101,152 @@ pub fn invalid_number(x0: &str, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn escaped_keyword(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Keywords cannot contain escape characters").with_label(span0)
+pub fn escaped_keyword(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Keywords cannot contain escape characters").with_label(span)
 }
 
 #[cold]
-pub fn auto_semicolon_insertion(span0: Span) -> OxcDiagnostic {
+pub fn auto_semicolon_insertion(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "Expected a semicolon or an implicit semicolon after a statement, but found none",
     )
     .with_help("Try insert a semicolon here")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn lineterminator_before_arrow(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Line terminator not permitted before arrow").with_label(span0)
+pub fn lineterminator_before_arrow(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Line terminator not permitted before arrow").with_label(span)
 }
 
 #[cold]
-pub fn invalid_destrucuring_declaration(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Missing initializer in destructuring declaration").with_label(span0)
+pub fn invalid_destrucuring_declaration(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Missing initializer in destructuring declaration").with_label(span)
 }
 
 #[cold]
-pub fn missinginitializer_in_const(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Missing initializer in const declaration").with_label(span0)
+pub fn missinginitializer_in_const(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Missing initializer in const declaration").with_label(span)
 }
 
 #[cold]
-pub fn lexical_declaration_single_statement(span0: Span) -> OxcDiagnostic {
+pub fn lexical_declaration_single_statement(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Lexical declaration cannot appear in a single-statement context")
         .with_help("Wrap this declaration in a block statement")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn async_function_declaration(span0: Span) -> OxcDiagnostic {
+pub fn async_function_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Async functions can only be declared at the top level or inside a block")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn generator_function_declaration(span0: Span) -> OxcDiagnostic {
+pub fn generator_function_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Generators can only be declared at the top level or inside a block")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn await_expression(span0: Span) -> OxcDiagnostic {
+pub fn await_expression(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "`await` is only allowed within async functions and at the top levels of modules",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn yield_expression(span0: Span) -> OxcDiagnostic {
+pub fn yield_expression(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("A 'yield' expression is only allowed in a generator body.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn class_declaration(span0: Span) -> OxcDiagnostic {
+pub fn class_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid class declaration")
         .with_help("Classes can only be declared at top level or inside a block")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn binding_rest_element_last(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest element must be last in a destructuring pattern").with_label(span0)
+pub fn binding_rest_element_last(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A rest element must be last in a destructuring pattern").with_label(span)
 }
 
 #[cold]
-pub fn rest_parameter_last(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest parameter must be last in a parameter list").with_label(span0)
+pub fn rest_parameter_last(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A rest parameter must be last in a parameter list").with_label(span)
 }
 
 #[cold]
-pub fn spread_last_element(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Spread must be last element").with_label(span0)
+pub fn spread_last_element(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Spread must be last element").with_label(span)
 }
 
 #[cold]
-pub fn binding_rest_element_trailing_comma(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected trailing comma after rest element").with_label(span0)
+pub fn binding_rest_element_trailing_comma(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected trailing comma after rest element").with_label(span)
 }
 
 #[cold]
-pub fn invalid_binding_rest_element(span0: Span) -> OxcDiagnostic {
+pub fn invalid_binding_rest_element(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid rest element")
         .with_help("Expected identifier in rest element")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn a_rest_parameter_cannot_be_optional(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest parameter cannot be optional").with_label(span0)
+pub fn a_rest_parameter_cannot_be_optional(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A rest parameter cannot be optional").with_label(span)
 }
 
 #[cold]
-pub fn invalid_assignment(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Cannot assign to this expression").with_label(span0)
+pub fn invalid_assignment(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Cannot assign to this expression").with_label(span)
 }
 
 #[cold]
-pub fn new_optional_chain(span0: Span) -> OxcDiagnostic {
+pub fn new_optional_chain(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Optional chaining cannot appear in the callee of new expressions")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn for_loop_async_of(span0: Span) -> OxcDiagnostic {
+pub fn for_loop_async_of(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("The left-hand side of a `for...of` statement may not be `async`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn for_await(span0: Span) -> OxcDiagnostic {
+pub fn for_await(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("await can only be used in conjunction with `for...of` statements")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn new_dynamic_import(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Cannot use new with dynamic import").with_label(span0)
+pub fn new_dynamic_import(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Cannot use new with dynamic import").with_label(span)
 }
 
 #[cold]
-pub fn private_name_constructor(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Classes can't have an element named '#constructor'").with_label(span0)
+pub fn private_name_constructor(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Classes can't have an element named '#constructor'").with_label(span)
 }
 
 #[cold]
-pub fn static_prototype(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Classes may not have a static property named prototype").with_label(span0)
+pub fn static_prototype(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Classes may not have a static property named prototype").with_label(span)
 }
 
 #[cold]
-pub fn constructor_getter_setter(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Constructor can't have get/set modifier").with_label(span0)
+pub fn constructor_getter_setter(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Constructor can't have get/set modifier").with_label(span)
 }
 
 #[cold]
-pub fn constructor_async(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Constructor can't be an async method").with_label(span0)
+pub fn constructor_async(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Constructor can't be an async method").with_label(span)
 }
 
 #[cold]
@@ -275,18 +275,18 @@ pub fn identifier_generator(x0: &str, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn constructor_generator(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Constructor can't be a generator").with_label(span0)
+pub fn constructor_generator(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Constructor can't be a generator").with_label(span)
 }
 
 #[cold]
-pub fn field_constructor(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Classes can't have a field named 'constructor'").with_label(span0)
+pub fn field_constructor(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Classes can't have a field named 'constructor'").with_label(span)
 }
 
 #[cold]
-pub fn export_lone_surrogate(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("An export name cannot include a unicode lone surrogate").with_label(span0)
+pub fn export_lone_surrogate(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("An export name cannot include a unicode lone surrogate").with_label(span)
 }
 
 #[cold]
@@ -304,13 +304,13 @@ pub fn export_reserved_word(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn template_literal(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Bad escape sequence in untagged template literal").with_label(span0)
+pub fn template_literal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Bad escape sequence in untagged template literal").with_label(span)
 }
 
 #[cold]
-pub fn empty_parenthesized_expression(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Empty parenthesized expression").with_label(span0)
+pub fn empty_parenthesized_expression(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Empty parenthesized expression").with_label(span)
 }
 
 #[cold]
@@ -322,108 +322,107 @@ pub fn illegal_newline(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn optional_chain_tagged_template(span0: Span) -> OxcDiagnostic {
+pub fn optional_chain_tagged_template(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Tagged template expressions are not permitted in an optional chain")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn ts_constructor_this_parameter(span0: Span) -> OxcDiagnostic {
-    ts_error("2681", "A constructor cannot have a `this` parameter.").with_label(span0)
+pub fn ts_constructor_this_parameter(span: Span) -> OxcDiagnostic {
+    ts_error("2681", "A constructor cannot have a `this` parameter.").with_label(span)
 }
 
 #[cold]
-pub fn ts_arrow_function_this_parameter(span0: Span) -> OxcDiagnostic {
-    ts_error("2730", "An arrow function cannot have a `this` parameter.").with_label(span0)
+pub fn ts_arrow_function_this_parameter(span: Span) -> OxcDiagnostic {
+    ts_error("2730", "An arrow function cannot have a `this` parameter.").with_label(span)
 }
 
 #[cold]
-pub fn unexpected_super(span0: Span) -> OxcDiagnostic {
+pub fn unexpected_super(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("'super' can only be used with function calls or in property accesses")
         .with_help("replace with `super()` or `super.prop` or `super[prop]`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn expect_function_name(span0: Span) -> OxcDiagnostic {
+pub fn expect_function_name(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Expected function name")
         .with_help("Function name is required in function declaration or named export")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn expect_catch_finally(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Missing catch or finally clause").with_label(span0)
+pub fn expect_catch_finally(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Missing catch or finally clause").with_label(span)
 }
 
 #[cold]
-pub fn a_set_accessor_cannot_have_a_return_type_annotation(span0: Span) -> OxcDiagnostic {
-    ts_error("1095", " A 'set' accessor cannot have a return type annotation.").with_label(span0)
+pub fn a_set_accessor_cannot_have_a_return_type_annotation(span: Span) -> OxcDiagnostic {
+    ts_error("1095", " A 'set' accessor cannot have a return type annotation.").with_label(span)
 }
 
 #[cold]
-pub fn return_statement_only_in_function_body(span0: Span) -> OxcDiagnostic {
+pub fn return_statement_only_in_function_body(span: Span) -> OxcDiagnostic {
     ts_error("1108", "A 'return' statement can only be used within a function body.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn jsx_expressions_may_not_use_the_comma_operator(span0: Span) -> OxcDiagnostic {
+pub fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
     // OxcDiagnostic::error("TS18007: JSX expressions may not use the comma
     // operator.")
     ts_error("18007", "JSX expressions may not use the comma operator")
         .with_help("Did you mean to write an array?")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn line_terminator_before_using_declaration(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Line terminator not permitted before using declaration.")
-        .with_label(span0)
+pub fn line_terminator_before_using_declaration(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Line terminator not permitted before using declaration.").with_label(span)
 }
 
 #[cold]
-pub fn await_in_using_declaration(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Await is not allowed in using declarations.").with_label(span0)
+pub fn await_in_using_declaration(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Await is not allowed in using declarations.").with_label(span)
 }
 
 #[cold]
-pub fn invalid_identifier_in_using_declaration(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Using declarations may not have binding patterns.").with_label(span0)
+pub fn invalid_identifier_in_using_declaration(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Using declarations may not have binding patterns.").with_label(span)
 }
 
 #[cold]
-pub fn await_using_declaration_not_allowed_in_for_in_statement(span0: Span) -> OxcDiagnostic {
+pub fn await_using_declaration_not_allowed_in_for_in_statement(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "The left-hand side of a for...in statement cannot be an await using declaration.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn using_declaration_not_allowed_in_for_in_statement(span0: Span) -> OxcDiagnostic {
+pub fn using_declaration_not_allowed_in_for_in_statement(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "The left-hand side of a for...in statement cannot be an using declaration.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn using_declarations_must_be_initialized(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Using declarations must have an initializer.").with_label(span0)
+pub fn using_declarations_must_be_initialized(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Using declarations must have an initializer.").with_label(span)
 }
 
 /// TS(1093)
 #[cold]
-pub fn static_constructor(span0: Span) -> OxcDiagnostic {
+pub fn static_constructor(span: Span) -> OxcDiagnostic {
     ts_error("1089", "`static` modifier cannot appear on a constructor declaration.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn jsx_element_no_match(span0: Span, span1: Span, name: &str) -> OxcDiagnostic {
+pub fn jsx_element_no_match(span: Span, span1: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Expected corresponding JSX closing tag for '{name}'."))
-        .with_labels([span0, span1])
+        .with_labels([span, span1])
 }
 
 // ================================= MODIFIERS =================================

--- a/crates/oxc_regular_expression/src/diagnostics.rs
+++ b/crates/oxc_regular_expression/src/diagnostics.rs
@@ -6,36 +6,36 @@ const PREFIX: &str = "Invalid regular expression:";
 // For (Literal)Parser ---
 
 #[cold]
-pub fn unexpected_literal_char(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Unexpected literal character")).with_label(span0)
+pub fn unexpected_literal_char(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unexpected literal character")).with_label(span)
 }
 
 #[cold]
-pub fn unterminated_literal(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Unterminated {kind}")).with_label(span0)
+pub fn unterminated_literal(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unterminated {kind}")).with_label(span)
 }
 
 #[cold]
-pub fn empty_literal(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Empty literal")).with_label(span0)
+pub fn empty_literal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Empty literal")).with_label(span)
 }
 
 // For FlagsParser ---
 
 #[cold]
-pub fn duplicated_flag(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Duplicated flag")).with_label(span0)
+pub fn duplicated_flag(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Duplicated flag")).with_label(span)
 }
 
 #[cold]
-pub fn unknown_flag(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Unknown flag")).with_label(span0)
+pub fn unknown_flag(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unknown flag")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_unicode_flags(span0: Span) -> OxcDiagnostic {
+pub fn invalid_unicode_flags(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Invalid flags, `u` and `v` should be used alone"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 // For PatternParser ---
@@ -46,147 +46,146 @@ pub fn duplicated_capturing_group_names(spans: Vec<Span>) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn too_may_capturing_groups(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Too many capturing groups")).with_label(span0)
+pub fn too_may_capturing_groups(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Too many capturing groups")).with_label(span)
 }
 
 #[cold]
-pub fn parse_pattern_incomplete(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Could not parse the entire pattern")).with_label(span0)
+pub fn parse_pattern_incomplete(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Could not parse the entire pattern")).with_label(span)
 }
 
 #[cold]
-pub fn lone_quantifier(span0: Span, kind: &str) -> OxcDiagnostic {
+pub fn lone_quantifier(span: Span, kind: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Lone quantifier found, expected with `{kind}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn unterminated_pattern(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Unterminated {kind}")).with_label(span0)
+pub fn unterminated_pattern(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unterminated {kind}")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_extended_atom_escape(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid extended atom escape")).with_label(span0)
+pub fn invalid_extended_atom_escape(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid extended atom escape")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_braced_quantifier(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid braced quantifier")).with_label(span0)
+pub fn invalid_braced_quantifier(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid braced quantifier")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_indexed_reference(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid indexed reference")).with_label(span0)
+pub fn invalid_indexed_reference(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid indexed reference")).with_label(span)
 }
 
 #[cold]
-pub fn empty_group_specifier(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Group specifier is empty")).with_label(span0)
+pub fn empty_group_specifier(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Group specifier is empty")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_named_reference(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid named reference")).with_label(span0)
+pub fn invalid_named_reference(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid named reference")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_unicode_property_name_negative_strings(span0: Span, name: &str) -> OxcDiagnostic {
+pub fn invalid_unicode_property_name_negative_strings(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!(
         "{PREFIX} Invalid property name `{name}`(negative + property of strings)"
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn invalid_character_class(span0: Span) -> OxcDiagnostic {
+pub fn invalid_character_class(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Invalid character class with strings unicode property"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn character_class_range_out_of_order(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Character {kind} range out of order")).with_label(span0)
+pub fn character_class_range_out_of_order(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Character {kind} range out of order")).with_label(span)
 }
 
 #[cold]
-pub fn character_class_range_invalid_atom(span0: Span) -> OxcDiagnostic {
+pub fn character_class_range_invalid_atom(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Character class range with invalid atom"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn invalid_class_atom(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid class atom")).with_label(span0)
+pub fn invalid_class_atom(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid class atom")).with_label(span)
 }
 
 #[cold]
-pub fn empty_class_set_expression(span0: Span) -> OxcDiagnostic {
+pub fn empty_class_set_expression(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Expected nonempty class set expression"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn class_intersection_unexpected_ampersand(span0: Span) -> OxcDiagnostic {
+pub fn class_intersection_unexpected_ampersand(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Unexpected `&` inside of class intersection"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn class_set_expression_invalid_character(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Unexpected character inside of {kind}"))
-        .with_label(span0)
+pub fn class_set_expression_invalid_character(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Unexpected character inside of {kind}")).with_label(span)
 }
 
 #[cold]
-pub fn character_class_contents_invalid_operands(span0: Span) -> OxcDiagnostic {
+pub fn character_class_contents_invalid_operands(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!(
         "{PREFIX} Invalid class operands inside of character class contents"
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[cold]
-pub fn missing_capturing_group_name(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Missing capturing group name")).with_label(span0)
+pub fn missing_capturing_group_name(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Missing capturing group name")).with_label(span)
 }
 
 #[cold]
-pub fn too_large_number_in_braced_quantifier(span0: Span) -> OxcDiagnostic {
+pub fn too_large_number_in_braced_quantifier(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Number is too large in braced quantifier"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn braced_quantifier_out_of_order(span0: Span) -> OxcDiagnostic {
+pub fn braced_quantifier_out_of_order(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Numbers out of order in braced quantifier"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn too_large_number_digits(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Number is too large in {kind} digits")).with_label(span0)
+pub fn too_large_number_digits(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Number is too large in {kind} digits")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_unicode_property(span0: Span, kind: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid unicode property {kind}")).with_label(span0)
+pub fn invalid_unicode_property(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid unicode property {kind}")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_unicode_property_of_strings(span0: Span, name: &str) -> OxcDiagnostic {
+pub fn invalid_unicode_property_of_strings(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{PREFIX} Invalid unicode property `{name}`"))
         .with_help("Enable `UnicodeSetsMode` to use this property")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[cold]
-pub fn invalid_unicode_escape_sequence(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid unicode escape sequence")).with_label(span0)
+pub fn invalid_unicode_escape_sequence(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid unicode escape sequence")).with_label(span)
 }
 
 #[cold]
-pub fn invalid_surrogate_pair(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("{PREFIX} Invalid surrogate pair")).with_label(span0)
+pub fn invalid_surrogate_pair(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("{PREFIX} Invalid surrogate pair")).with_label(span)
 }

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -107,8 +107,8 @@ pub fn check_module_record(ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn class_static_block_await(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Cannot use await in class static initialization block").with_label(span0)
+fn class_static_block_await(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Cannot use await in class static initialization block").with_label(span)
 }
 
 fn reserved_keyword(x0: &str, span1: Span) -> OxcDiagnostic {
@@ -268,16 +268,16 @@ fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn legacy_octal(span0: Span) -> OxcDiagnostic {
+fn legacy_octal(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("'0'-prefixed octal literals and octal escape sequences are deprecated")
         .with_help("for octal literals use the '0o' prefix instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn leading_zero_decimal(span0: Span) -> OxcDiagnostic {
+fn leading_zero_decimal(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Decimals with leading zeros are not allowed in strict mode")
         .with_help("remove the leading zero")
-        .with_label(span0)
+        .with_label(span)
 }
 
 pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
@@ -307,10 +307,10 @@ pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn non_octal_decimal_escape_sequence(span0: Span) -> OxcDiagnostic {
+fn non_octal_decimal_escape_sequence(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid escape sequence")
         .with_help("\\8 and \\9 are not allowed in strict mode")
-        .with_label(span0)
+        .with_label(span)
 }
 
 pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
@@ -343,11 +343,11 @@ pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn illegal_use_strict(span0: Span) -> OxcDiagnostic {
+fn illegal_use_strict(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "Illegal 'use strict' directive in function with non-simple parameter list",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 // It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true and IsSimpleParameterList of FormalParameters is false.
@@ -416,24 +416,24 @@ pub fn check_module_declaration<'a>(
     }
 }
 
-fn new_target(span0: Span) -> OxcDiagnostic {
+fn new_target(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unexpected new.target expression")
 .with_help("new.target is only allowed in constructors and functions invoked using thew `new` operator")
-.with_label(span0)
+.with_label(span)
 }
 
-fn new_target_property(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("The only valid meta property for new is new.target").with_label(span0)
+fn new_target_property(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("The only valid meta property for new is new.target").with_label(span)
 }
 
-fn import_meta(span0: Span) -> OxcDiagnostic {
+fn import_meta(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unexpected import.meta expression")
         .with_help("import.meta is only allowed in module code")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn import_meta_property(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("The only valid meta property for import is import.meta").with_label(span0)
+fn import_meta_property(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("The only valid meta property for import is import.meta").with_label(span)
 }
 
 pub fn check_meta_property<'a>(prop: &MetaProperty, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
@@ -472,18 +472,18 @@ pub fn check_meta_property<'a>(prop: &MetaProperty, node: &AstNode<'a>, ctx: &Se
     }
 }
 
-fn function_declaration_strict(span0: Span) -> OxcDiagnostic {
+fn function_declaration_strict(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid function declaration")
         .with_help(
             "In strict mode code, functions can only be declared at top level or inside a block",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn function_declaration_non_strict(span0: Span) -> OxcDiagnostic {
+fn function_declaration_non_strict(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid function declaration")
 .with_help("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement")
-.with_label(span0)
+.with_label(span)
 }
 
 pub fn check_function_declaration<'a>(
@@ -501,11 +501,11 @@ pub fn check_function_declaration<'a>(
     };
 }
 
-fn reg_exp_flag_u_and_v(span0: Span) -> OxcDiagnostic {
+fn reg_exp_flag_u_and_v(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "The 'u' and 'v' regular expression flags cannot be enabled at the same time",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 pub fn check_regexp_literal(lit: &RegExpLiteral, ctx: &SemanticBuilder<'_>) {
@@ -515,8 +515,8 @@ pub fn check_regexp_literal(lit: &RegExpLiteral, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn with_statement(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("'with' statements are not allowed").with_label(span0)
+fn with_statement(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'with' statements are not allowed").with_label(span)
 }
 
 pub fn check_with_statement(stmt: &WithStatement, ctx: &SemanticBuilder<'_>) {
@@ -538,12 +538,12 @@ pub fn check_switch_statement<'a>(stmt: &SwitchStatement<'a>, ctx: &SemanticBuil
     }
 }
 
-fn invalid_label_jump_target(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Jump target cannot cross function boundary.").with_label(span0)
+fn invalid_label_jump_target(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Jump target cannot cross function boundary.").with_label(span)
 }
 
-fn invalid_label_target(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Use of undefined label").with_label(span0)
+fn invalid_label_target(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Use of undefined label").with_label(span)
 }
 
 fn invalid_label_non_iteration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
@@ -554,10 +554,10 @@ fn invalid_label_non_iteration(x0: &str, span1: Span, span2: Span) -> OxcDiagnos
         ])
 }
 
-fn invalid_break(span0: Span) -> OxcDiagnostic {
+fn invalid_break(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Illegal break statement")
 .with_help("A `break` statement can only be used within an enclosing iteration or switch statement.")
-.with_label(span0)
+.with_label(span)
 }
 
 pub fn check_break_statement<'a>(
@@ -600,10 +600,10 @@ pub fn check_break_statement<'a>(
     }
 }
 
-fn invalid_continue(span0: Span) -> OxcDiagnostic {
+fn invalid_continue(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Illegal continue statement: no surrounding iteration statement")
 .with_help("A `continue` statement can only be used within an enclosing `for`, `while` or `do while` ")
-.with_label(span0)
+.with_label(span)
 }
 
 pub fn check_continue_statement<'a>(
@@ -726,18 +726,15 @@ pub fn check_for_statement_left<'a>(
     }
 }
 
-fn duplicate_constructor(span0: Span, span1: Span) -> OxcDiagnostic {
+fn duplicate_constructor(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Multiple constructor implementations are not allowed.").with_labels([
-        LabeledSpan::new_with_span(
-            Some("constructor has already been declared here".into()),
-            span0,
-        ),
+        LabeledSpan::new_with_span(Some("constructor has already been declared here".into()), span),
         LabeledSpan::new_with_span(Some("it cannot be redeclared here".into()), span1),
     ])
 }
 
-fn require_class_name(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A class name is required.").with_label(span0)
+fn require_class_name(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A class name is required.").with_label(span)
 }
 
 pub fn check_class(class: &Class, node: &AstNode<'_>, ctx: &SemanticBuilder<'_>) {
@@ -772,12 +769,12 @@ pub fn check_class(class: &Class, node: &AstNode<'_>, ctx: &SemanticBuilder<'_>)
     }
 }
 
-fn setter_with_parameters(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A 'set' accessor must have exactly one parameter.").with_label(span0)
+fn setter_with_parameters(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A 'set' accessor must have exactly one parameter.").with_label(span)
 }
 
-fn setter_with_rest_parameter(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A 'set' accessor cannot have rest parameter.").with_label(span0)
+fn setter_with_rest_parameter(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A 'set' accessor cannot have rest parameter.").with_label(span)
 }
 
 fn check_setter(function: &Function<'_>, ctx: &SemanticBuilder<'_>) {
@@ -793,8 +790,8 @@ fn check_setter(function: &Function<'_>, ctx: &SemanticBuilder<'_>) {
     );
 }
 
-fn getter_parameters(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A 'get' accessor must not have any formal parameters.").with_label(span0)
+fn getter_parameters(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A 'get' accessor must not have any formal parameters.").with_label(span)
 }
 
 fn check_getter(function: &Function<'_>, ctx: &SemanticBuilder<'_>) {
@@ -811,23 +808,23 @@ pub fn check_method_definition(method: &MethodDefinition<'_>, ctx: &SemanticBuil
     }
 }
 
-fn super_without_derived_class(span0: Span, span1: Span) -> OxcDiagnostic {
+fn super_without_derived_class(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("'super' can only be referenced in a derived class.")
         .with_help("either remove this super, or extend the class")
         .with_labels([
-            span0.into(),
+            span.into(),
             LabeledSpan::new_with_span(Some("class does not have `extends`".into()), span1),
         ])
 }
 
-fn unexpected_super_call(span0: Span) -> OxcDiagnostic {
+fn unexpected_super_call(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Super calls are not permitted outside constructors or in nested functions inside constructors.")
-.with_label(span0)
+.with_label(span)
 }
 
-fn unexpected_super_reference(span0: Span) -> OxcDiagnostic {
+fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("'super' can only be referenced in members of derived classes or object literal expressions.")
-.with_label(span0)
+.with_label(span)
 }
 
 pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
@@ -915,10 +912,10 @@ pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a
     }
 }
 
-fn cover_initialized_name(span0: Span) -> OxcDiagnostic {
+fn cover_initialized_name(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid assignment in object literal")
 .with_help("Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.")
-.with_label(span0)
+.with_label(span)
 }
 
 pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
@@ -937,8 +934,8 @@ pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn a_rest_parameter_cannot_have_an_initializer(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest parameter cannot have an initializer").with_label(span0)
+fn a_rest_parameter_cannot_have_an_initializer(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A rest parameter cannot have an initializer").with_label(span)
 }
 
 pub fn check_formal_parameters<'a>(
@@ -963,8 +960,8 @@ pub fn check_array_pattern(pattern: &ArrayPattern, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn assignment_is_not_simple(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span0)
+fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
 }
 
 pub fn check_assignment_expression(assign_expr: &AssignmentExpression, ctx: &SemanticBuilder<'_>) {
@@ -1020,10 +1017,10 @@ pub fn check_binary_expression(binary_expr: &BinaryExpression, ctx: &SemanticBui
     }
 }
 
-fn mixed_coalesce(span0: Span) -> OxcDiagnostic {
+fn mixed_coalesce(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Logical expressions and coalesce expressions cannot be mixed")
         .with_help("Wrap either expression by parentheses")
-        .with_label(span0)
+        .with_label(span)
 }
 
 pub fn check_logical_expression(logical_expr: &LogicalExpression, ctx: &SemanticBuilder<'_>) {
@@ -1047,8 +1044,8 @@ pub fn check_logical_expression(logical_expr: &LogicalExpression, ctx: &Semantic
     }
 }
 
-fn super_private(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span0)
+fn super_private(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span)
 }
 
 pub fn check_member_expression(member_expr: &MemberExpression, ctx: &SemanticBuilder<'_>) {
@@ -1060,12 +1057,12 @@ pub fn check_member_expression(member_expr: &MemberExpression, ctx: &SemanticBui
     }
 }
 
-fn delete_of_unqualified(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span0)
+fn delete_of_unqualified(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span)
 }
 
-fn delete_private_field(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Private fields can not be deleted").with_label(span0)
+fn delete_private_field(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Private fields can not be deleted").with_label(span)
 }
 
 pub fn check_unary_expression<'a>(

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -13,8 +13,8 @@ fn ts_error<M: Into<Cow<'static, str>>>(code: &'static str, message: M) -> OxcDi
     OxcDiagnostic::error(message).with_error_code("TS", code)
 }
 
-fn empty_type_parameter_list(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Type parameter list cannot be empty.").with_label(span0)
+fn empty_type_parameter_list(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Type parameter list cannot be empty.").with_label(span)
 }
 
 pub fn check_ts_type_parameter_declaration(
@@ -41,8 +41,8 @@ pub fn check_variable_declaration(decl: &VariableDeclaration, ctx: &SemanticBuil
     }
 }
 
-fn unexpected_optional(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected `?` operator").with_label(span0)
+fn unexpected_optional(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected `?` operator").with_label(span)
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -55,14 +55,14 @@ pub fn check_variable_declarator(decl: &VariableDeclarator, ctx: &SemanticBuilde
     }
 }
 
-fn required_parameter_after_optional_parameter(span0: Span) -> OxcDiagnostic {
+fn required_parameter_after_optional_parameter(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("A required parameter cannot follow an optional parameter.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn parameter_property_outside_constructor(span0: Span) -> OxcDiagnostic {
+fn parameter_property_outside_constructor(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("A parameter property is only allowed in a constructor implementation.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {
@@ -99,11 +99,11 @@ fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &Sem
     });
 }
 
-fn unexpected_assignment(span0: Span) -> OxcDiagnostic {
+fn unexpected_assignment(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "The left-hand side of an assignment expression must be a variable or a property access.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 pub fn check_simple_assignment_target<'a>(
@@ -122,8 +122,8 @@ pub fn check_simple_assignment_target<'a>(
     }
 }
 
-fn unexpected_type_annotation(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected type annotation").with_label(span0)
+fn unexpected_type_annotation(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Unexpected type annotation").with_label(span)
 }
 
 pub fn check_array_pattern<'a>(pattern: &ArrayPattern<'a>, ctx: &SemanticBuilder<'a>) {
@@ -137,12 +137,12 @@ pub fn check_array_pattern<'a>(pattern: &ArrayPattern<'a>, ctx: &SemanticBuilder
 }
 
 /// An interface can only extend an identifier/qualified-name with optional type arguments.(2499)
-fn invalid_interface_extend(span0: Span) -> OxcDiagnostic {
+fn invalid_interface_extend(span: Span) -> OxcDiagnostic {
     ts_error(
         "2499",
         "An interface can only extend an identifier/qualified-name with optional type arguments.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 pub fn check_ts_interface_declaration<'a>(
@@ -161,11 +161,11 @@ pub fn check_ts_interface_declaration<'a>(
     }
 }
 
-fn not_allowed_namespace_declaration(span0: Span) -> OxcDiagnostic {
+fn not_allowed_namespace_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "A namespace declaration is only allowed at the top level of a namespace or module.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &SemanticBuilder<'a>) {
@@ -187,8 +187,8 @@ pub fn check_ts_module_declaration<'a>(decl: &TSModuleDeclaration<'a>, ctx: &Sem
     }
 }
 
-fn enum_member_must_have_initializer(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Enum member must have initializer.").with_label(span0)
+fn enum_member_must_have_initializer(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Enum member must have initializer.").with_label(span)
 }
 
 pub fn check_ts_enum_declaration<'a>(decl: &TSEnumDeclaration<'a>, ctx: &SemanticBuilder<'a>) {

--- a/crates/oxc_transformer/src/typescript/diagnostics.rs
+++ b/crates/oxc_transformer/src/typescript/diagnostics.rs
@@ -11,17 +11,17 @@ pub fn export_assignment_unsupported(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub fn ambient_module_nested(span0: Span) -> OxcDiagnostic {
+pub fn ambient_module_nested(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Ambient modules cannot be nested in other modules or namespaces.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-pub fn namespace_exporting_non_const(span0: Span) -> OxcDiagnostic {
+pub fn namespace_exporting_non_const(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript")
-        .with_label(span0)
+        .with_label(span)
 }
 
-pub fn namespace_not_supported(span0: Span) -> OxcDiagnostic {
+pub fn namespace_not_supported(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Namespace not marked type-only declare. Non-declarative namespaces are only supported experimentally in Babel. To enable and review caveats see: https://babeljs.io/docs/en/babel-plugin-transform-typescript")
-        .with_label(span0)
+        .with_label(span)
 }


### PR DESCRIPTION
Also add `pending` fix labels to many rules.