### PR TITLE
fix(linter): typescript/no-magic-numbers: remove double minus for reporting negative bigint numbers

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_magic_numbers.rs
@@ -267,7 +267,7 @@ impl InternConfig<'_> {
                     InternConfig {
                         node: parent_node,
                         value: NoMagicNumbersNumber::BigInt(raw.clone()),
-                        raw
+                        raw,
                     }
                 } else {
                     InternConfig {

--- a/crates/oxc_linter/src/rules/typescript/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_magic_numbers.rs
@@ -267,7 +267,7 @@ impl InternConfig<'_> {
                     InternConfig {
                         node: parent_node,
                         value: NoMagicNumbersNumber::BigInt(raw.clone()),
-                        raw: format!("-{raw}"),
+                        raw
                     }
                 } else {
                     InternConfig {

--- a/crates/oxc_linter/src/snapshots/no_magic_numbers.snap
+++ b/crates/oxc_linter/src/snapshots/no_magic_numbers.snap
@@ -337,7 +337,7 @@ source: crates/oxc_linter/src/tester.rs
    ·   ────
    ╰────
 
-  ⚠ typescript-eslint(no-magic-numbers): No magic number: --100n
+  ⚠ typescript-eslint(no-magic-numbers): No magic number: -100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(-100n)
    ·   ─────
@@ -757,7 +757,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ──
    ╰────
 
-  ⚠ typescript-eslint(no-magic-numbers): No magic number: --4n
+  ⚠ typescript-eslint(no-magic-numbers): No magic number: -4n
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -4n;
    ·            ───


### PR DESCRIPTION
@DonIsaac small bug I found after 10x review