### PR TITLE
feat(linter): implement `no-plusplus` rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -90,6 +90,7 @@ mod eslint {
     pub mod no_new_wrappers;
     pub mod no_nonoctal_decimal_escape;
     pub mod no_obj_calls;
+    pub mod no_plusplus;
     pub mod no_proto;
     pub mod no_prototype_builtins;
     pub mod no_redeclare;
@@ -548,6 +549,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_new_wrappers,
     eslint::no_nonoctal_decimal_escape,
     eslint::no_obj_calls,
+    eslint::no_plusplus,
     eslint::no_proto,
     eslint::no_prototype_builtins,
     eslint::no_redeclare,

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -10,16 +10,19 @@ fn no_plusplus_diagnostic(span: Span, operator: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!("Unary operator '{}' used.", operator)).with_label(span);
 
     if operator == "++" {
-        return diagnostic.with_help("Use the assignment expression `+=` instead.");
+        return diagnostic.with_help("Use the assignment operator `+=` instead.");
     } else if operator == "--" {
-        return diagnostic.with_help("Use the assignment expression `-=` instead.");
+        return diagnostic.with_help("Use the assignment operator `-=` instead.");
     }
 
     diagnostic
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct NoPlusplus;
+pub struct NoPlusplus {
+    /// Whether to allow `++` and `--` in for loop afterthoughts.
+    allow_for_loop_afterthoughts: bool,
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -74,13 +77,74 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoPlusplus {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let obj = value.get(0);
+        Self {
+            allow_for_loop_afterthoughts: obj
+                .and_then(|v| v.get("allowForLoopAfterthoughts"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        }
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::UpdateExpression(expr) = node.kind() else {
             return;
         };
 
+        if self.allow_for_loop_afterthoughts && is_for_loop_afterthought(node, ctx) {
+            return;
+        }
+
         ctx.diagnostic(no_plusplus_diagnostic(expr.span, expr.operator.as_str()));
     }
+}
+
+/// Whether the given AST node is a ++ or -- inside of a for-loop update.
+fn is_for_statement_update(node: &AstNode, ctx: &LintContext) -> bool {
+    let Some(parent) = ctx.nodes().parent_node(node.id()) else {
+        return false;
+    };
+    let AstKind::ForStatement(for_stmt) = parent.kind() else {
+        return false;
+    };
+
+    for_stmt.update.as_ref().is_some_and(|update| is_eq_node_expr(node, update))
+}
+
+/// Checks if the given node is equivalent to the given expression (i.e., they have the same span).
+fn is_eq_node_expr(node: &AstNode, expr: &Expression) -> bool {
+    // TODO: This logic should be moved to somewhere more general and shared across rules and expanded
+    // to cover all expressions and node types
+    let node_span = match node.kind() {
+        AstKind::UpdateExpression(expr) => expr.span,
+        AstKind::SequenceExpression(expr) => expr.span,
+        _ => return false,
+    };
+    let expr_span = match expr {
+        Expression::UpdateExpression(expr) => expr.span,
+        Expression::SequenceExpression(expr) => expr.span,
+        _ => return false,
+    };
+    node_span == expr_span
+}
+
+/// Determines whether the given node is considered to be a for loop "afterthought" by the logic of this rule.
+/// In particular, it returns `true` if the given node is either:
+///   - The update node of a `ForStatement`: for (;; i++) {}
+///   - An operand of a sequence expression that is the update node: for (;; foo(), i++) {}
+///   - An operand of a sequence expression that is child of another sequence expression, etc.,
+///     up to the sequence expression that is the update node: for (;; foo(), (bar(), (baz(), i++))) {}
+fn is_for_loop_afterthought(node: &AstNode, ctx: &LintContext) -> bool {
+    if let Some(parent) = ctx.nodes().parent_node(node.id()) {
+        match parent.kind() {
+            AstKind::SequenceExpression(_) => return is_for_loop_afterthought(parent, ctx),
+            AstKind::ParenthesizedExpression(_) => return is_for_loop_afterthought(parent, ctx),
+            _ => (),
+        }
+    }
+
+    is_for_statement_update(node, ctx)
 }
 
 #[test]
@@ -89,6 +153,8 @@ fn test() {
 
     let pass = vec![
         ("var foo = 0; foo=+1;", None),
+        ("var foo = 0; foo+=1;", None),
+        ("var foo = 0; foo-=1;", None),
         ("var foo = 0; foo=+1;", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
         (
             "for (i = 0; i < l; i++) { console.log(i); }",
@@ -125,6 +191,8 @@ fn test() {
     let fail = vec![
         ("var foo = 0; foo++;", None),
         ("var foo = 0; foo--;", None),
+        ("var foo = 0; --foo;", None),
+        ("var foo = 0; ++foo;", None),
         ("for (i = 0; i < l; i++) { console.log(i); }", None),
         ("for (i = 0; i < l; foo, i++) { console.log(i); }", None),
         ("var foo = 0; foo++;", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -1,0 +1,102 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+    AstNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct NoPlusplus;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    NoPlusplus,
+    restriction,
+);
+
+impl Rule for NoPlusplus {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var foo = 0; foo=+1;", None),
+        ("var foo = 0; foo=+1;", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        (
+            "for (i = 0; i < l; i++) { console.log(i); }",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        (
+            "for (var i = 0, j = i + 1; j < example.length; i++, j++) {}",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        ("for (;; i--, foo());", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        ("for (;; foo(), --i);", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        (
+            "for (;; foo(), ++i, bar);",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        (
+            "for (;; i++, (++j, k--));",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        (
+            "for (;; foo(), (bar(), i++), baz());",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        (
+            "for (;; (--i, j += 2), bar = j + 1);",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        (
+            "for (;; a, (i--, (b, ++j, c)), d);",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("var foo = 0; foo++;", None),
+        ("var foo = 0; foo--;", None),
+        ("for (i = 0; i < l; i++) { console.log(i); }", None),
+        ("for (i = 0; i < l; foo, i++) { console.log(i); }", None),
+        ("var foo = 0; foo++;", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        (
+            "for (i = 0; i < l; i++) { v++; }",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+        ("for (i++;;);", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        ("for (;--i;);", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        ("for (;;) ++i;", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        ("for (;; i = j++);", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        ("for (;; i++, f(--j));", Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }]))),
+        (
+            "for (;; foo + (i++, bar));",
+            Some(serde_json::json!([{ "allowForLoopAfterthoughts": true }])),
+        ),
+    ];
+
+    Tester::new(NoPlusplus::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -68,7 +68,7 @@ declare_oxc_lint!(
     /// ```js
     /// var x = 0; x += 1;
     /// var y = 0; y -= 1;
-    /// for (i = 0; i < l; i += 1) {
+    /// for (let i = 0; i < l; i += 1) {
     ///    doSomething(i);
     /// }
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_plusplus_diagnostic(span: Span, operator: &str) -> OxcDiagnostic {
     let diagnostic =
-        OxcDiagnostic::warn(format!("Unary operator '{}' used.", operator)).with_label(span);
+        OxcDiagnostic::warn(format!("Unary operator '{operator}' used.")).with_label(span);
 
     if operator == "++" {
         return diagnostic.with_help("Use the assignment operator `+=` instead.");
@@ -138,8 +138,9 @@ fn is_eq_node_expr(node: &AstNode, expr: &Expression) -> bool {
 fn is_for_loop_afterthought(node: &AstNode, ctx: &LintContext) -> bool {
     if let Some(parent) = ctx.nodes().parent_node(node.id()) {
         match parent.kind() {
-            AstKind::SequenceExpression(_) => return is_for_loop_afterthought(parent, ctx),
-            AstKind::ParenthesizedExpression(_) => return is_for_loop_afterthought(parent, ctx),
+            AstKind::SequenceExpression(_) | AstKind::ParenthesizedExpression(_) => {
+                return is_for_loop_afterthought(parent, ctx)
+            }
             _ => (),
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
     /// ```js
     /// var x = 0; x++;
     /// var y = 0; y--;
-    /// for (i = 0; i < l; i++) {
+    /// for (let i = 0; i < l; i++) {
     ///     doSomething(i);
     /// }
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -74,6 +74,7 @@ declare_oxc_lint!(
     /// ```
     NoPlusplus,
     restriction,
+    pending
 );
 
 impl Rule for NoPlusplus {

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::Expression, AstKind};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -92,41 +92,13 @@ impl Rule for NoPlusplus {
             return;
         };
 
-        if self.allow_for_loop_afterthoughts && is_for_loop_afterthought(node, ctx) {
+        if self.allow_for_loop_afterthoughts && is_for_loop_afterthought(node, ctx).unwrap_or(false)
+        {
             return;
         }
 
         ctx.diagnostic(no_plusplus_diagnostic(expr.span, expr.operator.as_str()));
     }
-}
-
-/// Whether the given AST node is a ++ or -- inside of a for-loop update.
-fn is_for_statement_update(node: &AstNode, ctx: &LintContext) -> bool {
-    let Some(parent) = ctx.nodes().parent_node(node.id()) else {
-        return false;
-    };
-    let AstKind::ForStatement(for_stmt) = parent.kind() else {
-        return false;
-    };
-
-    for_stmt.update.as_ref().is_some_and(|update| is_eq_node_expr(node, update))
-}
-
-/// Checks if the given node is equivalent to the given expression (i.e., they have the same span).
-fn is_eq_node_expr(node: &AstNode, expr: &Expression) -> bool {
-    // TODO: This logic should be moved to somewhere more general and shared across rules and expanded
-    // to cover all expressions and node types
-    let node_span = match node.kind() {
-        AstKind::UpdateExpression(expr) => expr.span,
-        AstKind::SequenceExpression(expr) => expr.span,
-        _ => return false,
-    };
-    let expr_span = match expr {
-        Expression::UpdateExpression(expr) => expr.span,
-        Expression::SequenceExpression(expr) => expr.span,
-        _ => return false,
-    };
-    node_span == expr_span
 }
 
 /// Determines whether the given node is considered to be a for loop "afterthought" by the logic of this rule.
@@ -135,17 +107,14 @@ fn is_eq_node_expr(node: &AstNode, expr: &Expression) -> bool {
 ///   - An operand of a sequence expression that is the update node: for (;; foo(), i++) {}
 ///   - An operand of a sequence expression that is child of another sequence expression, etc.,
 ///     up to the sequence expression that is the update node: for (;; foo(), (bar(), (baz(), i++))) {}
-fn is_for_loop_afterthought(node: &AstNode, ctx: &LintContext) -> bool {
-    if let Some(parent) = ctx.nodes().parent_node(node.id()) {
-        match parent.kind() {
-            AstKind::SequenceExpression(_) | AstKind::ParenthesizedExpression(_) => {
-                return is_for_loop_afterthought(parent, ctx)
-            }
-            _ => (),
-        }
+fn is_for_loop_afterthought(node: &AstNode, ctx: &LintContext) -> Option<bool> {
+    let mut cur = ctx.nodes().parent_node(node.id())?;
+
+    while let AstKind::SequenceExpression(_) | AstKind::ParenthesizedExpression(_) = cur.kind() {
+        cur = ctx.nodes().parent_node(cur.id())?;
     }
 
-    is_for_statement_update(node, ctx)
+    Some(matches!(cur.kind(), AstKind::ForStatement(stmt) if stmt.update.is_some()))
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/no_plusplus.snap
+++ b/crates/oxc_linter/src/snapshots/no_plusplus.snap
@@ -1,0 +1,100 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:14]
+ 1 │ var foo = 0; foo++;
+   ·              ─────
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '--' used.
+   ╭─[no_plusplus.tsx:1:14]
+ 1 │ var foo = 0; foo--;
+   ·              ─────
+   ╰────
+  help: Use the assignment operator `-=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '--' used.
+   ╭─[no_plusplus.tsx:1:14]
+ 1 │ var foo = 0; --foo;
+   ·              ─────
+   ╰────
+  help: Use the assignment operator `-=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:14]
+ 1 │ var foo = 0; ++foo;
+   ·              ─────
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:20]
+ 1 │ for (i = 0; i < l; i++) { console.log(i); }
+   ·                    ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:25]
+ 1 │ for (i = 0; i < l; foo, i++) { console.log(i); }
+   ·                         ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:14]
+ 1 │ var foo = 0; foo++;
+   ·              ─────
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:27]
+ 1 │ for (i = 0; i < l; i++) { v++; }
+   ·                           ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:6]
+ 1 │ for (i++;;);
+   ·      ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '--' used.
+   ╭─[no_plusplus.tsx:1:7]
+ 1 │ for (;--i;);
+   ·       ───
+   ╰────
+  help: Use the assignment operator `-=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:10]
+ 1 │ for (;;) ++i;
+   ·          ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:13]
+ 1 │ for (;; i = j++);
+   ·             ───
+   ╰────
+  help: Use the assignment operator `+=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '--' used.
+   ╭─[no_plusplus.tsx:1:16]
+ 1 │ for (;; i++, f(--j));
+   ·                ───
+   ╰────
+  help: Use the assignment operator `-=` instead.
+
+  ⚠ eslint(no-plusplus): Unary operator '++' used.
+   ╭─[no_plusplus.tsx:1:16]
+ 1 │ for (;; foo + (i++, bar));
+   ·                ───
+   ╰────
+  help: Use the assignment operator `+=` instead.


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/479

This PR implements the `no-plusplus` rule and is more-or-less a direct port of the ESLint version of the rule.