### PR TITLE
refactor(ast_tools): only use type names to ignore fields in the `DeriveContentHash`.

### DIFF
--- a/tasks/ast_tools/src/derives/content_hash.rs
+++ b/tasks/ast_tools/src/derives/content_hash.rs
@@ -13,13 +13,11 @@ define_derive! {
     pub struct DeriveContentHash;
 }
 
-const IGNORE_FIELDS: [(/* field name */ &str, /* field type */ &str); 6] = [
-    ("span", "Span"),
-    ("trailing_comma", "Span"),
-    ("this_span", "Span"),
-    ("scope_id", "ScopeId"),
-    ("symbol_id", "SymbolId"),
-    ("reference_id", "ReferenceId"),
+const IGNORE_FIELD_TYPES: [/* type name */ &str; 4] = [
+    "Span",
+    "ScopeId",
+    "SymbolId",
+    "ReferenceId",
 ];
 
 impl Derive for DeriveContentHash {
@@ -90,10 +88,7 @@ fn derive_struct(def: &StructDef) -> (&str, TokenStream) {
             .fields
             .iter()
             .filter(|field| {
-                let Some(name) = field.name.as_ref() else { return false };
-                !IGNORE_FIELDS
-                    .iter()
-                    .any(|it| name == it.0 && field.typ.name().inner_name() == it.1)
+                !IGNORE_FIELD_TYPES.iter().any(|it| field.typ.name().inner_name() == *it)
             })
             .map(|field| {
                 let ident = field.ident();


### PR DESCRIPTION
related to https://github.com/oxc-project/backlog/issues/107