### PR TITLE
fix(ast_tools, ci): watch `tasks/ast_tools` instead of `tasks/ast_codegen`.

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -27,5 +27,5 @@ src:
   - 'crates/oxc_ast/src/generated/ast_builder.rs'
   - 'crates/oxc_ast/src/generated/visit.rs'
   - 'crates/oxc_ast/src/generated/visit_mut.rs'
-  - 'tasks/ast_codegen/src/**/*'
+  - 'tasks/ast_tools/src/**'
   - '.github/.generated_ast_watch_list.yml'

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -133,7 +133,7 @@ fn write_ci_filter(
         push_item(side_effect.as_str());
     }
 
-    push_item("tasks/ast_codegen/src/**/*");
+    push_item("tasks/ast_tools/src/**");
     push_item(output_path);
 
     log!("Writing {output_path}...");


### PR DESCRIPTION
I was so confused as to why the `AST Changes` step wasn't running at times. Turns out we weren't watching it at all😅

This means for a duration of time we weren't running the `AST Changes` step on PRs that edited only `ast_tools` that didn't update any side-effects.