### PR TITLE
refactor: enable clippy::ref_as_ptr 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ too_many_lines         = "allow"
 must_use_candidate = "allow"
 # used_underscore_binding= "allow"
 doc_markdown = "allow"
-ref_as_ptr   = "allow" # FIXME or give a reason
 # nursery
 # `const` functions do not make sense for our project because this is not a `const` library.
 # This rule also confuses newcomers and forces them to add `const` blindlessly without any reason.

--- a/crates/oxc_ast/src/ast/macros.rs
+++ b/crates/oxc_ast/src/ast/macros.rs
@@ -891,10 +891,10 @@ macro_rules! shared_enum_variants {
             #[inline]
             pub fn $as_child(&self) -> Option<&$child<'a>> {
                 if self.$is_child() {
-                    #[allow(unsafe_code, clippy::ptr_as_ptr)]
+                    #[allow(unsafe_code)]
                     // SAFETY: Transmute is safe because discriminants + types are identical between
                     // `$parent` and `$child` for $child variants
-                    Some(unsafe { &*(self as *const _ as *const $child) })
+                    Some(unsafe { &*std::ptr::from_ref(self).cast::<$child>() })
                 } else {
                     None
                 }
@@ -904,10 +904,10 @@ macro_rules! shared_enum_variants {
             #[inline]
             pub fn $as_child_mut(&mut self) -> Option<&mut $child<'a>> {
                 if self.$is_child() {
-                    #[allow(unsafe_code, clippy::ptr_as_ptr)]
+                    #[allow(unsafe_code)]
                     // SAFETY: Transmute is safe because discriminants + types are identical between
                     // `$parent` and `$child` for $child variants
-                    Some(unsafe { &mut *(self as *mut _ as *mut $child) })
+                    Some(unsafe { &mut *std::ptr::from_mut(self).cast::<$child>() })
                 } else {
                     None
                 }

--- a/crates/oxc_index/src/idxslice.rs
+++ b/crates/oxc_index/src/idxslice.rs
@@ -75,7 +75,7 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
     pub fn from_slice(s: &[T]) -> &Self {
         // SAFETY: `IndexSlice` is a thin wrapper around `[T]` with the added marker for the index.
 
-        unsafe { &*(s as *const [T] as *const Self) }
+        unsafe { &*(core::ptr::from_ref::<[T]>(s) as *const Self) }
     }
 
     /// Construct a new mutable IdxSlice by wrapping an existing mutable slice.
@@ -83,7 +83,7 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
     pub fn from_slice_mut(s: &mut [T]) -> &mut Self {
         // SAFETY: `IndexSlice` is a thin wrapper around `[T]` with the added marker for the index.
 
-        unsafe { &mut *(s as *mut [T] as *mut Self) }
+        unsafe { &mut *(core::ptr::from_mut::<[T]>(s) as *mut Self) }
     }
 
     /// Copies `self` into a new `IndexVec`.

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -66,7 +66,7 @@ impl Rule for NoUselessSwitchCase {
         let default_case = default_cases[0];
 
         // Check if the `default` case is the last case
-        if default_case as *const _ != cases.last().unwrap() as *const _ {
+        if std::ptr::from_ref(default_case) != std::ptr::from_ref(cases.last().unwrap()) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -63,7 +63,7 @@ impl Rule for PreferEventTarget {
                     return;
                 };
 
-                if ident as *const _ != std::ptr::addr_of!(**callee_ident) {
+                if std::ptr::from_ref(ident) != std::ptr::addr_of!(**callee_ident) {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -87,7 +87,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the for statement is the same node as the call expression.
-                if std::ptr::addr_of!(**call_expr2) != call_expr as *const _ {
+                if std::ptr::addr_of!(**call_expr2) != std::ptr::from_ref(call_expr) {
                     return;
                 }
             }
@@ -97,7 +97,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the conditional expression is the same node as the call expression.
-                if std::ptr::addr_of!(**call_expr2) != call_expr as *const _ {
+                if std::ptr::addr_of!(**call_expr2) != std::ptr::from_ref(call_expr) {
                     return;
                 }
             }

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -20,7 +20,8 @@ export default function generateWalkFunctionsCode(types) {
             clippy::semicolon_if_nothing_returned,
             clippy::ptr_as_ptr,
             clippy::borrow_as_ptr,
-            clippy::cast_ptr_alignment
+            clippy::cast_ptr_alignment,
+            clippy::ref_as_ptr
         )]
 
         use std::{cell::Cell, marker::PhantomData};

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -18,10 +18,7 @@ export default function generateWalkFunctionsCode(types) {
             clippy::missing_panics_doc,
             clippy::undocumented_unsafe_blocks,
             clippy::semicolon_if_nothing_returned,
-            clippy::ptr_as_ptr,
-            clippy::borrow_as_ptr,
-            clippy::cast_ptr_alignment,
-            clippy::ref_as_ptr
+            clippy::cast_ptr_alignment
         )]
 
         use std::{cell::Cell, marker::PhantomData};
@@ -111,19 +108,19 @@ function generateWalkForStruct(type, types) {
             if (field.wrappers.length === 2 && field.wrappers[1] === 'Vec') {
                 if (field.typeNameInner === 'Statement') {
                     // Special case for `Option<Vec<Statement>>`
-                    walkCode = `walk_statements(traverser, field as *mut _, ctx);`;
+                    walkCode = `walk_statements(traverser, std::ptr::from_mut(field), ctx);`;
                 } else {
                     walkCode = `
                         for item in field.iter_mut() {
-                            ${fieldWalkName}(traverser, item as *mut _, ctx);
+                            ${fieldWalkName}(traverser, std::ptr::from_mut(item), ctx);
                         }
                     `.trim();
                 }
             } else if (field.wrappers.length === 2 && field.wrappers[1] === 'Box') {
-                walkCode = `${fieldWalkName}(traverser, (&mut **field) as *mut _, ctx);`;
+                walkCode = `${fieldWalkName}(traverser, std::ptr::from_mut(&mut **field), ctx);`;
             } else {
                 assert(field.wrappers.length === 1, `Cannot handle struct field with type ${field.typeName}`);
-                walkCode = `${fieldWalkName}(traverser, field as *mut _, ctx);`;
+                walkCode = `${fieldWalkName}(traverser, std::ptr::from_mut(field), ctx);`;
             }
 
             return `
@@ -142,7 +139,7 @@ function generateWalkForStruct(type, types) {
                 // Special case for `Vec<Statement>`
                 walkVecCode = `walk_statements(traverser, ${fieldCode}, ctx);`
             } else {
-                let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
+                let walkCode = `${fieldWalkName}(traverser, std::ptr::from_mut(item), ctx);`,
                     iterModifier = '';
                 if (field.wrappers.length === 2 && field.wrappers[1] === 'Option') {
                     iterModifier = '.flatten()';
@@ -170,7 +167,7 @@ function generateWalkForStruct(type, types) {
             return `
                 ${scopeCode}
                 ${tagCode || retagCode}
-                ${fieldWalkName}(traverser, (&mut **(${fieldCode})) as *mut _, ctx);
+                ${fieldWalkName}(traverser, std::ptr::from_mut(&mut **(${fieldCode})), ctx);
             `;
         }
 
@@ -201,7 +198,7 @@ function generateWalkForStruct(type, types) {
 }
 
 function makeFieldCode(field) {
-    return `(node as *mut u8).add(ancestor::${field.offsetVarName}) as *mut ${field.typeName}`;
+    return `node.cast::<u8>().add(ancestor::${field.offsetVarName}).cast::<${field.typeName}>()`;
 }
 
 function generateWalkForEnum(type, types) {
@@ -209,7 +206,7 @@ function generateWalkForEnum(type, types) {
         const variantType = types[variant.innerTypeName];
         assert(variantType, `Cannot handle enum variant with type: ${variant.type}`);
 
-        let nodeCode = 'node';
+        let nodeCode = '(node)';
         if (variant.wrappers.length === 1 && variant.wrappers[0] === 'Box') {
             nodeCode = '(&mut **node)';
         } else {
@@ -217,7 +214,7 @@ function generateWalkForEnum(type, types) {
         }
 
         return `${type.name}::${variant.name}(node) => `
-            + `walk_${camelToSnake(variant.innerTypeName)}(traverser, ${nodeCode} as *mut _, ctx),`;
+            + `walk_${camelToSnake(variant.innerTypeName)}(traverser, std::ptr::from_mut${nodeCode}, ctx),`;
     });
 
     const missingVariants = [];
@@ -240,7 +237,7 @@ function generateWalkForEnum(type, types) {
 
         variantCodes.push(
             `${variantMatches.join(' | ')} => `
-            + `walk_${camelToSnake(inheritedTypeName)}(traverser, node as *mut _, ctx),`
+            + `walk_${camelToSnake(inheritedTypeName)}(traverser, node.cast(), ctx),`
         );
     }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -10,7 +10,8 @@
     clippy::semicolon_if_nothing_returned,
     clippy::ptr_as_ptr,
     clippy::borrow_as_ptr,
-    clippy::cast_ptr_alignment
+    clippy::cast_ptr_alignment,
+    clippy::ref_as_ptr
 )]
 
 use std::{cell::Cell, marker::PhantomData};

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -161,5 +161,5 @@ pub fn walk_program<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     // SAFETY: Walk functions are constructed to avoid unsoundness
-    unsafe { walk::walk_program(traverser, program as *mut Program, ctx) };
+    unsafe { walk::walk_program(traverser, std::ptr::from_mut::<Program>(program), ctx) };
 }


### PR DESCRIPTION
#5567 
`clippy::borrow_as_ptr` is also enabled in `oxc_traverse/src/generated/walk.rs`.