### PR TITLE
test(linter): add a passing case to no_undef

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -157,6 +157,7 @@ fn test() {
         "class C { static { function a() {} a; } }",
         "class C { static { a; function a() {} } }",
         "String;Array;Boolean;",
+        "function resolve<T>(path: string): T { return { path } as T; }"
     ];
 
     let fail = vec![


### PR DESCRIPTION
closes #2093