### PR TITLE
fix(linter): fix no_unused_vars panic when encountering unicode

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/mod.rs
@@ -10,5 +10,5 @@ use super::{NoUnusedVars, Symbol};
 // getting cast to a u32
 #[allow(clippy::cast_possible_truncation)]
 fn count_whitespace_or_commas<I: Iterator<Item = char>>(iter: I) -> u32 {
-    iter.take_while(|c| c.is_whitespace() || *c == ',').count() as u32
+    iter.take_while(|c| *c == ',' || c.is_whitespace()).map(|c| c.len_utf8() as u32).sum()
 }


### PR DESCRIPTION
closes #4887