### PR TITLE
refactor(linter): replace ast "compare by hash" to "compare by content"

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -155,7 +155,7 @@ fn is_equal<'a, 'b>(a: &'a Expression<'b>, b: &'a Expression<'b>) -> bool {
                 || (is_equal(&a.left, &b.right) && is_equal(&a.right, &b.left))
         }
 
-        (a, b) => a.content_eq(&b),
+        (a, b) => a.content_eq(b),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -4,10 +4,11 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_span::cmp::ContentEq;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::LogicalOperator;
 
-use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_dupe_else_if_diagnostic(first_test: Span, second_test: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("duplicate conditions in if-else-if chains")
@@ -154,7 +155,7 @@ fn is_equal<'a, 'b>(a: &'a Expression<'b>, b: &'a Expression<'b>) -> bool {
                 || (is_equal(&a.left, &b.right) && is_equal(&a.right, &b.left))
         }
 
-        (a, b) => calculate_hash(a) == calculate_hash(b),
+        (a, b) => a.content_eq(&b),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -1,9 +1,10 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_span::cmp::ContentEq;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_self_compare_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow comparisons where both sides are exactly the same")
@@ -44,10 +45,8 @@ impl Rule for NoSelfCompare {
         if !binary_expr.operator.is_compare() && !binary_expr.operator.is_equality() {
             return;
         }
-        let left = calculate_hash(&binary_expr.left);
-        let right = calculate_hash(&binary_expr.right);
 
-        if left == right {
+        if binary_expr.left.content_eq(&binary_expr.right) {
             ctx.diagnostic(no_self_compare_diagnostic(
                 binary_expr.left.span(),
                 binary_expr.right.span(),


### PR DESCRIPTION
closes #5600 

I currently don't have a good idea on how to replace the following code:

https://github.com/oxc-project/oxc/blob/63a830e08c82314660d65d2669cf753026fa9232/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs#L88-L98