### PR TITLE
docs(traverse): correct code comment 2

### DIFF
--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -453,7 +453,7 @@ impl TraverseScoping {
         // `CompactStr`, rather than generating a new string on each attempt.
         // Postfixes greater than 99 should be very uncommon, so don't bother optimizing.
 
-        // Try single-digit postfixes (i.e. `_temp1`, `_temp2` ... `_temp9`)
+        // Try single-digit postfixes (i.e. `_temp2`, `_temp3` ... `_temp9`)
         name.push('2');
         if self.name_is_unique(&name) {
             return name;


### PR DESCRIPTION
Numbering UIDs skips 1 i.e. `_foo`, `_foo2`, `_foo3`, etc. Correct comment to reflect this.