### PR TITLE
feat(span): `format_compact_str!` macro

### DIFF
--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -18,3 +18,9 @@ pub use crate::{
     },
     span::{GetSpan, GetSpanMut, Span, SPAN},
 };
+
+#[doc(hidden)]
+pub mod __internal {
+    // Used by `format_compact_str!` macro defined in `compact_str.rs`
+    pub use ::compact_str::format_compact;
+}


### PR DESCRIPTION
Add `format_compact_str!` macro to create a `CompactStr`, like `format!`.