### PR TITLE
perf(traverse): `generate_uid` cache available binding names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -31,3 +31,4 @@ oxc_syntax = { workspace = true }
 
 compact_str = { workspace = true }
 memoffset = { workspace = true }
+rustc-hash = { workspace = true }


### PR DESCRIPTION
Close #5488.

`generate_uid` previously iterated through every symbol and unresolved reference in the AST to find a unique var name. If the first var name it tried was already in use, it'd iterate again.

Instead build a hash map recording existing var names in use for every name which could clash with a UID (any var name starting with `_`). Once built, use that hash map to generate UIDs without iterating through all symbols again.

I had hoped to make `generate_uid` cheaper still by just recording the highest digits postfix for each var name, and then incrementing that postfix for each UID. i.e. if AST contains vars `_foo1` and `_foo6`, create UIDs starting at one number higher - `_foo7`, `_foo8` etc. This method would be more efficient, but unfortunately it does not match Babel, and so causes some of Babel's tests to fail.