### PR TITLE
fix(span): treat `.js` as `module` file (reverts the previous breaking change)

### DIFF
--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -380,8 +380,7 @@ impl SourceType {
             })?;
 
         let (language, module_kind) = match extension {
-            "js" => (Language::JavaScript, ModuleKind::Unambiguous),
-            "mjs" | "jsx" => (Language::JavaScript, ModuleKind::Module),
+            "js" | "mjs" | "jsx" => (Language::JavaScript, ModuleKind::Module),
             "cjs" => (Language::JavaScript, ModuleKind::Script),
             "ts" if file_name.ends_with(".d.ts") => {
                 (Language::TypeScriptDefinition, ModuleKind::Module)
@@ -508,15 +507,15 @@ mod tests {
             assert!(!ty.is_typescript(), "{ty:?}");
         }
 
-        assert_eq!(SourceType::jsx().with_unambiguous(true), js);
+        assert_eq!(SourceType::jsx(), js);
         assert_eq!(SourceType::jsx().with_module(true), jsx);
 
-        assert!(js.is_unambiguous());
+        assert!(js.is_module());
         assert!(mjs.is_module());
         assert!(cjs.is_script());
         assert!(jsx.is_module());
 
-        assert!(!js.is_strict());
+        assert!(js.is_strict());
         assert!(mjs.is_strict());
         assert!(!cjs.is_strict());
         assert!(jsx.is_strict());

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -1,9 +1,9 @@
 commit: 3bcfee23
 
 parser_babel Summary:
-AST Parsed     : 2089/2101 (99.43%)
-Positive Passed: 2079/2101 (98.95%)
-Negative Passed: 1381/1493 (92.50%)
+AST Parsed     : 2093/2101 (99.62%)
+Positive Passed: 2083/2101 (99.14%)
+Negative Passed: 1382/1493 (92.57%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -27,7 +27,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/no-pattern-in-rest-with-ts/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-trailing-comma/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2020/dynamic-import-createImportExpression-false/invalid-trailing-comma/input.js
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2020/import-meta/error-in-script/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/invalid-param-strict-mode/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0101/input.js
@@ -116,20 +115,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-required-after-labeled-optional/input.ts
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/1.1-html-comments-close/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/annex-b/enabled/1.1-html-comments-close/input.js:1:3]
- 1 │ -->b;
-   ·   ─
-   ╰────
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/html/first-line/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/comments/html/first-line/input.js:1:8]
- 1 │ /**/ --> comment
-   ·        ─
-   ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
 
   × Unexpected new.target expression
@@ -147,22 +132,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/o
    ·                 ──────────
    ╰────
   help: new.target is only allowed in constructors and functions invoked using thew `new` operator
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/343/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/343/input.js:2:4]
- 1 │ x = y-->10;
- 2 │  --> nothing
-   ·    ─
-   ╰────
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/538/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/538/input.js:1:2]
- 1 │ <!--
-   ·  ─
- 2 │ ;
-   ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
 
   × Expected `<` but found `EOF`
@@ -5057,6 +5026,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·        ──────────
    ╰────
 
+  × Cannot use export statement outside a module
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-escape-export-async-function/input.js:1:1]
+ 1 │ export \u0061sync function y() { await x }
+   · ──────
+   ╰────
+
   × Keywords cannot contain escape characters
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-escape-export-dflt-async-function/input.js:1:16]
  1 │ export default \u0061sync function y() { await x }
@@ -5557,6 +5532,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ import();
    ·        ─
    ╰────
+
+  × Unexpected import.meta expression
+   ╭─[babel/packages/babel-parser/test/fixtures/es2020/import-meta/error-in-script/input.js:1:11]
+ 1 │ const x = import.meta;
+   ·           ───────────
+   ╰────
+  help: import.meta is only allowed in module code
 
   × The only valid meta property for import is import.meta
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/import-meta/no-other-prop-names/input.js:1:1]
@@ -7372,10 +7354,10 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ───────────
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_expression_await/input.js:1:21]
+  × Cannot use export statement outside a module
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_expression_await/input.js:1:1]
  1 │ export var answer = await + 1;
-   ·                     ─────
+   · ──────
    ╰────
 
   × Invalid Character `🀒`
@@ -7397,10 +7379,10 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × The keyword 'await' is reserved
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_var_await/input.js:1:12]
+  × Cannot use export statement outside a module
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_var_await/input.js:1:1]
  1 │ export var await;
-   ·            ─────
+   · ──────
    ╰────
 
   × Expected `from` but found `default`

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,15 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 29/29 (100.00%)
-Positive Passed: 28/29 (96.55%)
+Positive Passed: 29/29 (100.00%)
 Negative Passed: 17/17 (100.00%)
-Expect to Parse: tasks/coverage/misc/pass/babel-16776-m.js
-
-  × The keyword 'await' is reserved
-   ╭─[misc/pass/babel-16776-m.js:1:1]
- 1 │ await /x.y/g;
-   · ─────
- 2 │ 
-   ╰────
 
   × Unexpected token
    ╭─[misc/fail/oxc-169.js:2:1]

--- a/tasks/coverage/semantic_babel.snap
+++ b/tasks/coverage/semantic_babel.snap
@@ -2,17 +2,11 @@ commit: 3bcfee23
 
 semantic_babel Summary:
 AST Parsed     : 2101/2101 (100.00%)
-Positive Passed: 1733/2101 (82.48%)
-tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/1.1-html-comments-close/input.js
-semantic error: Unexpected token
-
+Positive Passed: 1737/2101 (82.67%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/html/first-line/input.js
-semantic error: Unexpected token
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
 semantic error: Bindings mismatch:
@@ -43,12 +37,6 @@ semantic error: A 'return' statement can only be used within a function body.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/328/input.js
 semantic error: A 'return' statement can only be used within a function body.
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/343/input.js
-semantic error: Unexpected token
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/538/input.js
-semantic error: Unexpected token
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/input.js
 semantic error: Bindings mismatch:

--- a/tasks/coverage/semantic_misc.snap
+++ b/tasks/coverage/semantic_misc.snap
@@ -2,7 +2,9 @@ semantic_misc Summary:
 AST Parsed     : 29/29 (100.00%)
 Positive Passed: 17/29 (58.62%)
 tasks/coverage/misc/pass/babel-16776-m.js
-semantic error: The keyword 'await' is reserved
+semantic error: Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/misc/pass/oxc-1288.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -131,6 +131,7 @@ impl Case for BabelCase {
         let options = BabelOptions::from_test_path(dir.parent().unwrap());
         let mut source_type = SourceType::from_path(&path)
             .unwrap()
+            .with_script(true)
             .with_jsx(options.is_jsx())
             .with_typescript(options.is_typescript())
             .with_typescript_definition(options.is_typescript_definition());

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,9 +1,10 @@
 commit: 3bcfee23
 
-Passed: 316/1021
+Passed: 329/1021
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
+* babel-preset-react
 * babel-plugin-transform-react-display-name
 * babel-plugin-transform-react-jsx-self
 * babel-plugin-transform-react-jsx-source
@@ -1952,16 +1953,16 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/const/input.ts
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -1971,8 +1972,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -1982,14 +1983,14 @@ Bindings mismatch:
 after transform: ScopeId(1): ["Animals", "Cat", "Dog"]
 rebuilt        : ScopeId(1): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["Animals", "CatDog"]
 rebuilt        : ScopeId(2): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2005,20 +2006,20 @@ Bindings mismatch:
 after transform: ScopeId(1): ["Animals", "Cat"]
 rebuilt        : ScopeId(1): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["Animals", "Dog"]
 rebuilt        : ScopeId(2): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["Animals", "CatDog"]
 rebuilt        : ScopeId(3): ["Animals"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -2057,8 +2058,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["E", "x", "y"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2068,8 +2069,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2082,8 +2083,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2093,14 +2094,14 @@ Bindings mismatch:
 after transform: ScopeId(1): ["E", "x", "y"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["E", "z"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2113,14 +2114,14 @@ Bindings mismatch:
 after transform: ScopeId(1): ["IPC", "SERVER", "SOCKET", "socketType"]
 rebuilt        : ScopeId(1): ["socketType"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["IPC", "SERVER", "SOCKET", "UV_READABLE", "UV_WRITABLE", "constants"]
 rebuilt        : ScopeId(2): ["constants"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2136,8 +2137,8 @@ x Output mismatch
 
 * enum/scoped/input.ts
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -2147,8 +2148,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2158,8 +2159,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -2169,8 +2170,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -3465,38 +3466,18 @@ after transform: ["T", "f"]
 rebuilt        : ["f"]
 
 
-# babel-preset-react (6/9)
-* preset-options/development-runtime-automatic/input.js
-x Output mismatch
-
-* preset-options/empty-options/input.js
-x Output mismatch
-
-* preset-options/runtime-automatic/input.js
-x Output mismatch
-
-
-# babel-plugin-transform-react-jsx (119/144)
-* pure/false-default-pragma-automatic-runtime/input.js
-x Output mismatch
-
+# babel-plugin-transform-react-jsx (124/144)
 * pure/false-pragma-comment-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 
 * pure/false-pragma-option-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* pure/true-default-pragma-automatic-runtime/input.js
-x Output mismatch
-
 * pure/true-pragma-comment-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 
 * pure/true-pragma-option-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
-
-* pure/unset-default-pragma-automatic-runtime/input.js
-x Output mismatch
 
 * pure/unset-pragma-comment-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
@@ -3582,12 +3563,6 @@ Spread children are not supported in React.
 * react-automatic/should-warn-when-pragma-or-pragmaFrag-is-set/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 
-* runtime/defaults-to-automatic/input.js
-x Output mismatch
-
-* runtime/runtime-automatic/input.js
-x Output mismatch
-
 * spread-transform/transform-to-babel-extend/input.js
 x Output mismatch
 
@@ -3595,7 +3570,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx-development (2/10)
+# babel-plugin-transform-react-jsx-development (7/10)
 * cross-platform/disallow-__self-as-jsx-attribute/input.js
   ! Duplicate __self prop found.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/input.js:1:14]
@@ -3611,21 +3586,6 @@ x Output mismatch
    :              ^^^^^^^^
    `----
 
-
-* cross-platform/fragments/input.js
-x Output mismatch
-
-* cross-platform/handle-fragments-with-key/input.js
-x Output mismatch
-
-* cross-platform/handle-nonstatic-children/input.js
-x Output mismatch
-
-* cross-platform/handle-static-children/input.js
-x Output mismatch
-
-* cross-platform/within-derived-classes-constructor/input.js
-x Output mismatch
 
 * cross-platform/within-ts-module-block/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 20/49
+Passed: 17/49
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -29,26 +29,26 @@ Bindings mismatch:
 after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
 rebuilt        : ScopeId(1): ["A"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
 rebuilt        : ScopeId(2): ["B"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(3): ["C", "a", "b", "c"]
 rebuilt        : ScopeId(3): ["C"]
 Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["D", "a", "b", "c"]
 rebuilt        : ScopeId(4): ["D"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -82,8 +82,8 @@ Bindings mismatch:
 after transform: ScopeId(1): ["Foo", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["Foo"]
 Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
@@ -106,12 +106,15 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Binding symbols mismatch:
 after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
 rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol flags mismatch:
-after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export | Function | TypeAlias)
-rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | Export | Function)
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
 Symbol span mismatch:
 after transform: SymbolId(9): Span { start: 205, end: 206 }
 rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
@@ -164,7 +167,7 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (6/27)
+# babel-plugin-transform-react-jsx (3/27)
 * refresh/can-handle-implicit-arrow-returns/input.jsx
 Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(23), ReferenceId(24), ReferenceId(25)]
@@ -240,15 +243,7 @@ after transform: ["X", "memo", "module", "useContext"]
 rebuilt        : ["$RefreshReg$", "$RefreshSig$", "X", "memo", "module", "useContext"]
 
 * refresh/does-not-consider-require-like-methods-to-be-hocs/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(10), ReferenceId(17), ReferenceId(18)]
-rebuilt        : SymbolId(7): [ReferenceId(15), ReferenceId(18)]
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("_c")
-rebuilt        : ReferenceId(17): None
-Unresolved references mismatch:
-after transform: ["foo", "gk", "require", "requireCond"]
-rebuilt        : ["$RefreshReg$", "foo", "gk", "require", "requireCond"]
+x Output mismatch
 
 * refresh/does-not-get-tripped-by-iifes/input.jsx
 Bindings mismatch:
@@ -271,185 +266,25 @@ after transform: ["item", "useFoo"]
 rebuilt        : ["$RefreshSig$", "item", "useFoo"]
 
 * refresh/generates-signatures-for-function-declarations-calling-hooks/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(9)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(5): [ReferenceId(8), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("_s")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["React", "useState"]
-rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "useState"]
+x Output mismatch
 
 * refresh/generates-signatures-for-function-expressions-calling-hooks/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(22): [ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30)]
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(23): [ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36)]
-rebuilt        : SymbolId(2): [ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(24)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(24): [ReferenceId(38), ReferenceId(39), ReferenceId(40)]
-rebuilt        : SymbolId(14): [ReferenceId(33), ReferenceId(34)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(15): [ReferenceId(17), ReferenceId(41), ReferenceId(42)]
-rebuilt        : SymbolId(19): [ReferenceId(7), ReferenceId(42)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(16): [ReferenceId(18), ReferenceId(43), ReferenceId(44)]
-rebuilt        : SymbolId(20): [ReferenceId(4), ReferenceId(44)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(17): [ReferenceId(19), ReferenceId(45), ReferenceId(46)]
-rebuilt        : SymbolId(21): [ReferenceId(15), ReferenceId(46)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(18): [ReferenceId(21), ReferenceId(47), ReferenceId(48)]
-rebuilt        : SymbolId(22): [ReferenceId(22), ReferenceId(48)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(19): [ReferenceId(22), ReferenceId(49), ReferenceId(50)]
-rebuilt        : SymbolId(23): [ReferenceId(19), ReferenceId(50)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(20): [ReferenceId(23), ReferenceId(51), ReferenceId(52)]
-rebuilt        : SymbolId(24): [ReferenceId(30), ReferenceId(52)]
-Reference symbol mismatch:
-after transform: ReferenceId(26): Some("_s")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(32): Some("_s2")
-rebuilt        : ReferenceId(1): None
-Reference flags mismatch:
-after transform: ReferenceId(18): ReferenceFlags(Write)
-rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(17): ReferenceFlags(Write)
-rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(22): ReferenceFlags(Write)
-rebuilt        : ReferenceId(19): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(21): ReferenceFlags(Write)
-rebuilt        : ReferenceId(22): ReferenceFlags(Read | Write)
-Reference symbol mismatch:
-after transform: ReferenceId(38): Some("_s3")
-rebuilt        : ReferenceId(32): None
-Reference symbol mismatch:
-after transform: ReferenceId(41): Some("_c")
-rebuilt        : ReferenceId(41): None
-Reference symbol mismatch:
-after transform: ReferenceId(43): Some("_c2")
-rebuilt        : ReferenceId(43): None
-Reference symbol mismatch:
-after transform: ReferenceId(45): Some("_c3")
-rebuilt        : ReferenceId(45): None
-Reference symbol mismatch:
-after transform: ReferenceId(47): Some("_c4")
-rebuilt        : ReferenceId(47): None
-Reference symbol mismatch:
-after transform: ReferenceId(49): Some("_c5")
-rebuilt        : ReferenceId(49): None
-Reference symbol mismatch:
-after transform: ReferenceId(51): Some("_c6")
-rebuilt        : ReferenceId(51): None
-Unresolved references mismatch:
-after transform: ["React", "ref", "useState"]
-rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "ref", "useState"]
+x Output mismatch
 
 * refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
-Missing ScopeId
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): [ReferenceId(17), ReferenceId(18), ReferenceId(20)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(16)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(9), ReferenceId(21), ReferenceId(22)]
-rebuilt        : SymbolId(10): [ReferenceId(19), ReferenceId(22)]
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("_s2")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("_s")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(21): Some("_c")
-rebuilt        : ReferenceId(21): None
-Unresolved references mismatch:
-after transform: ["React", "useFancyEffect", "useThePlatform"]
-rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "useFancyEffect", "useThePlatform"]
+x Output mismatch
+
+* refresh/ignores-complex-definitions/input.jsx
+x Output mismatch
+
+* refresh/ignores-hoc-definitions/input.jsx
+x Output mismatch
 
 * refresh/includes-custom-hooks-into-the-signatures/input.jsx
-Missing ScopeId
-Missing ScopeId
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(9), ReferenceId(10), ReferenceId(12)]
-rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(16)]
-rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(12)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): [ReferenceId(19), ReferenceId(20), ReferenceId(22)]
-rebuilt        : SymbolId(3): [ReferenceId(14), ReferenceId(18)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(6), ReferenceId(23), ReferenceId(24)]
-rebuilt        : SymbolId(10): [ReferenceId(21), ReferenceId(24)]
-Reference symbol mismatch:
-after transform: ReferenceId(9): Some("_s")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("_s2")
-rebuilt        : ReferenceId(1): None
-Reference symbol mismatch:
-after transform: ReferenceId(19): Some("_s3")
-rebuilt        : ReferenceId(2): None
-Reference symbol mismatch:
-after transform: ReferenceId(23): Some("_c")
-rebuilt        : ReferenceId(23): None
-Unresolved references mismatch:
-after transform: ["React"]
-rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React"]
+x Output mismatch
 
 * refresh/registers-capitalized-identifiers-in-hoc-calls/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(15)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(8), ReferenceId(16), ReferenceId(17)]
-rebuilt        : SymbolId(5): [ReferenceId(3), ReferenceId(17)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(9), ReferenceId(18), ReferenceId(19)]
-rebuilt        : SymbolId(6): [ReferenceId(8), ReferenceId(19)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(21)]
-rebuilt        : SymbolId(7): [ReferenceId(12), ReferenceId(21)]
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
-Reference symbol mismatch:
-after transform: ReferenceId(14): Some("_c")
-rebuilt        : ReferenceId(14): None
-Reference symbol mismatch:
-after transform: ReferenceId(16): Some("_c2")
-rebuilt        : ReferenceId(16): None
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("_c3")
-rebuilt        : ReferenceId(18): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("_c4")
-rebuilt        : ReferenceId(20): None
-Unresolved references mismatch:
-after transform: ["hoc"]
-rebuilt        : ["$RefreshReg$", "hoc"]
+x Output mismatch
 
 * refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
 x Output mismatch
@@ -458,266 +293,39 @@ x Output mismatch
 x Output mismatch
 
 * refresh/registers-likely-hocs-with-inline-functions-1/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(5), ReferenceId(18), ReferenceId(19)]
-rebuilt        : SymbolId(5): [ReferenceId(1), ReferenceId(19)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(20), ReferenceId(21)]
-rebuilt        : SymbolId(6): [ReferenceId(3), ReferenceId(21)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(8), ReferenceId(22), ReferenceId(23)]
-rebuilt        : SymbolId(7): [ReferenceId(8), ReferenceId(23)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(9), ReferenceId(24), ReferenceId(25)]
-rebuilt        : SymbolId(8): [ReferenceId(6), ReferenceId(25)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(10), ReferenceId(26), ReferenceId(27)]
-rebuilt        : SymbolId(9): [ReferenceId(10), ReferenceId(27)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): [ReferenceId(12), ReferenceId(28), ReferenceId(29)]
-rebuilt        : SymbolId(10): [ReferenceId(16), ReferenceId(29)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(10): [ReferenceId(13), ReferenceId(30), ReferenceId(31)]
-rebuilt        : SymbolId(11): [ReferenceId(14), ReferenceId(31)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(11): [ReferenceId(14), ReferenceId(32), ReferenceId(33)]
-rebuilt        : SymbolId(12): [ReferenceId(12), ReferenceId(33)]
-Reference flags mismatch:
-after transform: ReferenceId(5): ReferenceFlags(Write)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(9): ReferenceFlags(Write)
-rebuilt        : ReferenceId(6): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
-rebuilt        : ReferenceId(8): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(14): ReferenceFlags(Write)
-rebuilt        : ReferenceId(12): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(13): ReferenceFlags(Write)
-rebuilt        : ReferenceId(14): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(12): ReferenceFlags(Write)
-rebuilt        : ReferenceId(16): ReferenceFlags(Read | Write)
-Reference symbol mismatch:
-after transform: ReferenceId(18): Some("_c")
-rebuilt        : ReferenceId(18): None
-Reference symbol mismatch:
-after transform: ReferenceId(20): Some("_c2")
-rebuilt        : ReferenceId(20): None
-Reference symbol mismatch:
-after transform: ReferenceId(22): Some("_c3")
-rebuilt        : ReferenceId(22): None
-Reference symbol mismatch:
-after transform: ReferenceId(24): Some("_c4")
-rebuilt        : ReferenceId(24): None
-Reference symbol mismatch:
-after transform: ReferenceId(26): Some("_c5")
-rebuilt        : ReferenceId(26): None
-Reference symbol mismatch:
-after transform: ReferenceId(28): Some("_c6")
-rebuilt        : ReferenceId(28): None
-Reference symbol mismatch:
-after transform: ReferenceId(30): Some("_c7")
-rebuilt        : ReferenceId(30): None
-Reference symbol mismatch:
-after transform: ReferenceId(32): Some("_c8")
-rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: ["React", "forwardRef", "memo"]
-rebuilt        : ["$RefreshReg$", "React", "forwardRef", "memo"]
+x Output mismatch
 
 * refresh/registers-likely-hocs-with-inline-functions-2/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(3), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(5): [ReferenceId(0), ReferenceId(11)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(3): ReferenceFlags(Write)
-rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(2): ReferenceFlags(Write)
-rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("_c")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("_c2")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c3")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["React", "forwardRef"]
-rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
+x Output mismatch
 
 * refresh/registers-likely-hocs-with-inline-functions-3/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(7)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(4), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(6): [ReferenceId(0), ReferenceId(11)]
-Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
-rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(3): ReferenceFlags(Write)
-rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
-Reference flags mismatch:
-after transform: ReferenceId(2): ReferenceFlags(Write)
-rebuilt        : ReferenceId(4): ReferenceFlags(Read | Write)
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("_c")
-rebuilt        : ReferenceId(6): None
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("_c2")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c3")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["React", "forwardRef"]
-rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
+x Output mismatch
 
 * refresh/registers-top-level-exported-function-declarations/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(4), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(14)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(6), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(16)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(9): [ReferenceId(8), ReferenceId(17), ReferenceId(18)]
-rebuilt        : SymbolId(10): [ReferenceId(9), ReferenceId(18)]
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("_c")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("_c2")
-rebuilt        : ReferenceId(15): None
-Reference symbol mismatch:
-after transform: ReferenceId(17): Some("_c3")
-rebuilt        : ReferenceId(17): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$RefreshReg$"]
+x Output mismatch
 
 * refresh/registers-top-level-exported-named-arrow-functions/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(5): [ReferenceId(2), ReferenceId(11)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(12), ReferenceId(13)]
-rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(13)]
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c")
-rebuilt        : ReferenceId(10): None
-Reference symbol mismatch:
-after transform: ReferenceId(12): Some("_c2")
-rebuilt        : ReferenceId(12): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$RefreshReg$"]
+x Output mismatch
 
 * refresh/registers-top-level-function-declarations/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(4), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(5): [ReferenceId(6), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("_c")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c2")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$RefreshReg$"]
+x Output mismatch
 
 * refresh/registers-top-level-variable-declarations-with-arrow-functions/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(2), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(12)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(6): [ReferenceId(4), ReferenceId(13), ReferenceId(14)]
-rebuilt        : SymbolId(7): [ReferenceId(6), ReferenceId(14)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(6), ReferenceId(15), ReferenceId(16)]
-rebuilt        : SymbolId(8): [ReferenceId(9), ReferenceId(16)]
-Reference symbol mismatch:
-after transform: ReferenceId(11): Some("_c")
-rebuilt        : ReferenceId(11): None
-Reference symbol mismatch:
-after transform: ReferenceId(13): Some("_c2")
-rebuilt        : ReferenceId(13): None
-Reference symbol mismatch:
-after transform: ReferenceId(15): Some("_c3")
-rebuilt        : ReferenceId(15): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$RefreshReg$"]
+x Output mismatch
 
 * refresh/registers-top-level-variable-declarations-with-function-expressions/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(7): [ReferenceId(2), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(9)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(4), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(9): [ReferenceId(6), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(8): Some("_c")
-rebuilt        : ReferenceId(8): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c2")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$RefreshReg$"]
+x Output mismatch
 
 * refresh/supports-typescript-namespace-syntax/input.tsx
 x Output mismatch
 
 * refresh/uses-custom-identifiers-for-refresh-reg-and-refresh-sig/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(7), ReferenceId(9)]
-rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(6)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(10), ReferenceId(11)]
-rebuilt        : SymbolId(3): [ReferenceId(8), ReferenceId(11)]
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("_s")
-rebuilt        : ReferenceId(0): None
-Reference symbol mismatch:
-after transform: ReferenceId(10): Some("_c")
-rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["Foo", "X", "useContext"]
-rebuilt        : ["Foo", "X", "import.meta.refreshReg", "import.meta.refreshSig", "useContext"]
+x Output mismatch
 
 * refresh/uses-original-function-declaration-if-it-get-reassigned/input.jsx
-Symbol reference IDs mismatch:
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(7)]
-Reference symbol mismatch:
-after transform: ReferenceId(6): Some("_c")
-rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: ["connect"]
-rebuilt        : ["$RefreshReg$", "connect"]
+x Output mismatch
+
+* unicode/input.jsx
+x Output mismatch
 
 

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -229,6 +229,7 @@ impl TestCase for ConformanceTestCase {
         let source_type = {
             let mut source_type = SourceType::from_path(&self.path)
                 .unwrap()
+                .with_script(true)
                 .with_jsx(self.options.get_plugin("syntax-jsx").is_some());
 
             source_type = match self.options.source_type.as_deref() {


### PR DESCRIPTION
As it turns out it's not ideal to treat `.js` as `script` in today's world anymore.

This makes https://github.com/oxc-project/oxlint-ecosystem-ci pass again.