### PR TITLE
perf(linter): `react/no_set_state` + `react/no_string_refs` rules reduce iteration over ancestors

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -3,12 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    context::LintContext,
-    rule::Rule,
-    utils::{get_parent_es5_component, get_parent_es6_component},
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, utils::get_parent_component, AstNode};
 
 fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use setState").with_label(span)
@@ -63,8 +58,7 @@ impl Rule for NoSetState {
 
         if !matches!(member_expr.object(), Expression::ThisExpression(_))
             || !member_expr.static_property_name().is_some_and(|str| str == "setState")
-            || !(get_parent_es5_component(node, ctx).is_some()
-                || get_parent_es6_component(node, ctx).is_some())
+            || get_parent_component(node, ctx).is_none()
         {
             return;
         }

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -9,12 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    context::LintContext,
-    rule::Rule,
-    utils::{get_parent_es5_component, get_parent_es6_component},
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, utils::get_parent_component, AstNode};
 
 fn this_refs_deprecated(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using this.refs is deprecated.")
@@ -121,8 +116,7 @@ impl Rule for NoStringRefs {
             AstKind::MemberExpression(member_expr) => {
                 if matches!(member_expr.object(), Expression::ThisExpression(_))
                     && member_expr.static_property_name() == Some("refs")
-                    && (get_parent_es5_component(node, ctx).is_some()
-                        || get_parent_es6_component(node, ctx).is_some())
+                    && get_parent_component(node, ctx).is_some()
                 {
                     ctx.diagnostic(this_refs_deprecated(member_expr.span()));
                 }

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -190,22 +190,17 @@ pub fn is_es6_component(node: &AstNode) -> bool {
     false
 }
 
-pub fn get_parent_es5_component<'a, 'b>(
+pub fn get_parent_component<'a, 'b>(
     node: &'b AstNode<'a>,
     ctx: &'b LintContext<'a>,
 ) -> Option<&'b AstNode<'a>> {
-    ctx.nodes().ancestors(node.id()).skip(1).find_map(|node_id| {
-        is_es5_component(ctx.nodes().get_node(node_id)).then(|| ctx.nodes().get_node(node_id))
-    })
-}
-
-pub fn get_parent_es6_component<'a, 'b>(
-    node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
-    ctx.nodes().ancestors(node.id()).find_map(|node_id| {
-        is_es6_component(ctx.nodes().get_node(node_id)).then(|| ctx.nodes().get_node(node_id))
-    })
+    for node_id in ctx.nodes().ancestors(node.id()) {
+        let node = ctx.nodes().get_node(node_id);
+        if is_es5_component(node) || is_es6_component(node) {
+            return Some(node);
+        }
+    }
+    None
 }
 
 /// Resolve element type(name) using jsx-a11y settings


### PR DESCRIPTION
`get_parent_es5_component` and `get_parent_es6_component` were always used together. Combine the two into a single function to only iterate over ancestors once, instead of twice.