### PR TITLE
refactor(semantic)!: remove `SymbolTable::iter_rev`

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -61,10 +61,6 @@ impl SymbolTable {
         self.spans.iter_enumerated().map(|(symbol_id, _)| symbol_id)
     }
 
-    pub fn iter_rev(&self) -> impl Iterator<Item = SymbolId> + '_ {
-        self.spans.iter_enumerated().rev().map(|(symbol_id, _)| symbol_id)
-    }
-
     pub fn get_symbol_id_from_span(&self, span: Span) -> Option<SymbolId> {
         self.spans
             .iter_enumerated()


### PR DESCRIPTION
#5615 removed the only usage of this method, so it's now dead code.