### PR TITLE
refactor(semantic)!: rename `SymbolTable::iter` to `symbol_ids`

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -125,7 +125,7 @@ impl Linter {
             rule.run_once(ctx);
         }
 
-        for symbol in semantic.symbols().iter() {
+        for symbol in semantic.symbols().symbol_ids() {
             for (rule, ctx) in &rules {
                 rule.run_on_symbol(symbol, ctx);
             }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -57,7 +57,7 @@ impl SymbolTable {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {
         self.spans.iter_enumerated().map(|(symbol_id, _)| symbol_id)
     }
 


### PR DESCRIPTION
`symbol_ids` is a more descriptive name.