### PR TITLE
refactor(semantic): `SymbolTable::is_empty` use `is_empty`

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -54,7 +54,7 @@ impl SymbolTable {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.spans.is_empty()
     }
 
     pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {


### PR DESCRIPTION
Nit. `is_empty()` is sometimes more performant than `len() == 0`.