### PR TITLE
test(traverse): enable tests for `oxc_traverse` crate

### DIFF
--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-test = false
+test = true
 # Doctests must be enabled for this crate as they are used to run tests
 # which check the soundness of its code
 doctest = true


### PR DESCRIPTION
Tests were disabled for some reason.