### PR TITLE
fix(regular_expression): Handle `-` in `/[\-]/u` as escaped character

### DIFF
--- a/crates/oxc_regular_expression/src/body_parser/parser.rs
+++ b/crates/oxc_regular_expression/src/body_parser/parser.rs
@@ -979,7 +979,7 @@ impl<'a> PatternParser<'a> {
         if self.state.unicode_mode && self.reader.eat('-') {
             return Ok(Some(ast::CharacterClassContents::Character(ast::Character {
                 span: self.span_factory.create(span_start, self.reader.offset()),
-                kind: ast::CharacterKind::Symbol,
+                kind: ast::CharacterKind::SingleEscape,
                 value: '-' as u32,
             })));
         }

--- a/crates/oxc_regular_expression/src/display.rs
+++ b/crates/oxc_regular_expression/src/display.rs
@@ -548,6 +548,10 @@ mod test {
         (r"/\udf06/u", Some(r"/\uDF06/u")),
         // we capitalize hex unicodes.
         (r"/^|\udf06/g", Some(r"/^|\uDF06/g")),
+        (r"/[\-]/", None),
+        (r"/[\-]/u", None),
+        (r"/[\-]/v", None),
+        (r"/([\-a-z]{0,31})/iu", None),
     ];
 
     fn test_display(allocator: &Allocator, (source, expect): &Case) {


### PR DESCRIPTION
Fixes #5487 