### PR TITLE
perf(linter): use cow_to_ascii_lowercase/uppercase

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use cow_utils::CowUtils;
 use oxc_ast::{ast::MemberExpression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -235,7 +236,7 @@ fn is_jest_call(name: &str) -> bool {
     //
     // import { jest as Jest } from "@jest/globals";
     // Jest.setTimeout
-    name.to_ascii_lowercase().eq_ignore_ascii_case("jest")
+    name.cow_to_ascii_lowercase().eq_ignore_ascii_case("jest")
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use oxc_ast::{
     ast::{match_member_expression, Expression},
     AstKind,
@@ -231,7 +232,9 @@ fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
         _ => return false,
     };
 
-    if ident.starts_with(|c: char| c.is_ascii_uppercase()) && ident.to_ascii_uppercase() != ident {
+    if ident.starts_with(|c: char| c.is_ascii_uppercase())
+        && ident.cow_to_ascii_uppercase() != ident
+    {
         return true;
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use oxc_ast::{
     ast::{JSXAttributeItem, JSXAttributeName},
     AstKind,
@@ -88,7 +89,7 @@ fn get_replacement(node: &str) -> Option<&'static str> {
         return None;
     }
 
-    let node_lower = node.to_ascii_lowercase();
+    let node_lower = node.cow_to_ascii_lowercase();
 
     if node_lower == "utf-8" || node_lower == "utf8" {
         return Some("utf8");

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, cmp::Ordering};
 
+use cow_utils::CowUtils;
 use oxc_ast::{
     ast::{
         match_member_expression, Argument, CallExpression, Expression, IdentifierName,
@@ -255,7 +256,7 @@ fn parse_jest_jest_fn_call<'a>(
     name: &'a str,
     local: &'a str,
 ) -> Option<ParsedJestFnCall<'a>> {
-    let lowercase_name = name.to_ascii_lowercase();
+    let lowercase_name = name.cow_to_ascii_lowercase();
 
     if !(lowercase_name == "jest" || lowercase_name == "vi") {
         return None;


### PR DESCRIPTION
part of #5586 

In addition, can a similar situation in the [formatter](https://github.com/oxc-project/oxc/blob/main/crates/oxc_prettier/src/format/mod.rs#L1406-L1409) be handled in this way?
