### PR TITLE
fix(ast_tools):  fix ast-tool panic

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -9,7 +9,7 @@ src:
   - 'crates/oxc_syntax/src/number.rs'
   - 'crates/oxc_syntax/src/operator.rs'
   - 'crates/oxc_span/src/span/types.rs'
-  - 'crates/oxc_span/src/source_type/types.rs'
+  - 'crates/oxc_span/src/source_type/mod.rs'
   - 'crates/oxc_regular_expression/src/ast.rs'
   - 'crates/oxc_ast/src/generated/derive_clone_in.rs'
   - 'crates/oxc_regular_expression/src/generated/derive_clone_in.rs'

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -33,7 +33,7 @@ static SOURCE_PATHS: &[&str] = &[
     "crates/oxc_syntax/src/number.rs",
     "crates/oxc_syntax/src/operator.rs",
     "crates/oxc_span/src/span/types.rs",
-    "crates/oxc_span/src/source_type/types.rs",
+    "crates/oxc_span/src/source_type/mod.rs",
     "crates/oxc_regular_expression/src/ast.rs",
 ];
 

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -33,7 +33,7 @@ static SOURCE_PATHS: &[&str] = &[
     "crates/oxc_syntax/src/number.rs",
     "crates/oxc_syntax/src/operator.rs",
     "crates/oxc_span/src/span/types.rs",
-    "crates/oxc_span/src/source_type/mod.rs",
+    "crates/oxc_span/src/source_type/types.rs",
     "crates/oxc_regular_expression/src/ast.rs",
 ];
 

--- a/tasks/ast_tools/src/rust_ast.rs
+++ b/tasks/ast_tools/src/rust_ast.rs
@@ -303,8 +303,9 @@ impl Module {
 
     pub fn load(mut self) -> Result<Self> {
         assert!(!self.loaded, "can't load twice!");
-
-        let mut file = std::fs::File::open(&self.file).normalize()?;
+        let mut file = std::fs::File::open(&self.file).normalize().map_err(|err| {
+            format!("Error reading file: {}, reason: {}", &self.file.to_string_lossy(), err)
+        })?;
         let mut content = String::new();
         file.read_to_string(&mut content).normalize()?;
         let file = parse_file(content.as_str()).normalize()?;


### PR DESCRIPTION
`just ast` panic due to https://github.com/oxc-project/oxc/commit/553262842c055fbe63089fd15a7678d9831c7c9e, change the filename to makesure `ast_tool` still working
1. crates/oxc_span/src/source_type/types.rs is removed in 553262842c055fbe63089fd15a7678d9831c7c9e