### PR TITLE
fix(transformer/react): don't transform declaration of function overloads

### DIFF
--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -788,7 +788,7 @@ impl<'a> ReactRefresh<'a> {
                     }
                     ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
                         if let Some(id) = &func.id {
-                            if !is_componentish_name(&id.name) {
+                            if func.is_typescript_syntax() || !is_componentish_name(&id.name) {
                                 return None;
                             }
 
@@ -812,7 +812,7 @@ impl<'a> ReactRefresh<'a> {
             return None;
         };
 
-        if !is_componentish_name(&id.name) {
+        if func.is_typescript_syntax() || !is_componentish_name(&id.name) {
             return None;
         }
 
@@ -950,7 +950,9 @@ fn get_symbol_id_from_function_and_declarator(stmt: &Statement<'_>) -> Vec<Symbo
     let mut symbol_ids = vec![];
     match stmt {
         Statement::FunctionDeclaration(ref func) => {
-            symbol_ids.push(func.symbol_id().unwrap());
+            if !func.is_typescript_syntax() {
+                symbol_ids.push(func.symbol_id().unwrap());
+            }
         }
         Statement::VariableDeclaration(ref decl) => {
             symbol_ids.extend(decl.declarations.iter().filter_map(|decl| {
@@ -959,7 +961,9 @@ fn get_symbol_id_from_function_and_declarator(stmt: &Statement<'_>) -> Vec<Symbo
         }
         Statement::ExportNamedDeclaration(ref export_decl) => {
             if let Some(Declaration::FunctionDeclaration(func)) = &export_decl.declaration {
-                symbol_ids.push(func.symbol_id().unwrap());
+                if !func.is_typescript_syntax() {
+                    symbol_ids.push(func.symbol_id().unwrap());
+                }
             } else if let Some(Declaration::VariableDeclaration(decl)) = &export_decl.declaration {
                 symbol_ids.extend(decl.declarations.iter().filter_map(|decl| {
                     decl.id.get_binding_identifier().and_then(|id| id.symbol_id.get())


### PR DESCRIPTION
Found a bug in https://github.com/oxc-project/oxc/actions/runs/10768809028/job/29858692560; We don't need to transform typescript-syntax-only function