### PR TITLE
refactor(linter): use `std::ptr::eq`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -66,7 +66,7 @@ impl Rule for NoUselessSwitchCase {
         let default_case = default_cases[0];
 
         // Check if the `default` case is the last case
-        if std::ptr::from_ref(default_case) != std::ptr::from_ref(cases.last().unwrap()) {
+        if !std::ptr::eq(default_case, cases.last().unwrap()) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -63,7 +63,7 @@ impl Rule for PreferEventTarget {
                     return;
                 };
 
-                if std::ptr::from_ref(ident) != std::ptr::addr_of!(**callee_ident) {
+                if !std::ptr::eq(ident, callee_ident.as_ref()) {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -87,7 +87,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the for statement is the same node as the call expression.
-                if std::ptr::addr_of!(**call_expr2) != std::ptr::from_ref(call_expr) {
+                if !std::ptr::eq(call_expr2.as_ref(), call_expr) {
                     return;
                 }
             }
@@ -97,7 +97,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the conditional expression is the same node as the call expression.
-                if std::ptr::addr_of!(**call_expr2) != std::ptr::from_ref(call_expr) {
+                if !std::ptr::eq(call_expr2.as_ref(), call_expr) {
                     return;
                 }
             }


### PR DESCRIPTION
Follow-on after #5577.

`!std::ptr::eq(x, y)` is more idiomatic than `std::ptr::from_ref(x) != std::ptr::from_ref(y)`.