### PR TITLE
refactor(index, traverse): remove unnecessary type annotations

### DIFF
--- a/crates/oxc_index/src/idxslice.rs
+++ b/crates/oxc_index/src/idxslice.rs
@@ -74,16 +74,14 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
     #[inline(always)]
     pub fn from_slice(s: &[T]) -> &Self {
         // SAFETY: `IndexSlice` is a thin wrapper around `[T]` with the added marker for the index.
-
-        unsafe { &*(core::ptr::from_ref::<[T]>(s) as *const Self) }
+        unsafe { &*(core::ptr::from_ref(s) as *const Self) }
     }
 
     /// Construct a new mutable IdxSlice by wrapping an existing mutable slice.
     #[inline(always)]
     pub fn from_slice_mut(s: &mut [T]) -> &mut Self {
         // SAFETY: `IndexSlice` is a thin wrapper around `[T]` with the added marker for the index.
-
-        unsafe { &mut *(core::ptr::from_mut::<[T]>(s) as *mut Self) }
+        unsafe { &mut *(core::ptr::from_mut(s) as *mut Self) }
     }
 
     /// Copies `self` into a new `IndexVec`.

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -161,5 +161,5 @@ pub fn walk_program<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     // SAFETY: Walk functions are constructed to avoid unsoundness
-    unsafe { walk::walk_program(traverser, std::ptr::from_mut::<Program>(program), ctx) };
+    unsafe { walk::walk_program(traverser, std::ptr::from_mut(program), ctx) };
 }


### PR DESCRIPTION
Follow-on after #5577. These type annotations are not required. Probably they were suggested by clippy.