### PR TITLE
style(traverse): fix formatting of traverse codegen

### DIFF
--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -32,16 +32,16 @@ export default function generateAncestorsCode(types) {
         if (otherField === field) continue;
 
         methodsCode += `
-                    #[inline]
-                    pub fn ${otherField.rawName}(self) -> &'t ${otherField.rawTypeName} {
-                        unsafe {
-                            &*(
-                                (self.0 as *const u8).add(${otherField.offsetVarName})
-                                as *const ${otherField.rawTypeName}
-                            )
-                        }
-                    }
-                `;
+          #[inline]
+          pub fn ${otherField.rawName}(self) -> &'t ${otherField.rawTypeName} {
+            unsafe {
+              &*(
+                (self.0 as *const u8).add(${otherField.offsetVarName})
+                as *const ${otherField.rawTypeName}
+              )
+            }
+          }
+        `;
       }
 
       const fieldNameCamel = snakeToCamel(field.name),
@@ -49,17 +49,17 @@ export default function generateAncestorsCode(types) {
         structName = `${type.name}Without${fieldNameCamel}${lifetimes}`;
 
       thisAncestorTypes += `
-                #[repr(transparent)]
-                #[derive(Clone, Copy, Debug)]
-                pub struct ${structName}(
-                    pub(crate) *const ${type.rawName},
-                    pub(crate) PhantomData<&'t ()>,
-                );
+        #[repr(transparent)]
+        #[derive(Clone, Copy, Debug)]
+        pub struct ${structName}(
+          pub(crate) *const ${type.rawName},
+          pub(crate) PhantomData<&'t ()>,
+        );
 
-                impl${lifetimes} ${structName} {
-                    ${methodsCode}
-                }
-            `;
+        impl${lifetimes} ${structName} {
+          ${methodsCode}
+        }
+      `;
 
       const variantName = `${type.name}${fieldNameCamel}`;
       variantNames.push(variantName);
@@ -76,85 +76,85 @@ export default function generateAncestorsCode(types) {
 
     if (variantNames.length > 0) {
       ancestorTypes += `
-                ${offsetCode}
-                ${thisAncestorTypes}
-            `;
+        ${offsetCode}
+        ${thisAncestorTypes}
+      `;
 
       isFunctions += `
-                #[inline]
-                pub fn is_${typeSnakeName}(self) -> bool {
-                    matches!(self, ${variantNames.map(name => `Self::${name}(_)`).join(' | ')})
-                }
-            `;
+        #[inline]
+        pub fn is_${typeSnakeName}(self) -> bool {
+          matches!(self, ${variantNames.map(name => `Self::${name}(_)`).join(' | ')})
+        }
+      `;
     }
   }
 
   for (const [typeName, variantNames] of Object.entries(variantNamesForEnums)) {
     isFunctions += `
-            #[inline]
-            pub fn is_via_${camelToSnake(typeName)}(self) -> bool {
-                matches!(self, ${variantNames.map(name => `Self::${name}(_)`).join(' | ')})
-            }
-        `;
+      #[inline]
+      pub fn is_via_${camelToSnake(typeName)}(self) -> bool {
+        matches!(self, ${variantNames.map(name => `Self::${name}(_)`).join(' | ')})
+      }
+    `;
   }
 
   return `
-        #![allow(
-            unsafe_code,
-            clippy::missing_safety_doc,
-            clippy::ptr_as_ptr,
-            clippy::undocumented_unsafe_blocks,
-            clippy::cast_ptr_alignment
-        )]
+    #![allow(
+      unsafe_code,
+      clippy::missing_safety_doc,
+      clippy::ptr_as_ptr,
+      clippy::undocumented_unsafe_blocks,
+      clippy::cast_ptr_alignment
+    )]
 
-        use std::{cell::Cell, marker::PhantomData};
+    use std::{cell::Cell, marker::PhantomData};
 
-        use memoffset::offset_of;
+    use memoffset::offset_of;
 
-        use oxc_allocator::{Box, Vec};
-        #[allow(clippy::wildcard_imports)]
-        use oxc_ast::ast::*;
-        use oxc_syntax::scope::ScopeId;
+    use oxc_allocator::{Box, Vec};
+    #[allow(clippy::wildcard_imports)]
+    use oxc_ast::ast::*;
+    use oxc_syntax::scope::ScopeId;
 
-        /// Type of [\`Ancestor\`].
-        /// Used in [\`crate::TraverseCtx::retag_stack\`].
-        #[repr(u16)]
-        #[derive(Clone, Copy)]
-        #[allow(dead_code)]
-        pub(crate) enum AncestorType {
-            None = 0,
-            ${ancestorTypeEnumVariants}
-        }
+    /// Type of [\`Ancestor\`].
+    /// Used in [\`crate::TraverseCtx::retag_stack\`].
+    #[repr(u16)]
+    #[derive(Clone, Copy)]
+    #[allow(dead_code)]
+    pub(crate) enum AncestorType {
+      None = 0,
+      ${ancestorTypeEnumVariants}
+    }
 
-        /// Ancestor type used in AST traversal.
-        ///
-        /// Encodes both the type of the parent, and child's location in the parent.
-        /// i.e. variants for \`BinaryExpressionLeft\` and \`BinaryExpressionRight\`, not just \`BinaryExpression\`.
-        ///
-        /// \`'a\` is lifetime of AST nodes.
-        /// \`'t\` is lifetime of the \`Ancestor\` (which inherits lifetime from \`&'t TraverseCtx'\`).
-        /// i.e. \`Ancestor\`s can only exist within the body of \`enter_*\` and \`exit_*\` methods
-        /// and cannot "escape" from them.
-        //
-        // SAFETY:
-        // * This type must be \`#[repr(u16)]\`.
-        // * Variant discriminants must correspond to those in \`AncestorType\`.
-        //
-        // These invariants make it possible to set the discriminant of an \`Ancestor\` without altering
-        // the "payload" pointer with:
-        // \`*(ancestor as *mut _ as *mut AncestorType) = AncestorType::Program\`.
-        // \`TraverseCtx::retag_stack\` uses this technique.
-        #[repr(C, u16)]
-        #[derive(Clone, Copy, Debug)]
-        pub enum Ancestor<'a, 't> {
-            None = AncestorType::None as u16,
-            ${ancestorEnumVariants}
-        }
+    /// Ancestor type used in AST traversal.
+    ///
+    /// Encodes both the type of the parent, and child's location in the parent.
+    /// i.e. variants for \`BinaryExpressionLeft\` and \`BinaryExpressionRight\`, not just \`BinaryExpression\`.
+    ///
+    /// \`'a\` is lifetime of AST nodes.
+    /// \`'t\` is lifetime of the \`Ancestor\` (which inherits lifetime from \`&'t TraverseCtx'\`).
+    /// i.e. \`Ancestor\`s can only exist within the body of \`enter_*\` and \`exit_*\` methods
+    /// and cannot "escape" from them.
+    //
+    // SAFETY:
+    // * This type must be \`#[repr(u16)]\`.
+    // * Variant discriminants must correspond to those in \`AncestorType\`.
+    //
+    // These invariants make it possible to set the discriminant of an \`Ancestor\` without altering
+    // the "payload" pointer with:
+    // \`*(ancestor as *mut _ as *mut AncestorType) = AncestorType::Program\`.
+    // \`TraverseCtx::retag_stack\` uses this technique.
+    #[repr(C, u16)]
+    #[derive(Clone, Copy, Debug)]
+    pub enum Ancestor<'a, 't> {
+      None = AncestorType::None as u16,
+      ${ancestorEnumVariants}
+    }
 
-        impl<'a, 't> Ancestor<'a, 't> {
-            ${isFunctions}
-        }
+    impl<'a, 't> Ancestor<'a, 't> {
+      ${isFunctions}
+    }
 
-        ${ancestorTypes}
-    `;
+    ${ancestorTypes}
+  `;
 }

--- a/crates/oxc_traverse/scripts/lib/scopes_collector.mjs
+++ b/crates/oxc_traverse/scripts/lib/scopes_collector.mjs
@@ -7,44 +7,44 @@ export default function generateScopesCollectorCode(types) {
 
     const extraParams = type.scopeArgs.flags === 'flags' ? ', _flags: ScopeFlags' : '';
     methods += `
-            #[inline]
-            fn visit_${camelToSnake(type.name)}(&mut self, it: &${type.rawName}${extraParams}) {
-                self.add_scope(&it.scope_id);
-            }
-        `;
+      #[inline]
+      fn visit_${camelToSnake(type.name)}(&mut self, it: &${type.rawName}${extraParams}) {
+        self.add_scope(&it.scope_id);
+      }
+    `;
   }
 
   return `
-        use std::cell::Cell;
+    use std::cell::Cell;
 
-        #[allow(clippy::wildcard_imports)]
-        use oxc_ast::{ast::*, visit::Visit};
-        use oxc_syntax::scope::{ScopeFlags, ScopeId};
+    #[allow(clippy::wildcard_imports)]
+    use oxc_ast::{ast::*, visit::Visit};
+    use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
-        /// Visitor that locates all child scopes.
-        /// NB: Child scopes only, not grandchild scopes.
-        /// Does not do full traversal - stops each time it hits a node with a scope.
-        pub(crate) struct ChildScopeCollector {
-            pub(crate) scope_ids: Vec<ScopeId>,
-        }
+    /// Visitor that locates all child scopes.
+    /// NB: Child scopes only, not grandchild scopes.
+    /// Does not do full traversal - stops each time it hits a node with a scope.
+    pub(crate) struct ChildScopeCollector {
+      pub(crate) scope_ids: Vec<ScopeId>,
+    }
 
-        impl ChildScopeCollector {
-            pub(crate) fn new() -> Self {
-                Self { scope_ids: vec![] }
-            }
+    impl ChildScopeCollector {
+      pub(crate) fn new() -> Self {
+        Self { scope_ids: vec![] }
+      }
 
-            pub(crate) fn add_scope(&mut self, scope_id: &Cell<Option<ScopeId>>) {
-                self.scope_ids.push(scope_id.get().unwrap());
-            }
-        }
+      pub(crate) fn add_scope(&mut self, scope_id: &Cell<Option<ScopeId>>) {
+        self.scope_ids.push(scope_id.get().unwrap());
+      }
+    }
 
-        impl<'a> Visit<'a> for ChildScopeCollector {
-            ${methods}
+    impl<'a> Visit<'a> for ChildScopeCollector {
+      ${methods}
 
-            #[inline]
-            fn visit_finally_clause(&mut self, it: &BlockStatement<'a>) {
-                self.add_scope(&it.scope_id);
-            }
-        }
-    `;
+      #[inline]
+      fn visit_finally_clause(&mut self, it: &BlockStatement<'a>) {
+        self.add_scope(&it.scope_id);
+      }
+    }
+  `;
 }

--- a/crates/oxc_traverse/scripts/lib/traverse.mjs
+++ b/crates/oxc_traverse/scripts/lib/traverse.mjs
@@ -8,23 +8,23 @@ export default function generateTraverseTraitCode(types) {
   for (const type of typesArr) {
     const snakeName = camelToSnake(type.name);
     traverseMethods += `
-            #[inline]
-            fn enter_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
-            #[inline]
-            fn exit_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
-        `;
+      #[inline]
+      fn enter_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
+      #[inline]
+      fn exit_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
+    `;
   }
 
   return `
-        use oxc_allocator::Vec;
-        #[allow(clippy::wildcard_imports)]
-        use oxc_ast::ast::*;
+    use oxc_allocator::Vec;
+    #[allow(clippy::wildcard_imports)]
+    use oxc_ast::ast::*;
 
-        use crate::TraverseCtx;
+    use crate::TraverseCtx;
 
-        #[allow(unused_variables)]
-        pub trait Traverse<'a> {
-            ${traverseMethods}
-        }
-    `;
+    #[allow(unused_variables)]
+    pub trait Traverse<'a> {
+      ${traverseMethods}
+    }
+  `;
 }


### PR DESCRIPTION
`dprint` rather mangled indentation of these files.