### PR TITLE
refactor(traverse): revert changes to `walk.rs`

### DIFF
--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -8,6 +8,9 @@
     clippy::missing_panics_doc,
     clippy::undocumented_unsafe_blocks,
     clippy::semicolon_if_nothing_returned,
+    clippy::ptr_as_ptr,
+    clippy::ref_as_ptr,
+    clippy::borrow_as_ptr,
     clippy::cast_ptr_alignment
 )]
 
@@ -31,31 +34,28 @@ pub(crate) unsafe fn walk_program<'a, Tr: Traverse<'a>>(
     traverser.enter_program(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_PROGRAM_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_SCOPE_ID) as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx
         .push_stack(Ancestor::ProgramHashbang(ancestor::ProgramWithoutHashbang(node, PhantomData)));
     if let Some(field) =
-        &mut *(node.cast::<u8>().add(ancestor::OFFSET_PROGRAM_HASHBANG).cast::<Option<Hashbang>>())
+        &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_HASHBANG) as *mut Option<Hashbang>)
     {
-        walk_hashbang(traverser, std::ptr::from_mut(field), ctx);
+        walk_hashbang(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramDirectives);
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_PROGRAM_DIRECTIVES).cast::<Vec<Directive>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES)
+        as *mut Vec<Directive>))
+        .iter_mut()
     {
-        walk_directive(traverser, std::ptr::from_mut(item), ctx);
+        walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramBody);
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_PROGRAM_BODY).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -71,124 +71,116 @@ pub(crate) unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
     traverser.enter_expression(&mut *node, ctx);
     match &mut *node {
         Expression::BooleanLiteral(node) => {
-            walk_boolean_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_boolean_literal(traverser, (&mut **node) as *mut _, ctx)
         }
-        Expression::NullLiteral(node) => {
-            walk_null_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        Expression::NullLiteral(node) => walk_null_literal(traverser, (&mut **node) as *mut _, ctx),
         Expression::NumericLiteral(node) => {
-            walk_numeric_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_numeric_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::BigIntLiteral(node) => {
-            walk_big_int_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_big_int_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::RegExpLiteral(node) => {
-            walk_reg_exp_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_reg_exp_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TemplateLiteral(node) => {
-            walk_template_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::Identifier(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::MetaProperty(node) => {
-            walk_meta_property(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_meta_property(traverser, (&mut **node) as *mut _, ctx)
         }
-        Expression::Super(node) => walk_super(traverser, std::ptr::from_mut(&mut **node), ctx),
+        Expression::Super(node) => walk_super(traverser, (&mut **node) as *mut _, ctx),
         Expression::ArrayExpression(node) => {
-            walk_array_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_array_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ArrowFunctionExpression(node) => {
-            walk_arrow_function_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_arrow_function_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::AssignmentExpression(node) => {
-            walk_assignment_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_assignment_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::AwaitExpression(node) => {
-            walk_await_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_await_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::BinaryExpression(node) => {
-            walk_binary_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_binary_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::CallExpression(node) => {
-            walk_call_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_call_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ChainExpression(node) => {
-            walk_chain_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_chain_expression(traverser, (&mut **node) as *mut _, ctx)
         }
-        Expression::ClassExpression(node) => {
-            walk_class(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        Expression::ClassExpression(node) => walk_class(traverser, (&mut **node) as *mut _, ctx),
         Expression::ConditionalExpression(node) => {
-            walk_conditional_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_conditional_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::FunctionExpression(node) => {
-            walk_function(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ImportExpression(node) => {
-            walk_import_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_import_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::LogicalExpression(node) => {
-            walk_logical_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_logical_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::NewExpression(node) => {
-            walk_new_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_new_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ObjectExpression(node) => {
-            walk_object_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_object_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ParenthesizedExpression(node) => {
-            walk_parenthesized_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_parenthesized_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::SequenceExpression(node) => {
-            walk_sequence_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_sequence_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TaggedTemplateExpression(node) => {
-            walk_tagged_template_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_tagged_template_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ThisExpression(node) => {
-            walk_this_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::UnaryExpression(node) => {
-            walk_unary_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_unary_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::UpdateExpression(node) => {
-            walk_update_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_update_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::YieldExpression(node) => {
-            walk_yield_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_yield_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::PrivateInExpression(node) => {
-            walk_private_in_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_private_in_expression(traverser, (&mut **node) as *mut _, ctx)
         }
-        Expression::JSXElement(node) => {
-            walk_jsx_element(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
-        Expression::JSXFragment(node) => {
-            walk_jsx_fragment(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        Expression::JSXElement(node) => walk_jsx_element(traverser, (&mut **node) as *mut _, ctx),
+        Expression::JSXFragment(node) => walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx),
         Expression::TSAsExpression(node) => {
-            walk_ts_as_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_as_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TSSatisfiesExpression(node) => {
-            walk_ts_satisfies_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_satisfies_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TSTypeAssertion(node) => {
-            walk_ts_type_assertion(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_assertion(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TSNonNullExpression(node) => {
-            walk_ts_non_null_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_non_null_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::TSInstantiationExpression(node) => {
-            walk_ts_instantiation_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_instantiation_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         Expression::ComputedMemberExpression(_)
         | Expression::StaticMemberExpression(_)
         | Expression::PrivateFieldExpression(_) => {
-            walk_member_expression(traverser, node.cast(), ctx)
+            walk_member_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_expression(&mut *node, ctx);
@@ -248,13 +240,11 @@ pub(crate) unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ArrayExpressionElements(
         ancestor::ArrayExpressionWithoutElements(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ARRAY_EXPRESSION_ELEMENTS)
-        .cast::<Vec<ArrayExpressionElement>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_EXPRESSION_ELEMENTS)
+        as *mut Vec<ArrayExpressionElement>))
+        .iter_mut()
     {
-        walk_array_expression_element(traverser, std::ptr::from_mut(item), ctx);
+        walk_array_expression_element(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_array_expression(&mut *node, ctx);
@@ -268,11 +258,9 @@ pub(crate) unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
     traverser.enter_array_expression_element(&mut *node, ctx);
     match &mut *node {
         ArrayExpressionElement::SpreadElement(node) => {
-            walk_spread_element(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
         }
-        ArrayExpressionElement::Elision(node) => {
-            walk_elision(traverser, std::ptr::from_mut(node), ctx)
-        }
+        ArrayExpressionElement::Elision(node) => walk_elision(traverser, node as *mut _, ctx),
         ArrayExpressionElement::BooleanLiteral(_)
         | ArrayExpressionElement::NullLiteral(_)
         | ArrayExpressionElement::NumericLiteral(_)
@@ -315,7 +303,7 @@ pub(crate) unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
         | ArrayExpressionElement::ComputedMemberExpression(_)
         | ArrayExpressionElement::StaticMemberExpression(_)
         | ArrayExpressionElement::PrivateFieldExpression(_) => {
-            walk_expression(traverser, node.cast(), ctx)
+            walk_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_array_expression_element(&mut *node, ctx);
@@ -339,13 +327,11 @@ pub(crate) unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ObjectExpressionProperties(
         ancestor::ObjectExpressionWithoutProperties(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_OBJECT_EXPRESSION_PROPERTIES)
-        .cast::<Vec<ObjectPropertyKind>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_OBJECT_EXPRESSION_PROPERTIES)
+        as *mut Vec<ObjectPropertyKind>))
+        .iter_mut()
     {
-        walk_object_property_kind(traverser, std::ptr::from_mut(item), ctx);
+        walk_object_property_kind(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_object_expression(&mut *node, ctx);
@@ -359,10 +345,10 @@ pub(crate) unsafe fn walk_object_property_kind<'a, Tr: Traverse<'a>>(
     traverser.enter_object_property_kind(&mut *node, ctx);
     match &mut *node {
         ObjectPropertyKind::ObjectProperty(node) => {
-            walk_object_property(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_object_property(traverser, (&mut **node) as *mut _, ctx)
         }
         ObjectPropertyKind::SpreadProperty(node) => {
-            walk_spread_element(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_object_property_kind(&mut *node, ctx);
@@ -379,22 +365,20 @@ pub(crate) unsafe fn walk_object_property<'a, Tr: Traverse<'a>>(
     ));
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_OBJECT_PROPERTY_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_OBJECT_PROPERTY_KEY) as *mut PropertyKey,
         ctx,
     );
     ctx.retag_stack(AncestorType::ObjectPropertyValue);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_OBJECT_PROPERTY_VALUE).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_OBJECT_PROPERTY_VALUE) as *mut Expression,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_OBJECT_PROPERTY_INIT)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PROPERTY_INIT)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::ObjectPropertyInit);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_object_property(&mut *node, ctx);
@@ -408,10 +392,10 @@ pub(crate) unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
     traverser.enter_property_key(&mut *node, ctx);
     match &mut *node {
         PropertyKey::StaticIdentifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
         PropertyKey::PrivateIdentifier(node) => {
-            walk_private_identifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_private_identifier(traverser, (&mut **node) as *mut _, ctx)
         }
         PropertyKey::BooleanLiteral(_)
         | PropertyKey::NullLiteral(_)
@@ -454,7 +438,7 @@ pub(crate) unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
         | PropertyKey::TSInstantiationExpression(_)
         | PropertyKey::ComputedMemberExpression(_)
         | PropertyKey::StaticMemberExpression(_)
-        | PropertyKey::PrivateFieldExpression(_) => walk_expression(traverser, node.cast(), ctx),
+        | PropertyKey::PrivateFieldExpression(_) => walk_expression(traverser, node as *mut _, ctx),
     }
     traverser.exit_property_key(&mut *node, ctx);
 }
@@ -468,22 +452,18 @@ pub(crate) unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TemplateLiteralQuasis(
         ancestor::TemplateLiteralWithoutQuasis(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TEMPLATE_LITERAL_QUASIS)
-        .cast::<Vec<TemplateElement>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_QUASIS)
+        as *mut Vec<TemplateElement>))
+        .iter_mut()
     {
-        walk_template_element(traverser, std::ptr::from_mut(item), ctx);
+        walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TemplateLiteralExpressions);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
-        .cast::<Vec<Expression>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
+        as *mut Vec<Expression>))
+        .iter_mut()
     {
-        walk_expression(traverser, std::ptr::from_mut(item), ctx);
+        walk_expression(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_template_literal(&mut *node, ctx);
@@ -500,24 +480,22 @@ pub(crate) unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TAG).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TAG) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::TaggedTemplateExpressionQuasi);
     walk_template_literal(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
-            .cast::<TemplateLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
+            as *mut TemplateLiteral,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_tagged_template_expression(&mut *node, ctx);
@@ -540,13 +518,13 @@ pub(crate) unsafe fn walk_member_expression<'a, Tr: Traverse<'a>>(
     traverser.enter_member_expression(&mut *node, ctx);
     match &mut *node {
         MemberExpression::ComputedMemberExpression(node) => {
-            walk_computed_member_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_computed_member_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         MemberExpression::StaticMemberExpression(node) => {
-            walk_static_member_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_static_member_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         MemberExpression::PrivateFieldExpression(node) => {
-            walk_private_field_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_private_field_expression(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_member_expression(&mut *node, ctx);
@@ -563,17 +541,15 @@ pub(crate) unsafe fn walk_computed_member_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_OBJECT)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_OBJECT)
+            as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ComputedMemberExpressionExpression);
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_EXPRESSION)
+            as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -591,17 +567,14 @@ pub(crate) unsafe fn walk_static_member_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_OBJECT)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_OBJECT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::StaticMemberExpressionProperty);
     walk_identifier_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_PROPERTY)
-            .cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_PROPERTY)
+            as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -619,17 +592,14 @@ pub(crate) unsafe fn walk_private_field_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_OBJECT)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_OBJECT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::PrivateFieldExpressionField);
     walk_private_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_FIELD)
-            .cast::<PrivateIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_FIELD)
+            as *mut PrivateIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -647,25 +617,22 @@ pub(crate) unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_CALL_EXPRESSION_CALLEE).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_CALLEE) as *mut Expression,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::CallExpressionTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::CallExpressionArguments);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CALL_EXPRESSION_ARGUMENTS)
-        .cast::<Vec<Argument>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>))
+        .iter_mut()
     {
-        walk_argument(traverser, std::ptr::from_mut(item), ctx);
+        walk_argument(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_call_expression(&mut *node, ctx);
@@ -682,25 +649,22 @@ pub(crate) unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_NEW_EXPRESSION_CALLEE).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_CALLEE) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::NewExpressionArguments);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
-        .cast::<Vec<Argument>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>))
+        .iter_mut()
     {
-        walk_argument(traverser, std::ptr::from_mut(item), ctx);
+        walk_argument(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::NewExpressionTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_new_expression(&mut *node, ctx);
@@ -718,13 +682,13 @@ pub(crate) unsafe fn walk_meta_property<'a, Tr: Traverse<'a>>(
     )));
     walk_identifier_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_META_PROPERTY_META).cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_META_PROPERTY_META) as *mut IdentifierName,
         ctx,
     );
     ctx.retag_stack(AncestorType::MetaPropertyProperty);
     walk_identifier_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_META_PROPERTY_PROPERTY).cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_META_PROPERTY_PROPERTY) as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -742,7 +706,7 @@ pub(crate) unsafe fn walk_spread_element<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_SPREAD_ELEMENT_ARGUMENT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_SPREAD_ELEMENT_ARGUMENT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -757,7 +721,7 @@ pub(crate) unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
     traverser.enter_argument(&mut *node, ctx);
     match &mut *node {
         Argument::SpreadElement(node) => {
-            walk_spread_element(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
         }
         Argument::BooleanLiteral(_)
         | Argument::NullLiteral(_)
@@ -800,7 +764,7 @@ pub(crate) unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
         | Argument::TSInstantiationExpression(_)
         | Argument::ComputedMemberExpression(_)
         | Argument::StaticMemberExpression(_)
-        | Argument::PrivateFieldExpression(_) => walk_expression(traverser, node.cast(), ctx),
+        | Argument::PrivateFieldExpression(_) => walk_expression(traverser, node as *mut _, ctx),
     }
     traverser.exit_argument(&mut *node, ctx);
 }
@@ -816,9 +780,8 @@ pub(crate) unsafe fn walk_update_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_simple_assignment_target(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_UPDATE_EXPRESSION_ARGUMENT)
-            .cast::<SimpleAssignmentTarget>(),
+        (node as *mut u8).add(ancestor::OFFSET_UPDATE_EXPRESSION_ARGUMENT)
+            as *mut SimpleAssignmentTarget,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -836,7 +799,7 @@ pub(crate) unsafe fn walk_unary_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_UNARY_EXPRESSION_ARGUMENT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_UNARY_EXPRESSION_ARGUMENT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -854,13 +817,13 @@ pub(crate) unsafe fn walk_binary_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BINARY_EXPRESSION_LEFT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINARY_EXPRESSION_LEFT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::BinaryExpressionRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BINARY_EXPRESSION_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINARY_EXPRESSION_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -878,15 +841,14 @@ pub(crate) unsafe fn walk_private_in_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_private_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_LEFT)
-            .cast::<PrivateIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_LEFT)
+            as *mut PrivateIdentifier,
         ctx,
     );
     ctx.retag_stack(AncestorType::PrivateInExpressionRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -904,13 +866,13 @@ pub(crate) unsafe fn walk_logical_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_LOGICAL_EXPRESSION_LEFT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_LOGICAL_EXPRESSION_LEFT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::LogicalExpressionRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_LOGICAL_EXPRESSION_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_LOGICAL_EXPRESSION_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -928,23 +890,20 @@ pub(crate) unsafe fn walk_conditional_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_TEST).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_TEST) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ConditionalExpressionConsequent);
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_CONSEQUENT)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_CONSEQUENT)
+            as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ConditionalExpressionAlternate);
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_ALTERNATE)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_ALTERNATE) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -962,15 +921,13 @@ pub(crate) unsafe fn walk_assignment_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_assignment_target(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_LEFT)
-            .cast::<AssignmentTarget>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_LEFT) as *mut AssignmentTarget,
         ctx,
     );
     ctx.retag_stack(AncestorType::AssignmentExpressionRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -993,11 +950,11 @@ pub(crate) unsafe fn walk_assignment_target<'a, Tr: Traverse<'a>>(
         | AssignmentTarget::ComputedMemberExpression(_)
         | AssignmentTarget::StaticMemberExpression(_)
         | AssignmentTarget::PrivateFieldExpression(_) => {
-            walk_simple_assignment_target(traverser, node.cast(), ctx)
+            walk_simple_assignment_target(traverser, node as *mut _, ctx)
         }
         AssignmentTarget::ArrayAssignmentTarget(_)
         | AssignmentTarget::ObjectAssignmentTarget(_) => {
-            walk_assignment_target_pattern(traverser, node.cast(), ctx)
+            walk_assignment_target_pattern(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_assignment_target(&mut *node, ctx);
@@ -1011,27 +968,27 @@ pub(crate) unsafe fn walk_simple_assignment_target<'a, Tr: Traverse<'a>>(
     traverser.enter_simple_assignment_target(&mut *node, ctx);
     match &mut *node {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::TSAsExpression(node) => {
-            walk_ts_as_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_as_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::TSSatisfiesExpression(node) => {
-            walk_ts_satisfies_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_satisfies_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::TSNonNullExpression(node) => {
-            walk_ts_non_null_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_non_null_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::TSTypeAssertion(node) => {
-            walk_ts_type_assertion(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_assertion(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::TSInstantiationExpression(node) => {
-            walk_ts_instantiation_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_instantiation_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         SimpleAssignmentTarget::ComputedMemberExpression(_)
         | SimpleAssignmentTarget::StaticMemberExpression(_)
         | SimpleAssignmentTarget::PrivateFieldExpression(_) => {
-            walk_member_expression(traverser, node.cast(), ctx)
+            walk_member_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_simple_assignment_target(&mut *node, ctx);
@@ -1045,10 +1002,10 @@ pub(crate) unsafe fn walk_assignment_target_pattern<'a, Tr: Traverse<'a>>(
     traverser.enter_assignment_target_pattern(&mut *node, ctx);
     match &mut *node {
         AssignmentTargetPattern::ArrayAssignmentTarget(node) => {
-            walk_array_assignment_target(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_array_assignment_target(traverser, (&mut **node) as *mut _, ctx)
         }
         AssignmentTargetPattern::ObjectAssignmentTarget(node) => {
-            walk_object_assignment_target(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_object_assignment_target(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_assignment_target_pattern(&mut *node, ctx);
@@ -1063,22 +1020,18 @@ pub(crate) unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ArrayAssignmentTargetElements(
         ancestor::ArrayAssignmentTargetWithoutElements(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
-        .cast::<Vec<Option<AssignmentTargetMaybeDefault>>>()))
-    .iter_mut()
-    .flatten()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
+        as *mut Vec<Option<AssignmentTargetMaybeDefault>>))
+        .iter_mut()
+        .flatten()
     {
-        walk_assignment_target_maybe_default(traverser, std::ptr::from_mut(item), ctx);
+        walk_assignment_target_maybe_default(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
-        .cast::<Option<AssignmentTargetRest>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
+        as *mut Option<AssignmentTargetRest>)
     {
         ctx.retag_stack(AncestorType::ArrayAssignmentTargetRest);
-        walk_assignment_target_rest(traverser, std::ptr::from_mut(field), ctx);
+        walk_assignment_target_rest(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_array_assignment_target(&mut *node, ctx);
@@ -1093,21 +1046,18 @@ pub(crate) unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ObjectAssignmentTargetProperties(
         ancestor::ObjectAssignmentTargetWithoutProperties(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
-        .cast::<Vec<AssignmentTargetProperty>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
+        as *mut Vec<AssignmentTargetProperty>))
+        .iter_mut()
     {
-        walk_assignment_target_property(traverser, std::ptr::from_mut(item), ctx);
+        walk_assignment_target_property(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
-        .cast::<Option<AssignmentTargetRest>>())
+        as *mut Option<AssignmentTargetRest>)
     {
         ctx.retag_stack(AncestorType::ObjectAssignmentTargetRest);
-        walk_assignment_target_rest(traverser, std::ptr::from_mut(field), ctx);
+        walk_assignment_target_rest(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_object_assignment_target(&mut *node, ctx);
@@ -1124,9 +1074,8 @@ pub(crate) unsafe fn walk_assignment_target_rest<'a, Tr: Traverse<'a>>(
     ));
     walk_assignment_target(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_REST_TARGET)
-            .cast::<AssignmentTarget>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_REST_TARGET)
+            as *mut AssignmentTarget,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1141,7 +1090,7 @@ pub(crate) unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
     traverser.enter_assignment_target_maybe_default(&mut *node, ctx);
     match &mut *node {
         AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(node) => {
-            walk_assignment_target_with_default(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_assignment_target_with_default(traverser, (&mut **node) as *mut _, ctx)
         }
         AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(_)
         | AssignmentTargetMaybeDefault::TSAsExpression(_)
@@ -1154,7 +1103,7 @@ pub(crate) unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
         | AssignmentTargetMaybeDefault::ComputedMemberExpression(_)
         | AssignmentTargetMaybeDefault::StaticMemberExpression(_)
         | AssignmentTargetMaybeDefault::PrivateFieldExpression(_) => {
-            walk_assignment_target(traverser, node.cast(), ctx)
+            walk_assignment_target(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_assignment_target_maybe_default(&mut *node, ctx);
@@ -1171,17 +1120,15 @@ pub(crate) unsafe fn walk_assignment_target_with_default<'a, Tr: Traverse<'a>>(
     ));
     walk_assignment_target(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_BINDING)
-            .cast::<AssignmentTarget>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_BINDING)
+            as *mut AssignmentTarget,
         ctx,
     );
     ctx.retag_stack(AncestorType::AssignmentTargetWithDefaultInit);
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_INIT)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_INIT)
+            as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1196,18 +1143,10 @@ pub(crate) unsafe fn walk_assignment_target_property<'a, Tr: Traverse<'a>>(
     traverser.enter_assignment_target_property(&mut *node, ctx);
     match &mut *node {
         AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(node) => {
-            walk_assignment_target_property_identifier(
-                traverser,
-                std::ptr::from_mut(&mut **node),
-                ctx,
-            )
+            walk_assignment_target_property_identifier(traverser, (&mut **node) as *mut _, ctx)
         }
         AssignmentTargetProperty::AssignmentTargetPropertyProperty(node) => {
-            walk_assignment_target_property_property(
-                traverser,
-                std::ptr::from_mut(&mut **node),
-                ctx,
-            )
+            walk_assignment_target_property_property(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_assignment_target_property(&mut *node, ctx);
@@ -1224,18 +1163,16 @@ pub(crate) unsafe fn walk_assignment_target_property_identifier<'a, Tr: Traverse
     ));
     walk_identifier_reference(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_BINDING)
-            .cast::<IdentifierReference>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_BINDING)
+            as *mut IdentifierReference,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_INIT)
-        .cast::<Option<Expression>>())
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::AssignmentTargetPropertyIdentifierInit);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_assignment_target_property_identifier(&mut *node, ctx);
@@ -1252,17 +1189,15 @@ pub(crate) unsafe fn walk_assignment_target_property_property<'a, Tr: Traverse<'
     ));
     walk_property_key(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_NAME)
-            .cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_NAME)
+            as *mut PropertyKey,
         ctx,
     );
     ctx.retag_stack(AncestorType::AssignmentTargetPropertyPropertyBinding);
     walk_assignment_target_maybe_default(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_BINDING)
-            .cast::<AssignmentTargetMaybeDefault>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_BINDING)
+            as *mut AssignmentTargetMaybeDefault,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1278,13 +1213,11 @@ pub(crate) unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::SequenceExpressionExpressions(
         ancestor::SequenceExpressionWithoutExpressions(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS)
-        .cast::<Vec<Expression>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS)
+        as *mut Vec<Expression>))
+        .iter_mut()
     {
-        walk_expression(traverser, std::ptr::from_mut(item), ctx);
+        walk_expression(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_sequence_expression(&mut *node, ctx);
@@ -1310,7 +1243,7 @@ pub(crate) unsafe fn walk_await_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_AWAIT_EXPRESSION_ARGUMENT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_AWAIT_EXPRESSION_ARGUMENT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1328,7 +1261,7 @@ pub(crate) unsafe fn walk_chain_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_chain_element(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_CHAIN_EXPRESSION_EXPRESSION).cast::<ChainElement>(),
+        (node as *mut u8).add(ancestor::OFFSET_CHAIN_EXPRESSION_EXPRESSION) as *mut ChainElement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1343,12 +1276,12 @@ pub(crate) unsafe fn walk_chain_element<'a, Tr: Traverse<'a>>(
     traverser.enter_chain_element(&mut *node, ctx);
     match &mut *node {
         ChainElement::CallExpression(node) => {
-            walk_call_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_call_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         ChainElement::ComputedMemberExpression(_)
         | ChainElement::StaticMemberExpression(_)
         | ChainElement::PrivateFieldExpression(_) => {
-            walk_member_expression(traverser, node.cast(), ctx)
+            walk_member_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_chain_element(&mut *node, ctx);
@@ -1365,9 +1298,8 @@ pub(crate) unsafe fn walk_parenthesized_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_PARENTHESIZED_EXPRESSION_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_PARENTHESIZED_EXPRESSION_EXPRESSION)
+            as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1382,58 +1314,56 @@ pub(crate) unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
     traverser.enter_statement(&mut *node, ctx);
     match &mut *node {
         Statement::BlockStatement(node) => {
-            walk_block_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_block_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::BreakStatement(node) => {
-            walk_break_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_break_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ContinueStatement(node) => {
-            walk_continue_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_continue_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::DebuggerStatement(node) => {
-            walk_debugger_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_debugger_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::DoWhileStatement(node) => {
-            walk_do_while_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_do_while_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::EmptyStatement(node) => {
-            walk_empty_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_empty_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ExpressionStatement(node) => {
-            walk_expression_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_expression_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ForInStatement(node) => {
-            walk_for_in_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_for_in_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ForOfStatement(node) => {
-            walk_for_of_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_for_of_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ForStatement(node) => {
-            walk_for_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_for_statement(traverser, (&mut **node) as *mut _, ctx)
         }
-        Statement::IfStatement(node) => {
-            walk_if_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        Statement::IfStatement(node) => walk_if_statement(traverser, (&mut **node) as *mut _, ctx),
         Statement::LabeledStatement(node) => {
-            walk_labeled_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_labeled_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ReturnStatement(node) => {
-            walk_return_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_return_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::SwitchStatement(node) => {
-            walk_switch_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_switch_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::ThrowStatement(node) => {
-            walk_throw_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_throw_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::TryStatement(node) => {
-            walk_try_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_try_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::WhileStatement(node) => {
-            walk_while_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_while_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::WithStatement(node) => {
-            walk_with_statement(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_with_statement(traverser, (&mut **node) as *mut _, ctx)
         }
         Statement::VariableDeclaration(_)
         | Statement::FunctionDeclaration(_)
@@ -1442,14 +1372,16 @@ pub(crate) unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
         | Statement::TSInterfaceDeclaration(_)
         | Statement::TSEnumDeclaration(_)
         | Statement::TSModuleDeclaration(_)
-        | Statement::TSImportEqualsDeclaration(_) => walk_declaration(traverser, node.cast(), ctx),
+        | Statement::TSImportEqualsDeclaration(_) => {
+            walk_declaration(traverser, node as *mut _, ctx)
+        }
         Statement::ImportDeclaration(_)
         | Statement::ExportAllDeclaration(_)
         | Statement::ExportDefaultDeclaration(_)
         | Statement::ExportNamedDeclaration(_)
         | Statement::TSExportAssignment(_)
         | Statement::TSNamespaceExportDeclaration(_) => {
-            walk_module_declaration(traverser, node.cast(), ctx)
+            walk_module_declaration(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_statement(&mut *node, ctx);
@@ -1466,7 +1398,7 @@ pub(crate) unsafe fn walk_directive<'a, Tr: Traverse<'a>>(
     ));
     walk_string_literal(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_DIRECTIVE_EXPRESSION).cast::<StringLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_DIRECTIVE_EXPRESSION) as *mut StringLiteral,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1490,19 +1422,17 @@ pub(crate) unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
     traverser.enter_block_statement(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_BLOCK_STATEMENT_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::BlockStatementBody(
         ancestor::BlockStatementWithoutBody(node, PhantomData),
     ));
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BLOCK_STATEMENT_BODY).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1518,28 +1448,26 @@ pub(crate) unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
     traverser.enter_declaration(&mut *node, ctx);
     match &mut *node {
         Declaration::VariableDeclaration(node) => {
-            walk_variable_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         Declaration::FunctionDeclaration(node) => {
-            walk_function(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
         }
-        Declaration::ClassDeclaration(node) => {
-            walk_class(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        Declaration::ClassDeclaration(node) => walk_class(traverser, (&mut **node) as *mut _, ctx),
         Declaration::TSTypeAliasDeclaration(node) => {
-            walk_ts_type_alias_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_alias_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         Declaration::TSInterfaceDeclaration(node) => {
-            walk_ts_interface_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_interface_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         Declaration::TSEnumDeclaration(node) => {
-            walk_ts_enum_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_enum_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         Declaration::TSModuleDeclaration(node) => {
-            walk_ts_module_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_module_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         Declaration::TSImportEqualsDeclaration(node) => {
-            walk_ts_import_equals_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_import_equals_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_declaration(&mut *node, ctx);
@@ -1554,13 +1482,11 @@ pub(crate) unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::VariableDeclarationDeclarations(
         ancestor::VariableDeclarationWithoutDeclarations(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_VARIABLE_DECLARATION_DECLARATIONS)
-        .cast::<Vec<VariableDeclarator>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATION_DECLARATIONS)
+        as *mut Vec<VariableDeclarator>))
+        .iter_mut()
     {
-        walk_variable_declarator(traverser, std::ptr::from_mut(item), ctx);
+        walk_variable_declarator(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_variable_declaration(&mut *node, ctx);
@@ -1577,16 +1503,14 @@ pub(crate) unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_VARIABLE_DECLARATOR_ID).cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATOR_ID) as *mut BindingPattern,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_VARIABLE_DECLARATOR_INIT)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATOR_INIT)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::VariableDeclaratorInit);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_variable_declarator(&mut *node, ctx);
@@ -1612,9 +1536,7 @@ pub(crate) unsafe fn walk_expression_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_EXPRESSION_STATEMENT_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPRESSION_STATEMENT_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1631,22 +1553,20 @@ pub(crate) unsafe fn walk_if_statement<'a, Tr: Traverse<'a>>(
         .push_stack(Ancestor::IfStatementTest(ancestor::IfStatementWithoutTest(node, PhantomData)));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IF_STATEMENT_TEST).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_TEST) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::IfStatementConsequent);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IF_STATEMENT_CONSEQUENT).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_CONSEQUENT) as *mut Statement,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_IF_STATEMENT_ALTERNATE)
-        .cast::<Option<Statement>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_ALTERNATE)
+        as *mut Option<Statement>)
     {
         ctx.retag_stack(AncestorType::IfStatementAlternate);
-        walk_statement(traverser, std::ptr::from_mut(field), ctx);
+        walk_statement(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_if_statement(&mut *node, ctx);
@@ -1663,13 +1583,13 @@ pub(crate) unsafe fn walk_do_while_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_DO_WHILE_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_DO_WHILE_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.retag_stack(AncestorType::DoWhileStatementTest);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_DO_WHILE_STATEMENT_TEST).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_DO_WHILE_STATEMENT_TEST) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1687,13 +1607,13 @@ pub(crate) unsafe fn walk_while_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_WHILE_STATEMENT_TEST).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_WHILE_STATEMENT_TEST) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::WhileStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_WHILE_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_WHILE_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1708,44 +1628,36 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
     traverser.enter_for_statement(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::ForStatementInit(ancestor::ForStatementWithoutInit(
         node,
         PhantomData,
     )));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FOR_STATEMENT_INIT)
-        .cast::<Option<ForStatementInit>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_INIT)
+        as *mut Option<ForStatementInit>)
     {
-        walk_for_statement_init(traverser, std::ptr::from_mut(field), ctx);
+        walk_for_statement_init(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FOR_STATEMENT_TEST)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_TEST)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::ForStatementTest);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FOR_STATEMENT_UPDATE)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_UPDATE)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::ForStatementUpdate);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ForStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1761,7 +1673,7 @@ pub(crate) unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
     traverser.enter_for_statement_init(&mut *node, ctx);
     match &mut *node {
         ForStatementInit::VariableDeclaration(node) => {
-            walk_variable_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ForStatementInit::BooleanLiteral(_)
         | ForStatementInit::NullLiteral(_)
@@ -1805,7 +1717,7 @@ pub(crate) unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
         | ForStatementInit::ComputedMemberExpression(_)
         | ForStatementInit::StaticMemberExpression(_)
         | ForStatementInit::PrivateFieldExpression(_) => {
-            walk_expression(traverser, node.cast(), ctx)
+            walk_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_for_statement_init(&mut *node, ctx);
@@ -1819,31 +1731,29 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
     traverser.enter_for_in_statement(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::ForInStatementLeft(
         ancestor::ForInStatementWithoutLeft(node, PhantomData),
     ));
     walk_for_statement_left(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_IN_STATEMENT_LEFT).cast::<ForStatementLeft>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_LEFT) as *mut ForStatementLeft,
         ctx,
     );
     ctx.retag_stack(AncestorType::ForInStatementRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_IN_STATEMENT_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ForInStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_IN_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1859,7 +1769,7 @@ pub(crate) unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
     traverser.enter_for_statement_left(&mut *node, ctx);
     match &mut *node {
         ForStatementLeft::VariableDeclaration(node) => {
-            walk_variable_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ForStatementLeft::AssignmentTargetIdentifier(_)
         | ForStatementLeft::TSAsExpression(_)
@@ -1872,7 +1782,7 @@ pub(crate) unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
         | ForStatementLeft::ComputedMemberExpression(_)
         | ForStatementLeft::StaticMemberExpression(_)
         | ForStatementLeft::PrivateFieldExpression(_) => {
-            walk_assignment_target(traverser, node.cast(), ctx)
+            walk_assignment_target(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_for_statement_left(&mut *node, ctx);
@@ -1886,31 +1796,29 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
     traverser.enter_for_of_statement(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::ForOfStatementLeft(
         ancestor::ForOfStatementWithoutLeft(node, PhantomData),
     ));
     walk_for_statement_left(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_OF_STATEMENT_LEFT).cast::<ForStatementLeft>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_LEFT) as *mut ForStatementLeft,
         ctx,
     );
     ctx.retag_stack(AncestorType::ForOfStatementRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_OF_STATEMENT_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ForOfStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FOR_OF_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1927,12 +1835,10 @@ pub(crate) unsafe fn walk_continue_statement<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ContinueStatementLabel(
         ancestor::ContinueStatementWithoutLabel(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CONTINUE_STATEMENT_LABEL)
-        .cast::<Option<LabelIdentifier>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CONTINUE_STATEMENT_LABEL)
+        as *mut Option<LabelIdentifier>)
     {
-        walk_label_identifier(traverser, std::ptr::from_mut(field), ctx);
+        walk_label_identifier(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_continue_statement(&mut *node, ctx);
@@ -1947,12 +1853,10 @@ pub(crate) unsafe fn walk_break_statement<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::BreakStatementLabel(
         ancestor::BreakStatementWithoutLabel(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_BREAK_STATEMENT_LABEL)
-        .cast::<Option<LabelIdentifier>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_BREAK_STATEMENT_LABEL)
+        as *mut Option<LabelIdentifier>)
     {
-        walk_label_identifier(traverser, std::ptr::from_mut(field), ctx);
+        walk_label_identifier(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_break_statement(&mut *node, ctx);
@@ -1967,12 +1871,10 @@ pub(crate) unsafe fn walk_return_statement<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ReturnStatementArgument(
         ancestor::ReturnStatementWithoutArgument(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_RETURN_STATEMENT_ARGUMENT)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_RETURN_STATEMENT_ARGUMENT)
+        as *mut Option<Expression>)
     {
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_return_statement(&mut *node, ctx);
@@ -1989,13 +1891,13 @@ pub(crate) unsafe fn walk_with_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_WITH_STATEMENT_OBJECT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_WITH_STATEMENT_OBJECT) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::WithStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_WITH_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_WITH_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2013,26 +1915,22 @@ pub(crate) unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_SWITCH_STATEMENT_DISCRIMINANT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_DISCRIMINANT) as *mut Expression,
         ctx,
     );
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_SWITCH_STATEMENT_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     ctx.retag_stack(AncestorType::SwitchStatementCases);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
-        .cast::<Vec<SwitchCase>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
+        as *mut Vec<SwitchCase>))
+        .iter_mut()
     {
-        walk_switch_case(traverser, std::ptr::from_mut(item), ctx);
+        walk_switch_case(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -2047,17 +1945,15 @@ pub(crate) unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
     traverser.enter_switch_case(&mut *node, ctx);
     let pop_token = ctx
         .push_stack(Ancestor::SwitchCaseTest(ancestor::SwitchCaseWithoutTest(node, PhantomData)));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_SWITCH_CASE_TEST)
-        .cast::<Option<Expression>>())
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_TEST) as *mut Option<Expression>)
     {
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::SwitchCaseConsequent);
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2075,13 +1971,13 @@ pub(crate) unsafe fn walk_labeled_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_label_identifier(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_LABELED_STATEMENT_LABEL).cast::<LabelIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_LABELED_STATEMENT_LABEL) as *mut LabelIdentifier,
         ctx,
     );
     ctx.retag_stack(AncestorType::LabeledStatementBody);
     walk_statement(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_LABELED_STATEMENT_BODY).cast::<Statement>(),
+        (node as *mut u8).add(ancestor::OFFSET_LABELED_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2099,7 +1995,7 @@ pub(crate) unsafe fn walk_throw_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_THROW_STATEMENT_ARGUMENT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_THROW_STATEMENT_ARGUMENT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2117,29 +2013,21 @@ pub(crate) unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_block_statement(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TRY_STATEMENT_BLOCK)
-                .cast::<Box<BlockStatement>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_BLOCK)
+            as *mut Box<BlockStatement>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TRY_STATEMENT_HANDLER)
-        .cast::<Option<Box<CatchClause>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_HANDLER)
+        as *mut Option<Box<CatchClause>>)
     {
         ctx.retag_stack(AncestorType::TryStatementHandler);
-        walk_catch_clause(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_catch_clause(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TRY_STATEMENT_FINALIZER)
-        .cast::<Option<Box<BlockStatement>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_FINALIZER)
+        as *mut Option<Box<BlockStatement>>)
     {
         ctx.retag_stack(AncestorType::TryStatementFinalizer);
-        walk_block_statement(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_block_statement(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_try_statement(&mut *node, ctx);
@@ -2153,33 +2041,25 @@ pub(crate) unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
     traverser.enter_catch_clause(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_CATCH_CLAUSE_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::CatchClauseParam(ancestor::CatchClauseWithoutParam(
         node,
         PhantomData,
     )));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CATCH_CLAUSE_PARAM)
-        .cast::<Option<CatchParameter>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_PARAM)
+        as *mut Option<CatchParameter>)
     {
-        walk_catch_parameter(traverser, std::ptr::from_mut(field), ctx);
+        walk_catch_parameter(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::CatchClauseBody);
     walk_block_statement(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_CATCH_CLAUSE_BODY)
-                .cast::<Box<BlockStatement>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_BODY)
+            as *mut Box<BlockStatement>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2198,7 +2078,7 @@ pub(crate) unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_CATCH_PARAMETER_PATTERN).cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_CATCH_PARAMETER_PATTERN) as *mut BindingPattern,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2225,16 +2105,15 @@ pub(crate) unsafe fn walk_binding_pattern<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_pattern_kind(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BINDING_PATTERN_KIND).cast::<BindingPatternKind>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_PATTERN_KIND) as *mut BindingPatternKind,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_BINDING_PATTERN_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::BindingPatternTypeAnnotation);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_binding_pattern(&mut *node, ctx);
@@ -2248,16 +2127,16 @@ pub(crate) unsafe fn walk_binding_pattern_kind<'a, Tr: Traverse<'a>>(
     traverser.enter_binding_pattern_kind(&mut *node, ctx);
     match &mut *node {
         BindingPatternKind::BindingIdentifier(node) => {
-            walk_binding_identifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_binding_identifier(traverser, (&mut **node) as *mut _, ctx)
         }
         BindingPatternKind::ObjectPattern(node) => {
-            walk_object_pattern(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_object_pattern(traverser, (&mut **node) as *mut _, ctx)
         }
         BindingPatternKind::ArrayPattern(node) => {
-            walk_array_pattern(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_array_pattern(traverser, (&mut **node) as *mut _, ctx)
         }
         BindingPatternKind::AssignmentPattern(node) => {
-            walk_assignment_pattern(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_assignment_pattern(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_binding_pattern_kind(&mut *node, ctx);
@@ -2274,13 +2153,13 @@ pub(crate) unsafe fn walk_assignment_pattern<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_ASSIGNMENT_PATTERN_LEFT).cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_PATTERN_LEFT) as *mut BindingPattern,
         ctx,
     );
     ctx.retag_stack(AncestorType::AssignmentPatternRight);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_ASSIGNMENT_PATTERN_RIGHT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_PATTERN_RIGHT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2296,21 +2175,17 @@ pub(crate) unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ObjectPatternProperties(
         ancestor::ObjectPatternWithoutProperties(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_OBJECT_PATTERN_PROPERTIES)
-        .cast::<Vec<BindingProperty>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_PROPERTIES)
+        as *mut Vec<BindingProperty>))
+        .iter_mut()
     {
-        walk_binding_property(traverser, std::ptr::from_mut(item), ctx);
+        walk_binding_property(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_OBJECT_PATTERN_REST)
-        .cast::<Option<Box<BindingRestElement>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_REST)
+        as *mut Option<Box<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ObjectPatternRest);
-        walk_binding_rest_element(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_object_pattern(&mut *node, ctx);
@@ -2327,13 +2202,13 @@ pub(crate) unsafe fn walk_binding_property<'a, Tr: Traverse<'a>>(
     ));
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BINDING_PROPERTY_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_PROPERTY_KEY) as *mut PropertyKey,
         ctx,
     );
     ctx.retag_stack(AncestorType::BindingPropertyValue);
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_BINDING_PROPERTY_VALUE).cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_PROPERTY_VALUE) as *mut BindingPattern,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2349,22 +2224,18 @@ pub(crate) unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ArrayPatternElements(
         ancestor::ArrayPatternWithoutElements(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ARRAY_PATTERN_ELEMENTS)
-        .cast::<Vec<Option<BindingPattern>>>()))
-    .iter_mut()
-    .flatten()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_ELEMENTS)
+        as *mut Vec<Option<BindingPattern>>))
+        .iter_mut()
+        .flatten()
     {
-        walk_binding_pattern(traverser, std::ptr::from_mut(item), ctx);
+        walk_binding_pattern(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ARRAY_PATTERN_REST)
-        .cast::<Option<Box<BindingRestElement>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_REST)
+        as *mut Option<Box<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ArrayPatternRest);
-        walk_binding_rest_element(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_array_pattern(&mut *node, ctx);
@@ -2381,9 +2252,8 @@ pub(crate) unsafe fn walk_binding_rest_element<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_BINDING_REST_ELEMENT_ARGUMENT)
-            .cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_REST_ELEMENT_ARGUMENT)
+            as *mut BindingPattern,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2398,64 +2268,48 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
     traverser.enter_function(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_FUNCTION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token =
         ctx.push_stack(Ancestor::FunctionId(ancestor::FunctionWithoutId(node, PhantomData)));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_ID)
-        .cast::<Option<BindingIdentifier>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_ID)
+        as *mut Option<BindingIdentifier>)
     {
-        walk_binding_identifier(traverser, std::ptr::from_mut(field), ctx);
+        walk_binding_identifier(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::FunctionTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
-        .cast::<Option<Box<TSThisParameter>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::FunctionThisParam);
-        walk_ts_this_parameter(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionParams);
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_FUNCTION_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_FUNCTION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FunctionReturnType);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_BODY)
-        .cast::<Option<Box<FunctionBody>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
+        as *mut Option<Box<FunctionBody>>)
     {
         ctx.retag_stack(AncestorType::FunctionBody);
-        walk_function_body(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_function_body(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -2471,21 +2325,17 @@ pub(crate) unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::FormalParametersItems(
         ancestor::FormalParametersWithoutItems(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FORMAL_PARAMETERS_ITEMS)
-        .cast::<Vec<FormalParameter>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_ITEMS)
+        as *mut Vec<FormalParameter>))
+        .iter_mut()
     {
-        walk_formal_parameter(traverser, std::ptr::from_mut(item), ctx);
+        walk_formal_parameter(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FORMAL_PARAMETERS_REST)
-        .cast::<Option<Box<BindingRestElement>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_REST)
+        as *mut Option<Box<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::FormalParametersRest);
-        walk_binding_rest_element(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_formal_parameters(&mut *node, ctx);
@@ -2500,18 +2350,16 @@ pub(crate) unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::FormalParameterDecorators(
         ancestor::FormalParameterWithoutDecorators(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FORMAL_PARAMETER_DECORATORS)
-        .cast::<Vec<Decorator>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_DECORATORS)
+        as *mut Vec<Decorator>))
+        .iter_mut()
     {
-        walk_decorator(traverser, std::ptr::from_mut(item), ctx);
+        walk_decorator(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FormalParameterPattern);
     walk_binding_pattern(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FORMAL_PARAMETER_PATTERN).cast::<BindingPattern>(),
+        (node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_PATTERN) as *mut BindingPattern,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2527,18 +2375,16 @@ pub(crate) unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::FunctionBodyDirectives(
         ancestor::FunctionBodyWithoutDirectives(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
-        .cast::<Vec<Directive>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
+        as *mut Vec<Directive>))
+        .iter_mut()
     {
-        walk_directive(traverser, std::ptr::from_mut(item), ctx);
+        walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionBodyStatements);
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2553,51 +2399,39 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     traverser.enter_arrow_function_expression(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::ArrowFunctionExpressionTypeParameters(
         ancestor::ArrowFunctionExpressionWithoutTypeParameters(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ArrowFunctionExpressionParams);
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ArrowFunctionExpressionBody);
     walk_function_body(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                .cast::<Box<FunctionBody>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
+            as *mut Box<FunctionBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2614,12 +2448,10 @@ pub(crate) unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::YieldExpressionArgument(
         ancestor::YieldExpressionWithoutArgument(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_YIELD_EXPRESSION_ARGUMENT)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_YIELD_EXPRESSION_ARGUMENT)
+        as *mut Option<Expression>)
     {
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_yield_expression(&mut *node, ctx);
@@ -2633,64 +2465,54 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     traverser.enter_class(&mut *node, ctx);
     let pop_token = ctx
         .push_stack(Ancestor::ClassDecorators(ancestor::ClassWithoutDecorators(node, PhantomData)));
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_CLASS_DECORATORS).cast::<Vec<Decorator>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut Vec<Decorator>))
+        .iter_mut()
     {
-        walk_decorator(traverser, std::ptr::from_mut(item), ctx);
+        walk_decorator(traverser, item as *mut _, ctx);
     }
     if let Some(field) =
-        &mut *(node.cast::<u8>().add(ancestor::OFFSET_CLASS_ID).cast::<Option<BindingIdentifier>>())
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_ID) as *mut Option<BindingIdentifier>)
     {
         ctx.retag_stack(AncestorType::ClassId);
-        walk_binding_identifier(traverser, std::ptr::from_mut(field), ctx);
+        walk_binding_identifier(traverser, field as *mut _, ctx);
     }
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node.cast::<u8>().add(ancestor::OFFSET_CLASS_SCOPE_ID).cast::<Cell<Option<ScopeId>>>()))
+        (*((node as *mut u8).add(ancestor::OFFSET_CLASS_SCOPE_ID) as *mut Cell<Option<ScopeId>>))
             .get()
             .unwrap(),
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::ClassTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CLASS_SUPER_CLASS)
-        .cast::<Option<Expression>>())
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_CLASS) as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::ClassSuperClass);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::ClassSuperTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_CLASS_IMPLEMENTS)
-        .cast::<Option<Vec<TSClassImplements>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_IMPLEMENTS)
+        as *mut Option<Vec<TSClassImplements>>)
     {
         ctx.retag_stack(AncestorType::ClassImplements);
         for item in field.iter_mut() {
-            walk_ts_class_implements(traverser, std::ptr::from_mut(item), ctx);
+            walk_ts_class_implements(traverser, item as *mut _, ctx);
         }
     }
     ctx.retag_stack(AncestorType::ClassBody);
     walk_class_body(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node.cast::<u8>().add(ancestor::OFFSET_CLASS_BODY).cast::<Box<ClassBody>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut Box<ClassBody>))
+            as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2706,11 +2528,11 @@ pub(crate) unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
     traverser.enter_class_body(&mut *node, ctx);
     let pop_token =
         ctx.push_stack(Ancestor::ClassBodyBody(ancestor::ClassBodyWithoutBody(node, PhantomData)));
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_CLASS_BODY_BODY).cast::<Vec<ClassElement>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY)
+        as *mut Vec<ClassElement>))
+        .iter_mut()
     {
-        walk_class_element(traverser, std::ptr::from_mut(item), ctx);
+        walk_class_element(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_class_body(&mut *node, ctx);
@@ -2724,19 +2546,19 @@ pub(crate) unsafe fn walk_class_element<'a, Tr: Traverse<'a>>(
     traverser.enter_class_element(&mut *node, ctx);
     match &mut *node {
         ClassElement::StaticBlock(node) => {
-            walk_static_block(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_static_block(traverser, (&mut **node) as *mut _, ctx)
         }
         ClassElement::MethodDefinition(node) => {
-            walk_method_definition(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_method_definition(traverser, (&mut **node) as *mut _, ctx)
         }
         ClassElement::PropertyDefinition(node) => {
-            walk_property_definition(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_property_definition(traverser, (&mut **node) as *mut _, ctx)
         }
         ClassElement::AccessorProperty(node) => {
-            walk_accessor_property(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_accessor_property(traverser, (&mut **node) as *mut _, ctx)
         }
         ClassElement::TSIndexSignature(node) => {
-            walk_ts_index_signature(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_index_signature(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_class_element(&mut *node, ctx);
@@ -2751,29 +2573,23 @@ pub(crate) unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::MethodDefinitionDecorators(
         ancestor::MethodDefinitionWithoutDecorators(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_METHOD_DEFINITION_DECORATORS)
-        .cast::<Vec<Decorator>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_DECORATORS)
+        as *mut Vec<Decorator>))
+        .iter_mut()
     {
-        walk_decorator(traverser, std::ptr::from_mut(item), ctx);
+        walk_decorator(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::MethodDefinitionKey);
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_METHOD_DEFINITION_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_KEY) as *mut PropertyKey,
         ctx,
     );
     ctx.retag_stack(AncestorType::MethodDefinitionValue);
     walk_function(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
-                .cast::<Box<Function>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
+            as *mut Box<Function>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2789,35 +2605,30 @@ pub(crate) unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::PropertyDefinitionDecorators(
         ancestor::PropertyDefinitionWithoutDecorators(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_PROPERTY_DEFINITION_DECORATORS)
-        .cast::<Vec<Decorator>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_DECORATORS)
+        as *mut Vec<Decorator>))
+        .iter_mut()
     {
-        walk_decorator(traverser, std::ptr::from_mut(item), ctx);
+        walk_decorator(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::PropertyDefinitionKey);
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_PROPERTY_DEFINITION_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_KEY) as *mut PropertyKey,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_PROPERTY_DEFINITION_VALUE)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_VALUE)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::PropertyDefinitionValue);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::PropertyDefinitionTypeAnnotation);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_property_definition(&mut *node, ctx);
@@ -2840,18 +2651,16 @@ pub(crate) unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
     traverser.enter_static_block(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_STATIC_BLOCK_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx
         .push_stack(Ancestor::StaticBlockBody(ancestor::StaticBlockWithoutBody(node, PhantomData)));
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_STATIC_BLOCK_BODY).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2867,22 +2676,22 @@ pub(crate) unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
     traverser.enter_module_declaration(&mut *node, ctx);
     match &mut *node {
         ModuleDeclaration::ImportDeclaration(node) => {
-            walk_import_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_import_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ModuleDeclaration::ExportAllDeclaration(node) => {
-            walk_export_all_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_export_all_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ModuleDeclaration::ExportDefaultDeclaration(node) => {
-            walk_export_default_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_export_default_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ModuleDeclaration::ExportNamedDeclaration(node) => {
-            walk_export_named_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_export_named_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ModuleDeclaration::TSExportAssignment(node) => {
-            walk_ts_export_assignment(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_export_assignment(traverser, (&mut **node) as *mut _, ctx)
         }
         ModuleDeclaration::TSNamespaceExportDeclaration(node) => {
-            walk_ts_namespace_export_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_namespace_export_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_module_declaration(&mut *node, ctx);
@@ -2897,35 +2706,30 @@ pub(crate) unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::AccessorPropertyDecorators(
         ancestor::AccessorPropertyWithoutDecorators(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-        .cast::<Vec<Decorator>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_DECORATORS)
+        as *mut Vec<Decorator>))
+        .iter_mut()
     {
-        walk_decorator(traverser, std::ptr::from_mut(item), ctx);
+        walk_decorator(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::AccessorPropertyKey);
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_ACCESSOR_PROPERTY_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_KEY) as *mut PropertyKey,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_ACCESSOR_PROPERTY_VALUE)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_VALUE)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::AccessorPropertyValue);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::AccessorPropertyTypeAnnotation);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_accessor_property(&mut *node, ctx);
@@ -2942,17 +2746,15 @@ pub(crate) unsafe fn walk_import_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IMPORT_EXPRESSION_SOURCE).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_EXPRESSION_SOURCE) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::ImportExpressionArguments);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_IMPORT_EXPRESSION_ARGUMENTS)
-        .cast::<Vec<Expression>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_IMPORT_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Expression>))
+        .iter_mut()
     {
-        walk_expression(traverser, std::ptr::from_mut(item), ctx);
+        walk_expression(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_import_expression(&mut *node, ctx);
@@ -2967,28 +2769,26 @@ pub(crate) unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ImportDeclarationSpecifiers(
         ancestor::ImportDeclarationWithoutSpecifiers(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-        .cast::<Option<Vec<ImportDeclarationSpecifier>>>())
+        as *mut Option<Vec<ImportDeclarationSpecifier>>)
     {
         for item in field.iter_mut() {
-            walk_import_declaration_specifier(traverser, std::ptr::from_mut(item), ctx);
+            walk_import_declaration_specifier(traverser, item as *mut _, ctx);
         }
     }
     ctx.retag_stack(AncestorType::ImportDeclarationSource);
     walk_string_literal(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IMPORT_DECLARATION_SOURCE).cast::<StringLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_DECLARATION_SOURCE) as *mut StringLiteral,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-        .cast::<Option<WithClause>>())
+        as *mut Option<WithClause>)
     {
         ctx.retag_stack(AncestorType::ImportDeclarationWithClause);
-        walk_with_clause(traverser, std::ptr::from_mut(field), ctx);
+        walk_with_clause(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_import_declaration(&mut *node, ctx);
@@ -3002,13 +2802,13 @@ pub(crate) unsafe fn walk_import_declaration_specifier<'a, Tr: Traverse<'a>>(
     traverser.enter_import_declaration_specifier(&mut *node, ctx);
     match &mut *node {
         ImportDeclarationSpecifier::ImportSpecifier(node) => {
-            walk_import_specifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_import_specifier(traverser, (&mut **node) as *mut _, ctx)
         }
         ImportDeclarationSpecifier::ImportDefaultSpecifier(node) => {
-            walk_import_default_specifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_import_default_specifier(traverser, (&mut **node) as *mut _, ctx)
         }
         ImportDeclarationSpecifier::ImportNamespaceSpecifier(node) => {
-            walk_import_namespace_specifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_import_namespace_specifier(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_import_declaration_specifier(&mut *node, ctx);
@@ -3025,15 +2825,13 @@ pub(crate) unsafe fn walk_import_specifier<'a, Tr: Traverse<'a>>(
     ));
     walk_module_export_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_IMPORT_SPECIFIER_IMPORTED)
-            .cast::<ModuleExportName>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_SPECIFIER_IMPORTED) as *mut ModuleExportName,
         ctx,
     );
     ctx.retag_stack(AncestorType::ImportSpecifierLocal);
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IMPORT_SPECIFIER_LOCAL).cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_SPECIFIER_LOCAL) as *mut BindingIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3051,9 +2849,8 @@ pub(crate) unsafe fn walk_import_default_specifier<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_IMPORT_DEFAULT_SPECIFIER_LOCAL)
-            .cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_DEFAULT_SPECIFIER_LOCAL)
+            as *mut BindingIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3071,9 +2868,8 @@ pub(crate) unsafe fn walk_import_namespace_specifier<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_IMPORT_NAMESPACE_SPECIFIER_LOCAL)
-            .cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_NAMESPACE_SPECIFIER_LOCAL)
+            as *mut BindingIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3091,19 +2887,16 @@ pub(crate) unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
     ));
     walk_identifier_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_WITH_CLAUSE_ATTRIBUTES_KEYWORD)
-            .cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_WITH_CLAUSE_ATTRIBUTES_KEYWORD)
+            as *mut IdentifierName,
         ctx,
     );
     ctx.retag_stack(AncestorType::WithClauseWithEntries);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_WITH_CLAUSE_WITH_ENTRIES)
-        .cast::<Vec<ImportAttribute>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_WITH_CLAUSE_WITH_ENTRIES)
+        as *mut Vec<ImportAttribute>))
+        .iter_mut()
     {
-        walk_import_attribute(traverser, std::ptr::from_mut(item), ctx);
+        walk_import_attribute(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_with_clause(&mut *node, ctx);
@@ -3120,13 +2913,13 @@ pub(crate) unsafe fn walk_import_attribute<'a, Tr: Traverse<'a>>(
     ));
     walk_import_attribute_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IMPORT_ATTRIBUTE_KEY).cast::<ImportAttributeKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_ATTRIBUTE_KEY) as *mut ImportAttributeKey,
         ctx,
     );
     ctx.retag_stack(AncestorType::ImportAttributeValue);
     walk_string_literal(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_IMPORT_ATTRIBUTE_VALUE).cast::<StringLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_ATTRIBUTE_VALUE) as *mut StringLiteral,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3141,10 +2934,10 @@ pub(crate) unsafe fn walk_import_attribute_key<'a, Tr: Traverse<'a>>(
     traverser.enter_import_attribute_key(&mut *node, ctx);
     match &mut *node {
         ImportAttributeKey::Identifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(node), ctx)
+            walk_identifier_name(traverser, node as *mut _, ctx)
         }
         ImportAttributeKey::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(node), ctx)
+            walk_string_literal(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_import_attribute_key(&mut *node, ctx);
@@ -3159,37 +2952,32 @@ pub(crate) unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ExportNamedDeclarationDeclaration(
         ancestor::ExportNamedDeclarationWithoutDeclaration(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_DECLARATION)
-        .cast::<Option<Declaration>>())
+        as *mut Option<Declaration>)
     {
-        walk_declaration(traverser, std::ptr::from_mut(field), ctx);
+        walk_declaration(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ExportNamedDeclarationSpecifiers);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-        .cast::<Vec<ExportSpecifier>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
+        as *mut Vec<ExportSpecifier>))
+        .iter_mut()
     {
-        walk_export_specifier(traverser, std::ptr::from_mut(item), ctx);
+        walk_export_specifier(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SOURCE)
-        .cast::<Option<StringLiteral>>())
+        as *mut Option<StringLiteral>)
     {
         ctx.retag_stack(AncestorType::ExportNamedDeclarationSource);
-        walk_string_literal(traverser, std::ptr::from_mut(field), ctx);
+        walk_string_literal(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-        .cast::<Option<WithClause>>())
+        as *mut Option<WithClause>)
     {
         ctx.retag_stack(AncestorType::ExportNamedDeclarationWithClause);
-        walk_with_clause(traverser, std::ptr::from_mut(field), ctx);
+        walk_with_clause(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_export_named_declaration(&mut *node, ctx);
@@ -3206,17 +2994,15 @@ pub(crate) unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_export_default_declaration_kind(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
-            .cast::<ExportDefaultDeclarationKind>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
+            as *mut ExportDefaultDeclarationKind,
         ctx,
     );
     ctx.retag_stack(AncestorType::ExportDefaultDeclarationExported);
     walk_module_export_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-            .cast::<ModuleExportName>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
+            as *mut ModuleExportName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3232,28 +3018,24 @@ pub(crate) unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::ExportAllDeclarationExported(
         ancestor::ExportAllDeclarationWithoutExported(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_EXPORTED)
-        .cast::<Option<ModuleExportName>>())
+        as *mut Option<ModuleExportName>)
     {
-        walk_module_export_name(traverser, std::ptr::from_mut(field), ctx);
+        walk_module_export_name(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ExportAllDeclarationSource);
     walk_string_literal(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_SOURCE)
-            .cast::<StringLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_SOURCE) as *mut StringLiteral,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-        .cast::<Option<WithClause>>())
+        as *mut Option<WithClause>)
     {
         ctx.retag_stack(AncestorType::ExportAllDeclarationWithClause);
-        walk_with_clause(traverser, std::ptr::from_mut(field), ctx);
+        walk_with_clause(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_export_all_declaration(&mut *node, ctx);
@@ -3270,15 +3052,13 @@ pub(crate) unsafe fn walk_export_specifier<'a, Tr: Traverse<'a>>(
     ));
     walk_module_export_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_EXPORT_SPECIFIER_LOCAL).cast::<ModuleExportName>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_SPECIFIER_LOCAL) as *mut ModuleExportName,
         ctx,
     );
     ctx.retag_stack(AncestorType::ExportSpecifierExported);
     walk_module_export_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_EXPORT_SPECIFIER_EXPORTED)
-            .cast::<ModuleExportName>(),
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_SPECIFIER_EXPORTED) as *mut ModuleExportName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3293,13 +3073,13 @@ pub(crate) unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
     traverser.enter_export_default_declaration_kind(&mut *node, ctx);
     match &mut *node {
         ExportDefaultDeclarationKind::FunctionDeclaration(node) => {
-            walk_function(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
         }
         ExportDefaultDeclarationKind::ClassDeclaration(node) => {
-            walk_class(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_class(traverser, (&mut **node) as *mut _, ctx)
         }
         ExportDefaultDeclarationKind::TSInterfaceDeclaration(node) => {
-            walk_ts_interface_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_interface_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         ExportDefaultDeclarationKind::BooleanLiteral(_)
         | ExportDefaultDeclarationKind::NullLiteral(_)
@@ -3343,7 +3123,7 @@ pub(crate) unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
         | ExportDefaultDeclarationKind::ComputedMemberExpression(_)
         | ExportDefaultDeclarationKind::StaticMemberExpression(_)
         | ExportDefaultDeclarationKind::PrivateFieldExpression(_) => {
-            walk_expression(traverser, node.cast(), ctx)
+            walk_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_export_default_declaration_kind(&mut *node, ctx);
@@ -3357,13 +3137,13 @@ pub(crate) unsafe fn walk_module_export_name<'a, Tr: Traverse<'a>>(
     traverser.enter_module_export_name(&mut *node, ctx);
     match &mut *node {
         ModuleExportName::IdentifierName(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(node), ctx)
+            walk_identifier_name(traverser, node as *mut _, ctx)
         }
         ModuleExportName::IdentifierReference(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(node), ctx)
+            walk_identifier_reference(traverser, node as *mut _, ctx)
         }
         ModuleExportName::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(node), ctx)
+            walk_string_literal(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_module_export_name(&mut *node, ctx);
@@ -3380,28 +3160,22 @@ pub(crate) unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_opening_element(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                .cast::<Box<JSXOpeningElement>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
+            as *mut Box<JSXOpeningElement>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-        .cast::<Option<Box<JSXClosingElement>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
+        as *mut Option<Box<JSXClosingElement>>)
     {
         ctx.retag_stack(AncestorType::JSXElementClosingElement);
-        walk_jsx_closing_element(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::JSXElementChildren);
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN).cast::<Vec<JSXChild>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN)
+        as *mut Vec<JSXChild>))
+        .iter_mut()
     {
-        walk_jsx_child(traverser, std::ptr::from_mut(item), ctx);
+        walk_jsx_child(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_element(&mut *node, ctx);
@@ -3418,25 +3192,22 @@ pub(crate) unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_element_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_JSX_OPENING_ELEMENT_NAME).cast::<JSXElementName>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_NAME) as *mut JSXElementName,
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-        .cast::<Vec<JSXAttributeItem>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
+        as *mut Vec<JSXAttributeItem>))
+        .iter_mut()
     {
-        walk_jsx_attribute_item(traverser, std::ptr::from_mut(item), ctx);
+        walk_jsx_attribute_item(traverser, item as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::JSXOpeningElementTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_opening_element(&mut *node, ctx);
@@ -3453,7 +3224,7 @@ pub(crate) unsafe fn walk_jsx_closing_element<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_element_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_JSX_CLOSING_ELEMENT_NAME).cast::<JSXElementName>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_CLOSING_ELEMENT_NAME) as *mut JSXElementName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3469,11 +3240,11 @@ pub(crate) unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::JSXFragmentChildren(
         ancestor::JSXFragmentWithoutChildren(node, PhantomData),
     ));
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN).cast::<Vec<JSXChild>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN)
+        as *mut Vec<JSXChild>))
+        .iter_mut()
     {
-        walk_jsx_child(traverser, std::ptr::from_mut(item), ctx);
+        walk_jsx_child(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_fragment(&mut *node, ctx);
@@ -3487,19 +3258,19 @@ pub(crate) unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_element_name(&mut *node, ctx);
     match &mut *node {
         JSXElementName::Identifier(node) => {
-            walk_jsx_identifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_identifier(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXElementName::IdentifierReference(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXElementName::NamespacedName(node) => {
-            walk_jsx_namespaced_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_namespaced_name(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXElementName::MemberExpression(node) => {
-            walk_jsx_member_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_member_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXElementName::ThisExpression(node) => {
-            walk_this_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_jsx_element_name(&mut *node, ctx);
@@ -3516,17 +3287,13 @@ pub(crate) unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAMESPACE)
-            .cast::<JSXIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAMESPACE) as *mut JSXIdentifier,
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXNamespacedNameProperty);
     walk_jsx_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JSX_NAMESPACED_NAME_PROPERTY)
-            .cast::<JSXIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_PROPERTY) as *mut JSXIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3544,17 +3311,15 @@ pub(crate) unsafe fn walk_jsx_member_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_member_expression_object(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_OBJECT)
-            .cast::<JSXMemberExpressionObject>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_OBJECT)
+            as *mut JSXMemberExpressionObject,
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXMemberExpressionProperty);
     walk_jsx_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_PROPERTY)
-            .cast::<JSXIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_PROPERTY)
+            as *mut JSXIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3569,13 +3334,13 @@ pub(crate) unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_member_expression_object(&mut *node, ctx);
     match &mut *node {
         JSXMemberExpressionObject::IdentifierReference(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXMemberExpressionObject::MemberExpression(node) => {
-            walk_jsx_member_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_member_expression(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXMemberExpressionObject::ThisExpression(node) => {
-            walk_this_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_jsx_member_expression_object(&mut *node, ctx);
@@ -3592,9 +3357,8 @@ pub(crate) unsafe fn walk_jsx_expression_container<'a, Tr: Traverse<'a>>(
     ));
     walk_jsx_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JSX_EXPRESSION_CONTAINER_EXPRESSION)
-            .cast::<JSXExpression>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_EXPRESSION_CONTAINER_EXPRESSION)
+            as *mut JSXExpression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3609,7 +3373,7 @@ pub(crate) unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_expression(&mut *node, ctx);
     match &mut *node {
         JSXExpression::EmptyExpression(node) => {
-            walk_jsx_empty_expression(traverser, std::ptr::from_mut(node), ctx)
+            walk_jsx_empty_expression(traverser, node as *mut _, ctx)
         }
         JSXExpression::BooleanLiteral(_)
         | JSXExpression::NullLiteral(_)
@@ -3652,7 +3416,9 @@ pub(crate) unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
         | JSXExpression::TSInstantiationExpression(_)
         | JSXExpression::ComputedMemberExpression(_)
         | JSXExpression::StaticMemberExpression(_)
-        | JSXExpression::PrivateFieldExpression(_) => walk_expression(traverser, node.cast(), ctx),
+        | JSXExpression::PrivateFieldExpression(_) => {
+            walk_expression(traverser, node as *mut _, ctx)
+        }
     }
     traverser.exit_jsx_expression(&mut *node, ctx);
 }
@@ -3674,10 +3440,10 @@ pub(crate) unsafe fn walk_jsx_attribute_item<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_attribute_item(&mut *node, ctx);
     match &mut *node {
         JSXAttributeItem::Attribute(node) => {
-            walk_jsx_attribute(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_attribute(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXAttributeItem::SpreadAttribute(node) => {
-            walk_jsx_spread_attribute(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_spread_attribute(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_jsx_attribute_item(&mut *node, ctx);
@@ -3695,16 +3461,14 @@ pub(crate) unsafe fn walk_jsx_attribute<'a, Tr: Traverse<'a>>(
     )));
     walk_jsx_attribute_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_JSX_ATTRIBUTE_NAME).cast::<JSXAttributeName>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_ATTRIBUTE_NAME) as *mut JSXAttributeName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_JSX_ATTRIBUTE_VALUE)
-        .cast::<Option<JSXAttributeValue>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ATTRIBUTE_VALUE)
+        as *mut Option<JSXAttributeValue>)
     {
         ctx.retag_stack(AncestorType::JSXAttributeValue);
-        walk_jsx_attribute_value(traverser, std::ptr::from_mut(field), ctx);
+        walk_jsx_attribute_value(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_attribute(&mut *node, ctx);
@@ -3721,7 +3485,7 @@ pub(crate) unsafe fn walk_jsx_spread_attribute<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_JSX_SPREAD_ATTRIBUTE_ARGUMENT).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_SPREAD_ATTRIBUTE_ARGUMENT) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3736,10 +3500,10 @@ pub(crate) unsafe fn walk_jsx_attribute_name<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_attribute_name(&mut *node, ctx);
     match &mut *node {
         JSXAttributeName::Identifier(node) => {
-            walk_jsx_identifier(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_identifier(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXAttributeName::NamespacedName(node) => {
-            walk_jsx_namespaced_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_namespaced_name(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_jsx_attribute_name(&mut *node, ctx);
@@ -3753,16 +3517,16 @@ pub(crate) unsafe fn walk_jsx_attribute_value<'a, Tr: Traverse<'a>>(
     traverser.enter_jsx_attribute_value(&mut *node, ctx);
     match &mut *node {
         JSXAttributeValue::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXAttributeValue::ExpressionContainer(node) => {
-            walk_jsx_expression_container(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_expression_container(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXAttributeValue::Element(node) => {
-            walk_jsx_element(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_element(traverser, (&mut **node) as *mut _, ctx)
         }
         JSXAttributeValue::Fragment(node) => {
-            walk_jsx_fragment(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_jsx_attribute_value(&mut *node, ctx);
@@ -3784,19 +3548,13 @@ pub(crate) unsafe fn walk_jsx_child<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_jsx_child(&mut *node, ctx);
     match &mut *node {
-        JSXChild::Text(node) => walk_jsx_text(traverser, std::ptr::from_mut(&mut **node), ctx),
-        JSXChild::Element(node) => {
-            walk_jsx_element(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
-        JSXChild::Fragment(node) => {
-            walk_jsx_fragment(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        JSXChild::Text(node) => walk_jsx_text(traverser, (&mut **node) as *mut _, ctx),
+        JSXChild::Element(node) => walk_jsx_element(traverser, (&mut **node) as *mut _, ctx),
+        JSXChild::Fragment(node) => walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx),
         JSXChild::ExpressionContainer(node) => {
-            walk_jsx_expression_container(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_jsx_expression_container(traverser, (&mut **node) as *mut _, ctx)
         }
-        JSXChild::Spread(node) => {
-            walk_jsx_spread_child(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        JSXChild::Spread(node) => walk_jsx_spread_child(traverser, (&mut **node) as *mut _, ctx),
     }
     traverser.exit_jsx_child(&mut *node, ctx);
 }
@@ -3812,7 +3570,7 @@ pub(crate) unsafe fn walk_jsx_spread_child<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_JSX_SPREAD_CHILD_EXPRESSION).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_JSX_SPREAD_CHILD_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -3891,12 +3649,11 @@ pub(crate) unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSThisParameterTypeAnnotation(
         ancestor::TSThisParameterWithoutTypeAnnotation(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_this_parameter(&mut *node, ctx);
@@ -3913,26 +3670,22 @@ pub(crate) unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_ENUM_DECLARATION_ID).cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_ID) as *mut BindingIdentifier,
         ctx,
     );
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_ENUM_DECLARATION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     ctx.retag_stack(AncestorType::TSEnumDeclarationMembers);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_ENUM_DECLARATION_MEMBERS)
-        .cast::<Vec<TSEnumMember>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_MEMBERS)
+        as *mut Vec<TSEnumMember>))
+        .iter_mut()
     {
-        walk_ts_enum_member(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_enum_member(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -3949,16 +3702,14 @@ pub(crate) unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
         .push_stack(Ancestor::TSEnumMemberId(ancestor::TSEnumMemberWithoutId(node, PhantomData)));
     walk_ts_enum_member_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_ENUM_MEMBER_ID).cast::<TSEnumMemberName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_MEMBER_ID) as *mut TSEnumMemberName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_ENUM_MEMBER_INITIALIZER)
-        .cast::<Option<Expression>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_MEMBER_INITIALIZER)
+        as *mut Option<Expression>)
     {
         ctx.retag_stack(AncestorType::TSEnumMemberInitializer);
-        walk_expression(traverser, std::ptr::from_mut(field), ctx);
+        walk_expression(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_enum_member(&mut *node, ctx);
@@ -3972,16 +3723,16 @@ pub(crate) unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_enum_member_name(&mut *node, ctx);
     match &mut *node {
         TSEnumMemberName::StaticIdentifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
         TSEnumMemberName::StaticStringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSEnumMemberName::StaticTemplateLiteral(node) => {
-            walk_template_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSEnumMemberName::StaticNumericLiteral(node) => {
-            walk_numeric_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_numeric_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSEnumMemberName::BooleanLiteral(_)
         | TSEnumMemberName::NullLiteral(_)
@@ -4025,7 +3776,7 @@ pub(crate) unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
         | TSEnumMemberName::ComputedMemberExpression(_)
         | TSEnumMemberName::StaticMemberExpression(_)
         | TSEnumMemberName::PrivateFieldExpression(_) => {
-            walk_expression(traverser, node.cast(), ctx)
+            walk_expression(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_ts_enum_member_name(&mut *node, ctx);
@@ -4042,7 +3793,7 @@ pub(crate) unsafe fn walk_ts_type_annotation<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_ANNOTATION_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ANNOTATION_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4060,7 +3811,7 @@ pub(crate) unsafe fn walk_ts_literal_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_literal(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_LITERAL_TYPE_LITERAL).cast::<TSLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_LITERAL_TYPE_LITERAL) as *mut TSLiteral,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4075,28 +3826,26 @@ pub(crate) unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_literal(&mut *node, ctx);
     match &mut *node {
         TSLiteral::BooleanLiteral(node) => {
-            walk_boolean_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_boolean_literal(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSLiteral::NullLiteral(node) => {
-            walk_null_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSLiteral::NullLiteral(node) => walk_null_literal(traverser, (&mut **node) as *mut _, ctx),
         TSLiteral::NumericLiteral(node) => {
-            walk_numeric_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_numeric_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSLiteral::BigIntLiteral(node) => {
-            walk_big_int_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_big_int_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSLiteral::RegExpLiteral(node) => {
-            walk_reg_exp_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_reg_exp_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSLiteral::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSLiteral::TemplateLiteral(node) => {
-            walk_template_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSLiteral::UnaryExpression(node) => {
-            walk_unary_expression(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_unary_expression(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_ts_literal(&mut *node, ctx);
@@ -4109,119 +3858,101 @@ pub(crate) unsafe fn walk_ts_type<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_ts_type(&mut *node, ctx);
     match &mut *node {
-        TSType::TSAnyKeyword(node) => {
-            walk_ts_any_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSAnyKeyword(node) => walk_ts_any_keyword(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSBigIntKeyword(node) => {
-            walk_ts_big_int_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_big_int_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSBooleanKeyword(node) => {
-            walk_ts_boolean_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_boolean_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSIntrinsicKeyword(node) => {
-            walk_ts_intrinsic_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_intrinsic_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSNeverKeyword(node) => {
-            walk_ts_never_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_never_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSNullKeyword(node) => {
-            walk_ts_null_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_null_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSNumberKeyword(node) => {
-            walk_ts_number_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_number_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSObjectKeyword(node) => {
-            walk_ts_object_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_object_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSStringKeyword(node) => {
-            walk_ts_string_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_string_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSSymbolKeyword(node) => {
-            walk_ts_symbol_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_symbol_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSUndefinedKeyword(node) => {
-            walk_ts_undefined_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_undefined_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSUnknownKeyword(node) => {
-            walk_ts_unknown_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_unknown_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSVoidKeyword(node) => {
-            walk_ts_void_keyword(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_void_keyword(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSArrayType(node) => {
-            walk_ts_array_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSArrayType(node) => walk_ts_array_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSConditionalType(node) => {
-            walk_ts_conditional_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_conditional_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSConstructorType(node) => {
-            walk_ts_constructor_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_constructor_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSFunctionType(node) => {
-            walk_ts_function_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_function_type(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSImportType(node) => {
-            walk_ts_import_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSImportType(node) => walk_ts_import_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSIndexedAccessType(node) => {
-            walk_ts_indexed_access_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_indexed_access_type(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSInferType(node) => {
-            walk_ts_infer_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSInferType(node) => walk_ts_infer_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSIntersectionType(node) => {
-            walk_ts_intersection_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_intersection_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSLiteralType(node) => {
-            walk_ts_literal_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_literal_type(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSMappedType(node) => {
-            walk_ts_mapped_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSMappedType(node) => walk_ts_mapped_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSNamedTupleMember(node) => {
-            walk_ts_named_tuple_member(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_named_tuple_member(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSQualifiedName(node) => {
-            walk_ts_qualified_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_qualified_name(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSTemplateLiteralType(node) => {
-            walk_ts_template_literal_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_template_literal_type(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSThisType(node) => {
-            walk_ts_this_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
-        TSType::TSTupleType(node) => {
-            walk_ts_tuple_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSThisType(node) => walk_ts_this_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSTupleType(node) => walk_ts_tuple_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSTypeLiteral(node) => {
-            walk_ts_type_literal(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_literal(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSTypeOperatorType(node) => {
-            walk_ts_type_operator(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_operator(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::TSTypePredicate(node) => {
-            walk_ts_type_predicate(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_predicate(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSTypeQuery(node) => {
-            walk_ts_type_query(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSTypeQuery(node) => walk_ts_type_query(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSTypeReference(node) => {
-            walk_ts_type_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_type_reference(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSType::TSUnionType(node) => {
-            walk_ts_union_type(traverser, std::ptr::from_mut(&mut **node), ctx)
-        }
+        TSType::TSUnionType(node) => walk_ts_union_type(traverser, (&mut **node) as *mut _, ctx),
         TSType::TSParenthesizedType(node) => {
-            walk_ts_parenthesized_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_parenthesized_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::JSDocNullableType(node) => {
-            walk_js_doc_nullable_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_js_doc_nullable_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::JSDocNonNullableType(node) => {
-            walk_js_doc_non_nullable_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_js_doc_non_nullable_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSType::JSDocUnknownType(node) => {
-            walk_js_doc_unknown_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_js_doc_unknown_type(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_ts_type(&mut *node, ctx);
@@ -4235,37 +3966,35 @@ pub(crate) unsafe fn walk_ts_conditional_type<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_conditional_type(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::TSConditionalTypeCheckType(
         ancestor::TSConditionalTypeWithoutCheckType(node, PhantomData),
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_CHECK_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_CHECK_TYPE) as *mut TSType,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConditionalTypeExtendsType);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_EXTENDS_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_EXTENDS_TYPE) as *mut TSType,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConditionalTypeTrueType);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_TRUE_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_TRUE_TYPE) as *mut TSType,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConditionalTypeFalseType);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_FALSE_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_FALSE_TYPE) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4283,11 +4012,10 @@ pub(crate) unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
         node,
         PhantomData,
     )));
-    for item in
-        (*(node.cast::<u8>().add(ancestor::OFFSET_TS_UNION_TYPE_TYPES).cast::<Vec<TSType>>()))
-            .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut Vec<TSType>))
+        .iter_mut()
     {
-        walk_ts_type(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_type(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_union_type(&mut *node, ctx);
@@ -4302,13 +4030,11 @@ pub(crate) unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSIntersectionTypeTypes(
         ancestor::TSIntersectionTypeWithoutTypes(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_INTERSECTION_TYPE_TYPES)
-        .cast::<Vec<TSType>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_INTERSECTION_TYPE_TYPES)
+        as *mut Vec<TSType>))
+        .iter_mut()
     {
-        walk_ts_type(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_type(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_intersection_type(&mut *node, ctx);
@@ -4325,9 +4051,8 @@ pub(crate) unsafe fn walk_ts_parenthesized_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_PARENTHESIZED_TYPE_TYPE_ANNOTATION)
-            .cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_PARENTHESIZED_TYPE_TYPE_ANNOTATION)
+            as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4345,7 +4070,7 @@ pub(crate) unsafe fn walk_ts_type_operator<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_OPERATOR_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_OPERATOR_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4363,7 +4088,7 @@ pub(crate) unsafe fn walk_ts_array_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_ARRAY_TYPE_ELEMENT_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_ARRAY_TYPE_ELEMENT_TYPE) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4381,13 +4106,13 @@ pub(crate) unsafe fn walk_ts_indexed_access_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_OBJECT_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_OBJECT_TYPE) as *mut TSType,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSIndexedAccessTypeIndexType);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_INDEX_TYPE).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_INDEX_TYPE) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4403,13 +4128,11 @@ pub(crate) unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSTupleTypeElementTypes(
         ancestor::TSTupleTypeWithoutElementTypes(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES)
-        .cast::<Vec<TSTupleElement>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES)
+        as *mut Vec<TSTupleElement>))
+        .iter_mut()
     {
-        walk_ts_tuple_element(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_tuple_element(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_tuple_type(&mut *node, ctx);
@@ -4426,17 +4149,14 @@ pub(crate) unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_tuple_element(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_ELEMENT_TYPE)
-            .cast::<TSTupleElement>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_ELEMENT_TYPE)
+            as *mut TSTupleElement,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSNamedTupleMemberLabel);
     walk_identifier_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL)
-            .cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL) as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4454,7 +4174,7 @@ pub(crate) unsafe fn walk_ts_optional_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_OPTIONAL_TYPE_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_OPTIONAL_TYPE_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4472,7 +4192,7 @@ pub(crate) unsafe fn walk_ts_rest_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_REST_TYPE_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_REST_TYPE_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4487,10 +4207,10 @@ pub(crate) unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_tuple_element(&mut *node, ctx);
     match &mut *node {
         TSTupleElement::TSOptionalType(node) => {
-            walk_ts_optional_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_optional_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSTupleElement::TSRestType(node) => {
-            walk_ts_rest_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_rest_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSTupleElement::TSAnyKeyword(_)
         | TSTupleElement::TSBigIntKeyword(_)
@@ -4529,7 +4249,7 @@ pub(crate) unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
         | TSTupleElement::TSParenthesizedType(_)
         | TSTupleElement::JSDocNullableType(_)
         | TSTupleElement::JSDocNonNullableType(_)
-        | TSTupleElement::JSDocUnknownType(_) => walk_ts_type(traverser, node.cast(), ctx),
+        | TSTupleElement::JSDocUnknownType(_) => walk_ts_type(traverser, node as *mut _, ctx),
     }
     traverser.exit_ts_tuple_element(&mut *node, ctx);
 }
@@ -4671,16 +4391,15 @@ pub(crate) unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_NAME).cast::<TSTypeName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_NAME) as *mut TSTypeName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeReferenceTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_reference(&mut *node, ctx);
@@ -4694,10 +4413,10 @@ pub(crate) unsafe fn walk_ts_type_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_type_name(&mut *node, ctx);
     match &mut *node {
         TSTypeName::IdentifierReference(node) => {
-            walk_identifier_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         TSTypeName::QualifiedName(node) => {
-            walk_ts_qualified_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_qualified_name(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_ts_type_name(&mut *node, ctx);
@@ -4714,13 +4433,13 @@ pub(crate) unsafe fn walk_ts_qualified_name<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_QUALIFIED_NAME_LEFT).cast::<TSTypeName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_QUALIFIED_NAME_LEFT) as *mut TSTypeName,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSQualifiedNameRight);
     walk_identifier_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_QUALIFIED_NAME_RIGHT).cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_QUALIFIED_NAME_RIGHT) as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4736,13 +4455,11 @@ pub(crate) unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSTypeParameterInstantiationParams(
         ancestor::TSTypeParameterInstantiationWithoutParams(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_PARAMS)
-        .cast::<Vec<TSType>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_PARAMS)
+        as *mut Vec<TSType>))
+        .iter_mut()
     {
-        walk_ts_type(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_type(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_parameter_instantiation(&mut *node, ctx);
@@ -4759,24 +4476,20 @@ pub(crate) unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_PARAMETER_NAME).cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_NAME) as *mut BindingIdentifier,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TYPE_PARAMETER_CONSTRAINT)
-        .cast::<Option<TSType>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_CONSTRAINT)
+        as *mut Option<TSType>)
     {
         ctx.retag_stack(AncestorType::TSTypeParameterConstraint);
-        walk_ts_type(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_type(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TYPE_PARAMETER_DEFAULT)
-        .cast::<Option<TSType>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DEFAULT)
+        as *mut Option<TSType>)
     {
         ctx.retag_stack(AncestorType::TSTypeParameterDefault);
-        walk_ts_type(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_type(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_parameter(&mut *node, ctx);
@@ -4791,13 +4504,11 @@ pub(crate) unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSTypeParameterDeclarationParams(
         ancestor::TSTypeParameterDeclarationWithoutParams(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS)
-        .cast::<Vec<TSTypeParameter>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS)
+        as *mut Vec<TSTypeParameter>))
+        .iter_mut()
     {
-        walk_ts_type_parameter(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_type_parameter(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_parameter_declaration(&mut *node, ctx);
@@ -4814,34 +4525,29 @@ pub(crate) unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_ID)
-            .cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_ID)
+            as *mut BindingIdentifier,
         ctx,
     );
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeAnnotation);
     walk_ts_type(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_ANNOTATION)
-            .cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_ANNOTATION)
+            as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4860,16 +4566,15 @@ pub(crate) unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_name(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION).cast::<TSTypeName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION) as *mut TSTypeName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSClassImplementsTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_class_implements(&mut *node, ctx);
@@ -4886,47 +4591,38 @@ pub(crate) unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_ID)
-            .cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_ID)
+            as *mut BindingIdentifier,
         ctx,
     );
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-        .cast::<Option<Vec<TSInterfaceHeritage>>>())
+        as *mut Option<Vec<TSInterfaceHeritage>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
         for item in field.iter_mut() {
-            walk_ts_interface_heritage(traverser, std::ptr::from_mut(item), ctx);
+            walk_ts_interface_heritage(traverser, item as *mut _, ctx);
         }
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSInterfaceDeclarationBody);
     walk_ts_interface_body(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                .cast::<Box<TSInterfaceBody>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_BODY)
+            as *mut Box<TSInterfaceBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4943,13 +4639,11 @@ pub(crate) unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSInterfaceBodyBody(
         ancestor::TSInterfaceBodyWithoutBody(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_INTERFACE_BODY_BODY)
-        .cast::<Vec<TSSignature>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_BODY_BODY)
+        as *mut Vec<TSSignature>))
+        .iter_mut()
     {
-        walk_ts_signature(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_signature(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_interface_body(&mut *node, ctx);
@@ -4966,16 +4660,15 @@ pub(crate) unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
     ));
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_KEY) as *mut PropertyKey,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSPropertySignatureTypeAnnotation);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_property_signature(&mut *node, ctx);
@@ -4989,19 +4682,19 @@ pub(crate) unsafe fn walk_ts_signature<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_signature(&mut *node, ctx);
     match &mut *node {
         TSSignature::TSIndexSignature(node) => {
-            walk_ts_index_signature(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_index_signature(traverser, (&mut **node) as *mut _, ctx)
         }
         TSSignature::TSPropertySignature(node) => {
-            walk_ts_property_signature(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_property_signature(traverser, (&mut **node) as *mut _, ctx)
         }
         TSSignature::TSCallSignatureDeclaration(node) => {
-            walk_ts_call_signature_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_call_signature_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         TSSignature::TSConstructSignatureDeclaration(node) => {
-            walk_ts_construct_signature_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_construct_signature_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         TSSignature::TSMethodSignature(node) => {
-            walk_ts_method_signature(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_method_signature(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_ts_signature(&mut *node, ctx);
@@ -5016,23 +4709,17 @@ pub(crate) unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureParameters(
         ancestor::TSIndexSignatureWithoutParameters(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
-        .cast::<Vec<TSIndexSignatureName>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
+        as *mut Vec<TSIndexSignatureName>))
+        .iter_mut()
     {
-        walk_ts_index_signature_name(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_index_signature_name(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSIndexSignatureTypeAnnotation);
     walk_ts_type_annotation(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
-                .cast::<Box<TSTypeAnnotation>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5048,39 +4735,32 @@ pub(crate) unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSCallSignatureDeclarationThisParam(
         ancestor::TSCallSignatureDeclarationWithoutThisParam(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-        .cast::<Option<TSThisParameter>>())
+        as *mut Option<TSThisParameter>)
     {
-        walk_ts_this_parameter(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_this_parameter(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSCallSignatureDeclarationParams);
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationReturnType);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_call_signature_declaration(&mut *node, ctx);
@@ -5094,55 +4774,46 @@ pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_method_signature(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::TSMethodSignatureKey(
         ancestor::TSMethodSignatureWithoutKey(node, PhantomData),
     ));
     walk_property_key(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_METHOD_SIGNATURE_KEY).cast::<PropertyKey>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_KEY) as *mut PropertyKey,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-        .cast::<Option<Box<TSThisParameter>>>())
+        as *mut Option<Box<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureThisParam);
-        walk_ts_this_parameter(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSMethodSignatureParams);
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureReturnType);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -5157,41 +4828,33 @@ pub(crate) unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a
     traverser.enter_ts_construct_signature_declaration(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::TSConstructSignatureDeclarationParams(
         ancestor::TSConstructSignatureDeclarationWithoutParams(node, PhantomData),
     ));
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationReturnType);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -5209,12 +4872,8 @@ pub(crate) unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_annotation(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
-                .cast::<Box<TSTypeAnnotation>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5232,18 +4891,15 @@ pub(crate) unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_EXPRESSION) as *mut Expression,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_interface_heritage(&mut *node, ctx);
@@ -5260,18 +4916,16 @@ pub(crate) unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_predicate_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_TYPE_PREDICATE_PARAMETER_NAME)
-            .cast::<TSTypePredicateName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PREDICATE_PARAMETER_NAME)
+            as *mut TSTypePredicateName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
-        .cast::<Option<Box<TSTypeAnnotation>>>())
+        as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSTypePredicateTypeAnnotation);
-        walk_ts_type_annotation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_predicate(&mut *node, ctx);
@@ -5285,11 +4939,9 @@ pub(crate) unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_type_predicate_name(&mut *node, ctx);
     match &mut *node {
         TSTypePredicateName::Identifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSTypePredicateName::This(node) => {
-            walk_ts_this_type(traverser, std::ptr::from_mut(node), ctx)
-        }
+        TSTypePredicateName::This(node) => walk_ts_this_type(traverser, node as *mut _, ctx),
     }
     traverser.exit_ts_type_predicate_name(&mut *node, ctx);
 }
@@ -5305,27 +4957,22 @@ pub(crate) unsafe fn walk_ts_module_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_module_declaration_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_MODULE_DECLARATION_ID)
-            .cast::<TSModuleDeclarationName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_ID)
+            as *mut TSModuleDeclarationName,
         ctx,
     );
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_MODULE_DECLARATION_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_MODULE_DECLARATION_BODY)
-        .cast::<Option<TSModuleDeclarationBody>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_BODY)
+        as *mut Option<TSModuleDeclarationBody>)
     {
         ctx.retag_stack(AncestorType::TSModuleDeclarationBody);
-        walk_ts_module_declaration_body(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_module_declaration_body(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -5340,10 +4987,10 @@ pub(crate) unsafe fn walk_ts_module_declaration_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_module_declaration_name(&mut *node, ctx);
     match &mut *node {
         TSModuleDeclarationName::Identifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(node), ctx)
+            walk_identifier_name(traverser, node as *mut _, ctx)
         }
         TSModuleDeclarationName::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(node), ctx)
+            walk_string_literal(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_ts_module_declaration_name(&mut *node, ctx);
@@ -5357,10 +5004,10 @@ pub(crate) unsafe fn walk_ts_module_declaration_body<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_module_declaration_body(&mut *node, ctx);
     match &mut *node {
         TSModuleDeclarationBody::TSModuleDeclaration(node) => {
-            walk_ts_module_declaration(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_module_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
         TSModuleDeclarationBody::TSModuleBlock(node) => {
-            walk_ts_module_block(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_module_block(traverser, (&mut **node) as *mut _, ctx)
         }
     }
     traverser.exit_ts_module_declaration_body(&mut *node, ctx);
@@ -5375,18 +5022,16 @@ pub(crate) unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSModuleBlockDirectives(
         ancestor::TSModuleBlockWithoutDirectives(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
-        .cast::<Vec<Directive>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
+        as *mut Vec<Directive>))
+        .iter_mut()
     {
-        walk_directive(traverser, std::ptr::from_mut(item), ctx);
+        walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSModuleBlockBody);
     walk_statements(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY).cast::<Vec<Statement>>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut Vec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5402,13 +5047,11 @@ pub(crate) unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSTypeLiteralMembers(
         ancestor::TSTypeLiteralWithoutMembers(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TYPE_LITERAL_MEMBERS)
-        .cast::<Vec<TSSignature>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_LITERAL_MEMBERS)
+        as *mut Vec<TSSignature>))
+        .iter_mut()
     {
-        walk_ts_signature(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_signature(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_literal(&mut *node, ctx);
@@ -5425,12 +5068,8 @@ pub(crate) unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_parameter(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_INFER_TYPE_TYPE_PARAMETER)
-                .cast::<Box<TSTypeParameter>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INFER_TYPE_TYPE_PARAMETER)
+            as *mut Box<TSTypeParameter>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5448,18 +5087,15 @@ pub(crate) unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type_query_expr_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_TYPE_QUERY_EXPR_NAME)
-            .cast::<TSTypeQueryExprName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_EXPR_NAME) as *mut TSTypeQueryExprName,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeQueryTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_type_query(&mut *node, ctx);
@@ -5473,10 +5109,10 @@ pub(crate) unsafe fn walk_ts_type_query_expr_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_type_query_expr_name(&mut *node, ctx);
     match &mut *node {
         TSTypeQueryExprName::TSImportType(node) => {
-            walk_ts_import_type(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_import_type(traverser, (&mut **node) as *mut _, ctx)
         }
         TSTypeQueryExprName::IdentifierReference(_) | TSTypeQueryExprName::QualifiedName(_) => {
-            walk_ts_type_name(traverser, node.cast(), ctx)
+            walk_ts_type_name(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_ts_type_query_expr_name(&mut *node, ctx);
@@ -5493,32 +5129,27 @@ pub(crate) unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_IMPORT_TYPE_PARAMETER).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_PARAMETER) as *mut TSType,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIER)
-        .cast::<Option<TSTypeName>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIER)
+        as *mut Option<TSTypeName>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeQualifier);
-        walk_ts_type_name(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_type_name(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
-        .cast::<Option<TSImportAttributes>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
+        as *mut Option<TSImportAttributes>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeAttributes);
-        walk_ts_import_attributes(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_import_attributes(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_IMPORT_TYPE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterInstantiation>>>())
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeTypeParameters);
-        walk_ts_type_parameter_instantiation(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_import_type(&mut *node, ctx);
@@ -5535,19 +5166,16 @@ pub(crate) unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
     ));
     walk_identifier_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
-            .cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
+            as *mut IdentifierName,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSImportAttributesElements);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
-        .cast::<Vec<TSImportAttribute>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
+        as *mut Vec<TSImportAttribute>))
+        .iter_mut()
     {
-        walk_ts_import_attribute(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_import_attribute(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_import_attributes(&mut *node, ctx);
@@ -5564,15 +5192,14 @@ pub(crate) unsafe fn walk_ts_import_attribute<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_import_attribute_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_NAME)
-            .cast::<TSImportAttributeName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_NAME)
+            as *mut TSImportAttributeName,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSImportAttributeValue);
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_VALUE).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_VALUE) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5587,10 +5214,10 @@ pub(crate) unsafe fn walk_ts_import_attribute_name<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_import_attribute_name(&mut *node, ctx);
     match &mut *node {
         TSImportAttributeName::Identifier(node) => {
-            walk_identifier_name(traverser, std::ptr::from_mut(node), ctx)
+            walk_identifier_name(traverser, node as *mut _, ctx)
         }
         TSImportAttributeName::StringLiteral(node) => {
-            walk_string_literal(traverser, std::ptr::from_mut(node), ctx)
+            walk_string_literal(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_ts_import_attribute_name(&mut *node, ctx);
@@ -5605,42 +5232,31 @@ pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSFunctionTypeThisParam(
         ancestor::TSFunctionTypeWithoutThisParam(node, PhantomData),
     ));
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-        .cast::<Option<Box<TSThisParameter>>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
     {
-        walk_ts_this_parameter(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSFunctionTypeParams);
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSFunctionTypeReturnType);
     walk_ts_type_annotation(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                .cast::<Box<TSTypeAnnotation>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSFunctionTypeTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_function_type(&mut *node, ctx);
@@ -5657,32 +5273,23 @@ pub(crate) unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     ));
     walk_formal_parameters(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-                .cast::<Box<FormalParameters>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConstructorTypeReturnType);
     walk_ts_type_annotation(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                .cast::<Box<TSTypeAnnotation>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-        .cast::<Option<Box<TSTypeParameterDeclaration>>>())
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSConstructorTypeTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, std::ptr::from_mut(&mut **field), ctx);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_constructor_type(&mut *node, ctx);
@@ -5696,41 +5303,32 @@ pub(crate) unsafe fn walk_ts_mapped_type<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_mapped_type(&mut *node, ctx);
     let previous_scope_id = ctx.current_scope_id();
     ctx.set_current_scope_id(
-        (*(node
-            .cast::<u8>()
-            .add(ancestor::OFFSET_TS_MAPPED_TYPE_SCOPE_ID)
-            .cast::<Cell<Option<ScopeId>>>()))
-        .get()
-        .unwrap(),
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
     );
     let pop_token = ctx.push_stack(Ancestor::TSMappedTypeTypeParameter(
         ancestor::TSMappedTypeWithoutTypeParameter(node, PhantomData),
     ));
     walk_ts_type_parameter(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER)
-                .cast::<Box<TSTypeParameter>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_TYPE_PARAMETER)
+            as *mut Box<TSTypeParameter>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_MAPPED_TYPE_NAME_TYPE)
-        .cast::<Option<TSType>>())
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_NAME_TYPE)
+        as *mut Option<TSType>)
     {
         ctx.retag_stack(AncestorType::TSMappedTypeNameType);
-        walk_ts_type(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_type(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *(node
-        .cast::<u8>()
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_MAPPED_TYPE_TYPE_ANNOTATION)
-        .cast::<Option<TSType>>())
+        as *mut Option<TSType>)
     {
         ctx.retag_stack(AncestorType::TSMappedTypeTypeAnnotation);
-        walk_ts_type(traverser, std::ptr::from_mut(field), ctx);
+        walk_ts_type(traverser, field as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -5746,22 +5344,18 @@ pub(crate) unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
     let pop_token = ctx.push_stack(Ancestor::TSTemplateLiteralTypeQuasis(
         ancestor::TSTemplateLiteralTypeWithoutQuasis(node, PhantomData),
     ));
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
-        .cast::<Vec<TemplateElement>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
+        as *mut Vec<TemplateElement>))
+        .iter_mut()
     {
-        walk_template_element(traverser, std::ptr::from_mut(item), ctx);
+        walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSTemplateLiteralTypeTypes);
-    for item in (*(node
-        .cast::<u8>()
-        .add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
-        .cast::<Vec<TSType>>()))
-    .iter_mut()
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
+        as *mut Vec<TSType>))
+        .iter_mut()
     {
-        walk_ts_type(traverser, std::ptr::from_mut(item), ctx);
+        walk_ts_type(traverser, item as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_template_literal_type(&mut *node, ctx);
@@ -5778,13 +5372,13 @@ pub(crate) unsafe fn walk_ts_as_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_AS_EXPRESSION_EXPRESSION).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_AS_EXPRESSION_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSAsExpressionTypeAnnotation);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_AS_EXPRESSION_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_AS_EXPRESSION_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5802,17 +5396,15 @@ pub(crate) unsafe fn walk_ts_satisfies_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_EXPRESSION)
+            as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSSatisfiesExpressionTypeAnnotation);
     walk_ts_type(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_TYPE_ANNOTATION)
-            .cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_TYPE_ANNOTATION)
+            as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5830,13 +5422,13 @@ pub(crate) unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_ASSERTION_EXPRESSION).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSTypeAssertionTypeAnnotation);
     walk_ts_type(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION).cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5854,17 +5446,15 @@ pub(crate) unsafe fn walk_ts_import_equals_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_binding_identifier(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_ID)
-            .cast::<BindingIdentifier>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_ID)
+            as *mut BindingIdentifier,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSImportEqualsDeclarationModuleReference);
     walk_ts_module_reference(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_MODULE_REFERENCE)
-            .cast::<TSModuleReference>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_MODULE_REFERENCE)
+            as *mut TSModuleReference,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5879,10 +5469,10 @@ pub(crate) unsafe fn walk_ts_module_reference<'a, Tr: Traverse<'a>>(
     traverser.enter_ts_module_reference(&mut *node, ctx);
     match &mut *node {
         TSModuleReference::ExternalModuleReference(node) => {
-            walk_ts_external_module_reference(traverser, std::ptr::from_mut(&mut **node), ctx)
+            walk_ts_external_module_reference(traverser, (&mut **node) as *mut _, ctx)
         }
         TSModuleReference::IdentifierReference(_) | TSModuleReference::QualifiedName(_) => {
-            walk_ts_type_name(traverser, node.cast(), ctx)
+            walk_ts_type_name(traverser, node as *mut _, ctx)
         }
     }
     traverser.exit_ts_module_reference(&mut *node, ctx);
@@ -5899,9 +5489,8 @@ pub(crate) unsafe fn walk_ts_external_module_reference<'a, Tr: Traverse<'a>>(
     ));
     walk_string_literal(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_EXTERNAL_MODULE_REFERENCE_EXPRESSION)
-            .cast::<StringLiteral>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_EXTERNAL_MODULE_REFERENCE_EXPRESSION)
+            as *mut StringLiteral,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5919,9 +5508,8 @@ pub(crate) unsafe fn walk_ts_non_null_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_NON_NULL_EXPRESSION_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_NON_NULL_EXPRESSION_EXPRESSION)
+            as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5939,7 +5527,7 @@ pub(crate) unsafe fn walk_decorator<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>().add(ancestor::OFFSET_DECORATOR_EXPRESSION).cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_DECORATOR_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5957,9 +5545,7 @@ pub(crate) unsafe fn walk_ts_export_assignment<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_EXPORT_ASSIGNMENT_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_EXPORT_ASSIGNMENT_EXPRESSION) as *mut Expression,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5977,9 +5563,8 @@ pub(crate) unsafe fn walk_ts_namespace_export_declaration<'a, Tr: Traverse<'a>>(
     ));
     walk_identifier_name(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_NAMESPACE_EXPORT_DECLARATION_ID)
-            .cast::<IdentifierName>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMESPACE_EXPORT_DECLARATION_ID)
+            as *mut IdentifierName,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5997,20 +5582,15 @@ pub(crate) unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
     ));
     walk_expression(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_EXPRESSION)
-            .cast::<Expression>(),
+        (node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_EXPRESSION)
+            as *mut Expression,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSInstantiationExpressionTypeParameters);
     walk_ts_type_parameter_instantiation(
         traverser,
-        std::ptr::from_mut(
-            &mut **(node
-                .cast::<u8>()
-                .add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_PARAMETERS)
-                .cast::<Box<TSTypeParameterInstantiation>>()),
-        ),
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_PARAMETERS)
+            as *mut Box<TSTypeParameterInstantiation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -6028,9 +5608,7 @@ pub(crate) unsafe fn walk_js_doc_nullable_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JS_DOC_NULLABLE_TYPE_TYPE_ANNOTATION)
-            .cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_JS_DOC_NULLABLE_TYPE_TYPE_ANNOTATION) as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -6048,9 +5626,8 @@ pub(crate) unsafe fn walk_js_doc_non_nullable_type<'a, Tr: Traverse<'a>>(
     ));
     walk_ts_type(
         traverser,
-        node.cast::<u8>()
-            .add(ancestor::OFFSET_JS_DOC_NON_NULLABLE_TYPE_TYPE_ANNOTATION)
-            .cast::<TSType>(),
+        (node as *mut u8).add(ancestor::OFFSET_JS_DOC_NON_NULLABLE_TYPE_TYPE_ANNOTATION)
+            as *mut TSType,
         ctx,
     );
     ctx.pop_stack(pop_token);


### PR DESCRIPTION
Revert the changes to `oxc_traverse` made in #5577.

Those changes may well have been good, but...

The soundness of `Traverse` is a finely balanced thing, and the pointer gymnastics are subtle, so I think it's best to be extremely conservative about changes. I last ran Miri on it with the original formulation (`as *mut _` etc) and it passed. Currently it's not possible to usefully run Miri on the transformer because it contains known unsound code (#3483). So until we're able to check soundness with Miri, I think it's best to avoid changes, as it'd be easy to trigger UB unintentionally.