### PR TITLE
fix(transformer/react): the refresh plugin cannot handle member expressions with React hooks

### DIFF
--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 18/51
+Passed: 19/52
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -167,7 +167,7 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (4/29)
+# babel-plugin-transform-react-jsx (5/30)
 * refresh/can-handle-implicit-arrow-returns/input.jsx
 Reference flags mismatch:
 after transform: ReferenceId(18): ReferenceFlags(Write)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/input.jsx
@@ -1,0 +1,3 @@
+export function Bar () {
+  A.B.C.useHook()
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/output.js
@@ -1,0 +1,9 @@
+var _s = $RefreshSig$();
+export function Bar() {
+    _s();
+    A.B.C.useHook();
+}
+_s(Bar, "useHook{}", true);
+_c = Bar;
+var _c;
+$RefreshReg$(_c, "Bar");


### PR DESCRIPTION
The previous implementation doesn't handle nested StaticMemberExpression. For example: `A.B.C.useHook`.