### PR TITLE
feat(napi/transform): align output `SourceMap` with Rollup's `ExistingRawSourceMap`

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -136,10 +136,12 @@ export interface ReactRefreshBindingOptions {
 export interface SourceMap {
   file?: string
   mappings?: string
+  names?: Array<string>
   sourceRoot?: string
   sources?: Array<string | undefined | null>
   sourcesContent?: Array<string | undefined | null>
-  names?: Array<string>
+  version: number
+  x_google_ignoreList?: Array<number>
 }
 
 /**

--- a/napi/transform/src/lib.rs
+++ b/napi/transform/src/lib.rs
@@ -5,36 +5,13 @@
 mod context;
 mod options;
 
-use napi_derive::napi;
-
-#[napi(object)]
-pub struct SourceMap {
-    pub file: Option<String>,
-    pub mappings: Option<String>,
-    pub source_root: Option<String>,
-    pub sources: Option<Vec<Option<String>>>,
-    pub sources_content: Option<Vec<Option<String>>>,
-    pub names: Option<Vec<String>>,
-}
-
 pub use crate::options::*;
+
+mod sourcemap;
+pub use crate::sourcemap::*;
 
 mod isolated_declaration;
 pub use isolated_declaration::*;
 
 mod transformer;
 pub use transformer::*;
-
-impl From<oxc_sourcemap::SourceMap> for SourceMap {
-    fn from(source_map: oxc_sourcemap::SourceMap) -> Self {
-        let json = source_map.to_json();
-        Self {
-            file: json.file,
-            mappings: json.mappings,
-            source_root: json.source_root,
-            sources: json.sources,
-            sources_content: json.sources_content,
-            names: json.names,
-        }
-    }
-}

--- a/napi/transform/src/sourcemap.rs
+++ b/napi/transform/src/sourcemap.rs
@@ -1,0 +1,46 @@
+use napi_derive::napi;
+
+// Aligned with Rollup's sourcemap input.
+//
+// <https://github.com/rollup/rollup/blob/766dbf90d69268971feaafa1f53f88a0755e8023/src/rollup/types.d.ts#L80-L89>
+//
+// ```
+// export interface ExistingRawSourceMap {
+//  file?: string;
+//  mappings: string;
+//  names: string[];
+//  sourceRoot?: string;
+//  sources: string[];
+//  sourcesContent?: string[];
+//  version: number;
+//  x_google_ignoreList?: number[];
+// }
+// ```
+#[napi(object)]
+pub struct SourceMap {
+    pub file: Option<String>,
+    pub mappings: Option<String>,
+    pub names: Option<Vec<String>>,
+    pub source_root: Option<String>,
+    pub sources: Option<Vec<Option<String>>>,
+    pub sources_content: Option<Vec<Option<String>>>,
+    pub version: u8,
+    #[napi(js_name = "x_google_ignoreList")]
+    pub x_google_ignorelist: Option<Vec<u32>>,
+}
+
+impl From<oxc_sourcemap::SourceMap> for SourceMap {
+    fn from(source_map: oxc_sourcemap::SourceMap) -> Self {
+        let json = source_map.to_json();
+        Self {
+            file: json.file,
+            mappings: json.mappings,
+            names: json.names,
+            source_root: json.source_root,
+            sources: json.sources,
+            sources_content: json.sources_content,
+            version: 3,
+            x_google_ignorelist: None,
+        }
+    }
+}

--- a/napi/transform/test.mjs
+++ b/napi/transform/test.mjs
@@ -3,16 +3,6 @@ import oxc from './index.js';
 
 console.log(`Testing on ${process.platform}-${process.arch}`);
 
-test(oxc.isolatedDeclaration('test.ts', 'class A {}', { sourcemap: true }), {
-  code: 'declare class A {}\n',
-  map: {
-    mappings: 'AAAA,cAAM,EAAE,CAAE',
-    names: [],
-    sources: ['test.ts'],
-    sourcesContent: ['class A {}'],
-  },
-});
-
 function test(ret, expected) {
   console.log(ret.code);
   console.log(ret.map);
@@ -23,3 +13,25 @@ function test(ret, expected) {
   assert.deepEqual(ret.map, expected.map);
   assert(ret.errors.length == 0);
 }
+
+test(oxc.isolatedDeclaration('test.ts', 'class A {}', { sourcemap: true }), {
+  code: 'declare class A {}\n',
+  map: {
+    mappings: 'AAAA,cAAM,EAAE,CAAE',
+    names: [],
+    sources: ['test.ts'],
+    sourcesContent: ['class A {}'],
+    version: 3,
+  },
+});
+
+test(oxc.transform('test.ts', 'class A<T> {}', { sourcemap: true }), {
+  code: 'class A {}\n',
+  map: {
+    mappings: 'AAAA,MAAM,EAAK,CAAE',
+    names: [],
+    sources: ['test.ts'],
+    sourcesContent: ['class A<T> {}'],
+    version: 3,
+  },
+});


### PR DESCRIPTION
closes #5578