### PR TITLE
perf(oxc_ast): optimize ast layout

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1790,7 +1790,7 @@ pub enum FormalParameterKind {
 pub struct FunctionBody<'a> {
     #[serde(flatten)]
     pub span: Span,
-    pub directives: Vec<'a, Directive<'a>>,
+    pub directives: Box<'a, Vec<'a, Directive<'a>>>,
     pub statements: Vec<'a, Statement<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -581,11 +581,11 @@ const _: () = {
     assert!(size_of::<FormalParameterKind>() == 1usize);
     assert!(align_of::<FormalParameterKind>() == 1usize);
 
-    assert!(size_of::<FunctionBody>() == 72usize);
+    assert!(size_of::<FunctionBody>() == 48usize);
     assert!(align_of::<FunctionBody>() == 8usize);
     assert!(offset_of!(FunctionBody, span) == 0usize);
     assert!(offset_of!(FunctionBody, directives) == 8usize);
-    assert!(offset_of!(FunctionBody, statements) == 40usize);
+    assert!(offset_of!(FunctionBody, statements) == 16usize);
 
     assert!(size_of::<ArrowFunctionExpression>() == 56usize);
     assert!(align_of::<ArrowFunctionExpression>() == 8usize);
@@ -2136,11 +2136,11 @@ const _: () = {
     assert!(size_of::<FormalParameterKind>() == 1usize);
     assert!(align_of::<FormalParameterKind>() == 1usize);
 
-    assert!(size_of::<FunctionBody>() == 40usize);
+    assert!(size_of::<FunctionBody>() == 28usize);
     assert!(align_of::<FunctionBody>() == 4usize);
     assert!(offset_of!(FunctionBody, span) == 0usize);
     assert!(offset_of!(FunctionBody, directives) == 8usize);
-    assert!(offset_of!(FunctionBody, statements) == 24usize);
+    assert!(offset_of!(FunctionBody, statements) == 12usize);
 
     assert!(size_of::<ArrowFunctionExpression>() == 32usize);
     assert!(align_of::<ArrowFunctionExpression>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -5928,13 +5928,16 @@ impl<'a> AstBuilder<'a> {
     /// - directives
     /// - statements
     #[inline]
-    pub fn function_body(
+    pub fn function_body<T1>(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
+        directives: T1,
         statements: Vec<'a, Statement<'a>>,
-    ) -> FunctionBody<'a> {
-        FunctionBody { span, directives, statements }
+    ) -> FunctionBody<'a>
+    where
+        T1: IntoIn<'a, Box<'a, Vec<'a, Directive<'a>>>>,
+    {
+        FunctionBody { span, directives: directives.into_in(self.allocator), statements }
     }
 
     /// Builds a [`FunctionBody`] and stores it in the memory arena.
@@ -5946,12 +5949,15 @@ impl<'a> AstBuilder<'a> {
     /// - directives
     /// - statements
     #[inline]
-    pub fn alloc_function_body(
+    pub fn alloc_function_body<T1>(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
+        directives: T1,
         statements: Vec<'a, Statement<'a>>,
-    ) -> Box<'a, FunctionBody<'a>> {
+    ) -> Box<'a, FunctionBody<'a>>
+    where
+        T1: IntoIn<'a, Box<'a, Vec<'a, Directive<'a>>>>,
+    {
         Box::new_in(self.function_body(span, directives, statements), self.allocator)
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -665,7 +665,7 @@ impl<'a> Gen for Function<'a> {
 impl<'a> Gen for FunctionBody<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_curly_braces(self.span, self.is_empty(), |p| {
-            for directive in &self.directives {
+            for directive in &*self.directives {
                 directive.gen(p, ctx);
             }
             for stmt in &self.statements {

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -174,7 +174,6 @@ function generateWalkForStruct(type, types) {
       } else {
         let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
           iterModifier = '';
-        console.log(`walkCode: `, walkCode);
 
         walkVecCode = `
                     for item in (*(${fieldCode})).iter_mut()${iterModifier} {

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -68,7 +68,7 @@ function generateWalkForStruct(type, types) {
       assert(
         scopeEnterField,
         `\`ast\` attr says to enter scope before field '${enterFieldName}' ` +
-        `in '${type.name}', but that field is not visited`,
+          `in '${type.name}', but that field is not visited`,
       );
     } else {
       scopeEnterField = visitedFields[0];
@@ -174,7 +174,7 @@ function generateWalkForStruct(type, types) {
       } else {
         let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
           iterModifier = '';
-        console.log(`walkCode: `, walkCode)
+        console.log(`walkCode: `, walkCode);
 
         walkVecCode = `
                     for item in (*(${fieldCode})).iter_mut()${iterModifier} {

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -135,7 +135,6 @@ function generateWalkForStruct(type, types) {
         }
       `;
     }
-    console.log('field', field)
 
     if (field.wrappers[0] === 'Vec') {
       let walkVecCode;
@@ -145,7 +144,6 @@ function generateWalkForStruct(type, types) {
       } else {
         let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
           iterModifier = '';
-        console.log(`walkCode: `, walkCode)
 
         if (field.wrappers.length === 2 && field.wrappers[1] === 'Option') {
           iterModifier = '.flatten()';
@@ -174,7 +172,7 @@ function generateWalkForStruct(type, types) {
         // Special case for `Vec<Statement>`
         walkVecCode = `walk_statements(traverser, ${fieldCode}, ctx);`;
       } else {
-        let walkCode = `${fieldWalkName}(traverser, std::ptr::from_mut(item), ctx);`,
+        let walkCode = `${fieldWalkName}(traverser, item as *mut _, ctx);`,
           iterModifier = '';
         console.log(`walkCode: `, walkCode)
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -6182,10 +6182,10 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t Box<'a, Vec<'a, Directive<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const Box<'a, Vec<'a, Directive<'a>>>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2379,7 +2379,7 @@ pub(crate) unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
         as *mut Box<Vec<Directive>>))
         .iter_mut()
     {
-        walk_directive(traverser, std::ptr::from_mut(item), ctx);
+        walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionBodyStatements);
     walk_statements(

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2376,10 +2376,10 @@ pub(crate) unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
         ancestor::FunctionBodyWithoutDirectives(node, PhantomData),
     ));
     for item in (*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
-        as *mut Vec<Directive>))
+        as *mut Box<Vec<Directive>>))
         .iter_mut()
     {
-        walk_directive(traverser, item as *mut _, ctx);
+        walk_directive(traverser, std::ptr::from_mut(item), ctx);
     }
     ctx.retag_stack(AncestorType::FunctionBodyStatements);
     walk_statements(

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -531,6 +531,11 @@ fn get_struct_params(struct_: &StructDef, ctx: &LateCtx) -> Vec<Param> {
                 let typ = def.to_type();
                 (Some(parse_quote!(#t)), Some((quote!(#t: IntoIn<'a, Box<'a, #typ>>), t)))
             }
+            (TypeWrapper::BoxVec, Some(def)) => {
+                let t = t_param();
+                let typ = def.to_type();
+                (Some(parse_quote!(#t)), Some((quote!(#t: IntoIn<'a, Box<'a, Vec<'a, #typ>>>), t)))
+            }
             (TypeWrapper::OptBox, Some(def)) => {
                 let t = t_param();
                 let typ = def.to_type();

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -497,7 +497,10 @@ impl<'a> VisitBuilder<'a> {
                     def,
                     matches!(
                         typ_wrapper,
-                        TypeWrapper::Vec | TypeWrapper::VecBox | TypeWrapper::OptVec
+                        TypeWrapper::Vec
+                            | TypeWrapper::VecBox
+                            | TypeWrapper::OptVec
+                            | TypeWrapper::BoxVec
                     ),
                     visit_as,
                 );

--- a/tasks/ast_tools/src/passes/calc_layout.rs
+++ b/tasks/ast_tools/src/passes/calc_layout.rs
@@ -144,7 +144,7 @@ fn calc_enum_layout(ty: &mut Enum, ctx: &EarlyCtx) -> Result<PlatformLayout> {
 
 fn calc_struct_layout(ty: &mut Struct, ctx: &EarlyCtx) -> Result<PlatformLayout> {
     fn collect_field_layouts(ty: &Struct, ctx: &EarlyCtx) -> Result<Vec<PlatformLayout>> {
-        let ret = if ty.item.fields.is_empty() {
+        if ty.item.fields.is_empty() {
             Ok(vec![PlatformLayout::zero()])
         } else {
             ty.item
@@ -155,13 +155,7 @@ fn calc_struct_layout(ty: &mut Struct, ctx: &EarlyCtx) -> Result<PlatformLayout>
                     calc_type_layout(&typ, ctx)
                 })
                 .collect()
-        };
-
-        if (ty.item.ident.to_string() == "FunctionBody") {
-            dbg!(&ty.meta.module_path, ty.item.ident.to_string());
-            dbg!(&ret);
         }
-        ret
     }
 
     fn with_padding(

--- a/tasks/ast_tools/src/util.rs
+++ b/tasks/ast_tools/src/util.rs
@@ -126,6 +126,7 @@ pub enum TypeWrapper {
     VecOpt,
     OptBox,
     OptVec,
+    BoxVec,
     Ref,
     /// We bailed on detecting the type wrapper
     Complex,
@@ -200,7 +201,11 @@ impl TypeExt for Type {
                 TypeIdentResult::Box(inner) => {
                     wrapper = TypeWrapper::Box;
                     let (inner, inner_kind) = analyze(inner)?;
-                    assert!(inner_kind == TypeWrapper::None,);
+                    if inner_kind == TypeWrapper::Vec {
+                        wrapper = TypeWrapper::BoxVec;
+                    } else {
+                        assert!(inner_kind == TypeWrapper::None,);
+                    }
                     inner
                 }
                 TypeIdentResult::Vec(inner) => {


### PR DESCRIPTION
1. as https://github.com/oxc-project/oxc/issues/5601#issuecomment-2338034345 suggested, this time only box `FunctionBody.directives`.
2. Also change `ast_tools` to support auto generated `Box<Vec<T>>`