### PR TITLE
refactor(linter): start internal/external split of `OxlintOptions`

### DIFF
--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -3,7 +3,7 @@ use std::{env, io::BufWriter, time::Instant};
 use ignore::gitignore::Gitignore;
 use oxc_diagnostics::{DiagnosticService, GraphicalReportHandler};
 use oxc_linter::{
-    partial_loader::LINT_PARTIAL_LOADER_EXT, LintOptions, LintService, LintServiceOptions, Linter,
+    partial_loader::LINT_PARTIAL_LOADER_EXT, LintService, LintServiceOptions, Linter, OxlintOptions,
 };
 use oxc_span::VALID_EXTENSIONS;
 
@@ -93,7 +93,7 @@ impl Runner for LintRunner {
 
         let cwd = std::env::current_dir().unwrap();
         let mut options = LintServiceOptions::new(cwd, paths);
-        let lint_options = LintOptions::default()
+        let lint_options = OxlintOptions::default()
             .with_filter(filter)
             .with_config_path(basic_options.config)
             .with_fix(fix_options.fix_kind())

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -7,7 +7,7 @@ use futures::future::join_all;
 use globset::Glob;
 use ignore::gitignore::Gitignore;
 use log::{debug, error, info};
-use oxc_linter::{FixKind, LintOptions, Linter};
+use oxc_linter::{FixKind, Linter, OxlintOptions};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, OnceCell, RwLock, SetError};
 use tower_lsp::{
@@ -345,7 +345,7 @@ impl Backend {
             let mut linter = self.server_linter.write().await;
             *linter = ServerLinter::new_with_linter(
                 Linter::from_options(
-                    LintOptions::default()
+                    OxlintOptions::default()
                         .with_fix(FixKind::SafeFix)
                         .with_config_path(Some(config_path)),
                 )

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -23,6 +23,7 @@ pub mod table;
 use std::{io::Write, path::Path, rc::Rc, sync::Arc};
 
 use config::LintConfig;
+use options::LintOptions;
 use oxc_diagnostics::Error;
 use oxc_semantic::{AstNode, Semantic};
 
@@ -31,7 +32,7 @@ pub use crate::{
     context::LintContext,
     fixer::FixKind,
     frameworks::FrameworkFlags,
-    options::{AllowWarnDeny, LintOptions},
+    options::{AllowWarnDeny, OxlintOptions},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
 };
@@ -60,7 +61,7 @@ pub struct Linter {
 
 impl Default for Linter {
     fn default() -> Self {
-        Self::from_options(LintOptions::default()).unwrap()
+        Self::from_options(OxlintOptions::default()).unwrap()
     }
 }
 
@@ -68,9 +69,9 @@ impl Linter {
     /// # Errors
     ///
     /// Returns `Err` if there are any errors parsing the configuration file.
-    pub fn from_options(options: LintOptions) -> Result<Self, Error> {
+    pub fn from_options(options: OxlintOptions) -> Result<Self, Error> {
         let (rules, config) = options.derive_rules_and_config()?;
-        Ok(Self { rules, options, config: Arc::new(config) })
+        Ok(Self { rules, options: options.into(), config: Arc::new(config) })
     }
 
     #[cfg(test)]
@@ -104,7 +105,7 @@ impl Linter {
         self
     }
 
-    pub fn options(&self) -> &LintOptions {
+    pub(crate) fn options(&self) -> &LintOptions {
         &self.options
     }
 

--- a/crates/oxc_linter/src/options/mod.rs
+++ b/crates/oxc_linter/src/options/mod.rs
@@ -16,8 +16,31 @@ use crate::{
     FrameworkFlags, RuleCategory, RuleEnum, RuleWithSeverity,
 };
 
+/// Subset of options used directly by the [`Linter`]. Derived from
+/// [`OxlintOptions`], which is the public-facing API. Do not expose this
+/// outside of this crate.
+///
+/// [`Linter`]: crate::Linter
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(PartialEq))]
+pub(crate) struct LintOptions {
+    pub fix: FixKind,
+    pub framework_hints: FrameworkFlags,
+    pub plugins: LintPluginOptions,
+}
+
+impl From<OxlintOptions> for LintOptions {
+    fn from(options: OxlintOptions) -> Self {
+        Self {
+            fix: options.fix,
+            framework_hints: options.framework_hints,
+            plugins: options.plugins,
+        }
+    }
+}
+
 #[derive(Debug)]
-pub struct LintOptions {
+pub struct OxlintOptions {
     /// Allow / Deny rules in order. [("allow" / "deny", rule name)]
     /// Defaults to [("deny", "correctness")]
     pub filter: Vec<(AllowWarnDeny, String)>,
@@ -32,7 +55,7 @@ pub struct LintOptions {
     pub framework_hints: FrameworkFlags,
 }
 
-impl Default for LintOptions {
+impl Default for OxlintOptions {
     fn default() -> Self {
         Self {
             filter: vec![(AllowWarnDeny::Warn, String::from("correctness"))],
@@ -44,7 +67,7 @@ impl Default for LintOptions {
     }
 }
 
-impl LintOptions {
+impl OxlintOptions {
     #[must_use]
     pub fn with_filter(mut self, filter: Vec<(AllowWarnDeny, String)>) -> Self {
         if !filter.is_empty() {
@@ -154,7 +177,7 @@ impl LintOptions {
     }
 }
 
-impl LintOptions {
+impl OxlintOptions {
     /// # Errors
     ///
     /// * Returns `Err` if there are any errors parsing the configuration file.

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    fixer::FixKind, options::LintPluginOptions, rules::RULES, AllowWarnDeny, Fixer, LintOptions,
-    LintService, LintServiceOptions, Linter, OxlintConfig, RuleEnum, RuleWithSeverity,
+    fixer::FixKind, options::LintPluginOptions, rules::RULES, AllowWarnDeny, Fixer, LintService,
+    LintServiceOptions, Linter, OxlintConfig, OxlintOptions, RuleEnum, RuleWithSeverity,
 };
 
 #[derive(Eq, PartialEq)]
@@ -349,7 +349,7 @@ impl Tester {
     ) -> TestResult {
         let allocator = Allocator::default();
         let rule = self.find_rule().read_json(rule_config.unwrap_or_default());
-        let options = LintOptions::default()
+        let options = OxlintOptions::default()
             .with_fix(fix.into())
             .with_import_plugin(self.plugins.import)
             .with_jest_plugin(self.plugins.jest)

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -2,7 +2,7 @@ use std::{env, path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, FixKind, LintOptions, Linter};
+use oxc_linter::{AllowWarnDeny, FixKind, Linter, OxlintOptions};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -37,7 +37,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     (AllowWarnDeny::Deny, "all".into()),
                     (AllowWarnDeny::Deny, "nursery".into()),
                 ];
-                let lint_options = LintOptions::default()
+                let lint_options = OxlintOptions::default()
                     .with_filter(filter)
                     .with_fix(FixKind::All)
                     .with_import_plugin(true)


### PR DESCRIPTION
re-creation of #5141 