### PR TITLE
refactor(linter): forbid string allocation methods such as `to_lowercase` and `replace`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,10 @@
 ignore-interior-mutability = ["oxc_linter::rule::RuleWithSeverity"]
 
 disallowed-methods = [
-  { path = "str::to_ascii_lowercase", reason = "Avoid memory allocation. Use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },
-  { path = "str::to_ascii_uppercase", reason = "Avoid memory allocation. Use `cow_utils::CowUtils::cow_to_ascii_uppercase` instead." },
+  { path = "str::to_ascii_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },
+  { path = "str::to_ascii_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_uppercase` instead." },
+  { path = "str::to_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_lowercase` instead." },
+  { path = "str::to_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_uppercase` instead." },
+  { path = "str::replace", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replace` instead." },
+  { path = "str::replacen", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replacen` instead." },
 ]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -232,9 +232,7 @@ fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
         _ => return false,
     };
 
-    if ident.starts_with(|c: char| c.is_ascii_uppercase())
-        && ident.cow_to_ascii_uppercase() != ident
-    {
+    if ident.cow_to_ascii_uppercase() != ident {
         return true;
     }
 

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods)]
 use std::{cell::RefCell, io::Read, path::PathBuf, rc::Rc};
 
 use bpaf::{Bpaf, Parser};

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods)]
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_parser::lexer::{Kind, Lexer};

--- a/tasks/common/src/lib.rs
+++ b/tasks/common/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stdout, clippy::disallowed_methods)]
 use std::path::{Path, PathBuf};
 
 mod diff;

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
 // Core
 mod runtime;
 mod suite;

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
 mod ignore_list;
 mod spec;
 

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
 use std::{
     borrow::Cow,
     collections::HashMap,

--- a/tasks/website/src/lib.rs
+++ b/tasks/website/src/lib.rs
@@ -1,3 +1,8 @@
-#![allow(clippy::print_stdout, clippy::print_stderr, clippy::missing_panics_doc)]
+#![allow(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::missing_panics_doc,
+    clippy::disallowed_methods
+)]
 
 pub mod linter;


### PR DESCRIPTION
closes #5586

Feel free to use the PR as the base and make changes.