### PR TITLE
refactor(semantic): compare nodes by pointer equality

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -1,6 +1,6 @@
 //! Declare symbol for `BindingIdentifier`s
 
-use std::borrow::Cow;
+use std::{borrow::Cow, ptr};
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
@@ -146,12 +146,12 @@ fn is_function_part_of_if_statement(function: &Function, builder: &SemanticBuild
         return false;
     };
     if let Statement::FunctionDeclaration(func) = &stmt.consequent {
-        if func.span == function.span {
+        if ptr::eq(func.as_ref(), function) {
             return true;
         }
     }
     if let Some(Statement::FunctionDeclaration(func)) = &stmt.alternate {
-        if func.span == function.span {
+        if ptr::eq(func.as_ref(), function) {
             return true;
         }
     }


### PR DESCRIPTION
Follow up after #5673.

It's safer to compare nodes by pointer equality than by equality of `Span`s. Transformer can create multiple nodes of same type with same span.

Once nodes have node IDs, we can use them for comparison instead.

That said, `ptr::eq` is much cheaper, as it doesn't have to follow the pointers to check equality. https://godbolt.org/z/hsqaeKr5M
