### PR TITLE
fix(transformer/react): incorrect scope_id for var hoisted in fast refresh plugin

### DIFF
--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -685,8 +685,14 @@ impl<'a> ReactRefresh<'a> {
                 .push(self.ctx.ast.argument_expression(ctx.ast.expression_from_function(function)));
         }
 
-        let symbol_id =
-            ctx.generate_uid("s", ctx.current_scope_id(), SymbolFlags::FunctionScopedVariable);
+        // TODO: Handle var hoisted in ctx API
+        let target_scope_id = ctx
+            .scopes()
+            .ancestors(ctx.current_scope_id())
+            .find(|scope_id| ctx.scopes().get_flags(*scope_id).is_var())
+            .unwrap_or_else(|| ctx.current_scope_id());
+
+        let symbol_id = ctx.generate_uid("s", target_scope_id, SymbolFlags::FunctionScopedVariable);
 
         let symbol_name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 40/52
+Passed: 41/52
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -167,18 +167,7 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (26/30)
-* refresh/does-not-get-tripped-by-iifes/input.jsx
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["_s"]
-Bindings mismatch:
-after transform: ScopeId(1): ["_s"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(1)
-rebuilt        : SymbolId(0): ScopeId(0)
-
+# babel-plugin-transform-react-jsx (27/30)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
 x Output mismatch
 


### PR DESCRIPTION
Fix the last one semantic error in the fast react plugin