### PR TITLE
fix(napi/transformer): refresh plugin doesn't work even after passing the refresh option

### DIFF
--- a/napi/transform/src/options.rs
+++ b/napi/transform/src/options.rs
@@ -161,7 +161,7 @@ impl From<ReactBindingOptions> for ReactOptions {
             pragma_frag: options.pragma_frag,
             use_built_ins: options.use_built_ins,
             use_spread: options.use_spread,
-            refresh: ops.refresh.map(Into::into),
+            refresh: options.refresh.map(Into::into),
             ..Default::default()
         }
     }

--- a/napi/transform/test.mjs
+++ b/napi/transform/test.mjs
@@ -35,3 +35,35 @@ test(oxc.transform('test.ts', 'class A<T> {}', { sourcemap: true }), {
     version: 3,
   },
 });
+
+// Test react refresh plugin
+test(
+  oxc.transform(
+    'test.tsx',
+    `
+  import { useState } from "react";
+  export const App = () => {
+    const [count, setCount] = useState(0);
+    return <button onClick={() => setCount(count + 1)}>count is {count}</button>;
+  };
+`,
+    { react: { refresh: {} } },
+  ),
+  {
+    code: 'var _s = $RefreshSig$();\n' +
+      'import { useState } from "react";\n' +
+      'import { jsxs as _jsxs } from "react/jsx-runtime";\n' +
+      'export const App = () => {\n' +
+      '\t_s();\n' +
+      '\tconst [count, setCount] = useState(0);\n' +
+      '\treturn _jsxs("button", {\n' +
+      '\t\tonClick: () => setCount(count + 1),\n' +
+      '\t\tchildren: ["count is ", count]\n' +
+      '\t});\n' +
+      '};\n' +
+      '_s(App, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");\n' +
+      '_c = App;\n' +
+      'var _c;\n' +
+      '$RefreshReg$(_c, "App");\n',
+  },
+);


### PR DESCRIPTION
The refresh plugin isn't enabled by default, we must enable it by passing refresh options