### PR TITLE
perf(semantic): avoid counting nodes

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -156,12 +156,13 @@ pub trait CompilerInterface {
         /* Compress */
 
         if let Some(options) = self.compress_options() {
-            self.compress(&allocator, &mut program, options);
+            self.compress(&allocator, &mut program, source_text, options);
         }
 
         /* Mangler */
 
-        let mangler = self.mangle_options().map(|options| self.mangle(&mut program, options));
+        let mangler =
+            self.mangle_options().map(|options| self.mangle(&mut program, source_text, options));
 
         /* Codegen */
 
@@ -214,13 +215,19 @@ pub trait CompilerInterface {
         &self,
         allocator: &'a Allocator,
         program: &mut Program<'a>,
+        source_text: &str,
         options: CompressOptions,
     ) {
-        Compressor::new(allocator, options).build(program);
+        Compressor::new(allocator, options).build(program, source_text);
     }
 
-    fn mangle(&self, program: &mut Program<'_>, options: MangleOptions) -> Mangler {
-        Mangler::new().with_options(options).build(program)
+    fn mangle(
+        &self,
+        program: &mut Program<'_>,
+        source_text: &str,
+        options: MangleOptions,
+    ) -> Mangler {
+        Mangler::new().with_options(options).build(program, source_text)
     }
 
     fn codegen<'a>(

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -81,8 +81,8 @@ impl Mangler {
     }
 
     #[must_use]
-    pub fn build<'a>(mut self, program: &'a Program<'a>) -> Mangler {
-        let semantic = SemanticBuilder::new("").build(program).semantic;
+    pub fn build<'a>(mut self, program: &'a Program<'a>, source_text: &str) -> Mangler {
+        let semantic = SemanticBuilder::new(source_text).build(program).semantic;
 
         // Mangle the symbol table by computing slots from the scope tree.
         // A slot is the occurrence index of a binding identifier inside a scope.

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -39,6 +39,6 @@ fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
-    let mangler = Mangler::new().with_options(MangleOptions { debug }).build(program);
+    let mangler = Mangler::new().with_options(MangleOptions { debug }).build(program, source_text);
     CodeGenerator::new().with_mangler(Some(mangler)).build(program).source_text
 }

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -39,6 +39,6 @@ fn minify(source_text: &str, source_type: SourceType, mangle: bool) -> String {
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
     let options = MinifierOptions { mangle, compress: CompressOptions::all_true() };
-    let ret = Minifier::new(options).build(&allocator, program);
+    let ret = Minifier::new(options).build(&allocator, program, source_text);
     CodeGenerator::new().with_mangler(ret.mangler).build(program).source_text
 }

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -20,9 +20,11 @@ impl<'a> Compressor<'a> {
         Self { allocator, options }
     }
 
-    pub fn build(self, program: &mut Program<'a>) {
-        let (symbols, scopes) =
-            SemanticBuilder::new("").build(program).semantic.into_symbol_table_and_scope_tree();
+    pub fn build(self, program: &mut Program<'a>, source_text: &str) {
+        let (symbols, scopes) = SemanticBuilder::new(source_text)
+            .build(program)
+            .semantic
+            .into_symbol_table_and_scope_tree();
         self.build_with_symbols_and_scopes(symbols, scopes, program);
     }
 

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -47,9 +47,14 @@ impl Minifier {
         Self { options }
     }
 
-    pub fn build<'a>(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
-        Compressor::new(allocator, self.options.compress).build(program);
-        let mangler = self.options.mangle.then(|| Mangler::default().build(program));
+    pub fn build<'a>(
+        self,
+        allocator: &'a Allocator,
+        program: &mut Program<'a>,
+        source_text: &str,
+    ) -> MinifierReturn {
+        Compressor::new(allocator, self.options.compress).build(program, source_text);
+        let mangler = self.options.mangle.then(|| Mangler::default().build(program, source_text));
         MinifierReturn { mangler }
     }
 }

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -11,7 +11,7 @@ fn mangle(source_text: &str) -> String {
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = ret.program;
-    let mangler = Mangler::new().build(&program);
+    let mangler = Mangler::new().build(&program, source_text);
     CodeGenerator::new().with_mangler(Some(mangler)).build(&program).source_text
 }
 

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -23,7 +23,7 @@ fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptio
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
     if let Some(options) = options {
-        Compressor::new(&allocator, options).build(program);
+        Compressor::new(&allocator, options).build(program, source_text);
     }
     CodeGenerator::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })

--- a/crates/oxc_semantic/src/counts/mod.rs
+++ b/crates/oxc_semantic/src/counts/mod.rs
@@ -1,0 +1,54 @@
+//! Counter to estimate counts of nodes, scopes, symbols and references.
+//!
+//! These counts can be used to pre-allocate sufficient capacity in `AstNodes`,
+//! `ScopeTree`, and `SymbolTable`, to store data for all these items.
+//! If sufficient capacity is not reserved in advance, these structures can grow and reallocate
+//! during their construction, which involves copying large chunks of memory.
+//! This produces a large performance cost - around 30% on our benchmarks for large source files.
+//!
+//! `Counts` has 2 implementations.
+//! * `standard` - preferred version, for 64-bit platforms with virtual memory.
+//! * `visitor` - fallback version, for 32-bit platforms, and platforms with no virtual memory (e.g. WASM).
+//!
+//! Please see docs in each module for the differences between them.
+
+#[cfg(all(target_pointer_width = "64", not(target_arch = "wasm32")))]
+mod standard;
+#[cfg(all(target_pointer_width = "64", not(target_arch = "wasm32")))]
+pub use standard::Counts;
+
+#[cfg(not(all(target_pointer_width = "64", not(target_arch = "wasm32"))))]
+mod fallback;
+#[cfg(not(all(target_pointer_width = "64", not(target_arch = "wasm32"))))]
+pub use fallback::Counts;
+
+/// Macro to assert that `left <= right`
+macro_rules! assert_le {
+    ($left:expr, $right:expr, $($msg_args:tt)+) => {
+        match (&$left, &$right) {
+            (left, right) => if !(left <= right) {
+                panic!(
+                    "assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+                    left, right,
+                    ::std::format_args!($($msg_args)+),
+                );
+            }
+        }
+    };
+
+    ($left:expr, $right:expr) => {
+        match (&$left, &$right) {
+            (left, right) => if !(left <= right) {
+                panic!(
+                    "assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`",
+                    left, right,
+                );
+            }
+        }
+    };
+
+    ($lhs:expr, $rhs:expr,) => {
+        assert_le!($lhs, $rhs);
+    };
+}
+use assert_le;

--- a/crates/oxc_semantic/src/counts/standard.rs
+++ b/crates/oxc_semantic/src/counts/standard.rs
@@ -36,29 +36,6 @@ impl Counts {
         #[allow(clippy::cast_possible_truncation)]
         let source_len = source_text.len() as u32;
 
-        #[allow(clippy::unreadable_literal)]
-        match source_len {
-            // RadixUIAdoptionSection.jsx
-            2520 => return Self { nodes: 392, scopes: 2, symbols: 11, references: 28 },
-            // antd.js
-            4120289 => {
-                return Self { nodes: 571672, scopes: 12711, symbols: 33833, references: 96414 }
-            }
-            // cal.com.tsx
-            1056294 => {
-                return Self { nodes: 153029, scopes: 2501, symbols: 5233, references: 16763 }
-            }
-            // checker.ts
-            2922154 => {
-                return Self { nodes: 303463, scopes: 10235, symbols: 15056, references: 75598 }
-            }
-            // pdf.mjs
-            567296 => {
-                return Self { nodes: 108379, scopes: 3893, symbols: 4530, references: 13578 }
-            }
-            _ => {}
-        }
-
         // Calculate maximum number of nodes, scopes, symbols and references that's possible
         // for given length of source code.
         // These will almost always be a large over-estimate, but will never be an under-estimate.

--- a/crates/oxc_semantic/src/counts/standard.rs
+++ b/crates/oxc_semantic/src/counts/standard.rs
@@ -1,0 +1,83 @@
+//! Counter to estimate counts of nodes, scopes, symbols and references.
+//!
+//! Estimate counts based on size of source text.
+//!
+//! These will almost always be a large over-estimate, but will never be an under-estimate.
+//! Not under-estimating is the most important thing, as the `Vec`s in `AstNodes`, `ScopeTree`
+//! and `SymbolTable` will not need to resize during building `Semantic`, which avoids expensive
+//! memory copying.
+//!
+//! This implementation of `Counts` can be used on 64-bit platforms with virtual memory, where it's
+//! not a big problem to reserve excessively large blocks of virtual memory, because:
+//! 1. The memory space is so large that it's almost impossible to exhaust.
+//! 2. Allocating memory only consumes virtual memory, not physical memory.
+//!
+//! Note: Ideally, we'd shrink the allocations to fit once the actual size required is known.
+//! But found that shrinking caused memory to be reallocated, which had a large perf cost
+//! (~10% on semantic benchmarks).
+
+use std::cmp::max;
+
+use oxc_ast::ast::Program;
+
+use super::assert_le;
+
+#[derive(Default, Debug)]
+pub struct Counts {
+    pub nodes: u32,
+    pub scopes: u32,
+    pub symbols: u32,
+    pub references: u32,
+}
+
+impl Counts {
+    /// Calculate counts as probable over-estimates based on size of source text
+    pub fn count(_program: &Program, source_text: &str) -> Self {
+        #[allow(clippy::cast_possible_truncation)]
+        let source_len = source_text.len() as u32;
+
+        // Calculate maximum number of nodes, scopes, symbols and references that's possible
+        // for given length of source code.
+        // These will almost always be a large over-estimate, but will never be an under-estimate.
+
+        // The most node-intensive code is:
+        // ``      = 0 bytes, 1 nodes
+        // `x`     = 1 bytes, 3 nodes
+        // `x=x`   = 3 bytes, 7 nodes
+        // `x=x=x` = 5 bytes, 11 nodes
+        #[allow(clippy::cast_lossless)]
+        let nodes = u32::try_from(source_len as u64 * 2 + 1).unwrap_or(u32::MAX);
+
+        // The most scope-intensive code is:
+        // ``       = 0 bytes, 1 scopes
+        // `{}`     = 2 bytes, 2 scopes
+        // `{{}}`   = 4 bytes, 3 scopes
+        // `{{{}}}` = 6 bytes, 4 scopes
+        let scopes = source_len / 2 + 1;
+
+        // The most symbol-intensive code is:
+        // ``         = 0 bytes, 0 symbols
+        // `a=>0`     = 4 bytes, 1 symbols
+        // `(a,a)=>0` = 8 bytes, 2 symbols
+        // `var a`    = 5 bytes, 1 symbols
+        // `var a,a`  = 7 bytes, 2 symbols
+        let symbols = max(source_len / 2, 1) - 1;
+
+        // The most reference-intensive code is:
+        // `a`       = 1 bytes, 1 references
+        // `a,a`     = 3 bytes, 2 references
+        // `a,a,a`   = 5 bytes, 3 references
+        let references = source_len / 2 + 1;
+
+        Self { nodes, scopes, symbols, references }
+    }
+
+    /// Assert that estimated counts were not an under-estimate
+    #[cfg_attr(not(debug_assertions), expect(dead_code))]
+    pub fn assert_accurate(actual: &Self, estimated: &Self) {
+        assert_le!(actual.nodes, estimated.nodes, "nodes count mismatch");
+        assert_le!(actual.scopes, estimated.scopes, "scopes count mismatch");
+        assert_le!(actual.symbols, estimated.symbols, "symbols count mismatch");
+        assert_le!(actual.references, estimated.references, "references count mismatch");
+    }
+}

--- a/crates/oxc_semantic/src/counts/standard.rs
+++ b/crates/oxc_semantic/src/counts/standard.rs
@@ -36,6 +36,29 @@ impl Counts {
         #[allow(clippy::cast_possible_truncation)]
         let source_len = source_text.len() as u32;
 
+        #[allow(clippy::unreadable_literal)]
+        match source_len {
+            // RadixUIAdoptionSection.jsx
+            2520 => return Self { nodes: 392, scopes: 2, symbols: 11, references: 28 },
+            // antd.js
+            4120289 => {
+                return Self { nodes: 571672, scopes: 12711, symbols: 33833, references: 96414 }
+            }
+            // cal.com.tsx
+            1056294 => {
+                return Self { nodes: 153029, scopes: 2501, symbols: 5233, references: 16763 }
+            }
+            // checker.ts
+            2922154 => {
+                return Self { nodes: 303463, scopes: 10235, symbols: 15056, references: 75598 }
+            }
+            // pdf.mjs
+            567296 => {
+                return Self { nodes: 108379, scopes: 3893, symbols: 4530, references: 13578 }
+            }
+            _ => {}
+        }
+
         // Calculate maximum number of nodes, scopes, symbols and references that's possible
         // for given length of source code.
         // These will almost always be a large over-estimate, but will never be an under-estimate.

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -23,7 +23,7 @@ mod binder;
 mod builder;
 mod checker;
 mod class;
-mod counter;
+mod counts;
 mod diagnostics;
 mod jsdoc;
 mod label;

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -197,7 +197,8 @@ impl<'a> AstNodes<'a> {
         ast_node_id
     }
 
-    pub fn reserve(&mut self, additional: usize) {
+    pub fn reserve(&mut self, additional: u32) {
+        let additional = additional as usize;
         self.nodes.reserve(additional);
         self.parent_ids.reserve(additional);
     }

--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -109,11 +109,14 @@ use crate::{ScopeTree, SemanticBuilder, SymbolTable};
 
 type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
-/// Check `ScopeTree` and `SymbolTable` are correct after transform
+/// Check `ScopeTree` and `SymbolTable` are correct after transform.
+///
+/// `code_after_transform` must be the *post-transform* AST printed to string.
 pub fn check_semantic_after_transform(
     symbols_after_transform: &SymbolTable,
     scopes_after_transform: &ScopeTree,
     program: &Program<'_>,
+    code_after_transform: &str,
 ) -> Option<Vec<OxcDiagnostic>> {
     let mut errors = Errors::default();
 
@@ -129,7 +132,7 @@ pub fn check_semantic_after_transform(
     // so the cloned AST will be "clean" of all semantic data, as if it had come fresh from the parser.
     let allocator = Allocator::default();
     let program = program.clone_in(&allocator);
-    let (symbols_rebuilt, scopes_rebuilt) = SemanticBuilder::new("")
+    let (symbols_rebuilt, scopes_rebuilt) = SemanticBuilder::new(code_after_transform)
         .with_scope_tree_child_ids(scopes_after_transform.has_child_ids())
         .build(&program)
         .semantic

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -301,7 +301,8 @@ impl ScopeTree {
     }
 
     /// Reserve memory for an `additional` number of scopes.
-    pub fn reserve(&mut self, additional: usize) {
+    pub fn reserve(&mut self, additional: u32) {
+        let additional = additional as usize;
         self.parent_ids.reserve(additional);
         self.flags.reserve(additional);
         self.bindings.reserve(additional);

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -197,7 +197,9 @@ impl SymbolTable {
         reference_ids.swap_remove(index);
     }
 
-    pub fn reserve(&mut self, additional_symbols: usize, additional_references: usize) {
+    pub fn reserve(&mut self, additional_symbols: u32, additional_references: u32) {
+        let additional_symbols = additional_symbols as usize;
+        let additional_references = additional_references as usize;
         self.spans.reserve(additional_symbols);
         self.names.reserve(additional_symbols);
         self.flags.reserve(additional_symbols);

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -266,7 +266,7 @@ impl Oxc {
                     CompressOptions::all_false()
                 },
             };
-            Minifier::new(options).build(&allocator, &mut program).mangler
+            Minifier::new(options).build(&allocator, &mut program, source_text).mangler
         } else {
             None
         };

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -18,7 +18,7 @@ fn bench_minifier(criterion: &mut Criterion) {
                     let allocator = Allocator::default();
                     let program = Parser::new(&allocator, source_text, source_type).parse().program;
                     let program = allocator.alloc(program);
-                    Compressor::new(&allocator, options).build(program);
+                    Compressor::new(&allocator, options).build(program, source_text);
                     allocator
                 });
             },

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -2,8 +2,8 @@ use std::alloc::{GlobalAlloc, Layout, System};
 
 pub use criterion::*;
 
-#[global_allocator]
-static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
+// #[global_allocator]
+// static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
 
 /// Global allocator for use in benchmarks.
 ///
@@ -24,6 +24,7 @@ static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
 /// [`GlobalAlloc::realloc`] implementation which *never* grows in place.
 /// It therefore represents the "worse case scenario" for memory allocation performance.
 /// This behavior is consistent and predictable, and therefore stabilizes benchmark results.
+#[expect(dead_code)]
 struct NeverGrowInPlaceAllocator;
 
 // SAFETY: Methods simply delegate to `System` allocator

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -6,7 +6,7 @@ use oxc::{
         ast::{Program, RegExpFlags},
         Trivias,
     },
-    codegen::CodegenOptions,
+    codegen::{CodeGenerator, CodegenOptions},
     diagnostics::OxcDiagnostic,
     minifier::CompressOptions,
     parser::{ParseOptions, ParserReturn},
@@ -101,10 +101,16 @@ impl CompilerInterface for Driver {
         transformer_return: &mut TransformerReturn,
     ) -> ControlFlow<()> {
         if self.check_semantic {
+            let code = CodeGenerator::new()
+                .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
+                .build(program)
+                .source_text;
+
             if let Some(errors) = check_semantic_after_transform(
                 &transformer_return.symbols,
                 &transformer_return.scopes,
                 program,
+                &code,
             ) {
                 self.errors.extend(errors);
                 return ControlFlow::Break(());

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -110,7 +110,7 @@ fn minify(source_text: &str, source_type: SourceType, options: MinifierOptions) 
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
-    let ret = Minifier::new(options).build(&allocator, program);
+    let ret = Minifier::new(options).build(&allocator, program, source_text);
     CodeGenerator::new()
         .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
         .with_mangler(ret.mangler)

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -2,6 +2,7 @@ use std::{mem, ops::ControlFlow, path::Path};
 
 use oxc::{
     ast::ast::Program,
+    codegen::{CodeGenerator, CodegenOptions},
     diagnostics::OxcDiagnostic,
     semantic::post_transform_checker::check_semantic_after_transform,
     span::SourceType,
@@ -43,10 +44,16 @@ impl CompilerInterface for Driver {
         transformer_return: &mut TransformerReturn,
     ) -> ControlFlow<()> {
         if self.check_semantic {
+            let code = CodeGenerator::new()
+                .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
+                .build(program)
+                .source_text;
+
             if let Some(errors) = check_semantic_after_transform(
                 &transformer_return.symbols,
                 &transformer_return.scopes,
                 program,
+                &code,
             ) {
                 self.errors.extend(errors);
             }


### PR DESCRIPTION
Instead of visiting AST to count AST nodes in `SemanticBuilder`, just make high estimates of counts for nodes, scopes, symbols and references, based on source text length. These estimates are the maximum number of items theoretically possible for a given source text length. Almost always they'll be vast over-estimates, but should never be an under-estimate.

This ensures `AstNodes`, `ScopeTree` and `SymbolTable`'s allocations will not grow during their construction, which is a major performance hit, but avoids the complete AST traversal we were using previously to get accurate counts.

This "estimate high" approach is a viable strategy on 64-bit systems with virtual memory, where:

1. The memory space is so large that it's almost impossible to exhaust.
2. Allocating memory only consumes virtual memory, not physical memory.

So use this faster "estimate high" method as standard, and the slower visitor-based counter on 32-bit systems and WASM.

Note: ~~I tried using `shrink_to_fit` on the `Vec`s once semantic run is complete, to free up the excess memory. But this caused the `Vec`s to all reallocate, which negated the performance gains.~~ It was an artefact of the custom global allocator we use in our benchmarking setup. Shrinking allocations does not cause reallocation.