### PR TITLE
refactor(semantic): re-order use statements

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -3,8 +3,8 @@
 use std::{borrow::Cow, ptr};
 
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::ast::*;
 use oxc_ast::{
+    ast::*,
     syntax_directed_operations::{BoundNames, IsSimpleParameterList},
     AstKind,
 };

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -6,6 +6,8 @@ use std::{
     sync::Arc,
 };
 
+use rustc_hash::FxHashMap;
+
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstKind, Trivias, Visit};
 use oxc_cfg::{
@@ -15,7 +17,6 @@ use oxc_cfg::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Atom, CompactStr, SourceType, Span};
 use oxc_syntax::{module_record::ModuleRecord, operator::AssignmentOperator};
-use rustc_hash::FxHashMap;
 
 use crate::{
     binder::Binder,

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1,3 +1,6 @@
+use phf::{phf_set, Set};
+use rustc_hash::FxHashMap;
+
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{
     ast::*,
@@ -11,8 +14,6 @@ use oxc_syntax::{
     number::NumberBase,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
 };
-use phf::{phf_set, Set};
-use rustc_hash::FxHashMap;
 
 use crate::{builder::SemanticBuilder, diagnostics::redeclaration, scope::ScopeFlags, AstNode};
 

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -1,12 +1,13 @@
+use oxc_ast::{
+    ast::{DoWhileStatement, ForStatement, WhileStatement},
+    AstKind,
+};
+
 mod javascript;
 mod typescript;
 
 use javascript as js;
 pub use javascript::check_module_record;
-use oxc_ast::{
-    ast::{DoWhileStatement, ForStatement, WhileStatement},
-    AstKind,
-};
 use typescript as ts;
 
 use crate::{builder::SemanticBuilder, AstNode};

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -1,11 +1,15 @@
 use std::borrow::Cow;
 
-use oxc_ast::syntax_directed_operations::{BoundNames, PropName};
+use rustc_hash::FxHashMap;
+
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::{ast::*, AstKind};
+use oxc_ast::{
+    ast::*,
+    syntax_directed_operations::{BoundNames, PropName},
+    AstKind,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Atom, GetSpan, Span};
-use rustc_hash::FxHashMap;
 
 use crate::{builder::SemanticBuilder, diagnostics::redeclaration};
 

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -8,11 +8,12 @@ use oxc_ast::{
 use oxc_span::GetSpan;
 use oxc_syntax::class::{ClassId, ElementKind};
 
+use crate::{AstNodeId, AstNodes};
+
 use super::{
     table::{Element, PrivateIdentifierReference},
     ClassTable,
 };
-use crate::{AstNodeId, AstNodes};
 
 #[derive(Debug, Default)]
 pub struct ClassTableBuilder {

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,7 +1,8 @@
+use rustc_hash::FxHashMap;
+
 use oxc_index::IndexVec;
 use oxc_span::{CompactStr, Span};
 use oxc_syntax::class::{ClassId, ElementId, ElementKind};
-use rustc_hash::FxHashMap;
 
 use crate::node::AstNodeId;
 

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 
-use oxc_ast::{AstKind, Comment, Trivias};
-use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
-use super::parser::JSDoc;
+use oxc_ast::{AstKind, Comment, Trivias};
+use oxc_span::{GetSpan, Span};
+
 use crate::jsdoc::JSDocFinder;
+
+use super::parser::JSDoc;
 
 pub struct JSDocBuilder<'a> {
     source_text: &'a str,

--- a/crates/oxc_semantic/src/jsdoc/finder.rs
+++ b/crates/oxc_semantic/src/jsdoc/finder.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use oxc_span::{GetSpan, Span};
 
-use super::parser::JSDoc;
 use crate::AstNode;
+
+use super::parser::JSDoc;
 
 #[derive(Debug, Default)]
 pub struct JSDocFinder<'a> {

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -1,9 +1,10 @@
 use oxc_span::Span;
 
+use crate::jsdoc::parser::utils;
+
 use super::jsdoc_parts::{
     JSDocCommentPart, JSDocTagKindPart, JSDocTagTypeNamePart, JSDocTagTypePart,
 };
-use crate::jsdoc::parser::utils;
 
 // Initially, I attempted to parse into specific structures such as:
 // - `@param {type} name comment`: `JSDocParameterTag { type, name, comment }`

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -4,6 +4,21 @@
 //! ```rust
 #![doc = include_str!("../examples/simple.rs")]
 //! ```
+
+use std::sync::Arc;
+
+use oxc_ast::{ast::IdentifierReference, AstKind, Trivias};
+use oxc_cfg::ControlFlowGraph;
+use oxc_span::{GetSpan, SourceType, Span};
+pub use oxc_syntax::{
+    module_record::ModuleRecord,
+    scope::{ScopeFlags, ScopeId},
+    symbol::{SymbolFlags, SymbolId},
+};
+
+pub mod dot;
+pub mod post_transform_checker;
+
 mod binder;
 mod builder;
 mod checker;
@@ -19,29 +34,15 @@ mod scope;
 mod symbol;
 mod unresolved_stack;
 
-pub mod dot;
-pub mod post_transform_checker;
-
-use std::sync::Arc;
-
-pub use builder::{SemanticBuilder, SemanticBuilderReturn};
-use class::ClassTable;
-pub use jsdoc::{JSDoc, JSDocFinder, JSDocTag};
-pub use node::{AstNode, AstNodeId, AstNodes};
-use oxc_ast::{ast::IdentifierReference, AstKind, Trivias};
-use oxc_cfg::ControlFlowGraph;
-use oxc_span::{GetSpan, SourceType, Span};
-pub use oxc_syntax::{
-    module_record::ModuleRecord,
-    scope::{ScopeFlags, ScopeId},
-    symbol::{SymbolFlags, SymbolId},
-};
-
 pub use crate::{
+    builder::{SemanticBuilder, SemanticBuilderReturn},
+    jsdoc::{JSDoc, JSDocFinder, JSDocTag},
+    node::{AstNode, AstNodeId, AstNodes},
     reference::{Reference, ReferenceFlags, ReferenceId},
     scope::ScopeTree,
     symbol::{IsGlobalReference, SymbolTable},
 };
+use class::ClassTable;
 
 /// Semantic analysis of a JavaScript/TypeScript program.
 ///

--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -92,6 +92,8 @@ use std::{
 };
 
 use indexmap::IndexMap;
+use rustc_hash::FxHasher;
+
 use oxc_allocator::{Allocator, CloneIn};
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, visit::walk, Visit};
@@ -102,7 +104,6 @@ use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolId,
 };
-use rustc_hash::FxHasher;
 
 use crate::{ScopeTree, SemanticBuilder, SymbolTable};
 

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,11 +1,12 @@
 // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
 #![allow(non_snake_case)]
 
-pub use oxc_syntax::reference::{ReferenceFlags, ReferenceId};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]
 use tsify::Tsify;
+
+pub use oxc_syntax::reference::{ReferenceFlags, ReferenceId};
 
 use crate::{symbol::SymbolId, AstNodeId};
 

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -1,11 +1,12 @@
 use std::hash::BuildHasherDefault;
 
 use indexmap::IndexMap;
+use rustc_hash::{FxHashMap, FxHasher};
+
 use oxc_index::IndexVec;
 use oxc_span::CompactStr;
 use oxc_syntax::reference::ReferenceId;
 pub use oxc_syntax::scope::{ScopeFlags, ScopeId};
-use rustc_hash::{FxHashMap, FxHasher};
 
 use crate::{symbol::SymbolId, AstNodeId};
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -1,5 +1,10 @@
 #![allow(non_snake_case)] // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
 
+#[cfg(feature = "serialize")]
+use serde::Serialize;
+#[cfg(feature = "serialize")]
+use tsify::Tsify;
+
 use oxc_ast::ast::{Expression, IdentifierReference};
 use oxc_index::IndexVec;
 use oxc_span::{CompactStr, Span};
@@ -7,10 +12,6 @@ pub use oxc_syntax::{
     scope::ScopeId,
     symbol::{RedeclarationId, SymbolFlags, SymbolId},
 };
-#[cfg(feature = "serialize")]
-use serde::Serialize;
-#[cfg(feature = "serialize")]
-use tsify::Tsify;
 
 use crate::{
     node::AstNodeId,

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,7 +1,8 @@
 use assert_unchecked::assert_unchecked;
+use rustc_hash::FxHashMap;
+
 use oxc_span::Atom;
 use oxc_syntax::reference::ReferenceId;
-use rustc_hash::FxHashMap;
 
 /// The difference with Scope's `UnresolvedReferences` is that this type uses Atom as the key. its clone is very cheap!
 type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<ReferenceId>>;


### PR DESCRIPTION
Pure refactor. Re-order `use` statements in `oxc_semantic` to follow this order:

1. `std`
2. External crates.
3. `oxc_*` crates.
4. Local crate.
5. `super`
6. `mod`

This is intended to be in order from "furthest above" to "furthest below".