### PR TITLE
perf(ast)!: revert: reduce byte size of `TaggedTemplateExpression::quasi` by `Boxing` it (#5679)

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -461,7 +461,7 @@ pub struct TaggedTemplateExpression<'a> {
     #[serde(flatten)]
     pub span: Span,
     pub tag: Expression<'a>,
-    pub quasi: Box<'a, TemplateLiteral<'a>>,
+    pub quasi: TemplateLiteral<'a>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -138,12 +138,12 @@ const _: () = {
     assert!(offset_of!(TemplateLiteral, quasis) == 8usize);
     assert!(offset_of!(TemplateLiteral, expressions) == 40usize);
 
-    assert!(size_of::<TaggedTemplateExpression>() == 40usize);
+    assert!(size_of::<TaggedTemplateExpression>() == 104usize);
     assert!(align_of::<TaggedTemplateExpression>() == 8usize);
     assert!(offset_of!(TaggedTemplateExpression, span) == 0usize);
     assert!(offset_of!(TaggedTemplateExpression, tag) == 8usize);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 24usize);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 32usize);
+    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 96usize);
 
     assert!(size_of::<TemplateElement>() == 48usize);
     assert!(align_of::<TemplateElement>() == 8usize);
@@ -1693,12 +1693,12 @@ const _: () = {
     assert!(offset_of!(TemplateLiteral, quasis) == 8usize);
     assert!(offset_of!(TemplateLiteral, expressions) == 24usize);
 
-    assert!(size_of::<TaggedTemplateExpression>() == 24usize);
+    assert!(size_of::<TaggedTemplateExpression>() == 60usize);
     assert!(align_of::<TaggedTemplateExpression>() == 4usize);
     assert!(offset_of!(TaggedTemplateExpression, span) == 0usize);
     assert!(offset_of!(TaggedTemplateExpression, tag) == 8usize);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 16usize);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 20usize);
+    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 56usize);
 
     assert!(size_of::<TemplateElement>() == 28usize);
     assert!(align_of::<TemplateElement>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1075,16 +1075,15 @@ impl<'a> AstBuilder<'a> {
     /// - quasi
     /// - type_parameters
     #[inline]
-    pub fn expression_tagged_template<T1, T2>(
+    pub fn expression_tagged_template<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
-        quasi: T1,
-        type_parameters: T2,
+        quasi: TemplateLiteral<'a>,
+        type_parameters: T1,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Box<'a, TemplateLiteral<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::TaggedTemplateExpression(self.alloc(self.tagged_template_expression(
             span,
@@ -1990,21 +1989,20 @@ impl<'a> AstBuilder<'a> {
     /// - quasi
     /// - type_parameters
     #[inline]
-    pub fn tagged_template_expression<T1, T2>(
+    pub fn tagged_template_expression<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
-        quasi: T1,
-        type_parameters: T2,
+        quasi: TemplateLiteral<'a>,
+        type_parameters: T1,
     ) -> TaggedTemplateExpression<'a>
     where
-        T1: IntoIn<'a, Box<'a, TemplateLiteral<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TaggedTemplateExpression {
             span,
             tag,
-            quasi: quasi.into_in(self.allocator),
+            quasi,
             type_parameters: type_parameters.into_in(self.allocator),
         }
     }
@@ -2019,16 +2017,15 @@ impl<'a> AstBuilder<'a> {
     /// - quasi
     /// - type_parameters
     #[inline]
-    pub fn alloc_tagged_template_expression<T1, T2>(
+    pub fn alloc_tagged_template_expression<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
-        quasi: T1,
-        type_parameters: T2,
+        quasi: TemplateLiteral<'a>,
+        type_parameters: T1,
     ) -> Box<'a, TaggedTemplateExpression<'a>>
     where
-        T1: IntoIn<'a, Box<'a, TemplateLiteral<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
             self.tagged_template_expression(span, tag, quasi, type_parameters),

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -2612,10 +2612,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
     }
 
     #[inline]
-    pub fn quasi(self) -> &'t Box<'a, TemplateLiteral<'a>> {
+    pub fn quasi(self) -> &'t TemplateLiteral<'a> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
-                as *const Box<'a, TemplateLiteral<'a>>)
+                as *const TemplateLiteral<'a>)
         }
     }
 
@@ -2684,10 +2684,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn quasi(self) -> &'t Box<'a, TemplateLiteral<'a>> {
+    pub fn quasi(self) -> &'t TemplateLiteral<'a> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
-                as *const Box<'a, TemplateLiteral<'a>>)
+                as *const TemplateLiteral<'a>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -486,8 +486,8 @@ pub(crate) unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
     ctx.retag_stack(AncestorType::TaggedTemplateExpressionQuasi);
     walk_template_literal(
         traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
-            as *mut Box<TemplateLiteral>)) as *mut _,
+        (node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
+            as *mut TemplateLiteral,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)


### PR DESCRIPTION
As discussed in #5601, there is little benefit to reducing type sizes for the sake of it. In this case, the `quasi` field in not in an `Option`, so putting it in a `Box` does not save data, only moves where that data is stored, and introduces pointer-indirection.