### PR TITLE
fix(linter/no-unused-vars): false positive when a variable used as a computed member property

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -37,6 +37,13 @@ fn test_vars_simple() {
             ",
             None,
         ),
+        (
+            "
+                const a = 0
+                obj[a]++;
+            ",
+            None,
+        ),
     ];
     let fail = vec![
         ("let a = 1", None),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -412,6 +412,13 @@ impl<'s, 'a> Symbol<'s, 'a> {
                 //    a = yield a // <- still considered used b/c it's propagated to the caller
                 // }
                 AstKind::YieldExpression(_) => return false,
+                AstKind::MemberExpression(MemberExpression::ComputedMemberExpression(computed)) => {
+                    // obj[a]++;
+                    //     ^ the reference is used as property
+                    if computed.expression.span().contains_inclusive(ref_span) {
+                        return false;
+                    }
+                }
                 _ => { /* continue up tree */ }
             }
         }


### PR DESCRIPTION
close: #5671 