### PR TITLE
perf(index): remove `Idx` bounds-checks from `first` + `last` methods

### DIFF
--- a/crates/oxc_index/src/idxslice.rs
+++ b/crates/oxc_index/src/idxslice.rs
@@ -409,26 +409,25 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
     /// Return the the last element, if we are not empty.
     #[inline(always)]
     pub fn last(&self) -> Option<&T> {
-        self.len().checked_sub(1).and_then(|i| self.get(I::from_usize(i)))
+        self.raw.last()
     }
 
     /// Return the the last element, if we are not empty.
     #[inline]
     pub fn last_mut(&mut self) -> Option<&mut T> {
-        let i = self.len().checked_sub(1)?;
-        self.get_mut(I::from_usize(i))
+        self.raw.last_mut()
     }
 
     /// Return the the first element, if we are not empty.
     #[inline]
     pub fn first(&self) -> Option<&T> {
-        self.get(I::from_usize(0))
+        self.raw.first()
     }
 
     /// Return the the first element, if we are not empty.
     #[inline]
     pub fn first_mut(&mut self) -> Option<&mut T> {
-        self.get_mut(I::from_usize(0))
+        self.raw.first_mut()
     }
 
     /// Copies elements from one part of the slice to another part of itself,


### PR DESCRIPTION
The following methods of `IndexVec` call `Idx::from_usize` which performs a bounds check, with a panicking branch:

* `first`
* `first_mut`
* `last`
* `last_mut`

These bounds checks are unnecessary. Remove them by delegating to the underlying `Vec`'s methods.