### PR TITLE
ci(benchmarks): `NeverGrowInPlaceAllocator` not `pub`

### DIFF
--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -24,7 +24,7 @@ static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
 /// [`GlobalAlloc::realloc`] implementation which *never* grows in place.
 /// It therefore represents the "worse case scenario" for memory allocation performance.
 /// This behavior is consistent and predictable, and therefore stabilizes benchmark results.
-pub struct NeverGrowInPlaceAllocator;
+struct NeverGrowInPlaceAllocator;
 
 // SAFETY: Methods simply delegate to `System` allocator
 #[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]


### PR DESCRIPTION
Global allocator used in benchmarks `NeverGrowInPlaceAllocator` doesn't need to be `pub`.