### PR TITLE
refactor(semantic): fix dead code warning in release mode

### DIFF
--- a/crates/oxc_semantic/src/counter.rs
+++ b/crates/oxc_semantic/src/counter.rs
@@ -30,7 +30,7 @@ impl Counts {
         counts
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg_attr(not(debug_assertions), expect(dead_code))]
     pub fn assert_accurate(actual: &Self, estimated: &Self) {
         assert_eq!(actual.nodes, estimated.nodes, "nodes count mismatch");
         assert_eq!(actual.scopes, estimated.scopes, "scopes count mismatch");


### PR DESCRIPTION
`Counts::assert_accurate` is only used in debug mode. Silence the dead code warning in release mode.