### PR TITLE
feat(index)!: remove ability to index `IndexVec` with `usize`

### DIFF
--- a/crates/oxc_index/src/idxslice.rs
+++ b/crates/oxc_index/src/idxslice.rs
@@ -668,7 +668,7 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
         } else {
             let last = self.last_idx();
             let split = self.split_at_mut(last);
-            Some((&mut split.1[0], split.0))
+            Some((&mut split.1[I::from_usize(0)], split.0))
         }
     }
 }

--- a/crates/oxc_index/src/indexing.rs
+++ b/crates/oxc_index/src/indexing.rs
@@ -109,32 +109,6 @@ impl<I: Idx, T> IdxSliceIndex<I, T> for core::ops::RangeFull {
     }
 }
 
-impl private_slice_index::Sealed for usize {}
-// As an ergonomic concession, implement this for `usize` as well, it's too painful without
-impl<I: Idx, T> IdxSliceIndex<I, T> for usize {
-    type Output = T;
-
-    #[inline]
-    fn get(self, slice: &IndexSlice<I, [T]>) -> Option<&Self::Output> {
-        slice.raw.get(self)
-    }
-
-    #[inline]
-    fn get_mut(self, slice: &mut IndexSlice<I, [T]>) -> Option<&mut Self::Output> {
-        slice.raw.get_mut(self)
-    }
-
-    #[inline]
-    fn index(self, slice: &IndexSlice<I, [T]>) -> &Self::Output {
-        &slice.raw[self]
-    }
-
-    #[inline]
-    fn index_mut(self, slice: &mut IndexSlice<I, [T]>) -> &mut Self::Output {
-        &mut slice.raw[self]
-    }
-}
-
 /// This trait to function in API signatures where `Vec<T>` or `[T]` use `R:
 /// RangeBounds<usize>`. There are blanket implementations for the basic range
 /// types in `core::ops` for all Idx types. e.g. `Range<I: Idx>`, `RangeFrom<I:

--- a/crates/oxc_index/tests/test.rs
+++ b/crates/oxc_index/tests/test.rs
@@ -453,8 +453,6 @@ fn test_indexing() {
 
     assert_eq!(v[IdxSz::new(3)], 3);
 
-    assert_eq!(v[3], 3); // usize is allowed.
-
     // Make sure the types are as expected
     let s: &IndexSlice<IdxSz, [i32]> = &v[..];
     assert_eq!(s, &[0, 1, 2, 3, 4]);
@@ -490,8 +488,6 @@ fn test_indexing() {
         assert_eq!(s, &[0, 1, 2, 3]);
     }
     assert_eq!(&mut v[IdxSz::new(3)], &mut 3);
-
-    assert_eq!(&mut v[3], &mut 3); // usize is allowed.
 }
 
 #[test]
@@ -510,7 +506,6 @@ fn test_get() {
     assert_eq!(s.unwrap(), &[0, 1, 2, 3]);
 
     assert_eq!(v.get(IdxSz::new(3)), Some(&3));
-    assert_eq!(v.get(3), Some(&3));
 }
 
 #[test]
@@ -527,7 +522,6 @@ fn test_get_mut() {
     let s: Option<&mut IndexSlice<IdxSz, [i32]>> = v.get_mut(..=IdxSz::new(3));
     assert_eq!(s.unwrap(), &[0, 1, 2, 3]);
     assert_eq!(v.get_mut(IdxSz::new(3)), Some(&mut 3));
-    assert_eq!(v.get_mut(3), Some(&mut 3));
 }
 
 #[test]


### PR DESCRIPTION
`IndexVec` should only be indexed into with its associated `Idx` type. The implementation taken from `index_vec` crate however also includes the ability to index into the `Vec` with a `usize` "as an ergonomic concession, it's too painful without":

https://docs.rs/index_vec/0.1.4/src/index_vec/indexing.rs.html#112-134

I think we want to be stricter than this, so remove this ability.