### PR TITLE
refactor(linter): shorten `Option` syntax

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -137,9 +137,7 @@ impl Rule for AnchorIsValid {
             };
             // Don't eagerly get `span` here, to avoid that work unless rule fails
             let get_span = || jsx_el.opening_element.name.span();
-            if let Option::Some(href_attr) =
-                has_jsx_prop_ignore_case(&jsx_el.opening_element, "href")
-            {
+            if let Some(href_attr) = has_jsx_prop_ignore_case(&jsx_el.opening_element, "href") {
                 let JSXAttributeItem::Attribute(attr) = href_attr else {
                     return;
                 };

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -142,7 +142,7 @@ impl Rule for AriaRole {
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
-            if let Option::Some(aria_role) = has_jsx_prop(&jsx_el.opening_element, "role") {
+            if let Some(aria_role) = has_jsx_prop(&jsx_el.opening_element, "role") {
                 let Some(element_type) = get_element_type(ctx, &jsx_el.opening_element) else {
                     return;
                 };

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -75,7 +75,7 @@ impl Rule for CatchErrorName {
             .unwrap_or(&vec![])
             .iter()
             .map(serde_json::Value::as_str)
-            .filter(std::option::Option::is_some)
+            .filter(Option::is_some)
             .map(|x| CompactStr::from(x.unwrap()))
             .collect::<Vec<CompactStr>>();
 


### PR DESCRIPTION
Use `Some` instead of `Option::Some`.