### PR TITLE
feat(ast): provide `NONE` type for AST builder calls

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -7,13 +7,24 @@
 
 use std::mem;
 
-use oxc_allocator::{Allocator, Box, String, Vec};
+use oxc_allocator::{Allocator, Box, FromIn, String, Vec};
 use oxc_span::{Atom, GetSpan, Span};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator};
 
 #[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 use crate::AstBuilder;
+
+/// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Anything<'a>>`.
+/// Pass `NONE` instead of `None::<Anything<'a>>`.
+#[allow(clippy::upper_case_acronyms)]
+pub struct NONE;
+
+impl<'a, T> FromIn<'a, NONE> for Option<Box<'a, T>> {
+    fn from_in(_: NONE, _: &'a Allocator) -> Self {
+        None
+    }
+}
 
 impl<'a> AstBuilder<'a> {
     #[inline]
@@ -145,19 +156,9 @@ impl<'a> AstBuilder<'a> {
         params: FormalParameters<'a>,
         body: Option<FunctionBody<'a>>,
     ) -> Box<'a, Function<'a>> {
-        self.alloc(self.function(
-            r#type,
-            span,
-            id,
-            false,
-            false,
-            false,
-            Option::<TSTypeParameterDeclaration>::None,
-            None::<Box<'a, TSThisParameter<'a>>>,
-            params,
-            Option::<TSTypeAnnotation>::None,
-            body,
-        ))
+        self.alloc(
+            self.function(r#type, span, id, false, false, false, NONE, NONE, params, NONE, body),
+        )
     }
 
     /* ---------- Modules ---------- */
@@ -174,7 +175,7 @@ impl<'a> AstBuilder<'a> {
             self.vec(),
             None,
             ImportOrExportKind::Value,
-            None::<WithClause>,
+            NONE,
         ))
     }
 
@@ -191,7 +192,7 @@ impl<'a> AstBuilder<'a> {
             specifiers,
             source,
             ImportOrExportKind::Value,
-            None::<WithClause>,
+            NONE,
         ))
     }
 

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -59,6 +59,7 @@ pub use num_bigint::BigUint;
 
 pub use crate::{
     ast_builder::AstBuilder,
+    ast_builder_impl::NONE,
     ast_kind::{AstKind, AstType},
     trivia::{Comment, CommentKind, SortedComments, Trivias},
     visit::{Visit, VisitMut},

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Box;
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::{Atom, GetSpan, SPAN};
 use rustc_hash::FxHashMap;
 
@@ -130,7 +130,7 @@ impl<'a> IsolatedDeclarations<'a> {
             unsafe { self.ast.copy(&function.this_param) },
             params,
             return_type,
-            Option::<FunctionBody>::None,
+            NONE,
         );
 
         self.ast.class_element_method_definition(
@@ -170,7 +170,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             false,
             false,
-            Option::<TSTypeAnnotation>::None,
+            NONE,
             accessibility,
         )
     }
@@ -228,7 +228,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     SPAN,
                     FormalParameterKind::Signature,
                     self.ast.vec(),
-                    Option::<BindingRestElement>::None,
+                    NONE,
                 );
                 self.transform_class_method_definition(method, params, None)
             }
@@ -491,20 +491,8 @@ impl<'a> IsolatedDeclarations<'a> {
             let r#type = PropertyDefinitionType::PropertyDefinition;
             let decorators = self.ast.vec();
             let element = self.ast.class_element_property_definition(
-                r#type,
-                SPAN,
-                decorators,
-                ident,
-                None,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                Option::<TSTypeAnnotation>::None,
-                None,
+                r#type, SPAN, decorators, ident, None, false, false, false, false, false, false,
+                false, NONE, None,
             );
 
             elements.insert(0, element);
@@ -562,11 +550,6 @@ impl<'a> IsolatedDeclarations<'a> {
         let parameter =
             self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, None, false, false);
         let items = self.ast.vec1(parameter);
-        self.ast.alloc_formal_parameters(
-            SPAN,
-            FormalParameterKind::Signature,
-            items,
-            Option::<BindingRestElement>::None,
-        )
+        self.ast.alloc_formal_parameters(SPAN, FormalParameterKind::Signature, items, NONE)
     }
 }

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,7 +1,6 @@
 use oxc_allocator::Box;
-use oxc_ast::ast::Function;
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::{Span, SPAN};
 
 use crate::{
@@ -41,7 +40,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 unsafe { self.ast.copy(&func.this_param) },
                 params,
                 return_type,
-                Option::<FunctionBody>::None,
+                NONE,
             ))
         }
     }

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -24,7 +24,7 @@ use std::{cell::RefCell, collections::VecDeque, mem};
 use diagnostics::function_with_assigning_properties;
 use oxc_allocator::Allocator;
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::{ast::*, AstBuilder, Visit};
+use oxc_ast::{ast::*, AstBuilder, Visit, NONE};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Atom, SourceType, SPAN};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -308,14 +308,8 @@ impl<'a> IsolatedDeclarations<'a> {
         if need_empty_export_marker {
             let specifiers = self.ast.vec();
             let kind = ImportOrExportKind::Value;
-            let empty_export = self.ast.alloc_export_named_declaration(
-                SPAN,
-                None,
-                specifiers,
-                None,
-                kind,
-                None::<WithClause>,
-            );
+            let empty_export =
+                self.ast.alloc_export_named_declaration(SPAN, None, specifiers, None, kind, NONE);
             new_ast_stmts
                 .push(Statement::from(ModuleDeclaration::ExportNamedDeclaration(empty_export)));
         }

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,8 +1,10 @@
-use oxc_allocator::Box;
-use oxc_ast::ast::{
-    ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
-    ObjectExpression, ObjectPropertyKind, TSLiteral, TSMethodSignatureKind, TSThisParameter,
-    TSTupleElement, TSType, TSTypeOperatorOperator,
+use oxc_ast::{
+    ast::{
+        ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
+        ObjectExpression, ObjectPropertyKind, TSLiteral, TSMethodSignatureKind, TSTupleElement,
+        TSType, TSTypeOperatorOperator,
+    },
+    NONE,
 };
 use oxc_span::{GetSpan, Span, SPAN};
 
@@ -55,7 +57,7 @@ impl<'a> IsolatedDeclarations<'a> {
         return_type.map(|return_type| {
             self.ast.ts_type_function_type(
                 func.span,
-                None::<Box<'a, TSThisParameter<'a>>>,
+                NONE,
                 params,
                 return_type,
                 // SAFETY: `ast.copy` is unsound! We need to fix.

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::*, syntax_directed_operations::BoundNames, AstBuilder, Visit};
+use oxc_ast::{ast::*, syntax_directed_operations::BoundNames, AstBuilder, Visit, NONE};
 use oxc_span::{Atom, Span, SPAN};
 
 pub struct KeepVar<'a> {
@@ -57,8 +57,7 @@ impl<'a> KeepVar<'a> {
         let kind = VariableDeclarationKind::Var;
         let decls = self.ast.vec_from_iter(self.vars.into_iter().map(|(name, span)| {
             let binding_kind = self.ast.binding_pattern_kind_binding_identifier(span, name);
-            let id =
-                self.ast.binding_pattern::<Option<TSTypeAnnotation>>(binding_kind, None, false);
+            let id = self.ast.binding_pattern(binding_kind, NONE, false);
             self.ast.variable_declarator(span, kind, id, None, false)
         }));
 

--- a/crates/oxc_minifier/src/plugins/inject_global_variables.rs
+++ b/crates/oxc_minifier/src/plugins/inject_global_variables.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cow_utils::CowUtils;
 
 use oxc_allocator::Allocator;
-use oxc_ast::{ast::*, AstBuilder};
+use oxc_ast::{ast::*, AstBuilder, NONE};
 use oxc_semantic::{ScopeTree, SymbolTable};
 use oxc_span::{CompactStr, SPAN};
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
@@ -197,13 +197,9 @@ impl<'a> InjectGlobalVariables<'a> {
             let specifiers = Some(self.ast.vec1(self.inject_import_to_specifier(inject)));
             let source = self.ast.string_literal(SPAN, inject.source.as_str());
             let kind = ImportOrExportKind::Value;
-            let import_decl = self.ast.module_declaration_import_declaration(
-                SPAN,
-                specifiers,
-                source,
-                None::<WithClause>,
-                kind,
-            );
+            let import_decl = self
+                .ast
+                .module_declaration_import_declaration(SPAN, specifiers, source, NONE, kind);
             self.ast.statement_module_declaration(import_decl)
         });
         program.body.splice(0..0, imports);

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Box;
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::Precedence;
@@ -218,13 +218,13 @@ impl<'a> ParserImpl<'a> {
             };
             let params_span = self.end_span(ident.span);
             let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
-            let pattern = self.ast.binding_pattern(ident, Option::<TSTypeAnnotation>::None, false);
+            let pattern = self.ast.binding_pattern(ident, NONE, false);
             let formal_parameter = self.ast.plain_formal_parameter(params_span, pattern);
             self.ast.alloc_formal_parameters(
                 params_span,
                 FormalParameterKind::ArrowFormalParameters,
                 self.ast.vec1(formal_parameter),
-                Option::<BindingRestElement>::None,
+                NONE,
             )
         };
 

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 
@@ -145,8 +145,7 @@ impl<'a> ParserImpl<'a> {
                 shorthand = true;
                 let identifier =
                     self.ast.binding_pattern_kind_binding_identifier(ident.span, &ident.name);
-                let left =
-                    self.ast.binding_pattern(identifier, Option::<TSTypeAnnotation>::None, false);
+                let left = self.ast.binding_pattern(identifier, NONE, false);
                 self.context(Context::In, Context::empty(), |p| p.parse_initializer(span, left))?
             } else {
                 return Err(self.unexpected());
@@ -172,7 +171,7 @@ impl<'a> ParserImpl<'a> {
             let expr = self.parse_assignment_expression_or_higher()?;
             Ok(self.ast.binding_pattern(
                 self.ast.binding_pattern_kind_assignment_pattern(self.end_span(span), left, expr),
-                Option::<TSTypeAnnotation>::None,
+                NONE,
                 false,
             ))
         } else {

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Box;
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 
@@ -113,7 +113,7 @@ impl<'a> ParserImpl<'a> {
             }
             (self.ast.binding_pattern(binding_kind, type_annotation, optional), definite)
         } else {
-            (self.ast.binding_pattern(binding_kind, Option::<TSTypeAnnotation>::None, false), false)
+            (self.ast.binding_pattern(binding_kind, NONE, false), false)
         };
 
         let init =

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{Box, Vec};
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
@@ -347,7 +347,7 @@ impl<'a> ParserImpl<'a> {
             self.ast.vec(),
             None,
             ImportOrExportKind::Value,
-            None::<WithClause>,
+            NONE,
         ))
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{Box, Vec};
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
@@ -1169,7 +1169,7 @@ impl<'a> ParserImpl<'a> {
             this_param,
             params,
             return_type,
-            Option::<TSTypeParameterDeclaration>::None,
+            NONE,
         ))
     }
 
@@ -1195,7 +1195,7 @@ impl<'a> ParserImpl<'a> {
             this_param,
             params,
             return_type,
-            Option::<TSTypeParameterDeclaration>::None,
+            NONE,
         ))
     }
 

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -62,7 +62,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::Vec;
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::SPAN;
 use oxc_syntax::{scope::ScopeFlags, symbol::SymbolFlags};
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -294,7 +294,7 @@ impl<'a> ArrowFunctions<'a> {
                 self.ctx
                     .ast
                     .binding_pattern_kind_from_binding_identifier(id.create_binding_identifier()),
-                Option::<TSTypeAnnotation>::None,
+                NONE,
                 false,
             );
 

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -33,7 +33,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
@@ -151,13 +151,7 @@ impl<'a> ExponentiationOperator<'a> {
         let mut arguments = ctx.ast.vec_with_capacity(2);
         arguments.push(Argument::from(left));
         arguments.push(Argument::from(right));
-        ctx.ast.expression_call(
-            SPAN,
-            callee,
-            None::<TSTypeParameterInstantiation<'_>>,
-            arguments,
-            false,
-        )
+        ctx.ast.expression_call(SPAN, callee, NONE, arguments, false)
     }
 
     /// Change `lhs **= 2` to `var temp; temp = lhs, lhs = Math.pow(temp, 2);`.
@@ -327,7 +321,7 @@ impl<'a> ExponentiationOperator<'a> {
             };
             let kind = VariableDeclarationKind::Var;
             let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
-            let id = ctx.ast.binding_pattern(id, None::<TSTypeAnnotation<'_>>, false);
+            let id = ctx.ast.binding_pattern(id, NONE, false);
             self.var_declarations
                 .last_mut()
                 .unwrap()

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
@@ -26,7 +26,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_semantic::{ReferenceFlags, SymbolId};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -84,13 +84,7 @@ impl<'a> Traverse<'a> for ObjectSpread<'a> {
         let callee = self.get_extend_object_callee(object_id, babel_helpers_id, ctx);
 
         // ({ ...x }) => _objectSpread({}, x)
-        *expr = ctx.ast.expression_call(
-            SPAN,
-            callee,
-            None::<TSTypeParameterInstantiation>,
-            arguments,
-            false,
-        );
+        *expr = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
 
         // ({ ...x, y, z }) => _objectSpread(_objectSpread({}, x), { y, z });
         if !obj_prop_list.is_empty() {
@@ -101,13 +95,7 @@ impl<'a> Traverse<'a> for ObjectSpread<'a> {
 
             let callee = self.get_extend_object_callee(object_id, babel_helpers_id, ctx);
 
-            *expr = ctx.ast.expression_call(
-                SPAN,
-                callee,
-                None::<TSTypeParameterInstantiation>,
-                arguments,
-                false,
-            );
+            *expr = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
         }
     }
 }

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -34,7 +34,7 @@
 
 use std::cell::Cell;
 
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -70,8 +70,7 @@ impl<'a> Traverse<'a> for OptionalCatchBinding<'a> {
             BindingIdentifier { span: SPAN, symbol_id: Cell::new(Some(symbol_id)), name };
         let binding_pattern_kind =
             ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
-        let binding_pattern =
-            ctx.ast.binding_pattern(binding_pattern_kind, None::<TSTypeAnnotation<'a>>, false);
+        let binding_pattern = ctx.ast.binding_pattern(binding_pattern_kind, NONE, false);
         let param = ctx.ast.catch_parameter(SPAN, binding_pattern);
         clause.param = Some(param);
     }

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -31,7 +31,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};
@@ -137,34 +137,19 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
                 SPAN,
                 FormalParameterKind::ArrowFormalParameters,
                 ctx.ast.vec1(param),
-                None::<BindingRestElement>,
+                NONE,
             );
             let body = ctx.ast.function_body(
                 SPAN,
                 ctx.ast.vec(),
                 ctx.ast.vec1(ctx.ast.statement_expression(SPAN, new_expr)),
             );
-            let type_parameters = None::<TSTypeParameterDeclaration>;
-            let type_annotation = None::<TSTypeAnnotation>;
-            let arrow_function = ctx.ast.arrow_function_expression(
-                SPAN,
-                true,
-                false,
-                type_parameters,
-                params,
-                type_annotation,
-                body,
-            );
+            let arrow_function =
+                ctx.ast.arrow_function_expression(SPAN, true, false, NONE, params, NONE, body);
             arrow_function.scope_id.set(Some(current_scope_id));
             let arrow_function = ctx.ast.expression_from_arrow_function(arrow_function);
             // `(x) => x;` -> `((x) => x)();`
-            new_expr = ctx.ast.expression_call(
-                SPAN,
-                arrow_function,
-                None::<TSTypeParameterInstantiation>,
-                ctx.ast.vec(),
-                false,
-            );
+            new_expr = ctx.ast.expression_call(SPAN, arrow_function, NONE, ctx.ast.vec(), false);
         } else {
             let kind = VariableDeclarationKind::Var;
             self.var_declarations
@@ -207,7 +192,7 @@ impl<'a> NullishCoalescingOperator<'a> {
             symbol_id: Cell::new(Some(symbol_id)),
         };
         let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
-        let id = ctx.ast.binding_pattern(id, None::<TSTypeAnnotation<'_>>, false);
+        let id = ctx.ast.binding_pattern(id, NONE, false);
         let reference =
             ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);
 

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -56,7 +56,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
@@ -367,7 +367,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
         };
         let kind = VariableDeclarationKind::Var;
         let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
-        let id = ctx.ast.binding_pattern(id, None::<TSTypeAnnotation>, false);
+        let id = ctx.ast.binding_pattern(id, NONE, false);
         self.var_declarations
             .last_mut()
             .unwrap()

--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, RefCell};
 
 use indexmap::IndexMap;
 use oxc_allocator::{Allocator, Vec};
-use oxc_ast::{ast::*, AstBuilder};
+use oxc_ast::{ast::*, AstBuilder, NONE};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{Atom, SPAN};
 use oxc_syntax::symbol::SymbolId;
@@ -108,7 +108,7 @@ impl<'a> ModuleImports<'a> {
             SPAN,
             Some(specifiers),
             StringLiteral::new(SPAN, source),
-            None::<WithClause>,
+            NONE,
             ImportOrExportKind::Value,
         );
         self.ast.statement_module_declaration(import_stmt)
@@ -139,18 +139,12 @@ impl<'a> ModuleImports<'a> {
             };
             self.ast.binding_pattern(
                 self.ast.binding_pattern_kind_from_binding_identifier(ident),
-                Option::<TSTypeAnnotation>::None,
+                NONE,
                 false,
             )
         };
         let decl = {
-            let init = self.ast.expression_call(
-                SPAN,
-                callee,
-                Option::<TSTypeParameterInstantiation>::None,
-                args,
-                false,
-            );
+            let init = self.ast.expression_call(SPAN, callee, NONE, args, false);
             let decl = self.ast.variable_declarator(SPAN, var_kind, id, Some(init), false);
             self.ast.vec1(decl)
         };

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use oxc_allocator::Vec;
-use oxc_ast::{ast::*, AstBuilder};
+use oxc_ast::{ast::*, AstBuilder, NONE};
 use oxc_span::{Atom, GetSpan, Span, SPAN};
 use oxc_syntax::{
     identifier::{is_irregular_whitespace, is_line_terminator},
@@ -641,13 +641,7 @@ impl<'a> ReactJsx<'a> {
         }
 
         let callee = self.get_create_element(has_key_after_props_spread, need_jsxs, ctx);
-        self.ast().expression_call(
-            e.span(),
-            callee,
-            Option::<TSTypeParameterInstantiation>::None,
-            arguments,
-            false,
-        )
+        self.ast().expression_call(e.span(), callee, NONE, arguments, false)
     }
 
     fn transform_element_name(&self, name: &JSXElementName<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};
@@ -164,7 +164,7 @@ impl<'a> ReactJsxSource<'a> {
         let id = {
             let ident = filename_var.create_binding_identifier();
             let ident = self.ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
-            self.ctx.ast.binding_pattern(ident, Option::<TSTypeAnnotation>::None, false)
+            self.ctx.ast.binding_pattern(ident, NONE, false)
         };
         let decl = {
             let init = self

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, iter::once};
 
 use base64::prelude::{Engine, BASE64_STANDARD};
 use oxc_allocator::CloneIn;
-use oxc_ast::{ast::*, match_expression, AstBuilder};
+use oxc_ast::{ast::*, match_expression, AstBuilder, NONE};
 use oxc_semantic::{Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{Atom, GetSpan, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
@@ -164,7 +164,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
                         ctx.ast.binding_pattern_kind_from_binding_identifier(
                             binding_identifier.clone(),
                         ),
-                        None::<TSTypeAnnotation<'a>>,
+                        NONE,
                         false,
                     ),
                     None,
@@ -182,13 +182,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
             ));
             new_statements.push(ctx.ast.statement_expression(
                 SPAN,
-                ctx.ast.expression_call(
-                    SPAN,
-                    callee,
-                    Option::<TSTypeParameterInstantiation>::None,
-                    arguments,
-                    false,
-                ),
+                ctx.ast.expression_call(SPAN, callee, NONE, arguments, false),
             ));
         }
         program.body.push(Statement::from(ctx.ast.declaration_variable(
@@ -299,7 +293,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
                             &binding_identifier,
                             ctx,
                         ),
-                        Option::<TSTypeParameterInstantiation>::None,
+                        NONE,
                         arguments,
                         false,
                     ),
@@ -329,7 +323,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
         *expr = self.ctx.ast.expression_call(
             SPAN,
             Self::create_identifier_reference_from_binding_identifier(&binding_identifier, ctx),
-            Option::<TSTypeParameterInstantiation>::None,
+            NONE,
             arguments,
             false,
         );
@@ -366,7 +360,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
                         &binding_identifier,
                         ctx,
                     ),
-                    Option::<TSTypeParameterInstantiation>::None,
+                    NONE,
                     arguments,
                     false,
                 ),
@@ -656,7 +650,7 @@ impl<'a> ReactRefresh<'a> {
                 SPAN,
                 FormalParameterKind::FormalParameter,
                 self.ctx.ast.vec(),
-                Option::<BindingRestElement>::None,
+                NONE,
             );
             let function_body = self.ctx.ast.function_body(
                 SPAN,
@@ -673,10 +667,10 @@ impl<'a> ReactRefresh<'a> {
                 false,
                 false,
                 false,
-                Option::<TSTypeParameterDeclaration>::None,
-                Option::<TSThisParameter>::None,
+                NONE,
+                NONE,
                 formal_parameters,
-                Option::<TSTypeAnnotation>::None,
+                NONE,
                 Some(function_body),
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
@@ -708,7 +702,7 @@ impl<'a> ReactRefresh<'a> {
             ctx.ast.expression_call(
                 SPAN,
                 Self::create_identifier_reference_from_binding_identifier(&binding_identifier, ctx),
-                Option::<TSTypeParameterInstantiation>::None,
+                NONE,
                 ctx.ast.vec(),
                 false,
             ),
@@ -722,13 +716,13 @@ impl<'a> ReactRefresh<'a> {
             VariableDeclarationKind::Var,
             ctx.ast.binding_pattern(
                 ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier.clone()),
-                Option::<TSTypeAnnotation>::None,
+                NONE,
                 false,
             ),
             Some(ctx.ast.expression_call(
                 SPAN,
                 self.refresh_sig.to_expression(ctx),
-                Option::<TSTypeParameterInstantiation>::None,
+                NONE,
                 ctx.ast.vec(),
                 false,
             )),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -46,7 +46,7 @@
 
 use std::borrow::Cow;
 
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;
 use oxc_regular_expression::ast::{
     CharacterClass, CharacterClassContents, LookAroundAssertionKind, Pattern, Term,
@@ -186,12 +186,7 @@ impl<'a> Traverse<'a> for RegExp<'a> {
             ctx.ast.argument_expression(ctx.ast.expression_string_literal(SPAN, flags_str));
         arguments.push(flags_str);
 
-        *expr = ctx.ast.expression_new(
-            regexp.span,
-            callee,
-            arguments,
-            None::<TSTypeParameterInstantiation>,
-        );
+        *expr = ctx.ast.expression_new(regexp.span, callee, arguments, NONE);
     }
 }
 

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::Vec;
-use oxc_ast::{ast::*, visit::walk_mut, VisitMut};
+use oxc_ast::{ast::*, visit::walk_mut, VisitMut, NONE};
 use oxc_span::{Atom, Span, SPAN};
 use oxc_syntax::{
     node::AstNodeId,
@@ -94,7 +94,7 @@ impl<'a> TypeScriptEnum<'a> {
             symbol_id: Cell::new(Some(param_symbol_id)),
         };
         let kind = ast.binding_pattern_kind_from_binding_identifier(ident.clone());
-        let id = ast.binding_pattern(kind, Option::<TSTypeAnnotation>::None, false);
+        let id = ast.binding_pattern(kind, NONE, false);
 
         // ((Foo) => {
         let params = ast.formal_parameter(SPAN, ast.vec(), id, None, false, false);
@@ -103,7 +103,7 @@ impl<'a> TypeScriptEnum<'a> {
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             params,
-            Option::<BindingRestElement>::None,
+            NONE,
         );
 
         // Foo[Foo["X"] = 0] = "X";
@@ -146,13 +146,7 @@ impl<'a> TypeScriptEnum<'a> {
             ast.vec1(Argument::from(expression))
         };
 
-        let call_expression = ast.expression_call(
-            SPAN,
-            callee,
-            Option::<TSTypeParameterInstantiation>::None,
-            arguments,
-            false,
-        );
+        let call_expression = ast.expression_call(SPAN, callee, NONE, arguments, false);
 
         if is_already_declared {
             let op = AssignmentOperator::Assign;
@@ -176,8 +170,7 @@ impl<'a> TypeScriptEnum<'a> {
             let binding_identifier = decl.id.clone();
             let binding_pattern_kind =
                 ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
-            let binding =
-                ast.binding_pattern(binding_pattern_kind, Option::<TSTypeAnnotation>::None, false);
+            let binding = ast.binding_pattern(binding_pattern_kind, NONE, false);
             let decl = ast.variable_declarator(SPAN, kind, binding, Some(call_expression), false);
             ast.vec1(decl)
         };

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Box;
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -58,11 +58,7 @@ impl<'a> TypeScriptModule<'a> {
         let decls = {
             let binding_pattern_kind =
                 ctx.ast.binding_pattern_kind_binding_identifier(SPAN, &decl.id.name);
-            let binding = ctx.ast.binding_pattern(
-                binding_pattern_kind,
-                Option::<TSTypeAnnotation>::None,
-                false,
-            );
+            let binding = ctx.ast.binding_pattern(binding_pattern_kind, NONE, false);
             let decl_span = decl.span;
 
             let init = match &mut decl.module_reference {
@@ -80,13 +76,7 @@ impl<'a> TypeScriptModule<'a> {
                     let arguments = ctx.ast.vec1(Argument::from(
                         ctx.ast.expression_from_string_literal(reference.expression.clone()),
                     ));
-                    ctx.ast.expression_call(
-                        SPAN,
-                        callee,
-                        Option::<TSTypeParameterInstantiation>::None,
-                        arguments,
-                        false,
-                    )
+                    ctx.ast.expression_call(SPAN, callee, NONE, arguments, false)
                 }
             };
             ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, binding, Some(init), false))

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use oxc_allocator::{Box, Vec};
-use oxc_ast::{ast::*, syntax_directed_operations::BoundNames};
+use oxc_ast::{ast::*, syntax_directed_operations::BoundNames, NONE};
 use oxc_span::{Atom, CompactStr, SPAN};
 use oxc_syntax::{
     operator::{AssignmentOperator, LogicalOperator},
@@ -298,8 +298,7 @@ impl<'a> TypeScriptNamespace<'a> {
         let kind = VariableDeclarationKind::Let;
         let declarations = {
             let pattern_kind = self.ctx.ast.binding_pattern_kind_binding_identifier(SPAN, name);
-            let binding =
-                self.ctx.ast.binding_pattern(pattern_kind, Option::<TSTypeAnnotation>::None, false);
+            let binding = self.ctx.ast.binding_pattern(pattern_kind, NONE, false);
             let decl = self.ctx.ast.variable_declarator(SPAN, kind, binding, None, false);
             self.ctx.ast.vec1(decl)
         };
@@ -325,14 +324,13 @@ impl<'a> TypeScriptNamespace<'a> {
             let body = self.ctx.ast.function_body(SPAN, directives, stmts);
             let params = {
                 let ident = self.ctx.ast.binding_pattern_kind_binding_identifier(SPAN, arg_name);
-                let pattern =
-                    self.ctx.ast.binding_pattern(ident, Option::<TSTypeAnnotation>::None, false);
+                let pattern = self.ctx.ast.binding_pattern(ident, NONE, false);
                 let items = self.ctx.ast.vec1(self.ctx.ast.plain_formal_parameter(SPAN, pattern));
                 self.ctx.ast.formal_parameters(
                     SPAN,
                     FormalParameterKind::FormalParameter,
                     items,
-                    Option::<BindingRestElement>::None,
+                    NONE,
                 )
             };
             let function = self.ctx.ast.plain_function(
@@ -410,13 +408,7 @@ impl<'a> TypeScriptNamespace<'a> {
             self.ctx.ast.vec1(self.ctx.ast.argument_expression(expr))
         };
 
-        let expr = self.ctx.ast.expression_call(
-            SPAN,
-            callee,
-            Option::<TSTypeParameterInstantiation>::None,
-            arguments,
-            false,
-        );
+        let expr = self.ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
         self.ctx.ast.statement_expression(SPAN, expr)
     }
 


### PR DESCRIPTION
Closes #5736.

Introduce a `NONE` type which can be used for any `AstBuilder` method call param which expects an `IntoIn<'a, Something<'a>>`, where otherwise you have to provide a verbose type annotation.

Before:

```rs
ast.arrow_function_expression(
    SPAN,
    is_expression,
    is_async,
    None::<TSTypeParameterDeclaration>,
    params,
    None::<TSTypeAnnotation>,
    body,
)
```

After:

```rs
ast.arrow_function_expression(SPAN, is_expression, is_async, NONE, params, NONE, body)
```