### PR TITLE
refactor(semantic): remove `more-asserts` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,12 +1233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "more-asserts"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
-
-[[package]]
 name = "napi"
 version = "3.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,7 +1852,6 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools",
- "more-asserts",
  "oxc_allocator",
  "oxc_ast",
  "oxc_cfg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,6 @@ memoffset = "0.9.1"
 miette = { version = "7.2.0", features = ["fancy-no-syscall"] }
 mimalloc = "0.1.43"
 mime_guess = "2.0.5"
-more-asserts = "0.3.1"
 nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -30,7 +30,6 @@ oxc_syntax = { workspace = true }
 assert-unchecked = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-more-asserts = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/oxc_semantic/src/counter.rs
+++ b/crates/oxc_semantic/src/counter.rs
@@ -4,8 +4,6 @@
 
 use std::cell::Cell;
 
-use more_asserts::assert_le;
-
 use oxc_ast::{
     ast::{
         BindingIdentifier, IdentifierReference, Program, TSEnumMemberName, TSModuleDeclarationName,
@@ -41,7 +39,12 @@ impl Counts {
         // This is not a big problem - allocating a `Vec` with excess capacity is cheap.
         // It's allocating with *not enough* capacity which is costly, as then the `Vec`
         // will grow and reallocate.
-        assert_le!(actual.symbols, estimated.symbols, "symbols count mismatch");
+        assert!(
+            actual.symbols <= estimated.symbols,
+            "symbols count mismatch {} <= {}",
+            actual.symbols,
+            estimated.symbols
+        );
     }
 }
 


### PR DESCRIPTION
Remove `more-asserts` dependency which was added in #5710.

As suggested by @Boshen in https://github.com/oxc-project/oxc/pull/5710#pullrequestreview-2299016692.