### PR TITLE
fix(linter/no-unused-vars): writes to members triggering false positive

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -41,6 +41,16 @@ fn test_vars_simple() {
             "
                 const a = 0
                 obj[a]++;
+                obj[a] += 1;
+            ",
+            None,
+        ),
+        (
+            "
+                const obj = 0
+                obj.a++;
+                obj.a += 1;
+                obj.b.c++;
             ",
             None,
         ),


### PR DESCRIPTION
close: #5246

similar to #5722 