### PR TITLE
fix(transformer/react): isStaticChildren should be false when there is only one child

### DIFF
--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -507,6 +507,7 @@ impl<'a> ReactJsx<'a> {
         let mut need_jsxs = false;
 
         let children = e.children();
+        let mut children_len = children.len();
 
         // Append children to object properties in automatic mode
         if is_automatic {
@@ -515,7 +516,7 @@ impl<'a> ReactJsx<'a> {
                 children.iter().filter_map(|child| self.transform_jsx_child(child, ctx)),
                 allocator,
             );
-            let children_len = children.len();
+            children_len = children.len();
             if children_len != 0 {
                 let value = if children_len == 1 {
                     children.pop().unwrap()
@@ -603,7 +604,7 @@ impl<'a> ReactJsx<'a> {
             if is_development {
                 arguments.push(Argument::from(self.ctx.ast.expression_boolean_literal(
                     SPAN,
-                    if is_fragment { false } else { children.len() > 1 },
+                    if is_fragment { false } else { children_len > 1 },
                 )));
             }
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 41/52
+Passed: 42/53
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -167,7 +167,7 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (27/30)
+# babel-plugin-transform-react-jsx (28/31)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
 x Output mismatch
 

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -101,7 +101,7 @@ impl TestRunner {
         root: &Path,
         filter: Option<&String>,
     ) -> (IndexMap<String, Vec<TestCaseKind>>, IndexMap<String, Vec<TestCaseKind>>) {
-        let cwd = babel_root();
+        let cwd = root.parent().unwrap_or(root);
         // use `IndexMap` to keep the order of the test cases the same in insert order.
         let mut transform_files = IndexMap::<String, Vec<TestCaseKind>>::new();
         let mut exec_files = IndexMap::<String, Vec<TestCaseKind>>::new();
@@ -119,8 +119,7 @@ impl TestRunner {
                                 return None;
                             }
                         }
-                        TestCaseKind::new(&cwd, path)
-                            .filter(|test_case| !test_case.skip_test_case())
+                        TestCaseKind::new(cwd, path).filter(|test_case| !test_case.skip_test_case())
                     })
                     .partition(|p| matches!(p, TestCaseKind::Transform(_)));
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/input.jsx
@@ -1,0 +1,7 @@
+<div>
+  { /*
+      There is only one child, so the isStaticChildren option should be false.
+      Please see: https://github.com/facebook/react/blob/206df66e70652e85711c3177ce1a0459609a7771/packages/react/src/jsx/ReactJSXElement.js#L614-L632
+   */}
+  <div></div>
+</div>

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["transform-react-jsx-development"]],
+  "sourceType": "module"
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/output.js
@@ -1,0 +1,11 @@
+var _jsxFileName = "<CWD>/tests/babel-plugin-transform-react-jsx/test/fixtures/static-children/input.jsx";
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+_jsxDEV("div", { children: _jsxDEV("div", {}, void 0, false, {
+       fileName: _jsxFileName,
+       lineNumber: 6,
+       columnNumber: 3
+}, this) }, void 0, false, {
+       fileName: _jsxFileName,
+       lineNumber: 1,
+       columnNumber: 1
+}, this);


### PR DESCRIPTION
We found a warning report [here](https://github.com/facebook/react/blob/206df66e70652e85711c3177ce1a0459609a7771/packages/react/src/jsx/ReactJSXElement.js#L614-L632). It caused by we transform incorrectly