### PR TITLE
refactor(semantic): `Stats::assert_accurate` take `self`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -270,7 +270,7 @@ impl<'a> SemanticBuilder<'a> {
                     self.symbols.len() as u32,
                     self.symbols.references.len() as u32,
                 );
-                Stats::assert_accurate(actual_stats, stats);
+                stats.assert_accurate(actual_stats);
             }
 
             // Checking syntax error on module record requires scope information from the previous AST pass


### PR DESCRIPTION
Improve API of `Stats::assert_accurate`.