### PR TITLE
fix(syntax): correctly check for valid `RedeclarationId`s

### DIFF
--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -36,7 +36,9 @@ pub struct RedeclarationId(NonMaxU32);
 impl Idx for RedeclarationId {
     #[allow(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
-        Self(NonMaxU32::new(idx as u32).unwrap())
+        assert!(idx < u32::MAX as usize);
+        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
+        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
     }
 
     fn index(self) -> usize {


### PR DESCRIPTION
Previously we truncated `usize` to `u32` and *then* checked validity of the `u32`. Fix that by checking validity *before* truncating.