### PR TITLE
refactor(syntax): replace `nonmax` crate with zero-cost non-max types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,12 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonmax"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1524,6 @@ dependencies = [
  "cow-utils",
  "daachorse",
  "insta",
- "nonmax",
  "once_cell",
  "oxc_allocator",
  "oxc_ast",
@@ -1911,7 +1904,6 @@ dependencies = [
  "assert-unchecked",
  "bitflags 2.6.0",
  "dashmap 6.0.1",
- "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,6 @@ memoffset = "0.9.1"
 miette = { version = "7.2.0", features = ["fancy-no-syscall"] }
 mimalloc = "0.1.43"
 mime_guess = "2.0.5"
-nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 once_cell = "1.19.0"

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -31,7 +31,6 @@ oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
 bitflags = { workspace = true }
 daachorse = { workspace = true }
-nonmax = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use nonmax::NonMaxU32;
 use oxc_index::{Idx, IndexVec};
 use oxc_span::Span;
-use oxc_syntax::identifier::{LS, PS};
+use oxc_syntax::{
+    identifier::{LS, PS},
+    nonmax::NonMaxU32,
+};
 
 // Irregular line breaks - '\u{2028}' (LS) and '\u{2029}' (PS)
 const LS_OR_PS_FIRST: u8 = 0xE2;
@@ -16,11 +18,12 @@ const PS_THIRD: u8 = 0xA9;
 pub struct ColumnOffsetsId(NonMaxU32);
 
 impl Idx for ColumnOffsetsId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `ColumnOffsetsId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -9,6 +9,7 @@ use oxc_ast::{
     AstKind,
 };
 use oxc_span::{GetSpan, SourceType};
+use oxc_syntax::nonmax::NonMaxU32;
 
 use crate::{
     scope::{ScopeFlags, ScopeId},
@@ -162,7 +163,7 @@ impl<'a> Binder<'a> for Function<'a> {
                     ident.span,
                     ident.name.clone().into(),
                     SymbolFlags::Function,
-                    ScopeId::new(u32::MAX - 1), // Not bound to any scope.
+                    ScopeId::new(NonMaxU32::MAX.get()), // Not bound to any scope.
                     builder.current_node_id,
                 );
                 ident.symbol_id.set(Some(symbol_id));

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -28,7 +28,6 @@ oxc_span = { workspace = true }
 assert-unchecked = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
-nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 unicode-id-start = { workspace = true }

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -6,6 +6,7 @@ pub mod keyword;
 pub mod module_graph_visitor;
 pub mod module_record;
 pub mod node;
+pub mod nonmax;
 pub mod number;
 pub mod operator;
 pub mod precedence;

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -1,8 +1,9 @@
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
 use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
+
+use crate::nonmax::NonMaxU32;
 
 /// AST Node ID
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -14,32 +15,29 @@ impl NodeId {
     /// Create `NodeId` from `u32`.
     ///
     /// # Panics
-    /// Panics if `idx` is `u32::MAX`.
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     pub const fn new(idx: u32) -> Self {
-        // We could use `NonMaxU32::new(idx).unwrap()` but `Option::unwrap` is not a const function
-        // and we want this function to be
-        assert!(idx != u32::MAX);
-        // SAFETY: We have checked that `idx` is not `u32::MAX`
-        unsafe { Self::new_unchecked(idx) }
+        Self(NonMaxU32::new_checked(idx))
     }
 
     /// Create `NodeId` from `u32` unchecked.
     ///
     /// # SAFETY
-    /// `idx` must not be `u32::MAX`.
+    /// `idx` must not exceed `NonMaxU32::MAX.get()`.
     #[allow(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
-        // SAFETY: Caller must ensure `idx` is not `u32::MAX`
+        // SAFETY: Caller must ensure `idx` does not exceed `NonMaxU32::MAX.get()`
         Self(NonMaxU32::new_unchecked(idx))
     }
 }
 
 impl Idx for NodeId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `NodeId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {

--- a/crates/oxc_syntax/src/nonmax.rs
+++ b/crates/oxc_syntax/src/nonmax.rs
@@ -1,0 +1,697 @@
+//! Niched non-max types, similar to `NonZero*`, but with the illegal values at top of the range,
+//! rather than 0.
+//!
+//! `nonmax` crate provides similar types, but they work by storing the value internally as a `NonZero*`,
+//! and inverting the bits on every read/write (`native_u32 = nonmax_u32 as u32 ^ u32::MAX`).
+//! This reserves only a single illegal value, but has (small) runtime cost on every read/write.
+//!
+//! The `NonMax*` types provided here make a different trade-off.
+//!
+//! `NonMaxU8` wraps an enum with a single illegal value (255).
+//! All the other types store the value as a number of `u8`s + a single `NonMaxU8` as highest byte.
+//! i.e. they reserve all values which have 255 as the highest byte.
+//!
+//! * `NonMaxU8` can represent the values `0` to `254`.
+//! * `NonMaxU16` can represent the values `0` to `(255 << 8) - 1`.
+//! * `NonMaxU32` can represent the values `0` to `(255 << 24) - 1`.
+//! * `NonMaxU64` can represent the values `0` to `(255 << 56) - 1`.
+//! * `NonMaxU128` can represent the values `0` to `(255 << 120) - 1`.
+//!
+//! We trade approx 0.4% of the legal range being unavailable, in return for zero runtime cost
+//! when reading or writing the values.
+//!
+//! All `NonMax*` types have a single niche (even though they have multiple illegal values).
+//! `Option<NonMax*>` is same size as its native equivalent, for all `NonMax*` types.
+//! e.g. `size_of::<Option<NonMaxU32>>() == size_of::<u32>()`.
+
+use std::{
+    cmp, fmt,
+    hash::{Hash, Hasher},
+    mem::{align_of, size_of},
+    ops::{BitAnd, BitAndAssign},
+};
+
+macro_rules! impl_nonmax {
+    ($nonmax:ident, $native:ident) => {
+        const _: () = {
+            assert!(size_of::<$nonmax>() == size_of::<$native>());
+            assert!(align_of::<$nonmax>() == align_of::<$native>());
+        };
+
+        impl $nonmax {
+            /// Zero for this non-max integer type
+            // SAFETY: 0 is a valid value for this type.
+            pub const ZERO: Self = unsafe { Self::new_unchecked(0) };
+
+            /// One for this non-max integer type.
+            // SAFETY: 1 is a valid value for this type.
+            pub const ONE: Self = unsafe { Self::new_unchecked(1) };
+
+            /// The smallest value that can be represented by this non-max integer type, 0.
+            pub const MIN: Self = Self::ZERO;
+
+            /// The largest value that can be represented by this non-max integer type.
+            // SAFETY: This is a valid value for this type.
+            // Equals highest byte 254, all other bytes 255.
+            // This corresponds to highest byte being a `NonMaxU8` and all other bytes being `u8`s.
+            pub const MAX: Self = unsafe {
+                Self::new_unchecked_internal(((255 as $native) << ($native::BITS - 8)) - 1)
+            };
+
+            /// The size of this non-max integer type in bits.
+            pub const BITS: u32 = $native::BITS;
+
+            #[doc = concat!("Create new `", stringify!($nonmax), "` from `", stringify!($native), "`.")]
+            #[doc = ""]
+            #[doc = concat!("Returns `None` if `n` is greater than `", stringify!($nonmax), "::MAX.get()`.")]
+            #[inline]
+            pub const fn new(n: $native) -> Option<Self> {
+                if n <= Self::MAX.get() {
+                    // SAFETY: We just checked `n` does not exceed `Self::MAX.get()`
+                    Some(unsafe { Self::new_unchecked(n) })
+                } else {
+                    None
+                }
+            }
+
+            #[doc = concat!("Create new `", stringify!($nonmax), "` from `", stringify!($native), "`,")]
+            #[doc = "panicking if `n` is invalid."]
+            #[doc = ""]
+            #[doc = "# Panics"]
+            #[doc = concat!("Panics if `n` is greater than `", stringify!($nonmax), "::MAX.get()`.")]
+            #[inline]
+            pub const fn new_checked(n: $native) -> Self {
+                assert!(n <= Self::MAX.get());
+                // SAFETY: We just checked `n` does not exceed `Self::MAX.get()`
+                unsafe { Self::new_unchecked(n) }
+            }
+
+            #[doc = concat!("Create new `", stringify!($nonmax), "` from `usize`.")]
+            #[doc = ""]
+            #[doc = "# Panics"]
+            #[doc = concat!("Panics if `n` is greater than `", stringify!($nonmax), "::MAX.get()`.")]
+            #[inline]
+            #[allow(clippy::cast_possible_truncation)]
+            pub const fn from_usize(n: usize) -> Self {
+                // If nonmax type is larger than `usize` (on 64-bit systems, only `NonMaxU128`),
+                // any `usize` is guaranteed to be valid, so skip assertion
+                if size_of::<Self>() <= size_of::<usize>() {
+                    assert!(n <= Self::MAX.get() as usize);
+                }
+
+                // SAFETY: We just checked `n` does not exceed `Self::MAX.get()`
+                unsafe { Self::new_unchecked(n as $native) }
+            }
+
+            #[doc = concat!("Create new `", stringify!($nonmax), "` from `", stringify!($native), "`, without checking validity of the input.")]
+            #[doc = ""]
+            #[doc = "# SAFETY"]
+            #[doc = concat!("Caller must ensure `n` does not exceed `", stringify!($nonmax), "::MAX.get()`.")]
+            #[inline]
+            #[allow(clippy::missing_safety_doc)]
+            pub const unsafe fn new_unchecked(n: $native) -> Self {
+                debug_assert!(n <= Self::MAX.get());
+                // SAFETY: Caller guarantees `n` does not exceed `Self::MAX.get()`.
+                // All bit patterns of native type `<= Self::MAX.get()` are valid bit patterns for non-max type.
+                // Size and align of non-max type and native type are the same.
+                unsafe { std::mem::transmute::<$native, Self>(n) }
+            }
+
+            /// Internal version of `new_unchecked`, without debug assertion.
+            /// Only used for initializing `MAX` constant, to avoid circularity.
+            #[inline]
+            #[allow(clippy::missing_safety_doc)]
+            const unsafe fn new_unchecked_internal(n: $native) -> Self {
+                // SAFETY: Caller guarantees `n` does not exceed `Self::MAX.get()`.
+                // All bit patterns of native type `<= Self::MAX.get()` are valid bit patterns for non-max type.
+                // Size and align of non-max type and native type are the same.
+                unsafe { std::mem::transmute::<$native, Self>(n) }
+            }
+
+            #[doc = concat!("Convert `", stringify!($nonmax), "` to `", stringify!($native), "`.")]
+            #[inline]
+            pub const fn get(self) -> $native {
+                // SAFETY: All valid bit patterns of non-max type are valid bit patterns for native type.
+                // Size and align of non-max type and native type are the same.
+                unsafe { std::mem::transmute::<Self, $native>(self) }
+            }
+        }
+
+        impl Default for $nonmax {
+            fn default() -> Self {
+                Self::ZERO
+            }
+        }
+
+        impl From<$nonmax> for $native {
+            #[doc = concat!("Convert `", stringify!($nonmax), "` to `", stringify!($native), "`.")]
+            #[inline]
+            fn from(n: $nonmax) -> $native {
+                n.get()
+            }
+        }
+
+        impl TryFrom<$native> for $nonmax {
+            type Error = ();
+
+            #[doc = concat!("Try to convert `", stringify!($native), "` to `", stringify!($nonmax), "`.")]
+            #[doc = ""]
+            #[doc = concat!("Returns `Err` if `n` is greater than `", stringify!($nonmax), "::MAX.get()`.")]
+            #[inline]
+            fn try_from(n: $native) -> Result<Self, ()> {
+                match Self::new(n) {
+                    Some(n) => Ok(n),
+                    None => Err(()),
+                }
+            }
+        }
+
+        impl PartialEq<Self> for $nonmax {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.get() == other.get()
+            }
+        }
+
+        impl Eq for $nonmax {}
+
+        impl PartialOrd for $nonmax {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+                Some(Ord::cmp(self, other))
+            }
+        }
+
+        impl Ord for $nonmax {
+            #[inline]
+            fn cmp(&self, other: &Self) -> cmp::Ordering {
+                Ord::cmp(&self.get(), &other.get())
+            }
+        }
+
+        impl Hash for $nonmax {
+            #[inline]
+            fn hash<H: Hasher>(&self, hasher: &mut H) {
+                Hash::hash(&self.get(), hasher)
+            }
+        }
+
+        // `NonZero*` can implement `BitOr`, but not `BitAnd`.
+        // `NonMax*` can implement `BitAnd` but not `BitOr`.
+
+        impl BitAnd<Self> for $nonmax {
+            type Output = Self;
+
+            #[inline]
+            fn bitand(self, rhs: Self) -> Self::Output {
+                // SAFETY: `self` is non-max type, so cannot have 255 as its top byte.
+                // This means at least one bit of top byte is 0.
+                // Therefore AND with any number will also have at least 1 bit of top byte unset.
+                // So top byte of result cannot be 255, which means result is a legal non-max value.
+                unsafe { Self::new_unchecked(self.get() & rhs.get()) }
+            }
+        }
+
+        impl BitAnd<$native> for $nonmax {
+            type Output = Self;
+
+            #[inline]
+            fn bitand(self, rhs: $native) -> Self::Output {
+                // SAFETY: `self` is non-max type, so cannot have 255 as its top byte.
+                // This means at least one bit of top byte is 0.
+                // Therefore AND with any number will also have at least 1 bit of top byte unset.
+                // So top byte of result cannot be 255, which means result is a legal non-max value.
+                unsafe { Self::new_unchecked(self.get() & rhs) }
+            }
+        }
+
+        impl BitAnd<$nonmax> for $native {
+            type Output = $nonmax;
+
+            #[inline]
+            fn bitand(self, rhs: $nonmax) -> Self::Output {
+                // SAFETY: `rhs` is non-max type, so cannot have 255 as its top byte.
+                // This means at least one bit of top byte is 0.
+                // Therefore AND with any number will also have at least 1 bit of top byte unset.
+                // So top byte of result cannot be 255, which means result is a legal non-max value.
+                unsafe { $nonmax::new_unchecked(self & rhs.get()) }
+            }
+        }
+
+        impl BitAndAssign<Self> for $nonmax {
+            #[inline]
+            fn bitand_assign(&mut self, rhs: Self) {
+                *self = *self & rhs;
+            }
+        }
+
+        impl BitAndAssign<$native> for $nonmax {
+            #[inline]
+            fn bitand_assign(&mut self, rhs: $native) {
+                *self = *self & rhs;
+            }
+        }
+
+        impl BitAndAssign<$nonmax> for $native {
+            #[inline]
+            fn bitand_assign(&mut self, rhs: $nonmax) {
+                *self = *self & rhs.get();
+            }
+        }
+
+        // https://doc.rust-lang.org/1.47.0/src/core/num/mod.rs.html#173-175
+        impl_fmt!(Debug, $nonmax);
+        impl_fmt!(Display, $nonmax);
+        impl_fmt!(Binary, $nonmax);
+        impl_fmt!(Octal, $nonmax);
+        impl_fmt!(LowerHex, $nonmax);
+        impl_fmt!(UpperHex, $nonmax);
+    };
+}
+
+// https://doc.rust-lang.org/1.47.0/src/core/num/mod.rs.html#31-43
+macro_rules! impl_fmt {
+    ($trait:ident, $nonmax:ident) => {
+        impl fmt::$trait for $nonmax {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::$trait::fmt(&self.get(), f)
+            }
+        }
+    };
+}
+
+/// `u8` with a niche for maximum value.
+///
+/// Equivalent of `NonZeroU8`, but with illegal value of `u8::MAX`, instead of 0.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct NonMaxU8(NonMaxU8Internal);
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum NonMaxU8Internal {
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    _3 = 3,
+    _4 = 4,
+    _5 = 5,
+    _6 = 6,
+    _7 = 7,
+    _8 = 8,
+    _9 = 9,
+    _10 = 10,
+    _11 = 11,
+    _12 = 12,
+    _13 = 13,
+    _14 = 14,
+    _15 = 15,
+    _16 = 16,
+    _17 = 17,
+    _18 = 18,
+    _19 = 19,
+    _20 = 20,
+    _21 = 21,
+    _22 = 22,
+    _23 = 23,
+    _24 = 24,
+    _25 = 25,
+    _26 = 26,
+    _27 = 27,
+    _28 = 28,
+    _29 = 29,
+    _30 = 30,
+    _31 = 31,
+    _32 = 32,
+    _33 = 33,
+    _34 = 34,
+    _35 = 35,
+    _36 = 36,
+    _37 = 37,
+    _38 = 38,
+    _39 = 39,
+    _40 = 40,
+    _41 = 41,
+    _42 = 42,
+    _43 = 43,
+    _44 = 44,
+    _45 = 45,
+    _46 = 46,
+    _47 = 47,
+    _48 = 48,
+    _49 = 49,
+    _50 = 50,
+    _51 = 51,
+    _52 = 52,
+    _53 = 53,
+    _54 = 54,
+    _55 = 55,
+    _56 = 56,
+    _57 = 57,
+    _58 = 58,
+    _59 = 59,
+    _60 = 60,
+    _61 = 61,
+    _62 = 62,
+    _63 = 63,
+    _64 = 64,
+    _65 = 65,
+    _66 = 66,
+    _67 = 67,
+    _68 = 68,
+    _69 = 69,
+    _70 = 70,
+    _71 = 71,
+    _72 = 72,
+    _73 = 73,
+    _74 = 74,
+    _75 = 75,
+    _76 = 76,
+    _77 = 77,
+    _78 = 78,
+    _79 = 79,
+    _80 = 80,
+    _81 = 81,
+    _82 = 82,
+    _83 = 83,
+    _84 = 84,
+    _85 = 85,
+    _86 = 86,
+    _87 = 87,
+    _88 = 88,
+    _89 = 89,
+    _90 = 90,
+    _91 = 91,
+    _92 = 92,
+    _93 = 93,
+    _94 = 94,
+    _95 = 95,
+    _96 = 96,
+    _97 = 97,
+    _98 = 98,
+    _99 = 99,
+    _100 = 100,
+    _101 = 101,
+    _102 = 102,
+    _103 = 103,
+    _104 = 104,
+    _105 = 105,
+    _106 = 106,
+    _107 = 107,
+    _108 = 108,
+    _109 = 109,
+    _110 = 110,
+    _111 = 111,
+    _112 = 112,
+    _113 = 113,
+    _114 = 114,
+    _115 = 115,
+    _116 = 116,
+    _117 = 117,
+    _118 = 118,
+    _119 = 119,
+    _120 = 120,
+    _121 = 121,
+    _122 = 122,
+    _123 = 123,
+    _124 = 124,
+    _125 = 125,
+    _126 = 126,
+    _127 = 127,
+    _128 = 128,
+    _129 = 129,
+    _130 = 130,
+    _131 = 131,
+    _132 = 132,
+    _133 = 133,
+    _134 = 134,
+    _135 = 135,
+    _136 = 136,
+    _137 = 137,
+    _138 = 138,
+    _139 = 139,
+    _140 = 140,
+    _141 = 141,
+    _142 = 142,
+    _143 = 143,
+    _144 = 144,
+    _145 = 145,
+    _146 = 146,
+    _147 = 147,
+    _148 = 148,
+    _149 = 149,
+    _150 = 150,
+    _151 = 151,
+    _152 = 152,
+    _153 = 153,
+    _154 = 154,
+    _155 = 155,
+    _156 = 156,
+    _157 = 157,
+    _158 = 158,
+    _159 = 159,
+    _160 = 160,
+    _161 = 161,
+    _162 = 162,
+    _163 = 163,
+    _164 = 164,
+    _165 = 165,
+    _166 = 166,
+    _167 = 167,
+    _168 = 168,
+    _169 = 169,
+    _170 = 170,
+    _171 = 171,
+    _172 = 172,
+    _173 = 173,
+    _174 = 174,
+    _175 = 175,
+    _176 = 176,
+    _177 = 177,
+    _178 = 178,
+    _179 = 179,
+    _180 = 180,
+    _181 = 181,
+    _182 = 182,
+    _183 = 183,
+    _184 = 184,
+    _185 = 185,
+    _186 = 186,
+    _187 = 187,
+    _188 = 188,
+    _189 = 189,
+    _190 = 190,
+    _191 = 191,
+    _192 = 192,
+    _193 = 193,
+    _194 = 194,
+    _195 = 195,
+    _196 = 196,
+    _197 = 197,
+    _198 = 198,
+    _199 = 199,
+    _200 = 200,
+    _201 = 201,
+    _202 = 202,
+    _203 = 203,
+    _204 = 204,
+    _205 = 205,
+    _206 = 206,
+    _207 = 207,
+    _208 = 208,
+    _209 = 209,
+    _210 = 210,
+    _211 = 211,
+    _212 = 212,
+    _213 = 213,
+    _214 = 214,
+    _215 = 215,
+    _216 = 216,
+    _217 = 217,
+    _218 = 218,
+    _219 = 219,
+    _220 = 220,
+    _221 = 221,
+    _222 = 222,
+    _223 = 223,
+    _224 = 224,
+    _225 = 225,
+    _226 = 226,
+    _227 = 227,
+    _228 = 228,
+    _229 = 229,
+    _230 = 230,
+    _231 = 231,
+    _232 = 232,
+    _233 = 233,
+    _234 = 234,
+    _235 = 235,
+    _236 = 236,
+    _237 = 237,
+    _238 = 238,
+    _239 = 239,
+    _240 = 240,
+    _241 = 241,
+    _242 = 242,
+    _243 = 243,
+    _244 = 244,
+    _245 = 245,
+    _246 = 246,
+    _247 = 247,
+    _248 = 248,
+    _249 = 249,
+    _250 = 250,
+    _251 = 251,
+    _252 = 252,
+    _253 = 253,
+    _254 = 254,
+    // No variant for 255
+}
+
+impl_nonmax!(NonMaxU8, u8);
+
+/// `u16` with niche for maximum values.
+///
+/// Equivalent of `NonZeroU16`, but with illegal values of `>= (255 << 8)`, instead of 0.
+///
+/// Although has 256 illegal values, this type has only a single niche.
+#[derive(Clone, Copy)]
+#[repr(C, align(2))]
+pub struct NonMaxU16 {
+    #[cfg(target_endian = "big")]
+    top: NonMaxU8,
+    bottom: u8,
+    #[cfg(target_endian = "little")]
+    top: NonMaxU8,
+}
+
+impl_nonmax!(NonMaxU16, u16);
+
+/// `u32` with niche for maximum values.
+///
+/// Equivalent of `NonZeroU32`, but with illegal values of `>= (255 << 24)`, instead of 0.
+///
+/// Although has `1 << 24` illegal values, this type has only a single niche.
+#[derive(Clone, Copy)]
+#[repr(C, align(4))]
+pub struct NonMaxU32 {
+    #[cfg(target_endian = "big")]
+    top: NonMaxU8,
+    bottom: [u8; 3],
+    #[cfg(target_endian = "little")]
+    top: NonMaxU8,
+}
+
+impl_nonmax!(NonMaxU32, u32);
+
+/// `u64` with niche for maximum values.
+///
+/// Equivalent of `NonZeroU64`, but with illegal values of `>= (255 << 56)`, instead of 0.
+///
+/// Although has `1 << 56` illegal values, this type has only a single niche.
+#[derive(Clone, Copy)]
+#[repr(C, align(8))]
+pub struct NonMaxU64 {
+    #[cfg(target_endian = "big")]
+    top: NonMaxU8,
+    bottom: [u8; 7],
+    #[cfg(target_endian = "little")]
+    top: NonMaxU8,
+}
+
+impl_nonmax!(NonMaxU64, u64);
+
+/// `u128` with niche for maximum values.
+///
+/// Equivalent of `NonZeroU128`, but with illegal values of `>= (255 << 120)`, instead of 0.
+///
+/// Although has `1 << 120` illegal values, this type has only a single niche.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct NonMaxU128 {
+    #[cfg(target_endian = "big")]
+    top: NonMaxU8,
+    bottom: [u8; 15],
+    #[cfg(target_endian = "little")]
+    top: NonMaxU8,
+    // Align same as `u128` which is 16 on new versions of rustc, 8 on older versions
+    _align: [u128; 0],
+}
+
+impl_nonmax!(NonMaxU128, u128);
+
+/// `usize` with niche for maximum values.
+///
+/// Equivalent of `NonZeroUsize`, but with illegal values of
+/// `>= (255 << ((std::mem::size_of::<usize>() - 1) * 8))`
+/// (`255 << 56` on 64-bit systems, `255 << 24` on 32-bit systems), instead of 0.
+///
+/// Although has `1 << ((std::mem::size_of::<usize>() - 1) * 8)` illegal values,
+/// this type has only a single niche.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct NonMaxUsize {
+    #[cfg(target_endian = "big")]
+    top: NonMaxU8,
+    bottom: [u8; size_of::<usize>() - 1],
+    #[cfg(target_endian = "little")]
+    top: NonMaxU8,
+    // Align same as `usize`
+    _align: [usize; 0],
+}
+
+impl_nonmax!(NonMaxUsize, usize);
+
+// https://doc.rust-lang.org/1.47.0/src/core/convert/num.rs.html#383-407
+macro_rules! impl_from_nonmax {
+    ($small:ident, $large:ident) => {
+        impl From<$small> for $large {
+            #[inline]
+            fn from(small: $small) -> Self {
+                // SAFETY: Smaller input type guarantees the value is valid for larger type
+                unsafe { Self::new_unchecked(small.get().into()) }
+            }
+        }
+    };
+}
+
+impl_from_nonmax!(NonMaxU8, NonMaxU16);
+impl_from_nonmax!(NonMaxU8, NonMaxU32);
+impl_from_nonmax!(NonMaxU8, NonMaxU64);
+impl_from_nonmax!(NonMaxU8, NonMaxU128);
+impl_from_nonmax!(NonMaxU8, NonMaxUsize);
+impl_from_nonmax!(NonMaxU16, NonMaxU32);
+impl_from_nonmax!(NonMaxU16, NonMaxU64);
+impl_from_nonmax!(NonMaxU16, NonMaxU128);
+impl_from_nonmax!(NonMaxU16, NonMaxUsize);
+impl_from_nonmax!(NonMaxU32, NonMaxU64);
+impl_from_nonmax!(NonMaxU32, NonMaxU128);
+impl_from_nonmax!(NonMaxU64, NonMaxU128);
+
+// https://doc.rust-lang.org/1.47.0/src/core/convert/num.rs.html#383-407
+macro_rules! impl_from_smaller {
+    ($small:ident, $nonmax:ident) => {
+        impl From<$small> for $nonmax {
+            #[inline]
+            fn from(small: $small) -> Self {
+                // SAFETY: Smaller input type guarantees the value is valid for larger type
+                unsafe { Self::new_unchecked(small.into()) }
+            }
+        }
+    };
+}
+
+// NB: `From<u16> for NonMaxUsize` is not valid on 16-bit systems.
+// `nonmax` crate does provide that impl, but I (@overlookmotel) think it's unsound.
+impl_from_smaller!(u8, NonMaxU16);
+impl_from_smaller!(u8, NonMaxU32);
+impl_from_smaller!(u8, NonMaxU64);
+impl_from_smaller!(u8, NonMaxU128);
+impl_from_smaller!(u8, NonMaxUsize);
+impl_from_smaller!(u16, NonMaxU32);
+impl_from_smaller!(u16, NonMaxU64);
+impl_from_smaller!(u16, NonMaxU128);
+impl_from_smaller!(u32, NonMaxU64);
+impl_from_smaller!(u32, NonMaxU128);
+impl_from_smaller!(u64, NonMaxU128);

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,19 +1,21 @@
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
 use oxc_allocator::CloneIn;
 use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
+use crate::nonmax::NonMaxU32;
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ReferenceId(NonMaxU32);
 
 impl Idx for ReferenceId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `ReferenceId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -1,8 +1,9 @@
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
 use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
+
+use crate::nonmax::NonMaxU32;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ScopeId(NonMaxU32);
@@ -11,32 +12,29 @@ impl ScopeId {
     /// Create `ScopeId` from `u32`.
     ///
     /// # Panics
-    /// Panics if `idx` is `u32::MAX`.
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     pub const fn new(idx: u32) -> Self {
-        // We could use `NonMaxU32::new(idx).unwrap()` but `Option::unwrap` is not a const function
-        // and we want this function to be
-        assert!(idx != u32::MAX);
-        // SAFETY: We have checked that `idx` is not `u32::MAX`
-        unsafe { Self::new_unchecked(idx) }
+        Self(NonMaxU32::new_checked(idx))
     }
 
     /// Create `ScopeId` from `u32` unchecked.
     ///
     /// # SAFETY
-    /// `idx` must not be `u32::MAX`.
+    /// `idx` must not exceed `NonMaxU32::MAX.get()`.
     #[allow(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
-        // SAFETY: Caller must ensure `idx` is not `u32::MAX`
+        // SAFETY: Caller must ensure `idx` does not exceed `NonMaxU32::MAX.get()`
         Self(NonMaxU32::new_unchecked(idx))
     }
 }
 
 impl Idx for ScopeId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `ScopeId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,18 +1,20 @@
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
 use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
+
+use crate::nonmax::NonMaxU32;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SymbolId(NonMaxU32);
 
 impl Idx for SymbolId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `SymbolId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {
@@ -34,11 +36,12 @@ impl Serialize for SymbolId {
 pub struct RedeclarationId(NonMaxU32);
 
 impl Idx for RedeclarationId {
-    #[allow(clippy::cast_possible_truncation)]
+    /// Create `RedeclarationId` from `usize`.
+    ///
+    /// # Panics
+    /// Panics if `idx` exceeds `NonMaxU32::MAX.get()`.
     fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is valid for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+        Self(NonMaxU32::from_usize(idx))
     }
 
     fn index(self) -> usize {

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -5,11 +5,11 @@ AST Parsed     : 2101/2101 (100.00%)
 Positive Passed: 1739/2101 (82.77%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
 semantic error: Bindings mismatch:
@@ -27,8 +27,8 @@ Unexpected new.target expression
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-hang-func/input.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/327/input.js
 semantic error: A 'return' statement can only be used within a function body.
@@ -138,8 +138,8 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/statement-if/migrated_0003/input.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
 semantic error: Unresolved references mismatch:

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -5,1119 +5,1119 @@ AST Parsed     : 43765/43765 (100.00%)
 Positive Passed: 43565/43765 (99.54%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-dft-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-dft-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(4): ScopeId(4294967294)
-rebuilt        : SymbolId(4): ScopeId(4294967294)
+after transform: SymbolId(4): ScopeId(4278190079)
+rebuilt        : SymbolId(4): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-dft-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-dft-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-dft-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(3): ScopeId(4294967294)
-rebuilt        : SymbolId(3): ScopeId(4294967294)
+after transform: SymbolId(3): ScopeId(4278190079)
+rebuilt        : SymbolId(3): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(2): ScopeId(4294967294)
-rebuilt        : SymbolId(2): ScopeId(4294967294)
+after transform: SymbolId(2): ScopeId(4278190079)
+rebuilt        : SymbolId(2): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-block-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-fn-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-fn-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-var-no-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-var-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-init.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-no-skip-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-block.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-switch.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-try.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(1): ScopeId(4294967294)
-rebuilt        : SymbolId(1): ScopeId(4294967294)
+after transform: SymbolId(1): ScopeId(4278190079)
+rebuilt        : SymbolId(1): ScopeId(4278190079)
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-update.js
 semantic error: Symbol scope ID mismatch:
-after transform: SymbolId(0): ScopeId(4294967294)
-rebuilt        : SymbolId(0): ScopeId(4294967294)
+after transform: SymbolId(0): ScopeId(4278190079)
+rebuilt        : SymbolId(0): ScopeId(4278190079)
 
 tasks/coverage/test262/test/language/module-code/eval-rqstd-once.js
 semantic error: Bindings mismatch:


### PR DESCRIPTION
Replace `nonmax` crate with own `NonMax*` types.

`nonmax`'s `NonMax*` types work by storing the value internally as a `NonZero*`, and inverting the bits on every read/write (`native_u32 = nonmax_u32 as u32 ^ u32::MAX`). This reserves only a single illegal value, but has (small) runtime cost on every read/write.

The `NonMax*` types provided here make a different trade-off.

`NonMaxU8` wraps an enum with a single illegal value (255). All the other types store the value as a number of `u8`s + a single `NonMaxU8` as highest byte. i.e. they reserve all values which have 255 as the highest byte.

* `NonMaxU8` can represent the values `0` to `254`.
* `NonMaxU16` can represent the values `0` to `(255 << 8) - 1`.
* `NonMaxU32` can represent the values `0` to `(255 << 24) - 1`.
* `NonMaxU64` can represent the values `0` to `(255 << 56) - 1`.
* `NonMaxU128` can represent the values `0` to `(255 << 120) - 1`.

We trade approx 0.4% of the legal range being unavailable, in return for zero runtime cost when reading or writing the values.

Linter snapshot change is because `PreferHooksInOrder` rule uses a hash map keyed by `ScopeId`. The hash of `NonMaxU32` is now same as hash of `u32`, which alters the hash map iteration order. This does not change what errors are output, only the order they're output in.