### PR TITLE
feat(semantic): add `SemanticBuilder::with_excess_capacity`

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -186,7 +186,14 @@ pub trait CompilerInterface {
         source_text: &'a str,
         source_path: &Path,
     ) -> SemanticBuilderReturn<'a> {
-        SemanticBuilder::new(source_text)
+        let mut builder = SemanticBuilder::new(source_text);
+
+        if self.transform_options().is_some() {
+            // Estimate transformer will triple scopes, symbols, references
+            builder = builder.with_excess_capacity(2.0);
+        }
+
+        builder
             .with_check_syntax_error(self.check_semantic_error())
             .with_scope_tree_child_ids(self.semantic_child_scope_ids())
             .build_module_record(source_path, program)

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -96,6 +96,23 @@ impl Stats {
         counter.stats
     }
 
+    /// Increase scope, symbol, and reference counts by provided `excess`.
+    ///
+    /// `excess` is provided as a fraction.
+    /// e.g. to over-allocate by 20%, pass `0.2` as `excess`.
+    #[must_use]
+    pub fn increase_by(mut self, excess: f64) -> Self {
+        let factor = excess + 1.0;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_lossless)]
+        let increase = |n: u32| (n as f64 * factor) as u32;
+
+        self.scopes = increase(self.scopes);
+        self.symbols = increase(self.symbols);
+        self.references = increase(self.references);
+
+        self
+    }
+
     /// Assert that estimated [`Stats`] match actual.
     ///
     /// # Panics

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -40,6 +40,8 @@ fn main() {
     let mut program = ret.program;
 
     let (symbols, scopes) = SemanticBuilder::new(&source_text)
+        // Estimate transformer will triple scopes, symbols, references
+        .with_excess_capacity(2.0)
         .build(&program)
         .semantic
         .into_symbol_table_and_scope_tree();

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -192,7 +192,12 @@ impl Oxc {
         self.ir = format!("{:#?}", program.body);
         self.ast = program.serialize(&self.serializer)?;
 
-        let semantic_ret = SemanticBuilder::new(source_text)
+        let mut semantic_builder = SemanticBuilder::new(source_text);
+        if run_options.transform.unwrap_or_default() {
+            // Estimate transformer will triple scopes, symbols, references
+            semantic_builder = semantic_builder.with_excess_capacity(2.0);
+        }
+        let semantic_ret = semantic_builder
             .with_trivias(trivias.clone())
             .with_check_syntax_error(true)
             .with_cfg(true)

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -100,6 +100,8 @@ pub fn transform(
 
 fn transpile(ctx: &TransformContext<'_>) -> CodegenReturn {
     let (symbols, scopes) = SemanticBuilder::new(ctx.source_text())
+        // Estimate transformer will triple scopes, symbols, references
+        .with_excess_capacity(2.0)
         .build(&ctx.program())
         .semantic
         .into_symbol_table_and_scope_tree();

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -30,6 +30,8 @@ fn bench_transformer(criterion: &mut Criterion) {
                     Parser::new(&allocator, source_text, source_type).parse();
                 let program = allocator.alloc(program);
                 let (symbols, scopes) = SemanticBuilder::new(source_text)
+                    // Estimate transformer will triple scopes, symbols, references
+                    .with_excess_capacity(2.0)
                     .build(program)
                     .semantic
                     .into_symbol_table_and_scope_tree();


### PR DESCRIPTION
Add `SemanticBuilder::with_excess_capacity` method to request that `SemanticBuilder` over-allocate space in `Semantic`'s `Vec`s.

Use this method to reserve 200% extra capacity for transformer to create more scopes, symbols and references.

200% is an unscientific guess of how much extra capacity is required. Obviously it depends on what transforms are enabled and content of the source code.