### PR TITLE
[WIP] feat: add oxc_eval crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_eval"
+version = "0.27.0"
+dependencies = [
+ "oxc_ast",
+ "oxc_diagnostics",
+ "oxc_span",
+]
+
+[[package]]
 name = "oxc_index"
 version = "0.29.0"
 dependencies = [

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -55,7 +55,7 @@ pub mod visit {
 }
 
 pub use generated::{ast_builder, ast_kind};
-pub use num_bigint::BigUint;
+pub use num_bigint::{BigInt, BigUint};
 
 pub use crate::{
     ast_builder::AstBuilder,

--- a/crates/oxc_eval/Cargo.toml
+++ b/crates/oxc_eval/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "oxc_eval"
+version = "0.27.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
+
+[dependencies]
+oxc_ast = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_span = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/oxc_eval/src/completion.rs
+++ b/crates/oxc_eval/src/completion.rs
@@ -1,0 +1,212 @@
+//! Contains an implementation of [6.2.4 Completion Records](https://262.ecma-international.org/15.0/index.html#sec-completion-record-specification-type).
+use std::borrow::Cow;
+
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::Value;
+
+// use crate::Value;
+
+/// 6.2.4 Completion Records
+///
+/// NOTE(@DonIsaac): it would be better to use an enum instead of a tagged
+/// struct. However, I'm not certain about how `UpdateEmpty` is used, so I'm
+/// just following the spec for now. Better to be safe than sorry and refactor later. See
+/// commented-out code below for a draft implementation
+#[derive(Debug)]
+pub struct CompletionRecord<'a> {
+    /// `[[Type]]`
+    ///
+    /// The type of completion that occurred..
+    ty: CompletionType,
+    /// `[[Value]]`
+    ///
+    /// The value that was produced
+    ///
+    /// Value: Any value except a [`CompletionRecord`].
+    ///
+    /// - NOTE(@DonIsaac): [`None`] is `EMPTY`.
+    /// - NOTE(@DonIsaac): use a generic? Will this ever contain a non-`Value`?
+    value: Option<Value<'a>>,
+    /// `[[Target]]`
+    ///
+    /// The target label for directed control transfers.
+    target: Option<Cow<'a, str>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompletionType {
+    /// A normal completion (e.g. a value was produced from evaluation)
+    ///
+    /// > NOTE(@DonIsaac): Normal completions should always have values and shouldn't have labels
+    Normal,
+    /// A break completion.
+    ///
+    /// NOTE(@DonIsaac): break completions shouldn't have values, but may have labels
+    /// > NOTE(@DonIsaac): Do yields produce value-full break completions?
+    Break,
+    /// A continue completion, e.g. `continue` statement within a loop
+    ///
+    /// > NOTE(@DonIsaac): continue completions shouldn't have values, but may have labels.
+    Continue,
+    /// A return completion, e.g. `return` statement within a function
+    Return,
+    /// A throw completion, e.g. `throw` statement`
+    ///
+    /// > NOTE(@DonIsaac): throw completions should always have values. I'm not sure about labels.
+    Throw,
+}
+
+impl<'a> CompletionRecord<'a> {
+    /// 6.2.4.1 NormalCompletion(`value`)
+    ///
+    /// > The abstract operation NormalCompletion takes argument `value` (any > [`value`](`Value`)
+    /// > except a [Completion Record](`CompletionRecord`)) and returns a [normal
+    /// > completion](`CompletionType::Normal`).
+    #[inline]
+    #[must_use]
+    pub fn normal(value: Value<'a>) -> Self {
+        // 1. Return Completion Record { [[Type]]: normal, [[Value]]: value, [[Target]]: empty }.
+        Self::new(CompletionType::Normal, Some(value), None)
+    }
+
+    /// 6.2.4.2 ThrowCompletion(`value`)
+    ///
+    /// > The abstract operation ThrowCompletion takes argument `value` ([an
+    /// > ECMAScript language value](`Value`) and returns a [throw
+    /// > completion](`CompletionType::Throw`).
+    #[inline]
+    #[must_use]
+    pub fn throw(value: Value<'a>) -> Self {
+        // 1. Return Completion Record { [[Type]]: throw, [[Value]]: value, [[Target]]: empty }.
+        Self::new(CompletionType::Throw, Some(value), None)
+    }
+
+    #[inline]
+    #[must_use]
+    pub(crate) fn new(
+        ty: CompletionType,
+        value: Option<Value<'a>>,
+        target: Option<Cow<'a, str>>,
+    ) -> Self {
+        Self { ty, value, target }
+    }
+
+    /// 6.2.4.3 UpdateEmpty (`completionRecord`, `value`)
+    ///
+    /// > The abstract operation UpdateEmpty takes arguments `completionRecord` (a
+    /// > [Completion Record](`CompletionRecord`) and value (any value except a Completion Record) and
+    /// > returns a [Completion Record](`CompletionRecord`).
+    #[must_use]
+    pub fn update_empty(self, value: Value<'a>) -> Self {
+        // 1. Assert: If completionRecord is either a return completion or a
+        //    throw completion, then completionRecord.[[Value]] is not empty.
+        #[cfg(debug_assertions)]
+        if matches!(self.ty, CompletionType::Return | CompletionType::Throw) {
+            assert!(self.value.is_some());
+        }
+        // 2. If completionRecord.[[Value]] is not empty, return ? completionRecord.
+        // 3. Return Completion Record { [[Type]]: completionRecord.[[Type]],
+        //    [[Value]]: value, [[Target]]: completionRecord.[[Target]] }.
+        match self.value {
+            Some(_) => self,
+            None => Self { value: Some(value), ..self },
+        }
+    }
+
+    /// The type of completion that occurred.
+    #[inline]
+    pub fn r#type(&self) -> CompletionType {
+        self.ty
+    }
+
+    /// The value that was produced.
+    #[inline]
+    pub fn value(&self) -> Option<&Value<'a>> {
+        self.value.as_ref()
+    }
+
+    /// The target label for directed control transfers.
+    #[inline]
+    pub fn target(&self) -> Option<&Cow<'a, str>> {
+        self.target.as_ref()
+    }
+}
+
+// /// Completion Record
+// ///
+// /// The _Completion Record_ specification type is used to explain the runtime
+// /// propagation of values and control flow such as the behaviour of statements
+// /// (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of
+// /// control.
+// ///
+// /// ### References
+// /// - [ECMA-262 - 6.2.4 The Completion Record Specification Type](https://262.ecma-international.org/15.0/index.html#sec-completion-record-specification-type)
+// pub enum CompletionRecord<'a> {
+//     // TODO: [[Target]]
+//     Normal(Value<'a>),
+//     Break,
+//     Continue,
+//     Return(Value<'a>),
+//     Throw(Value<'a>),
+// }
+
+// impl<'a> CompletionRecord<'a> {
+//     /// > _abrupt completion_ refers to any Completion Record with a [[Type]] value other than NORMAL.
+//     #[inline]
+//     pub fn is_abrupt(&self) -> bool {
+//         !matches!(self, Self::Normal(_))
+//     }
+
+//     // /// ### 6.2.4.3 UpdateEmpty(`completionRecord`, `value`)
+//     // /// >The abstract operation UpdateEmpty takes arguments `completionRecord` (a
+//     // /// Completion Record) and `value` (any value except a Completion Record) and
+//     // /// returns a [`CompletionRecord`].
+//     // /// ### References
+//     // /// - [ECMA-262 6.2.4.3 UpdateEmpty](https://262.ecma-international.org/15.0/index.html#sec-updateempty)
+//     // pub fn update_empty(mut self, value: Value<'a>) -> Self {
+//     //     // 1. Assert: if completionRecord is either a return completion or a
+//     //     //    throw completion, then completionRecord.[[Value]] is not empty.
+//     // }
+// }
+
+// pub struct TypeError(OxcDiagnostic);
+
+// impl TypeError {
+//     pub fn new<S>(message: S) -> Self
+//     where
+//         S: Into<Cow<'static, str>>,
+//     {
+//         Self(OxcDiagnostic::error(message))
+//     }
+// }
+
+// impl Deref for TypeError {
+//     type Target = OxcDiagnostic;
+
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
+
+// impl From<&'static str> for TypeError {
+//     fn from(value: &'static str) -> Self {
+//         Self(OxcDiagnostic::error(value))
+//     }
+// }
+
+// impl<T> From<TypeError> for Result<T, TypeError> {
+//     #[inline]
+//     fn from(val: TypeError) -> Self {
+//         Err(val)
+//     }
+// }
+
+// impl From<TypeError> for OxcDiagnostic {
+//     #[inline]
+//     fn from(val: TypeError) -> Self {
+//         val.0
+//     }
+// }
+
+pub type TypeError = OxcDiagnostic;

--- a/crates/oxc_eval/src/context.rs
+++ b/crates/oxc_eval/src/context.rs
@@ -1,0 +1,24 @@
+use std::marker::PhantomData;
+
+#[derive(Debug, Default)]
+pub struct EvalContext<'a> {
+    strict: bool,
+    // TODO
+    marker: PhantomData<&'a ()>,
+}
+impl<'a> EvalContext<'a> {
+    #[inline]
+    fn is_strict(&self) -> bool {
+        self.strict
+    }
+
+    #[inline]
+    pub fn enter_strict(&mut self) {
+        self.strict = true;
+    }
+
+    #[inline]
+    pub fn leave_strict(&mut self, strict: bool) {
+        self.strict = strict;
+    }
+}

--- a/crates/oxc_eval/src/eval/expr/binary_op.rs
+++ b/crates/oxc_eval/src/eval/expr/binary_op.rs
@@ -1,0 +1,163 @@
+use crate::{Eval, EvalContext};
+use oxc_ast::ast::{BinaryExpression, BinaryOperator, LogicalExpression, LogicalOperator};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::{
+    completion::TypeError,
+    value::{Number, Numeric, Value},
+    EvalResult,
+};
+
+macro_rules! ok {
+    ($val:expr) => {
+        Ok(From::from($val))
+    };
+    (num; $num:expr) => {
+        Ok(Value::Number($num))
+    };
+}
+
+macro_rules! err {
+    ($msg:expr) => {
+        Err(Some(OxcDiagnostic::error($msg)))
+    };
+}
+
+// ### 13.15.4 EvaluateStringOrNumericBinaryExpression ( `leftOperand`, `opText`, `rightOperand` )
+//
+// > The abstract operation EvaluateStringOrNumericBinaryExpression takes
+// > arguments `leftOperand` (a Parse Node), `opText` (a sequence of Unicode code
+// > points), and `rightOperand` (a Parse Node) and returns either a normal
+// > completion containing either a `String`, a `BigInt`, or a `Number`, or an abrupt
+// > completion. It performs the following steps when called:
+impl<'a> Eval<'a> for BinaryExpression<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        // 1. Let lref be ? Evaluation of leftOperand.
+        // 2. Let lval be ? GetValue(lref).
+        // 3. Let rref be ? Evaluation of rightOperand.
+        // 4. Let rval be ? GetValue(rref).
+        // 5. Return ? ApplyStringOrNumericBinaryOperator(lval, opText, rval).
+        // NOTE: ReferenceRecord isn't implemented yet, so GetValue is a no-op.
+        let lval = self.left.eval(ctx)?;
+        let rval = self.right.eval(ctx)?;
+        apply_string_or_numeric_binary_op(lval, self.operator, rval)
+    }
+}
+
+/// ### 13.15.3 ApplyStringOrNumericBinaryOperator ( `lval`, `opText`, `rval` )
+///
+/// > The abstract operation ApplyStringOrNumericBinaryOperator takes arguments lval (an ECMAScript
+/// > language value), opText (`**`, `*`, `/`, `%`, `+`, `-`, `<<`, `>>`, `>>>`, `&`, `^`, or `|`),
+/// > and rval (an [ECMAScript language value](`Value`)) and returns either a normal completion
+/// > containing either a `String`, a `BigInt`, or a `Number`, or a throw completion.
+fn apply_string_or_numeric_binary_op<'a>(
+    left: Value<'a>,
+    op: BinaryOperator,
+    right: Value<'a>,
+) -> EvalResult<'a> {
+    // 1. is opText is +, then
+    if matches!(op, BinaryOperator::Addition) {
+        // a. let lprim be ? ToPrimitive(lval).
+        // b. let rprim be ? ToPrimitive(rval).
+        let lprim = left.clone().to_primitive(None)?;
+        let rprim = right.clone().to_primitive(None)?;
+        // c. if lprim is a String or rprim is a String, then
+        if lprim.is_string() || rprim.is_string() {
+            // i. let lstr be ? ToString(lprim).
+            // ii. let rstr be ? ToString(rprim).
+            // iii. return the String that is the result of concatenating lstr and rstr.
+            return ok!(format!("{}{}", lprim.to_string()?, rprim.to_string()?));
+        }
+    }
+    // 2. NOTE: ath this point, it must be a numeric operation
+    // 3. let lnum be ? ToNumeric(lval).
+    // 4. let rnum be ? ToNumeric(rval).
+    assert!(op.is_arithmetic() || op.is_bitwise());
+    let lnum = left.to_numeric()?;
+    let rnum = right.to_numeric()?;
+    // 5. if Type(lnum) is not Type(rnum), throw a TypeError exception
+    match (lnum, rnum) {
+        // 6. if lnum is a BigInt, then
+        (Numeric::BigInt(left), Numeric::BigInt(right)) => {
+            todo!("BigInt::exponentiate et al")
+        }
+        (Numeric::Number(left), Numeric::Number(right)) => {
+            match op {
+                BinaryOperator::Exponential => ok!(left.powf(*right)),
+                BinaryOperator::Multiplication => ok!(num; left * right),
+                BinaryOperator::Division => {
+                    if right == Number::ZERO {
+                        err!(format!("Cannot divide {left} by 0."))
+                    } else {
+                        ok!(left / right)
+                    }
+                }
+                BinaryOperator::Remainder => ok!(num; left % right),
+                BinaryOperator::Addition => ok!(num; left + right),
+                BinaryOperator::Subtraction => ok!(num; left - right),
+                // https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-leftShift
+                BinaryOperator::ShiftLeft => ok!(num; left << right),
+                BinaryOperator::ShiftRight => ok!(num; left >> right),
+                BinaryOperator::BitwiseAnd => ok!(num; left & right),
+                BinaryOperator::BitwiseXOR => ok!(num; left ^ right),
+                BinaryOperator::BitwiseOR => ok!(num; left | right),
+                _ => unreachable!("Invalid binary operator"),
+            }
+        }
+        // TODO: make this message better
+        _ => Err(Some(TypeError::error("Cannot perform binary operation on different types"))),
+    }
+}
+
+// 13.13.1 Binary Logical Operators - Runtime Semantics: Evaluation
+// https://262.ecma-international.org/15.0/index.html#sec-binary-logical-operators-runtime-semantics-evaluation
+impl<'a> Eval<'a> for LogicalExpression<'a> {
+    fn eval(&self, ctx: &mut crate::EvalContext<'a>) -> EvalResult<'a> {
+        // All three parts of this piecewise function share steps 1 and 2.
+        let left = self.left.eval(ctx)?;
+        // 2. Let lval be ? GetValue(lref).
+        // NOTE: ReferenceRecord ils not supported yet, so this will always be a "regular" value.
+        let lval = left;
+
+        match self.operator {
+            // LogicalANDExpression : LogicalANDExpression && BitwiseORExpression
+            LogicalOperator::And => {
+                // 3. let lbool be ToBoolean(lval).
+                let lbool = lval.to_boolean();
+                // 4. if lbool is false, return lval.
+                if !lbool {
+                    return Ok(lval);
+                }
+                // 5. Let rref be ? Evaluation of BitwiseORExpression
+                // 6. return ? GetValue(rref).
+                self.right.eval(ctx)
+            }
+
+            // LogicalORExpression : LogicalORExpression || LogicalANDExpression
+            LogicalOperator::Or => {
+                // 3. let lbool be ToBoolean(lval).
+                let lbool = lval.to_boolean();
+                // 4. if lbool is true, return lval.
+                if lbool {
+                    return Ok(lval);
+                }
+                // 5. Let rref be ? Evaluation of LogicalANDExpression
+                // 6. return ? GetValue(rref).
+                self.right.eval(ctx)
+            }
+
+            // CoalesceExpression : CoalesceExpression ?? BitwiseORExpression
+            LogicalOperator::Coalesce => {
+                // 3. if lval is either undefined or null, then
+                if lval.is_null_or_undefined() {
+                    // a. let rref be ? Evaluation of BitwiseORExpression.
+                    // b. return ? GetValue(rref).
+                    return self.right.eval(ctx);
+                }
+                // 4. Else,
+                //   a. return lval.
+                Ok(lval)
+            }
+        }
+    }
+}

--- a/crates/oxc_eval/src/eval/expr/compound.rs
+++ b/crates/oxc_eval/src/eval/expr/compound.rs
@@ -1,0 +1,52 @@
+//! compound expressions (e.g. sequence exprs, ternaries)
+
+use oxc_ast::ast::{ConditionalExpression, SequenceExpression};
+
+use crate::{Eval, EvalContext, EvalResult, Value};
+
+// 13.16.1 Comma Operator - Runtime Semantics: Evaluation
+// https://262.ecma-international.org/15.0/index.html#sec-comma-operator-runtime-semantics-evaluation
+impl<'a> Eval<'a> for SequenceExpression<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        // 1. Let lref be ? Evaluation of Expression.
+        // 2. Perform ? GetValue(lref).
+        // 3. Let rref be ? Evaluation of AssignmentExpression.
+        // 4. Return ? GetValue(rref).
+
+        let len = self.expressions.len();
+        if len == 0 {
+            // I don't think this should ever happen, but better safe than sorry
+            return Ok(Value::Undefined);
+        }
+
+        let last_index = self.expressions.len() - 1;
+        for (i, expr) in self.expressions.iter().enumerate() {
+            if i == last_index {
+                break;
+            }
+            let _ = expr.eval(ctx)?;
+            // NOTE: ReferenceRecord isn't implemented yet, so there's no GetValue
+        }
+
+        self.expressions[last_index].eval(ctx)
+    }
+}
+
+impl<'a> Eval<'a> for ConditionalExpression<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        // 1. Let lref be ? Evaluation of ShortCircuitExpression.
+        // 2. Let lval be ToBoolean(? GetValue(lref)).
+        let lval = self.test.eval(ctx)?.to_boolean();
+
+        // 3. If lval is true, then
+        if lval {
+            // a. Let trueRef be ? Evaluation of the first AssignmentExpression.
+            // b. Return ? GetValue(trueRef).
+            self.consequent.eval(ctx)
+        } else {
+            // a. Let falseRef be ? Evaluation of the second AssignmentExpression.
+            // b. Return ? GetValue(falseRef).
+            self.alternate.eval(ctx)
+        }
+    }
+}

--- a/crates/oxc_eval/src/eval/expr/literal.rs
+++ b/crates/oxc_eval/src/eval/expr/literal.rs
@@ -1,0 +1,44 @@
+#[allow(clippy::wildcard_imports)]
+use oxc_ast::{ast::*, BigInt};
+use oxc_diagnostics::OxcDiagnostic;
+use std::str::FromStr;
+
+use crate::{Eval, EvalContext, EvalResult, Value};
+
+impl<'a> Eval<'a> for BooleanLiteral {
+    #[inline]
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> crate::EvalResult<'a> {
+        Ok(Value::Boolean(self.value))
+    }
+}
+
+impl<'a> Eval<'a> for NullLiteral {
+    #[inline]
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> crate::EvalResult<'a> {
+        Ok(Value::Null)
+    }
+}
+
+impl<'a> Eval<'a> for StringLiteral<'a> {
+    #[inline]
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> crate::EvalResult<'a> {
+        Ok(Value::from(self.value.clone()))
+    }
+}
+
+impl<'a> Eval<'a> for NumericLiteral<'a> {
+    #[inline]
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> crate::EvalResult<'a> {
+        Ok(self.value.into())
+    }
+}
+
+impl<'a> Eval<'a> for BigIntLiteral<'a> {
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        BigInt::from_str(self.raw.as_str())
+            .map(Value::BigInt)
+            .map_err(|e| Some(OxcDiagnostic::error(format!("Invalid BigInt: {e}"))))
+    }
+}
+
+// impl<'a> ConstEval<'a> for

--- a/crates/oxc_eval/src/eval/expr/mod.rs
+++ b/crates/oxc_eval/src/eval/expr/mod.rs
@@ -1,0 +1,3 @@
+pub mod binary_op;
+pub mod compound;
+pub mod literal;

--- a/crates/oxc_eval/src/eval/mod.rs
+++ b/crates/oxc_eval/src/eval/mod.rs
@@ -1,0 +1,128 @@
+//! Constant-time evaluation through the [`Eval`] trait.
+
+mod expr;
+mod stmt;
+
+use oxc_ast::{
+    ast::{Expression, Program, Statement},
+    match_declaration, match_module_declaration,
+};
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::{EvalContext, Value};
+
+/// [`None`] for unimplemented logic or logic that cannot be evaluated without non-constant
+/// techniques. [`Some`] for an error that occurred during evaluation.
+///
+/// The [`Some`] variant is equivalent to a throw completion. This and [`EvalResult`] will both be
+/// replaced in the future with [CompletionRecord](`crate::completion::CompletionRecord`) when the
+/// `try_trait_v2` feature stabilizes.
+pub type EvalError = Option<OxcDiagnostic>;
+
+/// A [`Result`] type that is a simplified version of a completion record.
+/// 1. [`Ok`] for a normal completion.
+/// 2. [`Err`] with `None` for an unimplemented logic or logic that cannot be evaluated without
+///    non-constant techniques.
+/// 3. [`Err`] with [`Some`] for an error that occurred during evaluation, i.e. a throw completion.
+///
+/// This will be replaced in the future with
+/// [CompletionRecord](`crate::completion::CompletionRecord`) when the `try_trait_v2` feature
+/// stabilizes.
+pub type EvalResult<'a> = Result<Value<'a>, EvalError>;
+pub const TODO: EvalResult<'static> = Err(None);
+pub const VOID: EvalResult<'static> = Ok(Value::Undefined);
+
+pub trait Eval<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a>;
+}
+
+impl<'a> Eval<'a> for Expression<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        match self {
+            Self::BooleanLiteral(lit) => lit.eval(ctx),
+            Self::NullLiteral(lit) => lit.eval(ctx),
+            Self::NumericLiteral(lit) => lit.eval(ctx),
+            Self::BigIntLiteral(lit) => lit.eval(ctx),
+            Self::RegExpLiteral(_) => TODO,
+            Self::StringLiteral(lit) => lit.eval(ctx),
+            Self::TemplateLiteral(_) => TODO,
+            Self::Identifier(_) => TODO,
+            Self::MetaProperty(_) => TODO,
+            Self::Super(_) => TODO,
+            Self::ArrayExpression(_) => TODO,
+            Self::ArrowFunctionExpression(_) => TODO,
+            Self::AssignmentExpression(_) => TODO,
+            Self::AwaitExpression(_) => TODO,
+            // Self::BinaryExpression(bin) => bin.eval(ctx),
+            Self::BinaryExpression(_) => TODO,
+            Self::CallExpression(_) => TODO,
+            Self::ChainExpression(_) => TODO,
+            Self::ClassExpression(_) => TODO,
+            Self::ConditionalExpression(expr) => expr.eval(ctx),
+            Self::FunctionExpression(_) => TODO,
+            Self::ImportExpression(_) => TODO,
+            Self::LogicalExpression(expr) => expr.eval(ctx),
+            Self::NewExpression(_) => TODO,
+            Self::ObjectExpression(_) => TODO,
+            Self::ParenthesizedExpression(expr) => expr.expression.eval(ctx),
+            Self::SequenceExpression(expr) => expr.eval(ctx),
+            Self::TaggedTemplateExpression(_) => TODO,
+            Self::ThisExpression(_) => TODO,
+            Self::UnaryExpression(_) => TODO,
+            Self::UpdateExpression(_) => TODO,
+            Self::YieldExpression(_) => TODO,
+            Self::PrivateInExpression(_) => TODO,
+            // jsx
+            Self::JSXElement(_) => TODO,
+            Self::JSXFragment(_) => TODO,
+            // ts
+            Self::TSAsExpression(expr) => expr.expression.eval(ctx),
+            Self::TSSatisfiesExpression(expr) => expr.expression.eval(ctx),
+            Self::TSTypeAssertion(expr) => expr.expression.eval(ctx),
+            Self::TSNonNullExpression(expr) => expr.expression.eval(ctx),
+            Self::TSInstantiationExpression(expr) => expr.expression.eval(ctx),
+            Self::ComputedMemberExpression(_) => TODO,
+            Self::StaticMemberExpression(_) => TODO,
+            Self::PrivateFieldExpression(_) => TODO,
+        }
+    }
+}
+
+impl<'a> Eval<'a> for Statement<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        match self {
+            Self::BlockStatement(stmt) => stmt.eval(ctx),
+            Self::BreakStatement(_) => TODO,
+            Self::ContinueStatement(_) => TODO,
+            Self::DebuggerStatement(_) => TODO,
+            Self::DoWhileStatement(_) => TODO,
+            Self::EmptyStatement(_) => VOID,
+            Self::ExpressionStatement(expr) => expr.expression.eval(ctx),
+            Self::ForInStatement(_) => TODO,
+            Self::ForOfStatement(_) => TODO,
+            Self::ForStatement(_) => TODO,
+            Self::IfStatement(_) => TODO,
+            Self::LabeledStatement(_) => TODO,
+            Self::ReturnStatement(_) => TODO,
+            Self::SwitchStatement(_) => TODO,
+            Self::ThrowStatement(_) => TODO,
+            Self::TryStatement(_) => TODO,
+            Self::WhileStatement(_) => TODO,
+            Self::WithStatement(_) => TODO,
+            _stmt @ match_declaration!(Self) => TODO,
+            _stmt @ match_module_declaration!(Self) => TODO,
+        }
+    }
+}
+
+impl<'a> Eval<'a> for Program<'a> {
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        if self.is_strict() {
+            ctx.enter_strict();
+        }
+        for stmt in &self.body {
+            let _ = stmt.eval(ctx)?;
+        }
+        VOID
+    }
+}

--- a/crates/oxc_eval/src/eval/stmt.rs
+++ b/crates/oxc_eval/src/eval/stmt.rs
@@ -1,0 +1,19 @@
+use super::{Eval, EvalContext, EvalResult, VOID};
+use oxc_ast::ast::{BlockStatement, EmptyStatement};
+
+impl<'a> Eval<'a> for BlockStatement<'a> {
+    #[inline]
+    fn eval(&self, ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        for stmt in &self.body {
+            let _ = stmt.eval(ctx)?;
+        }
+        VOID
+    }
+}
+
+impl<'a> Eval<'a> for EmptyStatement {
+    #[inline]
+    fn eval(&self, _ctx: &mut EvalContext<'a>) -> EvalResult<'a> {
+        VOID
+    }
+}

--- a/crates/oxc_eval/src/js_conversion.rs
+++ b/crates/oxc_eval/src/js_conversion.rs
@@ -1,0 +1,69 @@
+use std::convert::Infallible;
+
+/// Like [`Into`], but conversion logic follows the ECMAScript specification.
+pub trait JsInto<T> {
+    fn into_js(self) -> T;
+}
+
+/// Like [`From`], but conversion logic follows the ECMAScript specification.
+pub trait JsFrom<T> {
+    #[must_use]
+    fn from_js(value: T) -> Self;
+}
+
+/// Like [`TryInto`], but conversion logic follows the ECMAScript specification.
+pub trait TryJsInto<T> {
+    /// The error type returned when the conversion fails.
+    type Error;
+    fn try_into_js(self) -> Result<T, Self::Error>;
+}
+
+/// Like [`TryFrom`], but conversion logic follows the ECMAScript specification.
+pub trait TryJsFrom<T>: Sized {
+    /// The error type returned when the conversion fails.
+    type Error;
+    fn try_from_js(value: T) -> Result<Self, Self::Error>;
+}
+
+// identity
+
+impl<T> JsFrom<T> for T {
+    #[inline]
+    fn from_js(value: T) -> Self {
+        value
+    }
+}
+
+// from/into reciprocal impls
+
+impl<T, U> JsInto<T> for U
+where
+    T: JsFrom<U>,
+{
+    #[must_use]
+    fn into_js(self) -> T {
+        T::from_js(self)
+    }
+}
+
+impl<T, U> TryJsInto<T> for U
+where
+    T: TryJsFrom<U>,
+{
+    type Error = T::Error;
+    fn try_into_js(self) -> Result<T, Self::Error> {
+        T::try_from_js(self)
+    }
+}
+
+impl<T, U> TryJsFrom<U> for T
+where
+    T: JsFrom<U>,
+{
+    type Error = Infallible;
+
+    #[inline]
+    fn try_from_js(value: U) -> Result<Self, Self::Error> {
+        Ok(Self::from_js(value))
+    }
+}

--- a/crates/oxc_eval/src/lib.rs
+++ b/crates/oxc_eval/src/lib.rs
@@ -1,0 +1,10 @@
+mod completion;
+mod context;
+mod eval;
+mod js_conversion;
+mod value;
+
+pub use context::EvalContext;
+pub use eval::{Eval, EvalResult};
+pub use js_conversion::{JsFrom, JsInto, TryJsFrom, TryJsInto};
+pub use value::Value;

--- a/crates/oxc_eval/src/value/mod.rs
+++ b/crates/oxc_eval/src/value/mod.rs
@@ -1,0 +1,234 @@
+//! Contains the [`Value`] enum, which represents an ECMAScript language value.
+
+mod numeric;
+mod object;
+mod type_conversion;
+
+use std::{
+    borrow::{Borrow, Cow},
+    rc::Rc,
+};
+
+use object::Object;
+use oxc_ast::BigInt;
+use oxc_span::Atom;
+
+pub use numeric::{Number, Numeric};
+
+/// ## References
+/// - [ECMAScript - 4.3.1 Objects](https://262.ecma-international.org/15.0/index.html#sec-objects)
+/// - [V8 - Value](https://github.com/v8/v8/blob/main/include/v8-value.h)
+#[derive(Debug, Default, Clone, Hash)]
+#[must_use]
+pub enum Value<'a> {
+    Boolean(bool),
+    Number(Number),
+    BigInt(BigInt),
+    String(Cow<'a, str>),
+    Symbol(Atom<'a>),
+
+    // TODO: objects, functions
+    Object(Rc<Object>),
+    #[default]
+    Undefined,
+    Null,
+}
+
+// impl<'a> From<Value<'a>> for f64 {
+//     fn from(val: Value<'a>) -> Self {
+//         val.as_number().unwrap_or(f64::NAN)
+//     }
+// }
+
+impl<'a> Value<'a> {
+    /// Returns `true` if this [`Value`] is the `undefined` [`Value`].
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// value === undefined
+    /// ```
+    ///
+    /// ## References
+    /// - [ECMA-262 `undefined` value](https://262.ecma-international.org/15.0/index.html#sec-undefined-value)
+    #[inline]
+    pub fn is_undefined(&self) -> bool {
+        matches!(self, Value::Undefined)
+    }
+
+    /// Returns `true` if this [`Value`] is the `null` [`Value`].
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// value === null
+    /// ```
+    ///
+    /// ## References
+    /// - [ECMA-262 - 4.4.16 `null` value](https://262.ecma-international.org/15.0/index.html#sec-null-value)
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    /// Returns `true` if this [`Value`] is the null or the undefined [`Value`].
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// value == null
+    /// ```
+    #[inline]
+    pub fn is_null_or_undefined(&self) -> bool {
+        self.is_null() || self.is_undefined()
+    }
+
+    /// Returns `true` if this [`Value`] is `true`.
+    ///
+    /// This is not the same as `BooleanValue()`. The latter performs a
+    /// conversion to [`Value::Boolean`], i.e.e the result of `Boolean(value)`
+    /// in JS, whereas this method checks `value === true`.
+    ///
+    /// Use [`Value::is_false`] to check for `false`.
+    ///
+    /// ## References
+    /// - [ECMA-262 4.4.18 Boolean type](https://262.ecma-international.org/15.0/index.html#sec-terms-and-definitions-boolean-type)
+    #[inline]
+    pub fn is_true(&self) -> bool {
+        matches!(self, Value::Boolean(true))
+    }
+
+    /// Returns `true` if this [`Value`] is `false`.
+    ///
+    /// This is not the same as `!BooleanValue()`. The latter performs a
+    /// conversion to [`Value::Boolean`], i.e.e the result of `!Boolean(value)`
+    /// in JS, whereas this method checks `value === false`.
+    ///
+    ///
+    /// Use [`Value::is_true`] to check for `true`.
+    ///
+    /// ## References
+    /// - [ECMA-262 4.4.18 Boolean type](https://262.ecma-international.org/15.0/index.html#sec-terms-and-definitions-boolean-type)
+    #[inline]
+    pub fn is_false(&self) -> bool {
+        matches!(self, Value::Boolean(false))
+    }
+
+    /// Returns `true` if this [`Value`] is a a [`symbol`] or [`string`]
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// typeof value === 'string' || typeof value === 'symbol'
+    /// ```
+    ///
+    /// [`symbol`]: Value::Symbol
+    /// [`string`]: Value::String
+    #[inline]
+    pub fn is_name(&self) -> bool {
+        matches!(self, Value::String(_) | Value::Symbol(_))
+    }
+
+    /// Returns `true` if this [`Value`] is an instance of the `String` type.
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// typeof value === 'string'
+    /// ```
+    ///
+    /// ## References
+    /// - [ECMA262 - 4.4.22 String object](https://262.ecma-international.org/15.0/index.html#sec-string-object)
+    #[inline]
+    pub fn is_string(&self) -> bool {
+        matches!(self, Value::String(_))
+    }
+
+    /// Returns `true` if this [`Value`] is a unique symbol.
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// typeof value === 'symbol'
+    /// ```
+    ///
+    /// ## References
+    /// - [ECMA262 - 4.4.31 Symbol value](https://262.ecma-international.org/15.0/index.html#sec-symbol-value)
+    #[inline]
+    pub fn is_symbol(&self) -> bool {
+        matches!(self, Value::Symbol(_))
+    }
+
+    /// Returns `true` if this [`Value`] is a function.
+    /// > _NOTE: functions are not yet implemented. This method will panic._
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// typeof value === 'function'
+    /// ```
+    ///
+    pub fn is_function(&self) -> bool {
+        todo!("Function values are not yet implemented")
+    }
+
+    /// Returns `true` if this [`Value`] is an object.
+    #[inline]
+    pub fn is_object(&self) -> bool {
+        // TODO: check if V8 also returns `true` for functions, arrays, etc
+        matches!(self, Value::Object(_))
+    }
+
+    /// Returns `true` if this [`Value`] is a bigint.
+    ///
+    /// This is equivalent to
+    /// ```js
+    /// typeof value === 'bigint'
+    /// ```
+    #[inline]
+    pub fn is_big_int(&self) -> bool {
+        matches!(self, Value::BigInt(_))
+    }
+
+    pub fn is_truthy(&self) -> bool {
+        match self {
+            Self::Boolean(b) => *b,
+            Self::Number(n) => *n != Number::ZERO,
+            Self::BigInt(n) => n != &BigInt::ZERO,
+            Self::String(s) => !s.is_empty(),
+            Self::Symbol(_) | Self::Object(_) => true,
+            Self::Undefined | Self::Null => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_falsey(&self) -> bool {
+        !self.is_truthy()
+    }
+
+    // pub fn as_number(&self) -> Option<f64> {
+    //     const fn int_to_float(n: i64) -> Option<f64> {
+    //         if n < (f64::MAX as i64) {
+    //             Some(n as f64)
+    //         } else {
+    //             None
+    //         }
+    //     }
+
+    //     match self {
+    //         Self::Undefined => None,
+    //         Self::Null => Some(0.0),
+    //         Self::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+    //         Self::Number(n) => Some(*n),
+    //         Self::BigInt(n) => i64::try_from(n).map(int_to_float).ok().flatten(),
+    //         Self::String(s) => s.parse().ok(),
+    //         Self::Symbol(_) | Self::Object(_) => None,
+    //     }
+    // }
+
+    pub fn as_str(&self) -> Cow<'_, str> {
+        match self {
+            Value::Undefined => Cow::Borrowed("undefined"),
+            Value::Null => Cow::Borrowed("null"),
+            Value::Boolean(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
+            Value::Number(n) => Cow::Owned(n.to_string()),
+            Value::BigInt(n) => Cow::Owned(n.to_string() + "n"),
+            Value::String(s) => Cow::Borrowed(s.borrow()),
+            Value::Symbol(s) => Cow::Borrowed(s.as_str()),
+            Value::Object(o) => Cow::Borrowed(o.name()),
+        }
+    }
+}

--- a/crates/oxc_eval/src/value/numeric.rs
+++ b/crates/oxc_eval/src/value/numeric.rs
@@ -1,0 +1,675 @@
+use std::{
+    cmp::Ordering,
+    fmt, hash,
+    ops::{self, Deref},
+};
+
+use oxc_ast::BigInt;
+
+use crate::{JsFrom, JsInto};
+
+use super::Value;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Numeric {
+    Number(Number),
+    BigInt(BigInt),
+}
+
+impl From<Numeric> for Value<'static> {
+    fn from(value: Numeric) -> Self {
+        match value {
+            Numeric::Number(n) => Value::Number(n),
+            Numeric::BigInt(n) => Value::BigInt(n),
+        }
+    }
+}
+
+/// ## [6.1.6.1 The Number Type](https://262.ecma-international.org/15.0/index.html#sec-ecmascript-language-types-number-type)
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[repr(transparent)]
+pub struct Number(f64); // TODO: add i32 variant, like V8's SMI?
+
+impl Deref for Number {
+    type Target = f64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Number {
+    pub const ZERO: Number = Number(0.0);
+    pub const NEG_ZERO: Number = Number(-0.0);
+    pub const ONE: Number = Number(1.0);
+    /// Not-a-Number.
+    ///
+    /// Do not compare values with this, instead use [`Number::is_nan`].
+    pub const NAN: Number = Number(f64::NAN);
+    pub const INFINITY: Number = Number(f64::INFINITY);
+    pub const NEG_INFINITY: Number = Number(f64::NEG_INFINITY);
+
+    #[inline]
+    #[must_use]
+    pub const fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// Returns `true` if this value is NaN.
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.0.is_nan()
+    }
+
+    #[inline]
+    pub fn float(f: f64) -> Self {
+        Self(f)
+    }
+
+    /// Returns `true` if this [`Number`] is _not_ +/- infinity or [NaN](`Self::NAN`).
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        !self.is_nan() && self != Self::INFINITY && self != Self::NEG_INFINITY
+    }
+
+    /// Returns `true` if this [`Number`] is +/- zero.
+    #[inline]
+    pub fn is_zero(self) -> bool {
+        self == Self::ZERO || self == Self::NEG_ZERO
+    }
+
+    /// Calls `f` when `self` is a valid number, or returns [`Self::NAN`] when
+    /// `self` is NaN.
+    fn map<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        // it would be nice to have access to the `unlikely` intrinsic...
+        if self.is_nan() {
+            Self::NAN
+        } else {
+            f(self)
+        }
+    }
+}
+
+// 6.1.6.1.1 unaryMinus(x)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-unaryMinus
+
+impl ops::Neg for Number {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        self.map(|n| Self(-n.0))
+    }
+}
+
+// 6.1.6.1.2 bitwiseNOT(x)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-bitwiseNOT
+// TODO
+
+// 6.1.6.1.3 Number::exponentiate ( base, exponent )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-exponentiate
+// TODO
+
+// 6.1.6.1.4 Number::multiply ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-multiply
+impl ops::Mul for Number {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        if rhs.is_nan() || rhs.is_nan() {
+            return Self::NAN;
+        }
+        Self(self.0 * rhs.0)
+    }
+}
+
+// 6.1.6.1.5 Number::divide (`x`, `y`)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-divide
+impl ops::Div for Number {
+    type Output = Self;
+    fn div(/* x */ self, y: Self) -> Self::Output {
+        // TODO: ensure this is correct w.r.t 6.1.6.1.5
+        // https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-divide
+        // 1. If x is NaN or y is NaN, return NaN.
+        if self.is_nan() || y.is_nan() {
+            return Self::NAN;
+        }
+        // 2. if x is +∞ or -∞,
+        if self.is_infinite() {
+            // a. if y is either +∞ or -∞, return NAN
+            if y.is_infinite() {
+                return Self::NAN;
+            }
+            // b. is y is +0 or y > +0, return x
+            if y >= Self::ZERO && y != Self::NEG_ZERO {
+                debug_assert_ne!(y, Self::NEG_ZERO);
+                return self;
+            }
+            // c. Return -x (NOTE: skip Number neg impl, use f64 directly)
+            return Self(-self.0);
+        }
+
+        // 3. if y is +∞, then
+        if y == Self::INFINITY {
+            // a. if x is +0 or x > +0, return +0. Otherwise, return -0
+            if self >= Self::ZERO {
+                return Self::ZERO;
+            }
+            return Self::NEG_ZERO;
+        } else if y == Self::NEG_INFINITY {
+            // 4. if y is -∞, then
+            // a. if x is +0 or x > +0, return -0. Otherwise, return +0
+            if self >= Self::ZERO {
+                return Self::NEG_ZERO;
+            }
+            return Self::ZERO;
+        }
+        // 5. if x is either +0 or -0, then
+        if self.is_zero() {
+            // a. if y is either +0 or -0, return NaN
+            if y.is_zero() {
+                return Self::NAN;
+            }
+            // b. if y > +0, return x
+            if y > Self::ZERO {
+                return self;
+            }
+            // c. return -x
+            return Self(-self.0);
+        }
+
+        // 6. if y is +0, then
+        if y == Self::ZERO {
+            // a. if x > +0, return +∞. Otherwise, return -∞
+            if self > Self::ZERO {
+                return Self::INFINITY;
+            } else {
+                return Self::NEG_INFINITY;
+            }
+        }
+
+        // 7. if y is -0, then
+        if y == Self::NEG_ZERO {
+            // a. if x > +0, return -∞. Otherwise, return +∞
+            if self > Self::ZERO {
+                return Self::NEG_INFINITY;
+            } else {
+                return Self::INFINITY;
+            }
+        }
+
+        // 8. Return F( R(x) / R(y) )
+        Self(self.0 / y.0)
+    }
+}
+
+// 6.1.6.1.6 Number::remainder ( n, d )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-remainder
+impl ops::Rem for Number {
+    type Output = Self;
+    fn rem(self, rhs: Self) -> Self::Output {
+        // 1. If n is NaN or d is NaN, return NaN.
+        // 2. If n is either +∞𝔽 or -∞𝔽, return NaN.
+        // 3. If d is either +∞𝔽 or -∞𝔽, return n.
+        // 4. If d is either +0𝔽 or -0𝔽, return NaN.
+        // 5. If n is either +0𝔽 or -0𝔽, return n.
+        // 6. Assert: n and d are finite and non-zero.
+        // 7. Let quotient be ℝ(n) / ℝ(d).
+        // 8. Let q be truncate(quotient).
+        // 9. Let r be ℝ(n) - (ℝ(d) × q).
+        // 10. If r = 0 and n < -0𝔽, return -0𝔽.
+        // 11. Return 𝔽(r).
+
+        // 1. If n is NaN or d is NaN, return NaN.
+        // 2. If n is either +∞𝔽 or -∞𝔽, return NaN.
+        if self.is_nan() || rhs.is_nan() || self.is_infinite() {
+            return Self::NAN;
+        }
+
+        // 3. If d is either +∞𝔽 or -∞𝔽, return n.
+        if rhs.is_infinite() {
+            return self;
+        }
+
+        // 4. If d is either +0𝔽 or -0𝔽, return NaN.
+        if rhs.is_zero() {
+            return Self::NAN;
+        }
+
+        // 5. If n is either +0𝔽 or -0𝔽, return n.
+        if self.is_zero() {
+            return self;
+        }
+
+        // 6. Assert: n and d are finite and non-zero.
+        debug_assert!(self.is_finite() && !self.is_zero());
+        debug_assert!(rhs.is_finite() && !rhs.is_zero());
+        let q = (self.0 / rhs.0).trunc();
+        let r = self.0 - (rhs.0 * q);
+        if r == 0.0 && self.is_sign_negative() {
+            Self::NEG_ZERO
+        } else {
+            Self(r)
+        }
+    }
+}
+
+// 6.1.6.1.7 Number::add (`x`, `y`)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-add
+impl ops::Add for Number {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+// 6.1.6.1.8 Number::subtract (`x`, `y`)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-subtract
+impl ops::Sub for Number {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+// 6.1.6.1.9 Number::leftShift (`x`, `y`)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-subtract
+impl ops::Shl for Number {
+    type Output = Self;
+
+    /// Performs the `<<` operation.
+    /// ## References
+    /// - [6.1.6.1.9 Number::leftShift (`x`, `y`)](https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-leftShift)
+    fn shl(self, rhs: Self) -> Self::Output {
+        // 1. Let lnum be ! ToInt32(x).
+        let lnum: i32 = self.into_js();
+        // 2. Let rnum be ! ToUint32(y).
+        let rnum: u32 = rhs.into_js();
+        // 3. Let shiftCount be ℝ(rnum) modulo 32.
+        let shift_count = rnum % 32;
+        // 4. Return the result of performing a sign-extending right shift of
+        //    lnum by shiftCount bits. The most significant bit is propagated.
+        //    The mathematical value of the result is exactly representable as a
+        //    32-bit two's complement bit string.
+        Self(f64::from(lnum << shift_count))
+    }
+}
+// 6.1.6.1.10 Number::signedRightShift ( `x`, `y` )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-signedRightShift
+// TODO
+
+// 6.1.6.1.11 Number::unsignedRightShift ( `x`, `y` )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-unsignedRightShift
+impl ops::Shr for Number {
+    type Output = Self;
+
+    fn shr(self, rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+// 6.1.6.1.12 Number::lessThan ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-lessThan
+impl PartialOrd for Number {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // 1. If x is NaN or y is NaN, return undefined.
+        // 2. if y is Nan< return undefined
+        if self.is_nan() || other.is_nan() {
+            return None;
+        }
+        // 3. is x is y, return false
+        if self.0 == other.0 {
+            return Some(Ordering::Equal);
+        }
+        // 4. if x is +0 and y is -0, return false
+        // 5. if x is -0 and y is +0, return true
+        if self.is_zero() && other.is_zero() {
+            return Some(Ordering::Equal);
+        }
+
+        // 6. if x is +∞, return false
+        // 7. if y is +∞, return true
+        // 8. if y is -∞, return false
+        // 9. if x is -∞, return true
+        // 10. Assert: x and y are finite.
+        // 11. If R(x) < R(y), return true. Otherwise, return false.
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+// 6.1.6.1.13 Number::equal ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-equal
+// derived by PartialEq
+
+// 6.1.6.1.14 Number::sameValue ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-sameValue
+impl Number {
+    /// 6.1.6.1.14 Number::sameValue (`x`, `y`)
+    ///
+    /// > The abstract operation Number::sameValue takes arguments `x` (a [`Number`]) and `y` (a
+    /// [`Number`]) and returns a Boolean.
+    pub fn same_value(&self, y: &Self) -> bool {
+        // 1. if ix is Nan and y is NaN, return true
+        if self.is_nan() && y.is_nan() {
+            return true;
+        }
+        // 2. if x is +0 and y is -0, return false
+        // 3. if x is -0 and y is +0, return false
+        if self.is_zero() && y.is_zero() {
+            return self.0.is_sign_positive() == y.0.is_sign_positive();
+        }
+        // 4. if x is y, return true
+        // 5. if x is NaN, return false
+        self.0 == y.0
+    }
+}
+
+// 6.1.6.1.15 Number::sameValueZero(`x`, `y`)
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-sameValueZero
+impl Number {
+    /// 6.1.6.1.15 Number::sameValueZero(`x`, `y`)
+    ///
+    /// > The abstract operation Number::sameValueZero takes arguments `x` (a [`Number`]) and `y`
+    /// (a [`Number`]) and returns a Boolean.
+    ///
+    /// ## References
+    /// - [ECMAScript Standard](https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-sameValueZero)
+    pub fn same_value_zero(&self, y: &Self) -> bool {
+        // 1. If x is NaN and y is NaN, return true.
+        if self.is_nan() && y.is_nan() {
+            return true;
+        }
+        // 2. If x is +0𝔽 and y is -0𝔽, return true.
+        // 3. If x is -0𝔽 and y is +0𝔽, return true.
+        if self.is_zero() && y.is_zero() {
+            return true;
+        }
+
+        // 4. If x is y, return true.
+        // 5. Return false.
+        self.0 == y.0
+    }
+}
+
+// 6.1.6.1.16 NumberBitwiseOp ( op, x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numberbitwiseop
+macro_rules! number_bitwise_op {
+    ($op:tt, $x:expr, $y:expr) => {{
+        #[cfg(debug_assertions)]
+        {
+            assert!(!Number::is_nan($x));
+            assert!(!Number::is_nan($y));
+        }
+
+        let x = i32::from_js($x);
+        let y = i32::from_js($y);
+        Number::from(x $op y)
+    }};
+}
+
+// 6.1.6.1.17 Number::bitwiseAND ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-bitwiseAND
+impl ops::BitAnd for Number {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        number_bitwise_op!(&, self, rhs)
+    }
+}
+
+// 6.1.6.1.18 Number::bitwiseXOR ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-bitwiseXOR
+impl ops::BitXor for Number {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        number_bitwise_op!(^, self, rhs)
+    }
+}
+
+// 6.1.6.1.19 Number::bitwiseOR ( x, y )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-bitwiseOR
+impl ops::BitOr for Number {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        number_bitwise_op!(|, self, rhs)
+    }
+}
+
+// 6.1.6.1.20 Number::toString ( x, radix )
+// https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-toString
+// TODO
+
+impl From<i32> for Number {
+    fn from(value: i32) -> Self {
+        Self(f64::from(value))
+    }
+}
+
+impl From<f64> for Number {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+impl From<Number> for f64 {
+    fn from(value: Number) -> Self {
+        value.0
+    }
+}
+
+impl JsFrom<f64> for Number {
+    #[inline]
+    fn from_js(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl JsFrom<Number> for f64 {
+    #[inline]
+    fn from_js(value: Number) -> Self {
+        value.0
+    }
+}
+
+impl JsFrom<Number> for i32 {
+    /// ## References
+    /// - `ToInt32(x)`: <https://262.ecma-international.org/15.0/index.html#sec-toint32>
+    /// - Rust casting behavior: <https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics>
+    #[allow(clippy::cast_possible_truncation)]
+    fn from_js(val: Number) -> Self {
+        let two_32: f64 = f64::powf(2.0, 32.0);
+        let two_31: f64 = f64::powf(2.0, 31.0);
+
+        match val {
+            // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
+            Number::ZERO | Number::INFINITY | Number::NEG_INFINITY => 0,
+            _ => {
+                // 3. Let int be truncate(ℝ(number)).
+                let int = f64::trunc(val.into());
+                // 4. Let int32bit be int modulo 2**32.
+                let int32bit = int % two_32;
+                // 5. If int32bit ≥ 2**31, return 𝔽(int32bit - 2**32);  otherwise return 𝔽(int32bit).
+
+                if int32bit >= two_31 {
+                    (int32bit - two_32) as i32
+                } else {
+                    int32bit as i32
+                }
+            }
+        }
+    }
+}
+
+impl JsFrom<Number> for u32 {
+    /// ## References
+    /// - `ToUint32(x)`: <https://262.ecma-international.org/15.0/index.html#sec-touint32>
+    /// - Rust casting behavior: <https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics>
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    fn from_js(val: Number) -> Self {
+        if val.is_infinite() || val == Number::ZERO {
+            return 0;
+        }
+        let int = f64::trunc(val.into());
+        let int32bit = int % f64::powf(2.0, 32.0);
+        int32bit as u32
+    }
+}
+
+impl hash::Hash for Number {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
+}
+
+impl fmt::Display for Number {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ops::*;
+
+    const INFINITIES: [Number; 2] = [Number::INFINITY, Number::NEG_INFINITY];
+
+    // NOTE: NAN is never equal to itself and cannot be used in assert_eq!. Use
+    // is_nan() instead.
+
+    // https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-unaryMinus
+    #[test]
+    fn test_number_unary_minus() {
+        assert!(Number::NAN.neg().is_nan());
+        assert_eq!(-Number::INFINITY, Number::NEG_INFINITY);
+        assert_eq!(-Number::NEG_INFINITY, Number::INFINITY);
+        assert_eq!(-Number::ZERO, Number::NEG_ZERO);
+        assert_eq!(-Number::NEG_ZERO, Number::ZERO);
+        assert_eq!(-Number::new(1.0), Number::new(-1.0));
+    }
+
+    // 6.1.6.1.4 Number::multiply ( x, y )
+    // https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-multiply
+    #[test]
+    fn test_number_mul() {
+        assert!((Number::NAN * Number::NAN).is_nan());
+        assert!((Number::INFINITY * Number::ZERO).is_nan());
+        assert!((Number::ZERO * Number::INFINITY).is_nan());
+        assert_eq!(Number::INFINITY * Number::INFINITY, Number::INFINITY);
+        assert_eq!(Number::ZERO * Number::new(1.0), Number::ZERO);
+    }
+
+    // 6.1.6.1.5 Number::divide ( x, y )
+    #[test]
+    fn test_number_div() {
+        // 1. if x is NaN or y is NaN, return NaN
+        assert!((Number::NAN / Number::NAN).is_nan());
+        assert!((Number::ONE / Number::NAN).is_nan());
+        assert!((Number::NAN / Number::ONE).is_nan());
+
+        // 2. if x is +∞ or -∞,
+        //   a. if y is either +∞ or -∞, return NAN
+        //   b. if y is +0 or y > +0, return x
+        //   c. Return -x
+        for x in INFINITIES {
+            assert!((x / Number::INFINITY).is_nan());
+            assert!((x / Number::NEG_INFINITY).is_nan());
+            assert_eq!(x / Number::ZERO, x, "{x:?} / Number::ZERO != {x:?}");
+            assert_eq!(x / Number::ONE, x);
+            assert_eq!(x / Number::new(-1.0), -x);
+        }
+
+        // 3. if y is +∞ or -∞, then
+        //   a. If x is +0 or x > +0, return +0. Otherwise, return -0
+        for y in INFINITIES {
+            assert_eq!(Number::ZERO / y, Number::ZERO);
+            assert_eq!(Number::ONE / y, Number::ZERO);
+            assert_eq!(Number::NEG_ZERO / y, Number::NEG_ZERO);
+            assert_eq!(Number::new(-1.0) / y, Number::NEG_ZERO);
+        }
+
+        assert_eq!(Number::INFINITY / Number::ZERO, Number::NAN);
+
+        assert_eq!(Number::INFINITY / Number::ZERO, Number::NAN);
+        assert_eq!(Number::ZERO / Number::INFINITY, Number::ZERO);
+        assert_eq!(Number::INFINITY / Number::INFINITY, Number::NAN);
+        assert_eq!(Number::ZERO / Number::new(1.0), Number::ZERO);
+    }
+
+    // 6.1.6.1.6 Number::remainder ( n, d )
+    // https://262.ecma-international.org/15.0/index.html#sec-numeric-types-number-remainder
+    #[test]
+    fn test_number_rem() {
+        // 1. If n is NaN or d is NaN, return NaN.
+        assert!((Number::NAN % Number::NAN).is_nan());
+
+        // 2. If n is either +∞ or -∞, return NaN.
+        for inf in INFINITIES {
+            assert!((inf % Number::NAN).is_nan());
+            assert!((inf % Number::new(1.0)).is_nan());
+            assert!((inf % Number::ZERO).is_nan());
+            assert!((inf % Number::INFINITY).is_nan());
+            assert!((inf % Number::NEG_INFINITY).is_nan());
+        }
+        // 3. if d is either +∞ or -∞, return n.
+        for inf in INFINITIES {
+            assert_eq!(Number::ZERO % inf, Number::ZERO);
+            assert_eq!(Number::ONE % inf, Number::ONE);
+            assert_eq!(Number::new(5.0) % inf, Number::new(5.0));
+            assert_eq!(Number::new(-5.0) % inf, Number::new(-5.0));
+        }
+    }
+
+    // 6.1.6.1.12 Number::lessThan(`x`, `y`)`
+    #[test]
+    fn test_number_less_than() {}
+
+    // 6.1.6.1.13 Number::equal(`x`, `y`)
+    #[test]
+    fn test_number_eq() {
+        // 1. If x is NaN, return false
+        // 2. If y is NaN, return false
+        assert_ne!(Number::NAN, Number::NAN);
+        // nan on lhs
+        assert_ne!(Number::NAN, Number::ONE);
+        assert_ne!(Number::NAN, Number::ZERO);
+        assert_ne!(Number::NAN, Number::INFINITY);
+        assert_ne!(Number::NAN, Number::new(5.0));
+        assert_ne!(Number::NAN, Number::new(-5.0));
+        // nan on rhs
+        assert_ne!(Number::ONE, Number::NAN);
+        assert_ne!(Number::ZERO, Number::NAN);
+        assert_ne!(Number::INFINITY, Number::NAN);
+        assert_ne!(Number::new(5.0), Number::NAN);
+        assert_ne!(Number::new(-5.0), Number::NAN);
+
+        // 3. if x is y, return true
+        assert_eq!(Number::ZERO, Number::ZERO);
+        assert_eq!(Number::NEG_ZERO, Number::NEG_ZERO);
+        assert_eq!(Number::ONE, Number::ONE);
+        assert_eq!(Number::INFINITY, Number::INFINITY);
+        assert_eq!(Number::NEG_INFINITY, Number::NEG_INFINITY);
+        assert_eq!(Number::new(5.0), Number::new(5.0));
+        assert_eq!(Number::new(-5.0), Number::new(-5.0));
+        assert_eq!(Number::new(0.01), Number::new(0.01));
+
+        // 4. if x is +_0 and y is -0, return true
+        // 5. if x is -0 and y is +0, return true
+        assert_eq!(Number::ZERO, Number::NEG_ZERO);
+        assert_eq!(Number::NEG_ZERO, Number::ZERO);
+
+        // 6. return false
+        assert_ne!(Number::ZERO, Number::ONE);
+        assert_ne!(Number::ZERO, Number::INFINITY);
+        assert_ne!(Number::ZERO, Number::NEG_INFINITY);
+        assert_ne!(Number::ZERO, Number::new(5.0));
+        assert_ne!(Number::ZERO, Number::new(-5.0));
+
+        assert_ne!(Number::ONE, Number::INFINITY);
+        assert_ne!(Number::ONE, Number::NEG_INFINITY);
+        assert_ne!(Number::ONE, Number::new(5.0));
+        assert_ne!(Number::ONE, Number::new(-5.0));
+
+        assert_ne!(Number::INFINITY, Number::NEG_INFINITY);
+        assert_ne!(Number::INFINITY, Number::ZERO);
+        assert_ne!(Number::INFINITY, Number::NEG_ZERO);
+        assert_ne!(Number::INFINITY, Number::new(5.0));
+        assert_ne!(Number::INFINITY, Number::new(-5.0));
+    }
+}

--- a/crates/oxc_eval/src/value/object.rs
+++ b/crates/oxc_eval/src/value/object.rs
@@ -1,0 +1,15 @@
+use std::rc::Rc;
+
+/// ## References
+/// - [EMCA-262 4.3.1 Objects](https://262.ecma-international.org/15.0/index.html#sec-objects)
+#[derive(Debug, Clone, Hash)]
+pub struct Object {
+    prototype: Option<Rc<Object>>,
+    // properties: Vec<Property>,
+    // name: String,
+}
+impl Object {
+    pub fn name(&self) -> &str {
+        "Object"
+    }
+}

--- a/crates/oxc_eval/src/value/type_conversion.rs
+++ b/crates/oxc_eval/src/value/type_conversion.rs
@@ -1,0 +1,280 @@
+//! [7.1 Type
+//! Conversion](https://262.ecma-international.org/15.0/index.html#sec-type-conversion)
+
+use std::borrow::Cow;
+
+use oxc_ast::BigInt;
+use oxc_span::Atom;
+
+use crate::{completion::TypeError, EvalResult, JsFrom, JsInto, TryJsFrom};
+
+use super::{numeric::Number, Numeric, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
+pub enum PreferredType {
+    String,
+    Number,
+}
+
+impl<'a> Value<'a> {
+    /// [7.1.1 ToPrimitive](https://262.ecma-international.org/15.0/index.html#sec-toprimitive)
+    ///
+    /// > The abstract operation ToPrimitive takes argument `input` (an ECMAScript
+    /// > language value) and optional argument `preferredType` (STRING or NUMBER)
+    /// > and returns either a normal completion containing an ECMAScript language
+    /// > value or a throw completion. It converts its input argument to a
+    /// > non-Object type. If an object is capable of converting to more than one
+    /// > primitive type, it may use the optional hint preferredType to favour
+    /// > that type.
+    ///
+    /// > Note:
+    /// >
+    /// > When ToPrimitive is called without a hint, then it generally behaves
+    /// > as if the hint were NUMBER. However, objects may over-ride this
+    /// > behaviour by defining a @@toPrimitive method. Of the objects defined in
+    /// > this specification only Dates (see 21.4.4.45) and Symbol objects (see
+    /// > 20.4.3.5) over-ride the default ToPrimitive behaviour. Dates treat the
+    /// > absence of a hint as if the hint were STRING.
+
+    pub fn to_primitive(self, _preferred_type: Option<PreferredType>) -> EvalResult<'a> {
+        match self {
+            // 1. If input is an Object, then:
+            Self::Object(_) => {
+                // a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+                // b. If exoticToPrim is not undefined, then:
+                //   i. If preferredType is not present, then:
+                //     1. Let hint be "default".
+                //   ii. Else if preferredType is STRING, then:
+                //     1. Let hint be "string".
+                //   iii. Else,
+                //     1. Assert: preferredType is NUMBER.
+                //     2. Let hint be "number".
+                //   iv. Let result be ? Call(exoticToPrim, input, « hint »).
+                //   v. If result is not an Object, return result.
+                //   vi. Throw a TypeError exception.
+                // c. If preferredType is not present, let preferredType be NUMBER
+                // d. Return ? OrdinaryToPrimitive(input, preferredType)
+
+                todo!("Value::to_primitive(Value::Object(_)")
+            }
+            _ => Ok(self),
+        }
+    }
+
+    /// ### 7.1.2 ToBoolean(`argument`)
+    /// > The abstract operation ToBoolean takes argument `argument` (an ECMAScript
+    /// > language value) and returns a Boolean. It converts argument to a value
+    /// > of type Boolean.
+    pub fn to_boolean(&self) -> bool {
+        match self {
+            Self::Boolean(b) => *b,
+            // NOTE: rounding errors could be a problem here
+            Self::Number(n) => *n != Number::ZERO && !n.is_nan(),
+            Self::BigInt(n) => n != &BigInt::ZERO,
+            Self::String(s) => !s.is_empty(),
+            Self::Null | Self::Undefined => false,
+            Self::Symbol(_) | Self::Object(_) => true,
+        }
+    }
+
+    /// ### 7.1.3 ToNumeric(`value`)
+    /// > The abstract operation ToNumeric takes argument `value` (an ECMAScript
+    /// > language value) and returns either a normal completion containing either
+    /// > a Number or a BigInt, or a throw completion. It returns `value` converted
+    /// > to a Number or a BigInt.
+    pub fn to_numeric(self) -> Result<Numeric, TypeError> {
+        // TODO: implement this algorithm when to_primitive is ready
+        // 1. Let primValue be ? ToPrimitive(value, NUMBER)
+        // 2. if primValue is a BigInt, return primValue
+        // 3. Return ? ToNumber(primValue)
+
+        match self {
+            Self::BigInt(int) => Ok(Numeric::BigInt(int)),
+            _ => self.to_number().map(Numeric::Number),
+        }
+    }
+
+    /// ### 7.1.4 ToNumber(`argument`)
+    /// > The abstract operation ToNumber takes argument `argument` (an ECMAScript
+    /// > language value) and returns either a normal completion containing a
+    /// > Number or a throw completion. It converts `argument` to a value of type
+    /// > Number.
+    pub fn to_number(self) -> Result<Number, TypeError> {
+        match self {
+            Self::Number(n) => Ok(n),
+            Self::Symbol(_) => type_err("Cannot convert a Symbol to a Number"),
+            Self::BigInt(_) => type_err("Cannot convert a BigInt to a Number"),
+            Self::Undefined => Ok(Number::NAN),
+            Self::Null | Self::Boolean(false) => Ok(Number::ZERO),
+            Self::Boolean(true) => Ok(Number::ONE),
+            Self::String(s) => Ok(string_to_number(&s)),
+            Self::Object(_obj) => {
+                // TODO: to_primitive
+                Ok(Number::NAN)
+            }
+        }
+    }
+
+    /// ### 7.1.17 ToString(`argument`)
+    /// > The abstract operation ToString takes argument `argument` (an ECMAScript
+    /// > language value) and returns either a normal completion containing a
+    /// > String or a throw completion. It converts `argument` to a value of type
+    /// > String.
+    pub fn to_string(self) -> Result<Cow<'a, str>, Option<TypeError>> {
+        match self {
+            // 1. if argument is a String, return argument
+            Self::String(s) => Ok(s),
+            // 2. if argument is a Symbol, throw a TypeError exception
+            Self::Symbol(_) => some_type_err("Cannot convert a Symbol to a String"),
+            // 3. if argument is undefined, return "undefined"
+            Self::Undefined => Ok(Cow::Borrowed("undefined")),
+            // 4. if argument is null, return "null"
+            Self::Null => Ok(Cow::Borrowed("null")),
+            // 5. if argument is true, return "true"
+            // 6. if argument is false, return "false"
+            Self::Boolean(b) => Ok(Cow::Borrowed(if b { "true" } else { "false" })),
+            // 7. If argument is a Number, return Number::toString(argument, 10).
+            Self::Number(n) => Ok(Cow::Owned(n.to_string())),
+            // 8. if argument is a BigInt, return BigInt::toString(argument, 10)
+            Self::BigInt(n) => Ok(Cow::Owned(n.to_string())),
+            // 9. Assert: argument is an Object
+            Self::Object(_obj) => {
+                // // 10. let primValue be ? ToPrimitive(argument, STRING)
+                // let prim = self.to_primitive(None)?;
+                // // 11. Assert: primValue is not an Object
+                // assert!(!prim.is_object());
+                // // 12. Return ? ToString(primValue)
+                // prim.to_string()
+                todo!("Value::to_string(Self::Object(_obj))")
+            }
+        }
+    }
+}
+
+// boolean
+
+impl From<bool> for Value<'static> {
+    #[inline]
+    fn from(b: bool) -> Self {
+        Self::Boolean(b)
+    }
+}
+
+impl JsFrom<bool> for Value<'static> {
+    #[inline]
+    fn from_js(value: bool) -> Self {
+        Self::from(value)
+    }
+}
+
+impl JsFrom<Value<'_>> for bool {
+    #[inline]
+    fn from_js(value: Value<'_>) -> bool {
+        value.to_boolean()
+    }
+}
+
+// numeric types
+
+impl<N: Into<Number>> From<N> for Value<'static> {
+    #[inline]
+    fn from(n: N) -> Self {
+        Value::Number(n.into())
+    }
+}
+impl<N: JsInto<Number>> JsFrom<N> for Value<'static> {
+    #[inline]
+    fn from_js(value: N) -> Self {
+        Value::Number(value.into_js())
+    }
+}
+
+impl From<BigInt> for Value<'static> {
+    #[inline]
+    fn from(n: BigInt) -> Self {
+        Value::BigInt(n)
+    }
+}
+
+impl TryJsFrom<Value<'_>> for Number {
+    type Error = TypeError;
+
+    #[inline]
+    fn try_from_js(value: Value<'_>) -> Result<Self, Self::Error> {
+        value.to_number()
+    }
+}
+
+impl TryJsFrom<Value<'_>> for Numeric {
+    type Error = TypeError;
+
+    #[inline]
+    fn try_from_js(value: Value<'_>) -> Result<Self, Self::Error> {
+        value.to_numeric()
+    }
+}
+
+// string types
+
+impl<'a> From<&'a str> for Value<'a> {
+    #[inline]
+    fn from(s: &'a str) -> Self {
+        Value::String(Cow::Borrowed(s))
+    }
+}
+
+impl<'a> From<Atom<'a>> for Value<'a> {
+    #[inline]
+    fn from(atom: Atom<'a>) -> Self {
+        Value::String(Cow::Borrowed(atom.as_str()))
+    }
+}
+
+impl From<String> for Value<'static> {
+    fn from(value: String) -> Self {
+        Value::String(Cow::Owned(value))
+    }
+}
+
+impl<'a> TryJsFrom<Value<'a>> for Cow<'a, str> {
+    type Error = Option<TypeError>;
+
+    #[inline]
+    fn try_from_js(value: Value<'a>) -> Result<Self, Self::Error> {
+        value.to_string()
+    }
+}
+
+impl<'a> TryJsFrom<Value<'a>> for String {
+    type Error = Option<TypeError>;
+
+    #[inline]
+    fn try_from_js(value: Value<'a>) -> Result<Self, Self::Error> {
+        value.to_string().map(Cow::into_owned)
+    }
+}
+
+/// ### 7.1.4.1.1 StringToNumber(`str`)
+///
+/// > The abstract operation StringToNumber takes argument `str` (a String) and
+/// > returns a Number.
+///
+/// ### Reference
+/// <https://262.ecma-international.org/15.0/index.html#sec-stringtonumber>
+fn string_to_number(s: &str) -> Number {
+    // TODO: follow implementation. This vvvv does not support non-base 10 numbers
+    let f: f64 = str::parse(s).unwrap_or(f64::NAN);
+    Number::float(f)
+}
+
+/// Shorthand for creating a throw completion with a [`TypeError`].
+#[inline]
+fn type_err<T>(msg: &'static str) -> Result<T, TypeError> {
+    Err(TypeError::error(msg))
+}
+
+/// Shorthand for creating a throw completion with a [`TypeError`].
+#[inline]
+fn some_type_err<T>(msg: &'static str) -> Result<T, Option<TypeError>> {
+    Err(Some(TypeError::error(msg)))
+}

--- a/crates/oxc_span/src/either.rs
+++ b/crates/oxc_span/src/either.rs
@@ -1,0 +1,269 @@
+use std::{borrow::Borrow, fmt, ops::Deref};
+
+/// Either is a symmetrical, general-purpose union type with a [left](`Either::Left`) and a
+/// [right](`Either::Right`) variant. It treats its variants the same way and without preference.
+/// For representing a successful and error value, use [`Result`] instead.
+///
+/// This enum is equivalent to `L | R` in TypeScript.
+///
+/// ## Examples
+/// ```
+/// use oxc_span::{compact_str::MAX_INLINE_LEN, Atom, CompactStr, Either};
+///
+/// let source_code = "let x = 42;";
+/// // if source_code can be inlined into a CompactStr, use that since it's more efficient.
+/// // otherwise, borrow the source code as an Atom to avoid allocations.
+/// let s: Either<Atom<'_>, CompactStr> = if source_code.len() > CompactStr::MAX_INLINE_LEN {
+///   Either::Left(Atom::from(source_code))
+/// } else {
+///   Either::Right(CompactStr::new_const(source_code))
+/// };
+/// // source code is less than 16, so CompactStr gets used
+/// assert!(s.is_right());      
+/// // Both left and right variants can be borrowed as a &str, so `s` can as well.
+/// assert_eq!(source_code, s.as_str());
+/// ```
+#[derive(Debug)]
+pub enum Either<L, R> {
+    /// A value of type `L`.
+    Left(L),
+    /// A value of type `R`.
+    Right(R),
+}
+
+impl<L: Clone, R: Clone> Clone for Either<L, R> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Left(val) => Self::Left(val.clone()),
+            Self::Right(val) => Self::Right(val.clone()),
+        }
+    }
+}
+
+impl<L: Copy, R: Copy> Copy for Either<L, R> {}
+
+// downcast methods
+impl<L, R> Either<L, R> {
+    /// Returns `true` if `self` contains a left value.
+    ///
+    /// # Examples
+    pub fn is_left(&self) -> bool {
+        matches!(self, Self::Left(_))
+    }
+
+    /// Get the left value if it exists. Returns [`None`] if `self` contains a right value.
+    pub fn as_left(&self) -> Option<&L> {
+        match self {
+            Self::Left(val) => Some(val),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Get the left value if it exists, consuming `self` in the process. Returns [`None`] If
+    /// `self` contains a right value.
+    pub fn into_left(self) -> Option<L> {
+        match self {
+            Self::Left(val) => Some(val),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Returns `true` if `self` contains a right value.
+    pub fn is_right(&self) -> bool {
+        !self.is_left()
+    }
+
+    /// Get the right value if it exists. Returns [`None`] if `self` contains a left value.
+    pub fn as_right(&self) -> Option<&R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(val) => Some(val),
+        }
+    }
+
+    /// Get the left value if it exists, consuming `self` in the process. Returns [`None`] if
+    /// `self` contains a right value.
+    pub fn into_right(self) -> Option<R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(val) => Some(val),
+        }
+    }
+}
+
+// conversion methods
+impl<L, R> Either<L, R> {
+    pub fn map_left<V, F: FnOnce(L) -> V>(self, f: F) -> Either<V, R> {
+        match self {
+            Self::Left(val) => Either::Left(f(val)),
+            Self::Right(val) => Either::Right(val),
+        }
+    }
+
+    pub fn map_right<V, F: FnOnce(R) -> V>(self, f: F) -> Either<L, V> {
+        match self {
+            Self::Left(val) => Either::Left(val),
+            Self::Right(val) => Either::Right(f(val)),
+        }
+    }
+
+    pub fn unwrap_left(self) -> L {
+        match self {
+            Self::Left(val) => val,
+            Self::Right(_) => panic!("called `Either::unwrap_left()` on a `Right` value"),
+        }
+    }
+
+    pub fn unwrap_right(self) -> R {
+        match self {
+            Self::Left(_) => panic!("called `Either::unwrap_right()` on a `Left` value"),
+            Self::Right(val) => val,
+        }
+    }
+}
+
+impl<T> Either<T, T> {
+    pub fn map<F, U>(self, f: F) -> Either<U, U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Self::Left(l) => Either::Left(f(l)),
+            Self::Right(r) => Either::Right(f(r)),
+        }
+    }
+}
+
+// comparison methods
+impl<L, R> PartialEq for Either<L, R>
+where
+    L: PartialEq,
+    R: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Left(l1), Self::Left(l2)) => l1.eq(l2),
+            (Self::Right(r1), Self::Right(r2)) => r1.eq(r2),
+            _ => false,
+        }
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Left(l1), Self::Left(l2)) => l1.ne(l2),
+            (Self::Right(r1), Self::Right(r2)) => r1.ne(r2),
+            _ => true,
+        }
+    }
+}
+
+impl<L, R> Eq for Either<L, R>
+where
+    L: Eq,
+    R: Eq,
+{
+}
+
+impl<L, R> PartialOrd for Either<L, R>
+where
+    L: PartialOrd,
+    R: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Self::Left(l1), Self::Left(l2)) => l1.partial_cmp(l2),
+            (Self::Right(r1), Self::Right(r2)) => r1.partial_cmp(r2),
+            _ => None,
+        }
+    }
+}
+
+// ref/deref methods
+impl<L, R> Either<L, R> {
+    pub fn as_ref(&self) -> Either<&L, &R> {
+        match self {
+            Self::Left(val) => Either::Left(val),
+            Self::Right(val) => Either::Right(val),
+        }
+    }
+}
+
+impl<L, R> Either<L, R>
+where
+    L: AsRef<str>,
+    R: AsRef<str>,
+{
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Left(val) => val.as_ref(),
+            Self::Right(val) => val.as_ref(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_str().len()
+    }
+}
+
+impl<L, R> Borrow<str> for Either<L, R>
+where
+    L: AsRef<str>,
+    R: AsRef<str>,
+{
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<L, R> AsRef<str> for Either<L, R>
+where
+    L: AsRef<str>,
+    R: AsRef<str>,
+{
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<L, R> Either<L, R>
+where
+    L: Deref,
+    R: Deref,
+{
+    pub fn as_deref(&self) -> Either<&L::Target, &R::Target> {
+        match self {
+            Self::Left(val) => Either::Left(val),
+            Self::Right(val) => Either::Right(val),
+        }
+    }
+}
+
+impl<L: fmt::Display, R: fmt::Display> fmt::Display for Either<L, R> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Left(l) => l.fmt(f),
+            Self::Right(r) => r.fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{compact_str::MAX_INLINE_LEN, Atom, CompactStr};
+
+    #[test]
+    fn test_as_str() {
+        let source_code = "let x = 42;";
+        // if source_code can be inlined into a CompactStr, use that since it's more efficient.
+        // otherwise, borrow the source code as an Atom to avoid allocations.
+        let s: Either<Atom<'_>, CompactStr> = if source_code.len() > MAX_INLINE_LEN {
+            Either::Left(Atom::from(source_code))
+        } else {
+            Either::Right(CompactStr::new_const(source_code))
+        };
+        // source code is less than 16, so CompactStr gets used
+        assert!(s.is_right());
+        assert_eq!(source_code, s.as_str());
+    }
+}

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod atom;
 mod compact_str;
+mod either;
 mod source_type;
 mod span;
 
@@ -13,6 +14,7 @@ pub mod hash;
 pub use crate::{
     atom::Atom,
     compact_str::{CompactStr, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN},
+    either::Either,
     source_type::{
         Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension, VALID_EXTENSIONS,
     },


### PR DESCRIPTION
# What This PR Does
> NOTE: This PR is very much a work in progress

Adds a new crate called `oxc_eval` that unifies constant evaluation logic that is currently spread across the minifier, transformer, and isolated declarations crates.

## Features
- [x] V8-inspired JSObject-like struct (`Value`)
- [x] Literal eval
- [ ] Binary op eval
- [ ] Eval for `const` identifiers
- [ ] Const function support for common builtins (e.g. `Symbol.for('foo'), `Math.max(...args)`, etc)


> Note: We should collaborate with the Nova team to see what features would be useful for them. Rolldown may also find this useful, but I'm not as certain about that.