### PR TITLE
refactor(semantic)!: rename `AstNode` to `Node` and `AstNodes` to `Nodes`

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{ast::BindingIdentifier, AstKind};
-use oxc_semantic::{AstNode, IsGlobalReference, NodeId, SymbolId};
+use oxc_semantic::{IsGlobalReference, Node, NodeId, SymbolId};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator};
 
@@ -181,9 +181,9 @@ impl<'a, 'b> IsConstant<'a, 'b> for SpreadElement<'a> {
 /// Return the innermost `Function` or `ArrowFunctionExpression` Node
 /// enclosing the specified node
 pub fn get_enclosing_function<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     let mut current_node = node;
     loop {
         if matches!(current_node.kind(), AstKind::Program(_)) {
@@ -204,7 +204,7 @@ pub fn is_nth_argument<'a>(call: &CallExpression<'a>, arg: &Argument<'a>, n: usi
 }
 
 /// Jump to the outer most of chained parentheses if any
-pub fn outermost_paren<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> &'b AstNode<'a> {
+pub fn outermost_paren<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> &'b Node<'a> {
     let mut node = node;
 
     loop {
@@ -222,9 +222,9 @@ pub fn outermost_paren<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
 }
 
 pub fn outermost_paren_parent<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     ctx.nodes()
         .iter_parents(node.id())
         .skip(1)
@@ -232,10 +232,10 @@ pub fn outermost_paren_parent<'a, 'b>(
 }
 
 pub fn nth_outermost_paren_parent<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
     n: usize,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     ctx.nodes()
         .iter_parents(node.id())
         .skip(1)
@@ -247,7 +247,7 @@ pub fn nth_outermost_paren_parent<'a, 'b>(
 pub fn iter_outer_expressions<'a, 'ctx>(
     ctx: &'ctx LintContext<'a>,
     node_id: NodeId,
-) -> impl Iterator<Item = &'ctx AstNode<'a>> + 'ctx {
+) -> impl Iterator<Item = &'ctx Node<'a>> + 'ctx {
     ctx.nodes().iter_parents(node_id).skip(1).filter(|parent| {
         !matches!(
             parent.kind(),
@@ -264,7 +264,7 @@ pub fn iter_outer_expressions<'a, 'ctx>(
 pub fn get_declaration_of_variable<'a, 'b>(
     ident: &IdentifierReference,
     ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     let symbol_id = get_symbol_id_of_variable(ident, ctx)?;
     let symbol_table = ctx.semantic().symbols();
     Some(ctx.nodes().get_node(symbol_table.get_declaration(symbol_id)))
@@ -391,7 +391,7 @@ pub fn is_global_require_call(call_expr: &CallExpression, ctx: &LintContext) -> 
     call_expr.callee.is_global_reference_name("require", ctx.symbols())
 }
 
-pub fn is_function_node(node: &AstNode) -> bool {
+pub fn is_function_node(node: &Node) -> bool {
     match node.kind() {
         AstKind::Function(f) if f.is_function_declaration() => true,
         AstKind::Function(f) if f.is_expression() => true,
@@ -401,7 +401,7 @@ pub fn is_function_node(node: &AstNode) -> bool {
 }
 
 pub fn get_function_like_declaration<'b>(
-    node: &AstNode<'b>,
+    node: &Node<'b>,
     ctx: &LintContext<'b>,
 ) -> Option<&'b BindingIdentifier<'b>> {
     let parent = outermost_paren_parent(node, ctx)?;

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
-use oxc_semantic::{AstNodes, JSDocFinder, ScopeTree, Semantic, SymbolTable};
+use oxc_semantic::{JSDocFinder, Nodes, ScopeTree, Semantic, SymbolTable};
 use oxc_span::{GetSpan, SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
@@ -349,7 +349,7 @@ impl<'a> LintContext<'a> {
     /// AST nodes
     ///
     /// Shorthand for `self.semantic().nodes()`.
-    pub fn nodes(&self) -> &AstNodes<'a> {
+    pub fn nodes(&self) -> &Nodes<'a> {
         self.semantic().nodes()
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -25,7 +25,7 @@ use std::{io::Write, path::Path, rc::Rc, sync::Arc};
 use config::LintConfig;
 use options::LintOptions;
 use oxc_diagnostics::Error;
-use oxc_semantic::{AstNode, Semantic};
+use oxc_semantic::{Node, Semantic};
 
 pub use crate::{
     config::OxlintConfig,

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -7,7 +7,7 @@ use std::{
 
 use oxc_semantic::SymbolId;
 
-use crate::{context::LintContext, AllowWarnDeny, AstNode, FixKind, RuleEnum};
+use crate::{context::LintContext, AllowWarnDeny, FixKind, Node, RuleEnum};
 
 pub trait Rule: Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
@@ -18,7 +18,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
     /// Visit each AST Node
     #[expect(unused_variables)]
     #[inline]
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {}
 
     /// Visit each symbol
     #[expect(unused_variables)]

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     ast_util::{get_enclosing_function, is_nth_argument, outermost_paren},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn expect_return(method_name: &str, span: Span) -> OxcDiagnostic {
@@ -76,7 +76,7 @@ impl Rule for ArrayCallbackReturn {
         Self { check_for_each, allow_implicit_return }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (function_body, always_explicit_return) = match node.kind() {
             // Async, generator, and single expression arrow functions
             // always have explicit return value
@@ -135,10 +135,7 @@ impl Rule for ArrayCallbackReturn {
 /// Code ported from [eslint](https://github.com/eslint/eslint/blob/main/lib/rules/array-callback-return.js)
 /// We're currently on a `Function` or `ArrowFunctionExpression`, findout if it is an argument
 /// to the target array methods we're interested in.
-pub fn get_array_method_name<'a>(
-    node: &AstNode<'a>,
-    ctx: &LintContext<'a>,
-) -> Option<&'static str> {
+pub fn get_array_method_name<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> Option<&'static str> {
     let mut current_node = node;
     while let Some(parent) = ctx.nodes().parent_node(current_node.id()) {
         match parent.kind() {

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -1,7 +1,7 @@
 use oxc_macros::declare_oxc_lint;
 
 // use oxc_span::Span;
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 // #[derive(Debug, Error, Diagnostic)]
 // #[error("Expected to call 'super()'.")]
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConstructorSuper {
-    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, _node: &Node<'a>, _ctx: &LintContext<'a>) {}
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::{Regex, RegexBuilder};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn default_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require default cases in switch statements.")
@@ -62,7 +62,7 @@ impl Rule for DefaultCase {
         Self(Box::new(cfg))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::SwitchStatement(switch) = node.kind() {
             let cases = &switch.cases;
 

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn default_case_last_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce default clauses in switch statements to be last")
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for DefaultCaseLast {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn default_param_last_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Default parameters should be last")
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for DefaultParamLast {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(function) => {
                 if !function.is_declaration() && !function.is_expression() {

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn eqeqeq_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Expected {x1} and instead saw {x0}"))
@@ -57,7 +57,7 @@ impl Rule for Eqeqeq {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, UpdateOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn for_direction_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The update clause in this loop moves the variable in the wrong direction")
@@ -82,7 +82,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ForDirection {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ForStatement(for_loop) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -16,7 +16,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected to always return a value in getter.")
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GetterReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
         if ctx.source_type().is_typescript() {
             return;
@@ -119,7 +119,7 @@ impl GetterReturn {
     }
 
     /// Checks whether it is necessary to check the node
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> Option<bool> {
+    fn is_wanted_node(node: &Node, ctx: &LintContext<'_>) -> Option<bool> {
         let parent = ctx.nodes().parent_node(node.id())?;
         match parent.kind() {
             AstKind::MethodDefinition(mdef) => {
@@ -177,7 +177,7 @@ impl GetterReturn {
         Some(false)
     }
 
-    fn run_diagnostic<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>, span: Span) {
+    fn run_diagnostic<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>, span: Span) {
         if !Self::is_wanted_node(node, ctx).unwrap_or_default() {
             return;
         }

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn guard_for_in_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require `for-in` loops to include an `if` statement")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GuardForIn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ForInStatement(for_in_statement) = node.kind() {
             match &for_in_statement.body {
                 Statement::EmptyStatement(_) | Statement::IfStatement(_) => return,

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(x0.to_string())
@@ -73,7 +73,7 @@ impl Rule for MaxParams {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(function) => {
                 if !function.is_declaration() & !function.is_expression() {

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeId;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_alert_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`alert`, `confirm` and `prompt` functions are not allowed")
@@ -88,7 +88,7 @@ fn is_shadowed<'a>(scope_id: ScopeId, name: &'a str, ctx: &LintContext<'a>) -> b
 }
 
 impl Rule for NoAlert {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `Array` constructors")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoArrayConstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (span, callee, arguments, type_parameters, optional) = match node.kind() {
             AstKind::CallExpression(call_expr) => (
                 call_expr.span,

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_async_promise_executor_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Promise executor functions should not be `async`.").with_label(span)
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncPromiseExecutor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_await_in_loop_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span)
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAwaitInLoop {
-    fn run(&self, node: &AstNode, ctx: &LintContext) {
+    fn run(&self, node: &Node, ctx: &LintContext) {
         // if node is AwaitExpression or AwaitForOfStatement
         let span = match node.kind() {
             // if the await attr of ForOfStatement is false, return
@@ -130,7 +130,7 @@ impl NoAwaitInLoop {
         }
     }
 
-    fn is_looped(span: Span, parent: &AstNode) -> bool {
+    fn is_looped(span: Span, parent: &Node) -> bool {
         match parent.kind() {
             AstKind::ForStatement(stmt) => {
                 let mut result = Self::node_matches_stmt_span(span, &stmt.body);
@@ -170,7 +170,7 @@ impl NoAwaitInLoop {
         span1.start <= span2.start && span1.end >= span2.end
     }
 
-    fn is_boundary(node: &AstNode) -> bool {
+    fn is_boundary(node: &Node) -> bool {
         match node.kind() {
             AstKind::Function(func) => func.is_declaration() || func.is_expression(),
             AstKind::ArrowFunctionExpression(_) => true,

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_bitwise_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected use of {x0:?}"))
@@ -70,7 +70,7 @@ impl Rule for NoBitwise {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BinaryExpression(bin_expr) => {
                 let op = bin_expr.operator.as_str();
@@ -111,7 +111,7 @@ fn allowed_operator(allow: &[String], operator: &str) -> bool {
     allow.iter().any(|s| s == operator)
 }
 
-fn is_int32_hint(int32_hint: bool, node: &AstNode) -> bool {
+fn is_int32_hint(int32_hint: bool, node: &Node) -> bool {
     if !int32_hint {
         return false;
     }

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_caller_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the use of arguments.caller or arguments.callee")
@@ -72,7 +72,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCaller {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(expr)) =
             node.kind()
         {

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_case_declarations_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span)
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCaseDeclarations {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::SwitchCase(switch_case) = node.kind() {
             let consequent = &switch_case.consequent;
 

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_compare_neg_zero_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use the {operator} operator to compare against -0."))
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCompareNegZero {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_cond_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a conditional expression and instead saw an assignment")
@@ -64,7 +64,7 @@ impl Rule for NoCondAssign {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::IfStatement(stmt) => self.check_expression(ctx, &stmt.test),
             AstKind::WhileStatement(stmt) => self.check_expression(ctx, &stmt.test),

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_console_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected console statement.").with_label(span)
@@ -67,7 +67,7 @@ impl Rule for NoConsole {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -9,7 +9,7 @@ use crate::{
     ast_util::{self, IsConstant},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 /// `https://eslint.org/docs/latest/rules/no-constant-binary-expression`
@@ -77,7 +77,7 @@ fn constant_both_always_new(span: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoConstantBinaryExpression {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::LogicalExpression(expr) => match expr.operator {
                 LogicalOperator::Or | LogicalOperator::And if expr.left.is_constant(true, ctx) => {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, Node};
 
 fn no_constant_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected constant condition")
@@ -78,7 +78,7 @@ impl Rule for NoConstantCondition {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::IfStatement(if_stmt) => {
                 if if_stmt.test.is_constant(true, ctx) {

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_constructor_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected return statement in constructor.").with_label(span)
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstructorReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ReturnStatement(ret) = node.kind() else { return };
         if ret.argument.is_none() {
             return;
@@ -58,7 +58,7 @@ impl Rule for NoConstructorReturn {
     }
 }
 
-fn is_constructor(node: &AstNode<'_>) -> bool {
+fn is_constructor(node: &Node<'_>) -> bool {
     matches!(
         node.kind(),
         AstKind::MethodDefinition(MethodDefinition { kind: MethodDefinitionKind::Constructor, .. })

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_continue_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of `continue` statement.")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoContinue {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ContinueStatement(continue_statement) = node.kind() {
             ctx.diagnostic(no_continue_diagnostic(Span::new(
                 continue_statement.span.start,

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use regex::{Matches, Regex};
 
-use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Node};
 
 fn no_control_regex_diagnostic(regex: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected control character(s)")
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoControlRegex {
-    fn run<'a>(&self, node: &AstNode<'a>, context: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, context: &LintContext<'a>) {
         if let Some(RegexPatternData { pattern, flags, span }) = regex_pattern(node) {
             let mut violations: Vec<&str> = Vec::new();
             let pattern = pattern.as_ref();
@@ -177,7 +177,7 @@ struct RegexPatternData<'a> {
 /// * new RegExp("foo") -> foo
 ///
 /// note: [`RegExpFlags`] and [`Span`]s are both tiny and cloneable.
-fn regex_pattern<'a>(node: &AstNode<'a>) -> Option<RegexPatternData<'a>> {
+fn regex_pattern<'a>(node: &Node<'a>) -> Option<RegexPatternData<'a>> {
     let kind = node.kind();
     match kind {
         // regex literal

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_debugger_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`debugger` statement is not allowed").with_label(span)
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDebugger {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::DebuggerStatement(stmt) = node.kind() {
             ctx.diagnostic_with_fix(no_debugger_diagnostic(stmt.span), |fixer| {
                 let Some(parent) = ctx

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_delete_var_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("variables should not be deleted").with_label(span)
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDeleteVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::UnaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_regular_expression::ast::{CharacterKind, Term};
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_div_regex_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("A regular expression literal can be confused with '/='.")
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDivRegex {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::RegExpLiteral(lit) = node.kind() {
             let Some(pattern) = lit.regex.pattern.as_pattern() else { return };
             if pattern

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -8,7 +8,7 @@ use oxc_span::cmp::ContentEq;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::LogicalOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_dupe_else_if_diagnostic(first_test: Span, second_test: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("duplicate conditions in if-else-if chains")
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeElseIf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // if (a) {} else if (a) {}
         //                ^^ get this if statement
         let AstKind::IfStatement(if_stmt) = node.kind() else {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_dupe_keys_diagnostic(first: Span, second: Span, key: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Duplicate key '{key}'"))
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeKeys {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ObjectExpression(obj_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{cmp::ContentEq, GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_duplicate_case_diagnostic(first: Span, second: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Duplicate case label")
@@ -79,7 +79,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let Some(ss) = node.kind().as_switch_statement() else { return };
         let mut previous_tests: Vec<&Expression<'_>> = vec![];
         for test in ss.cases.iter().filter_map(|c| c.test.as_ref()) {

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_diagnostic(stmt_kind: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty block statements")
@@ -46,7 +46,7 @@ impl Rule for NoEmpty {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BlockStatement(block) if block.body.is_empty() => {
                 let parent = ctx.nodes().parent_kind(node.id());

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -6,7 +6,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_character_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Empty character class")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyCharacterClass {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         lazy_static! {
             /*
             * plain-English description of the following regexp:

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_function_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty functions")
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyFunction {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::FunctionBody(fb) = node.kind() {
             if fb.is_empty() && !ctx.semantic().trivias().has_comments_between(fb.span) {
                 ctx.diagnostic(no_empty_function_diagnostic(fb.span));

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_pattern_diagnostic(pattern_type: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty destructuring patterns.")
@@ -75,7 +75,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyPattern {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (pattern_type, span) = match node.kind() {
             AstKind::ArrayPattern(array) if array.is_empty() => ("array", array.span),
             AstKind::ObjectPattern(object) if object.is_empty() => ("object", object.span),

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_static_block_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty static blocks")
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyStaticBlock {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::StaticBlock(static_block) = node.kind() {
             if static_block.body.is_empty() {
                 if ctx.semantic().trivias().has_comments_between(static_block.span) {

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -6,7 +6,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_eq_null_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use '===' to compare with null")
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEqNull {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::BinaryExpression(binary_expression) = node.kind() {
             let bad_operator = matches!(
                 binary_expression.operator,

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -2,7 +2,7 @@
 use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -56,7 +56,7 @@ impl Rule for NoEval {
         Self { allow_indirect }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let kind = node.kind();
 
         if let AstKind::IdentifierReference(ident) = kind {

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -18,7 +18,7 @@ use oxc_span::{GetSpan, Span};
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_fallthrough_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a 'break' statement before 'case'.").with_label(span)
@@ -257,7 +257,7 @@ impl Rule for NoFallthrough {
         Self::new(comment_pattern, allow_empty_case, report_unused_fallthrough_comment)
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::SwitchStatement(switch) = node.kind() else { return };
 
         let cfg = ctx.cfg();
@@ -429,7 +429,7 @@ impl NoFallthrough {
 // Issue: <https://github.com/oxc-project/oxc/issues/3662>
 fn get_switch_semantic_cases(
     ctx: &LintContext,
-    node: &AstNode,
+    node: &Node,
     switch: &SwitchStatement,
 ) -> (
     Vec<BasicBlockId>,

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_inner_declarations_diagnostic(decl_type: &str, body: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
@@ -59,7 +59,7 @@ impl Rule for NoInnerDeclarations {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let span = match node.kind() {
             AstKind::VariableDeclaration(decl)
                 if decl.kind.is_var() && self.config == NoInnerDeclarationsConfig::Both =>

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoInvalidRegexp(Box<NoInvalidRegexpConfig>);
@@ -55,7 +55,7 @@ impl Rule for NoInvalidRegexp {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (pattern_arg, flags_arg) = match node.kind() {
             AstKind::NewExpression(expr) if expr.callee.is_specific_id("RegExp") => {
                 parse_arguments_to_check(expr.arguments.first(), expr.arguments.get(1))

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_iterator_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Reserved name '__iterator__'")
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIterator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(member_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_label_var_diagnostic(name: &str, id_span: Span, label_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Found identifier '{name}' with the same name as a label."))
@@ -59,7 +59,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLabelVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::LabeledStatement(labeled_stmt) = node.kind() else { return };
 
         if let Some(symbol_id) =

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_loss_of_precision_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span)
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLossOfPrecision {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::NumericLiteral(node) if Self::lose_precision(node) => {
                 ctx.diagnostic(no_loss_of_precision_diagnostic(node.span));

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_multi_str_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected multi string.").with_label(span)
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMultiStr {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::StringLiteral(literal) = node.kind() {
             let source = literal.span.source_text(ctx.source_text());
             // https://github.com/eslint/eslint/blob/9e6d6405c3ee774c2e716a3453ede9696ced1be7/lib/shared/ast-utils.js#L12

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span)
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_func(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The Function constructor is eval.").with_label(span)
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewFunc {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let id_and_span = match node.kind() {
             AstKind::NewExpression(new_expr) => {
                 let Some(id) = new_expr.callee.get_identifier_reference() else {
@@ -62,7 +62,7 @@ impl Rule for NoNewFunc {
                 Some((obj_id, call_expr.span))
             }
             AstKind::MemberExpression(mem_expr) => {
-                let parent: Option<&AstNode<'a>> =
+                let parent: Option<&Node<'a>> =
                     ctx.nodes().iter_parents(node.id()).skip(1).find(|node| {
                         !matches!(
                             node.kind(),
@@ -70,8 +70,7 @@ impl Rule for NoNewFunc {
                         )
                     });
 
-                let Some(AstKind::CallExpression(parent_call_expr)) = parent.map(AstNode::kind)
-                else {
+                let Some(AstKind::CallExpression(parent_call_expr)) = parent.map(Node::kind) else {
                     return;
                 };
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_native_nonconstructor_diagnostic(fn_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{fn_name}` cannot be called as a constructor.")).with_label(span)
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewNativeNonconstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_wrappers_diagnostic(builtin_name: &str, new_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow new operators with the String, Number, and Boolean objects")
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewWrappers {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -5,7 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::{Captures, Regex};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn replacement(escape_sequence: &str, replacement: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Don't use '{escape_sequence}' escape sequence."))
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonoctalDecimalEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::StringLiteral(literal) = node.kind() {
             check_string(ctx, literal.span.source_text(ctx.source_text()));
         }

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, ScopeId};
+use oxc_semantic::{Node, ScopeId};
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -126,7 +126,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
 }
 
 impl Rule for NoObjCalls {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         #[allow(clippy::needless_return)]
         let (callee, span) = match node.kind() {
             AstKind::NewExpression(expr) => (&expr.callee, expr.span),

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_plusplus_diagnostic(span: Span, operator: UpdateOperator) -> OxcDiagnostic {
     let diagnostic = OxcDiagnostic::warn(format!(
@@ -92,7 +92,7 @@ impl Rule for NoPlusplus {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::UpdateExpression(expr) = node.kind() else {
             return;
         };
@@ -112,7 +112,7 @@ impl Rule for NoPlusplus {
 ///   - An operand of a sequence expression that is the update node: for (;; foo(), i++) {}
 ///   - An operand of a sequence expression that is child of another sequence expression, etc.,
 ///     up to the sequence expression that is the update node: for (;; foo(), (bar(), (baz(), i++))) {}
-fn is_for_loop_afterthought(node: &AstNode, ctx: &LintContext) -> Option<bool> {
+fn is_for_loop_afterthought(node: &Node, ctx: &LintContext) -> Option<bool> {
     let mut cur = ctx.nodes().parent_node(node.id())?;
 
     while let AstKind::SequenceExpression(_) | AstKind::ParenthesizedExpression(_) = cur.kind() {

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_proto_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The '__proto__' property is deprecated")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoProto {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(member_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_prototype_builtins_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 const DISALLOWED_PROPS: &[&str; 3] = &["hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable"];
 
 impl Rule for NoPrototypeBuiltins {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_regex_spaces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Spaces are hard to count.")
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRegexSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::RegExpLiteral(lit) => {
                 if let Some(span) = Self::find_literal_to_report(lit, ctx) {

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -5,7 +5,7 @@ use oxc_span::Span;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_restricted_globals(global_name: &str, suffix: &str, span: Span) -> OxcDiagnostic {
     let warn_text = if suffix.is_empty() {
@@ -79,7 +79,7 @@ impl Rule for NoRestrictedGlobals {
         Self { restricted_globals: Box::new(list) }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::IdentifierReference(ident) = node.kind() {
             let Some(message) = self.restricted_globals.get(ident.name.as_str()) else {
                 return;

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_script_url_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Script URL is a form of eval")
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoScriptUrl {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StringLiteral(literal)
                 if literal.value.cow_to_lowercase().starts_with("javascript:") =>
@@ -67,7 +67,7 @@ fn emit_diagnostic(ctx: &LintContext, span: Span) {
     ctx.diagnostic(no_script_url_diagnostic(Span::new(span.start, span.end)));
 }
 
-fn is_tagged_template_expression(ctx: &LintContext, node: &AstNode, literal_span: Span) -> bool {
+fn is_tagged_template_expression(ctx: &LintContext, node: &Node, literal_span: Span) -> bool {
     matches!(
         ctx.nodes().parent_kind(node.id()),
         Some(AstKind::TaggedTemplateExpression(expr)) if expr.quasi.span == literal_span

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -11,7 +11,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::AssignmentOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
@@ -58,7 +58,7 @@ impl Rule for NoSelfAssign {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assignment) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::cmp::ContentEq;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_self_compare_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow comparisons where both sides are exactly the same")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSelfCompare {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_setter_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Setter cannot return a value").with_label(span)
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetterReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ReturnStatement(stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -2,7 +2,7 @@ use oxc_ast::{ast::ArrayExpressionElement, AstKind};
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoSparseArrays;
@@ -26,7 +26,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSparseArrays {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ArrayExpression(array_expr) = node.kind() {
             let violations = array_expr
                 .elements

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_template_curly_in_string_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected template string expression")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTemplateCurlyInString {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::StringLiteral(literal) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_ternary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of ternary expression")
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ConditionalExpression(cond_expr) = node.kind() {
             ctx.diagnostic(no_ternary_diagnostic(Span::new(
                 cond_expr.span.start,

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -13,7 +13,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_this_before_super_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected to always call super() before this/super property access.")
@@ -133,7 +133,7 @@ impl Rule for NoThisBeforeSuper {
 }
 
 impl NoThisBeforeSuper {
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> Option<bool> {
+    fn is_wanted_node(node: &Node, ctx: &LintContext<'_>) -> Option<bool> {
         let parent = ctx.nodes().parent_node(node.id())?;
         let method_def = parent.kind().as_method_definition()?;
 

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the use of undeclared variables.")
@@ -73,7 +73,7 @@ impl Rule for NoUndef {
     }
 }
 
-fn has_typeof_operator(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn has_typeof_operator(node: &Node<'_>, ctx: &LintContext<'_>) -> bool {
     ctx.nodes().parent_node(node.id()).map_or(false, |parent| match parent.kind() {
         AstKind::UnaryExpression(expr) => expr.operator == UnaryOperator::Typeof,
         AstKind::ParenthesizedExpression(_) => has_typeof_operator(parent, ctx),

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUndefined;
@@ -65,7 +65,7 @@ fn diagnostic_undefined_keyword(name: &str, span: Span, ctx: &LintContext) {
 }
 
 impl Rule for NoUndefined {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::IdentifierReference(ident) => {
                 diagnostic_undefined_keyword(ident.name.as_str(), ident.span, ctx);

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unsafe_finally_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe finally block")
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeFinally {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let kind = node.kind();
 
         let sentinel_node_type = match kind {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, AstNode};
+use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, Node};
 
 fn no_unsafe_negation_diagnostic(operator: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected logical not in the left hand side of '{operator}' operator"))
@@ -53,7 +53,7 @@ impl Rule for NoUnsafeNegation {
         Self { enforce_for_ordering_relations }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::LogicalOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unsafe_optional_chaining_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe usage of optional chaining")
@@ -63,7 +63,7 @@ impl Rule for NoUnsafeOptionalChaining {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::CallExpression(expr) if !expr.optional => {
                 Self::check_unsafe_usage(&expr.callee, ctx);

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, AstNodes, NodeId};
+use oxc_semantic::{Node, NodeId, Nodes};
 use oxc_span::Span;
 use oxc_syntax::class::ElementKind;
 
@@ -114,10 +114,10 @@ impl Rule for NoUnusedPrivateClassMembers {
     }
 }
 
-fn is_read(current_node_id: NodeId, nodes: &AstNodes) -> bool {
+fn is_read(current_node_id: NodeId, nodes: &Nodes) -> bool {
     for (curr, parent) in nodes
         .iter_parents(nodes.parent_id(current_node_id).unwrap_or(current_node_id))
-        .tuple_windows::<(&AstNode<'_>, &AstNode<'_>)>()
+        .tuple_windows::<(&Node<'_>, &Node<'_>)>()
     {
         match (curr.kind(), parent.kind()) {
             (

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -2,7 +2,7 @@
 //! consider variables ignored by name pattern, but by where they are declared.
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstKind};
-use oxc_semantic::{AstNode, NodeId, Semantic};
+use oxc_semantic::{Node, NodeId, Semantic};
 use oxc_span::GetSpan;
 
 use super::{options::ArgsOption, NoUnusedVars, Symbol};
@@ -244,7 +244,7 @@ impl NoUnusedVars {
         param: &FormalParameter<'a>,
         params_id: NodeId,
     ) -> bool {
-        let mut parents_iter = semantic.nodes().iter_parents(params_id).skip(1).map(AstNode::kind);
+        let mut parents_iter = semantic.nodes().iter_parents(params_id).skip(1).map(Node::kind);
 
         // in function declarations, the parent immediately before the
         // FormalParameters is a TSDeclareBlock

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     ast::{Expression, VariableDeclarator},
     AstKind,
 };
-use oxc_semantic::{AstNode, NodeId};
+use oxc_semantic::{Node, NodeId};
 use oxc_span::CompactStr;
 use regex::Regex;
 
@@ -34,7 +34,7 @@ impl NoUnusedVars {
             return fixer.noop();
         }
 
-        let Some(parent) = symbol.nodes().parent_node(decl_id).map(AstNode::kind) else {
+        let Some(parent) = symbol.nodes().parent_node(decl_id).map(Node::kind) else {
             #[cfg(debug_assertions)]
             panic!("VariableDeclarator nodes should always have a parent node");
             #[cfg(not(debug_assertions))]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -14,7 +14,7 @@ use std::ops::Deref;
 use options::NoUnusedVarsOptions;
 use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, ScopeFlags, SymbolFlags, SymbolId};
+use oxc_semantic::{Node, ScopeFlags, SymbolFlags, SymbolId};
 use oxc_span::GetSpan;
 use symbol::Symbol;
 
@@ -259,7 +259,7 @@ impl NoUnusedVars {
             | AstKind::ImportNamespaceSpecifier(_) => {
                 let diagnostic = diagnostic::imported(symbol);
                 let declaration =
-                    symbol.iter_self_and_parents().map(AstNode::kind).find_map(|kind| match kind {
+                    symbol.iter_self_and_parents().map(Node::kind).find_map(|kind| match kind {
                         AstKind::ImportDeclaration(import) => Some(import),
                         _ => None,
                     });

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
     AstKind,
 };
 use oxc_semantic::{
-    AstNode, AstNodes, NodeId, Reference, ScopeId, ScopeTree, Semantic, SymbolFlags, SymbolId,
+    Node, NodeId, Nodes, Reference, ScopeId, ScopeTree, Semantic, SymbolFlags, SymbolId,
     SymbolTable,
 };
 use oxc_span::{GetSpan, Span};
@@ -55,7 +55,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 
     #[inline]
-    pub fn declaration(&self) -> &AstNode<'a> {
+    pub fn declaration(&self) -> &Node<'a> {
         self.nodes().get_node(self.declaration_id())
     }
 
@@ -82,7 +82,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 
     #[inline]
-    pub fn nodes(&self) -> &AstNodes<'a> {
+    pub fn nodes(&self) -> &Nodes<'a> {
         self.semantic.nodes()
     }
 
@@ -97,18 +97,18 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 
     #[inline]
-    pub fn iter_parents(&self) -> impl Iterator<Item = &AstNode<'a>> + '_ {
+    pub fn iter_parents(&self) -> impl Iterator<Item = &Node<'a>> + '_ {
         self.iter_self_and_parents().skip(1)
     }
 
-    pub fn iter_self_and_parents(&self) -> impl Iterator<Item = &AstNode<'a>> + '_ {
+    pub fn iter_self_and_parents(&self) -> impl Iterator<Item = &Node<'a>> + '_ {
         self.nodes().iter_parents(self.declaration_id())
     }
 
     pub fn iter_relevant_parents(
         &self,
         node_id: NodeId,
-    ) -> impl Iterator<Item = &AstNode<'a>> + Clone + '_ {
+    ) -> impl Iterator<Item = &Node<'a>> + Clone + '_ {
         self.nodes().iter_parents(node_id).skip(1).filter(|n| Self::is_relevant_kind(n.kind()))
     }
 
@@ -120,7 +120,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
         let parents_iter = self
             .nodes()
             .iter_parents(node_id)
-            .map(AstNode::kind)
+            .map(Node::kind)
             // no skip
             .filter(|kind| Self::is_relevant_kind(*kind));
 
@@ -136,7 +136,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
 
     /// <https://github.com/oxc-project/oxc/issues/4739>
     fn derive_span(&self) -> Span {
-        for kind in self.iter_self_and_parents().map(AstNode::kind) {
+        for kind in self.iter_self_and_parents().map(Node::kind) {
             match kind {
                 AstKind::BindingIdentifier(_) => continue,
                 AstKind::BindingRestElement(rest) => return rest.span,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -3,7 +3,7 @@
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstKind};
-use oxc_semantic::{AstNode, NodeId, Reference, ScopeId, SymbolFlags, SymbolId};
+use oxc_semantic::{Node, NodeId, Reference, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{GetSpan, Span};
 
 use super::{ignored::FoundStatus, NoUnusedVars, Symbol};
@@ -194,7 +194,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
             return false;
         }
 
-        for parent in self.nodes().iter_parents(reference.node_id()).map(AstNode::kind) {
+        for parent in self.nodes().iter_parents(reference.node_id()).map(Node::kind) {
             match parent {
                 AstKind::IdentifierReference(_)
                 | AstKind::SimpleAssignmentTarget(_)
@@ -244,7 +244,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     /// type Foo = Array<Bar>
     /// ```
     fn is_type_self_usage(&self, reference: &Reference) -> bool {
-        for parent in self.iter_relevant_parents(reference.node_id()).map(AstNode::kind) {
+        for parent in self.iter_relevant_parents(reference.node_id()).map(Node::kind) {
             match parent {
                 AstKind::TSTypeAliasDeclaration(decl) => {
                     return self == &decl.id;
@@ -423,9 +423,9 @@ impl<'s, 'a> Symbol<'s, 'a> {
         !is_used_by_others
     }
 
-    /// Check if a [`AstNode`] is within a return statement or implicit return.
+    /// Check if a [`Node`] is within a return statement or implicit return.
     fn is_in_return_statement(&self, node_id: NodeId) -> bool {
-        for parent in self.iter_relevant_parents(node_id).map(AstNode::kind) {
+        for parent in self.iter_relevant_parents(node_id).map(Node::kind) {
             match parent {
                 AstKind::ReturnStatement(_) => return true,
                 AstKind::ExpressionStatement(_) => continue,
@@ -567,7 +567,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
         false
     }
 
-    fn is_self_function_expr_assignment(&self, ref_node: &AstNode<'a>) -> bool {
+    fn is_self_function_expr_assignment(&self, ref_node: &Node<'a>) -> bool {
         for (parent, grandparent) in self.iter_relevant_parent_and_grandparent_kinds(ref_node.id())
         {
             match (parent, grandparent) {
@@ -640,7 +640,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
         self.nodes().get_node(reference.node_id()).scope_id()
     }
 
-    /// Get the [`Span`] covering the [`AstNode`] containing a [`Reference`].
+    /// Get the [`Span`] covering the [`Node`] containing a [`Reference`].
     #[inline]
     fn get_ref_span(&self, reference: &Reference) -> Span {
         self.nodes().get_node(reference.node_id()).kind().span()
@@ -651,7 +651,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     ///    which isn't useful for checking kinds/usage, so we want the parent
     /// 2. "relevant" nodes are non "transparent". For example, parenthesis are "transparent".
     #[inline]
-    fn get_ref_relevant_node(&self, reference: &Reference) -> Option<&AstNode<'a>> {
+    fn get_ref_relevant_node(&self, reference: &Reference) -> Option<&Node<'a>> {
         self.iter_relevant_parents(reference.node_id()).next()
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_useless_catch_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary try/catch wrapper")
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessCatch {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TryStatement(try_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{identifier::is_line_terminator, operator::BinaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUselessConcat;
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessConcat {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_constructor(constructor_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Empty constructors are unnecessary")
@@ -82,7 +82,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessConstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MethodDefinition(constructor) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -5,7 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_useless_escape_diagnostic(escape_char: char, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unnecessary escape character {escape_char:?}")).with_label(span)
@@ -69,7 +69,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::RegExpLiteral(literal)
                 if literal.regex.pattern.len() + literal.regex.flags.iter().count()

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -83,7 +83,7 @@ impl Rule for NoUselessRename {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ObjectPattern(object_pattern) => {
                 if self.ignore_destructuring {

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_var_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected var, use let or const instead.")
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::VariableDeclaration(dec) = node.kind() {
             if dec.kind == VariableDeclarationKind::Var {
                 let is_written_to = dec.declarations.iter().any(|v| is_written_to(&v.id, ctx));

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_void_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `void` operators")
@@ -49,7 +49,7 @@ impl Rule for NoVoid {
         Self { allow_as_statement }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::UnaryExpression(unary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_with_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of `with` statement.")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWith {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::WithStatement(with_statement) = node.kind() {
             ctx.diagnostic(no_with_diagnostic(Span::new(
                 with_statement.span.start,

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -4,8 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
-    ast_util::is_method_call, context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule,
-    AstNode,
+    ast_util::is_method_call, context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, Node,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -35,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferExponentiationOperator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -11,8 +11,7 @@ use oxc_span::Span;
 use phf::{phf_map, phf_ordered_set, Map};
 
 use crate::{
-    ast_util::get_symbol_id_of_variable, context::LintContext, fixer::RuleFixer, rule::Rule,
-    AstNode,
+    ast_util::get_symbol_id_of_variable, context::LintContext, fixer::RuleFixer, rule::Rule, Node,
 };
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
@@ -58,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNumericLiterals {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn missing_parameters(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing parameters.").with_label(span)
@@ -66,7 +66,7 @@ impl Rule for Radix {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct RequireAwait;
@@ -72,7 +72,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::FunctionBody(body) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn require_yield_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("This generator function does not have 'yield'").with_label(span)
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireYield {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::Function(func) = node.kind() {
             if !node.flags().has_yield()
                 && func.generator

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::print_stdout, clippy::disallowed_methods)]
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 use itertools::all;
 use oxc_ast::ast::ObjectPropertyKind;
 use oxc_ast::syntax_directed_operations::PropName;
@@ -127,7 +127,7 @@ impl Rule for SortKeys {
             allow_line_separated_groups,
         }))
     }
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ObjectExpression(dec) = node.kind() {
             if dec.properties.len() < self.min_keys {
                 return;

--- a/crates/oxc_linter/src/rules/eslint/sort_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_vars.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn sort_vars_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Variable declarations should be sorted").with_label(span)
@@ -59,7 +59,7 @@ impl Rule for SortVars {
         Self { ignore_case }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::VariableDeclaration(var_decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct SymbolDescription;
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for SymbolDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn comparison_with_na_n(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
@@ -79,7 +79,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for UseIsnan {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BinaryExpression(expr) if expr.operator.is_compare() => {
                 if is_nan_identifier(&expr.left) {

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -5,7 +5,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use phf::{phf_set, Set};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn not_string(help: Option<&'static str>, span: Span) -> OxcDiagnostic {
     let mut d =
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ValidTypeof {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // match on `typeof` unary expression for better performance
         let _unary_expr = match node.kind() {
             AstKind::UnaryExpression(unary_expr)

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, ModuleRecord};
+use oxc_semantic::{ModuleRecord, Node};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::module_record::{ExportExportName, ExportImportName, ImportImportName};
 
@@ -219,7 +219,7 @@ fn get_module_request_name(name: &str, module_record: &ModuleRecord) -> Option<S
 }
 
 fn check_deep_namespace_for_node(
-    node: &AstNode,
+    node: &Node,
     source: &str,
     namespaces: &[String],
     module: &Arc<ModuleRecord>,

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_amd_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use AMD `require` and `define` calls.")
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-amd.js>
 impl Rule for NoAmd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // not in top level
         if node.scope_id() != ctx.scopes().root_scope_id() {
             return;

--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_dnyamic_require_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a literal string or immutable template literal")
@@ -54,7 +54,7 @@ impl Rule for NoDynamicRequire {
         Self { esmodule }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ImportExpression(import) => {
                 if self.esmodule && !is_static_value(&import.source) {

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWebpackLoaderSyntax {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // not in top level
         if node.scope_id() != ctx.scopes().root_scope_id() {
             return;

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, NodeId};
+use oxc_semantic::{Node, NodeId};
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
@@ -97,7 +97,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
 }
 
 fn check_parents<'a>(
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     visited: &mut FxHashSet<NodeId>,
     in_conditional: InConditional,
     ctx: &LintContext<'a>,

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -94,7 +94,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConditionalInTest {
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::Node<'a>, ctx: &LintContext<'a>) {
         if matches!(
             node.kind(),
             AstKind::IfStatement(_)

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -4,7 +4,7 @@ use cow_utils::CowUtils;
 use oxc_ast::{ast::MemberExpression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, NodeId, ReferenceId};
+use oxc_semantic::{Node, NodeId, ReferenceId};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -198,7 +198,7 @@ fn handle_jest_set_time_out<'a>(
 }
 
 fn is_jest_fn_call<'a>(
-    parent_node: &AstNode<'a>,
+    parent_node: &Node<'a>,
     id_to_jest_node_map: &HashMap<NodeId, &PossibleJestNode<'a, '_>>,
     ctx: &LintContext<'a>,
 ) -> bool {

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -107,7 +107,7 @@ impl Rule for NoDeprecatedFunctions {
         }))
     }
 
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(mem_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -16,7 +16,7 @@ use crate::{
         collect_possible_jest_call_node, parse_general_jest_fn_call, JestFnKind, JestGeneralFnKind,
         PossibleJestNode,
     },
-    AstNode,
+    Node,
 };
 
 fn describe_repeat(span: Span) -> OxcDiagnostic {
@@ -154,7 +154,7 @@ fn filter_and_process_jest_result<'a>(
     }
 }
 
-fn get_closest_block(node: &AstNode, ctx: &LintContext) -> Option<NodeId> {
+fn get_closest_block(node: &Node, ctx: &LintContext) -> Option<NodeId> {
     match node.kind() {
         AstKind::BlockStatement(_) | AstKind::FunctionBody(_) | AstKind::Program(_) => {
             Some(node.id())

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -65,7 +65,7 @@ impl Rule for NoJasmineGlobals {
         }
     }
 
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::AssignmentExpression(assign_expr) = node.kind() {
             diagnostic_assign_expr(assign_expr, ctx);
         } else if let AstKind::CallExpression(call_expr) = node.kind() {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -14,7 +14,7 @@ use crate::{
         parse_general_jest_fn_call, JestFnKind, JestGeneralFnKind, KnownMemberExpressionParentKind,
         ParsedExpectFnCall, PossibleJestNode,
     },
-    AstNode,
+    Node,
 };
 
 fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
@@ -127,7 +127,7 @@ impl NoStandaloneExpect {
 }
 
 fn is_correct_place_to_call_expect<'a>(
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     additional_test_block_functions: &[String],
     id_nodes_mapping: &HashMap<NodeId, &PossibleJestNode<'a, '_>>,
     ctx: &LintContext<'a>,
@@ -195,7 +195,7 @@ fn is_correct_place_to_call_expect<'a>(
 }
 
 fn is_var_declarator_or_test_block<'a>(
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     additional_test_block_functions: &[String],
     id_nodes_mapping: &HashMap<NodeId, &PossibleJestNode<'a, '_>>,
     ctx: &LintContext<'a>,

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTestReturnStatement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 check_call_expression(call_expr, node, ctx);
@@ -61,7 +61,7 @@ impl Rule for NoTestReturnStatement {
 
 fn check_call_expression<'a>(
     call_expr: &'a CallExpression<'a>,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &LintContext<'a>,
 ) {
     if !is_type_of_jest_fn_call(

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -1,7 +1,7 @@
 use oxc_ast::{ast::CallExpression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, ScopeId};
+use oxc_semantic::{Node, ScopeId};
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 
@@ -140,7 +140,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferHooksInOrder {
     fn run_once(&self, ctx: &LintContext) {
-        let mut hook_groups: FxHashMap<ScopeId, Vec<AstNode>> = FxHashMap::default();
+        let mut hook_groups: FxHashMap<ScopeId, Vec<Node>> = FxHashMap::default();
 
         for node in ctx.nodes().iter() {
             hook_groups.entry(node.scope_id()).or_default().push(*node);

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::{phf_set, Set};
 
-use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, Node};
 
 fn use_jest_mocked(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `jest.mocked()` over `fn as jest.Mock`.")
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferJestMocked {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSAsExpression(ts_expr) = node.kind() {
             if !matches!(ctx.nodes().parent_kind(node.id()), Some(AstKind::TSAsExpression(_))) {
                 Self::check_ts_as_expression(node, ts_expr, ctx);
@@ -75,7 +75,7 @@ const MOCK_TYPES: Set<&'static str> = phf_set! {
 
 impl PreferJestMocked {
     fn check_ts_as_expression<'a>(
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         as_expr: &TSAsExpression,
         ctx: &LintContext<'a>,
     ) {
@@ -87,7 +87,7 @@ impl PreferJestMocked {
     }
 
     fn check_assert_type<'a>(
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         assert_type: &TSTypeAssertion,
         ctx: &LintContext<'a>,
     ) {
@@ -99,7 +99,7 @@ impl PreferJestMocked {
     }
 
     fn check<'a>(
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         ts_reference: &TSTypeReference,
         arg_span: Span,
         span: Span,
@@ -129,7 +129,7 @@ impl PreferJestMocked {
     }
 }
 
-fn can_fix<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+fn can_fix<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
     outermost_paren_parent(node, ctx)
         .map_or(false, |parent| !matches!(parent.kind(), AstKind::SimpleAssignmentTarget(_)))
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferMockPromiseShorthand {
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSpyOn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assign_expr) = node.kind() else {
             return;
         };
@@ -93,7 +93,7 @@ impl PreferSpyOn {
         assign_expr: &AssignmentExpression,
         call_expr: &'a CallExpression<'a>,
         left_assign: &MemberExpression,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         ctx: &LintContext<'a>,
     ) {
         let Some(jest_fn_call) =

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{
@@ -161,7 +161,7 @@ impl Rule for RequireHook {
         Self(Box::new(RequireHookConfig { allowed_function_calls }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let kind = node.kind();
 
         if let AstKind::Program(program) = kind {
@@ -197,7 +197,7 @@ impl Rule for RequireHook {
 impl RequireHook {
     fn check_block_body<'a>(
         &self,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         statements: &'a OxcVec<'a, Statement<'_>>,
         ctx: &LintContext<'a>,
     ) {
@@ -206,7 +206,7 @@ impl RequireHook {
         }
     }
 
-    fn check<'a>(&self, node: &AstNode<'a>, stmt: &'a Statement<'_>, ctx: &LintContext<'a>) {
+    fn check<'a>(&self, node: &Node<'a>, stmt: &'a Statement<'_>, ctx: &LintContext<'a>) {
         if let Statement::ExpressionStatement(expr_stmt) = stmt {
             self.check_should_report_in_hook(node, &expr_stmt.expression, ctx);
         } else if let Statement::VariableDeclaration(var_decl) = stmt {
@@ -225,7 +225,7 @@ impl RequireHook {
 
     fn check_should_report_in_hook<'a>(
         &self,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         expr: &'a Expression<'a>,
         ctx: &LintContext<'a>,
     ) {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -14,7 +14,7 @@ use crate::{
     utils::{
         collect_possible_jest_call_node, parse_expect_jest_fn_call, ExpectError, PossibleJestNode,
     },
-    AstNode,
+    Node,
 };
 
 fn valid_expect_diagnostic<S: Into<Cow<'static, str>>>(
@@ -230,7 +230,7 @@ impl ValidExpect {
 }
 
 fn find_top_most_member_expression<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
 ) -> Option<&'b MemberExpression<'a>> {
     let mut top_most_member_expression = None;
@@ -255,7 +255,7 @@ fn find_top_most_member_expression<'a, 'b>(
 }
 
 fn is_acceptable_return_node<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     allow_return: bool,
     ctx: &'b LintContext<'a>,
 ) -> bool {
@@ -282,12 +282,12 @@ fn is_acceptable_return_node<'a, 'b>(
     }
 }
 
-type ParentAndIsFirstItem<'a, 'b> = (&'b AstNode<'a>, bool);
+type ParentAndIsFirstItem<'a, 'b> = (&'b Node<'a>, bool);
 
 // Returns the parent node of the given node, ignoring some nodes,
 // and return whether the first item if parent is an array.
 fn get_parent_with_ignore<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
 ) -> Option<ParentAndIsFirstItem<'a, 'b>> {
     let mut node = node;
@@ -320,10 +320,10 @@ fn get_parent_with_ignore<'a, 'b>(
 }
 
 fn find_promise_call_expression_node<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
-    default_node: &'b AstNode<'a>,
-) -> Option<&'b AstNode<'a>> {
+    default_node: &'b Node<'a>,
+) -> Option<&'b Node<'a>> {
     let Some((mut parent, is_first_array_item)) = get_parent_with_ignore(node, ctx) else {
         return Some(default_node);
     };
@@ -357,10 +357,7 @@ fn find_promise_call_expression_node<'a, 'b>(
     Some(default_node)
 }
 
-fn get_parent_if_thenable<'a, 'b>(
-    node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
-) -> &'b AstNode<'a> {
+fn get_parent_if_thenable<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> &'b Node<'a> {
     let grandparent =
         ctx.nodes().parent_node(node.id()).and_then(|node| ctx.nodes().parent_node(node.id()));
 

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -8,7 +8,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
-    AstNode,
+    Node,
 };
 
 fn implements_on_classes_diagnostic(span: Span) -> OxcDiagnostic {
@@ -58,7 +58,7 @@ declare_oxc_lint!(
     correctness
 );
 
-fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_function_inside_of_class<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let mut current_node = node;
     while let Some(parent_node) = ctx.nodes().parent_node(current_node.id()) {
         match parent_node.kind() {
@@ -75,7 +75,7 @@ fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintConte
 }
 
 impl Rule for ImplementsOnClasses {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -8,7 +8,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
-    AstNode,
+    Node,
 };
 
 fn no_defaults_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
@@ -64,7 +64,7 @@ impl Rule for NoDefaults {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use oxc_ast::{ast::MethodDefinitionKind, AstKind};
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, JSDoc};
+use oxc_semantic::{JSDoc, Node};
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
@@ -104,7 +104,7 @@ impl Rule for RequireParam {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -10,7 +10,7 @@ use crate::{
         collect_params, get_function_nearest_jsdoc_node, should_ignore_as_internal,
         should_ignore_as_private, ParamKind,
     },
-    AstNode,
+    Node,
 };
 
 fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
-    AstNode,
+    Node,
 };
 
 fn missing_name_diagnostic(span: Span) -> OxcDiagnostic {
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamName {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -10,7 +10,7 @@ use crate::{
         collect_params, get_function_nearest_jsdoc_node, should_ignore_as_internal,
         should_ignore_as_private, ParamKind,
     },
-    AstNode,
+    Node,
 };
 
 fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -109,7 +109,7 @@ impl Rule for RequireReturns {
         // Search `ReturnStatement` when visiting `Function` requires a lot of work.
         // Instead, we collect all functions and their attributes first.
 
-        // Value of map: (AstNode, Span, Attrs: (isAsync, hasReturnValue))
+        // Value of map: (Node, Span, Attrs: (isAsync, hasReturnValue))
         let mut functions_to_check = FxHashMap::default();
         'visit_node: for node in ctx.nodes().iter() {
             match node.kind() {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
-    AstNode,
+    Node,
 };
 
 fn missing_description_diagnostic(span: Span) -> OxcDiagnostic {
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireReturnsDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_function_nearest_jsdoc_node, should_ignore_as_internal, should_ignore_as_private},
-    AstNode,
+    Node,
 };
 
 fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireReturnsType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -13,7 +13,7 @@ use crate::{
         get_function_nearest_jsdoc_node, should_ignore_as_avoid, should_ignore_as_internal,
         should_ignore_as_private,
     },
-    AstNode,
+    Node,
 };
 
 fn missing_yields(span: Span) -> OxcDiagnostic {
@@ -101,7 +101,7 @@ impl Rule for RequireYields {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let config = &self.0;
 
         // This rule checks generator function should have JSDoc `@yields` tag.

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -13,7 +13,7 @@ use crate::{
         get_element_type, get_prop_value, get_string_literal_prop_value, has_jsx_prop_ignore_case,
         object_has_accessible_child,
     },
-    AstNode,
+    Node,
 };
 
 fn missing_alt_prop(span: Span) -> OxcDiagnostic {
@@ -170,7 +170,7 @@ impl Rule for AltText {
         Self(Box::new(alt_text))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };
@@ -189,8 +189,7 @@ impl Rule for AltText {
         // <object>
         if let Some(custom_tags) = &self.object {
             if name == "object" || custom_tags.iter().any(|i| i == name) {
-                let maybe_parent =
-                    ctx.nodes().parent_node(node.id()).map(oxc_semantic::AstNode::kind);
+                let maybe_parent = ctx.nodes().parent_node(node.id()).map(oxc_semantic::Node::kind);
                 if let Some(AstKind::JSXElement(parent)) = maybe_parent {
                     object_rule(jsx_el, parent, ctx);
                     return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -14,7 +14,7 @@ use crate::{
         get_element_type, has_jsx_prop_ignore_case, is_hidden_from_screen_reader,
         object_has_accessible_child,
     },
-    AstNode,
+    Node,
 };
 
 fn missing_content(span: Span) -> OxcDiagnostic {
@@ -62,7 +62,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AnchorHasContent {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             let Some(name) = &get_element_type(ctx, &jsx_el.opening_element) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn missing_href_attribute(span: Span) -> OxcDiagnostic {
@@ -127,7 +127,7 @@ impl Rule for AnchorIsValid {
         Self(Box::new(valid_hrefs.iter().collect()))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             let Some(name) = &get_element_type(ctx, &jsx_el.opening_element) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -11,7 +11,7 @@ use crate::{
     globals::HTML_TAG,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case, is_interactive_element, parse_jsx_value},
-    AstNode,
+    Node,
 };
 
 fn aria_activedescendant_has_tabindex_diagnostic(span: Span, el_name: &str) -> OxcDiagnostic {
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AriaActivedescendantHasTabindex {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     context::LintContext, globals::VALID_ARIA_PROPS, rule::Rule, utils::get_jsx_attribute_name,
-    AstNode,
+    Node,
 };
 
 fn aria_props_diagnostic(span: Span, prop_name: &str, suggestion: Option<&str>) -> OxcDiagnostic {
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) = node.kind() {
             let name = get_jsx_attribute_name(&attr.name);
             let name = name.cow_to_lowercase();

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -11,7 +11,7 @@ use crate::{
     globals::{HTML_TAG, VALID_ARIA_ROLES},
     rule::Rule,
     utils::{get_element_type, get_prop_value, has_jsx_prop},
-    AstNode,
+    Node,
 };
 
 fn aria_role_diagnostic(span: Span, help_suffix: &str) -> OxcDiagnostic {
@@ -140,7 +140,7 @@ impl Rule for AriaRole {
         Self(Box::new(AriaRoleConfig { ignore_non_dom, allowed_invalid_roles }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             if let Some(aria_role) = has_jsx_prop(&jsx_el.opening_element, "role") {
                 let Some(element_type) = get_element_type(ctx, &jsx_el.opening_element) else {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -9,7 +9,7 @@ use crate::{
     globals::RESERVED_HTML_TAG,
     rule::Rule,
     utils::{get_element_type, get_jsx_attribute_name},
-    AstNode, LintContext,
+    LintContext, Node,
 };
 
 declare_oxc_lint! {
@@ -47,7 +47,7 @@ fn aria_unsupported_elements_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
 }
 
 impl Rule for AriaUnsupportedElements {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(el_type) = get_element_type(ctx, jsx_el) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnostic {
@@ -179,7 +179,7 @@ impl Rule for AutocompleteValid {
             .unwrap_or_default()
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(name) = &get_element_type(ctx, jsx_el) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -11,7 +11,7 @@ use crate::{
         get_element_type, has_jsx_prop, is_hidden_from_screen_reader, is_interactive_element,
         is_presentation_role,
     },
-    AstNode,
+    Node,
 };
 
 fn click_events_have_key_events_diagnostic(span: Span) -> OxcDiagnostic {
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ClickEventsHaveKeyEvents {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, is_hidden_from_screen_reader, object_has_accessible_child},
-    AstNode,
+    Node,
 };
 
 fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
@@ -82,7 +82,7 @@ impl Rule for HeadingHasContent {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };
@@ -105,7 +105,7 @@ impl Rule for HeadingHasContent {
             return;
         }
 
-        let maybe_parent = ctx.nodes().parent_node(node.id()).map(oxc_semantic::AstNode::kind);
+        let maybe_parent = ctx.nodes().parent_node(node.id()).map(oxc_semantic::Node::kind);
         if let Some(AstKind::JSXElement(parent)) = maybe_parent {
             if object_has_accessible_child(ctx, parent) {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, get_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn missing_lang_prop(span: Span) -> OxcDiagnostic {
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for HtmlHasLang {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, get_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn iframe_has_title_diagnostic(span: Span) -> OxcDiagnostic {
@@ -61,7 +61,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for IframeHasTitle {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -14,7 +14,7 @@ use crate::{
     utils::{
         get_element_type, get_prop_value, has_jsx_prop_ignore_case, is_hidden_from_screen_reader,
     },
-    AstNode,
+    Node,
 };
 
 fn img_redundant_alt_diagnostic(span: Span) -> OxcDiagnostic {
@@ -120,7 +120,7 @@ impl Rule for ImgRedundantAlt {
         Self(Box::new(ImgRedundantAltConfig::new(components, words.as_slice()).unwrap()))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, get_jsx_attribute_name, has_jsx_prop, is_react_component_name},
-    AstNode,
+    Node,
 };
 
 fn label_has_associated_control_diagnostic(span: Span) -> OxcDiagnostic {
@@ -201,7 +201,7 @@ impl Rule for LabelHasAssociatedControl {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXElement(element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -11,7 +11,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, get_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn lang_diagnostic(span: Span) -> OxcDiagnostic {
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Lang {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -9,7 +9,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, utils::get_element_type, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_element_type, Node};
 
 fn media_has_caption_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing <track> element with captions inside <audio> or <video> element")
@@ -105,7 +105,7 @@ impl Rule for MediaHasCaption {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -8,7 +8,7 @@ use crate::{
     globals::HTML_TAG,
     rule::Rule,
     utils::{get_element_type, get_prop_value, has_jsx_prop},
-    AstNode,
+    Node,
 };
 
 fn miss_on_focus(span: Span, attr_name: &str) -> OxcDiagnostic {
@@ -97,7 +97,7 @@ impl Rule for MouseEventsHaveKeyEvents {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case, Node};
 
 fn no_access_key_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No access key attribute allowed.")
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAccessKey {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case, parse_jsx_value},
-    AstNode,
+    Node,
 };
 
 fn no_aria_hidden_on_focusable_diagnostic(span: Span) -> OxcDiagnostic {
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAriaHiddenOnFocusable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -8,7 +8,7 @@ use crate::{
     globals::HTML_TAG,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop},
-    AstNode,
+    Node,
 };
 
 fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
@@ -93,7 +93,7 @@ impl Rule for NoAutofocus {
         no_focus
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::{GetSpan, Span};
 
 use crate::{rule::Rule, utils::get_element_type, LintContext};
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDistractingElements {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -11,7 +11,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
@@ -57,7 +57,7 @@ static DEFAULT_ROLE_EXCEPTIONS: phf::Map<&'static str, &'static str> = phf_map! 
 };
 
 impl Rule for NoRedundantRoles {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -12,7 +12,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn prefer_tag_over_role_diagnostic(span: Span, tag: &str, role: &str) -> OxcDiagnostic {
@@ -90,7 +90,7 @@ static ROLE_TO_TAG_MAP: Lazy<phf::Map<&'static str, &'static str>> = Lazy::new(|
 });
 
 impl Rule for PreferTagOverRole {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             if let Some(name) = get_element_type(ctx, jsx_el) {
                 if let Some(role_prop) = has_jsx_prop_ignore_case(jsx_el, "role") {

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::{phf_map, phf_set};
 
-use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case, Node};
 
 fn role_has_required_aria_props_diagnostic(span: Span, role: &str, props: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{role}` role is missing required aria props `{props}`."))
@@ -55,7 +55,7 @@ static ROLE_TO_REQUIRED_ARIA_PROPS: phf::Map<&'static str, phf::Set<&'static str
 };
 
 impl Rule for RoleHasRequiredAriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(role_prop) = has_jsx_prop_ignore_case(jsx_el, "role") else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -16,7 +16,7 @@ use crate::{
         get_element_type, get_jsx_attribute_name, get_string_literal_prop_value,
         has_jsx_prop_ignore_case,
     },
-    AstNode,
+    Node,
 };
 
 declare_oxc_lint!(
@@ -64,7 +64,7 @@ fn is_implicit_diagnostic(span: Span, attr_name: &str, role: &str, el_name: &str
 }
 
 impl Rule for RoleSupportsAriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -8,7 +8,7 @@ use crate::{
     globals::HTML_TAG,
     rule::Rule,
     utils::{get_element_type, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn scope_diagnostic(span: Span) -> OxcDiagnostic {
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Scope {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{has_jsx_prop_ignore_case, parse_jsx_value},
-    AstNode,
+    Node,
 };
 
 fn tabindex_no_positive_diagnostic(span: Span) -> OxcDiagnostic {
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for TabindexNoPositive {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_string_literal_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn font_display_parameter_missing(span: Span) -> OxcDiagnostic {
@@ -79,7 +79,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GoogleFontDisplay {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_string_literal_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn google_font_preconnect_diagnostic(span: Span) -> OxcDiagnostic {
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GoogleFontPreconnect {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn inline_script_id_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for InlineScriptId {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ImportDefaultSpecifier(specifier) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_string_literal_prop_value, has_jsx_prop_ignore_case},
-    AstNode,
+    Node,
 };
 
 fn next_script_for_ga_diagnostic(span: Span) -> OxcDiagnostic {
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NextScriptForGa {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_assign_module_variable_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not assign to the variable `module`.")
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAssignModuleVariable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::VariableDeclaration(variable_decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_next_script_import_local_name, is_document_page, is_in_app_dir},
-    AstNode,
+    Node,
 };
 
 fn no_before_interactive_script_outside_document_diagnostic(span: Span) -> OxcDiagnostic {
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoBeforeInteractiveScriptOutsideDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(file_path) = ctx.file_path().to_str() else {
                 return;

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::get_string_literal_prop_value, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_string_literal_prop_value, Node};
 
 fn no_css_tags_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not include stylesheets manually.")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCssTags {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::is_document_page, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_document_page, Node};
 
 fn no_document_import_in_page_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page").with_help("Prevent importing `next/document` outside of `pages/_document.js`.").with_label(span)
@@ -27,7 +27,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDocumentImportInPage {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::is_in_app_dir, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_in_app_dir, Node};
 
 fn no_head_element_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `<head>` element. Use `<Head />` from `next/head` instead.")
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoHeadElement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let Some(full_file_path) = ctx.file_path().to_str() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_head_import_in_document_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `next/head` in `pages/_document.js`.")
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoHeadImportInDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_img_element_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `<img>` element due to slower LCP and higher bandwidth.")
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImgElement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn not_added_in_document(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged.")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoPageCustomFont {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(element) = node.kind() else {
             return;
         };
@@ -76,7 +76,7 @@ impl Rule for NoPageCustomFont {
     }
 }
 
-fn is_inside_export_default(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn is_inside_export_default(node: &Node<'_>, ctx: &LintContext<'_>) -> bool {
     let mut is_inside_export_default = false;
     for parent_node in ctx.nodes().iter_parents(node.id()) {
         // export default function/class

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_script_component_in_head_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `next/script` in `next/head` component.")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoScriptComponentInHead {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_styled_jsx_in_document_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`styled-jsx` should not be used in `pages/_document.js`")
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoStyledJsxInDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_sync_scripts_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent synchronous scripts.")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSyncScripts {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_title_in_document_head_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `<title>` with `Head` component from `next/document`.")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTitleInDocumentHead {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::phf_set;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_typos_diagnostic(typo: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("{typo} may be a typo. Did you mean {suggestion}?"))
@@ -60,7 +60,7 @@ impl Rule for NoTypos {
         true
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ModuleDeclaration(ModuleDeclaration::ExportNamedDeclaration(en_decl)) =
             node.kind()
         {

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 use phf::{phf_set, Set};
 
@@ -106,7 +106,7 @@ const NEXT_POLYFILLED_FEATURES: Set<&'static str> = phf_set! {
 };
 
 impl Rule for NoUnwantedPolyfillio {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_exports_assign(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the assignment to `exports`.")
@@ -70,7 +70,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExportsAssign {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assign_expr) = node.kind() else {
             return;
         };
@@ -86,7 +86,7 @@ impl Rule for NoExportsAssign {
         }
 
         let parent = ctx.nodes().parent_node(node.id());
-        if let Some(AstKind::AssignmentExpression(assign_expr)) = parent.map(AstNode::kind) {
+        if let Some(AstKind::AssignmentExpression(assign_expr)) = parent.map(Node::kind) {
             if is_module_exports(assign_expr.left.as_member_expression(), ctx) {
                 return;
             }

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn approx_constant_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Approximate value of `{method_name}` found."))
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ApproxConstant {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NumericLiteral(number_literal) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn bad_array_method_on_arguments_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad array method on arguments")
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadArrayMethodOnArguments {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !node.kind().is_specific_id_reference("arguments") {
             return;
         }

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn bad_bitwise_operator_diagnostic(
     bad_operator: &str,
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadBitwiseOperator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BinaryExpression(bin_expr) => {
                 if is_mistype_short_circuit(node) {
@@ -81,7 +81,7 @@ impl Rule for BadBitwiseOperator {
     }
 }
 
-fn is_mistype_short_circuit(node: &AstNode) -> bool {
+fn is_mistype_short_circuit(node: &Node) -> bool {
     match node.kind() {
         AstKind::BinaryExpression(bin_expr) => {
             if bin_expr.operator != BinaryOperator::BitwiseAnd {
@@ -104,7 +104,7 @@ fn is_mistype_short_circuit(node: &AstNode) -> bool {
     }
 }
 
-fn is_mistype_option_fallback(node: &AstNode) -> bool {
+fn is_mistype_option_fallback(node: &Node) -> bool {
     let AstKind::BinaryExpression(binary_expr) = node.kind() else {
         return false;
     };

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn bad_char_at_comparison_diagnostic(
     char_at: Span,
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadCharAtComparison {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn bad_comparison_sequence_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad comparison sequence").with_help("Comparison result should not be used directly as an operand of another comparison. If you need to compare three or more operands, you should connect each comparison operation with logical AND operator (`&&`)").with_label(span)
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadComparisonSequence {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };
@@ -44,10 +44,7 @@ impl Rule for BadComparisonSequence {
     }
 }
 
-fn has_no_bad_comparison_in_parents<'a, 'b>(
-    node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
-) -> bool {
+fn has_no_bad_comparison_in_parents<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     for node_id in ctx.nodes().ancestors(node.id()).skip(1) {
         let kind = ctx.nodes().kind(node_id);
 

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn bad_min_max_func_diagnostic(constant_result: f64, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Math.min and Math.max combination leads to constant result")
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadMinMaxFunc {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn object_comparison(span: Span, const_result: bool) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected object literal comparison.")
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadObjectLiteralComparison {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(binary_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -10,7 +10,7 @@ use crate::{
     ast_util::{extract_regex_flags, get_declaration_of_variable, is_method_call},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn bad_replace_all_arg_diagnostic(replace_all_span: Span, regex_span: Span) -> OxcDiagnostic {
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadReplaceAllArg {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
-use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_same_reference, Node};
 
 fn redundant_left_hand_side(span: Span, span1: Span, help: String) -> OxcDiagnostic {
     OxcDiagnostic::warn("Left-hand side of `&&` operator has no effect.")
@@ -73,7 +73,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConstComparisons {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(logical_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
-use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_same_reference, Node};
 
 fn double_comparisons_diagnostic(span: Span, operator: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected double comparisons.")
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 
 #[allow(clippy::similar_names)]
 impl Rule for DoubleComparisons {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(logical_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn erasing_op_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected erasing operation. This expression will always evaluate to zero.")
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ErasingOp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(binary_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -12,7 +12,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_same_member_expression, is_same_reference},
-    AstNode,
+    Node,
 };
 
 fn misrefactored_assign_op_diagnostic(span: Span, suggestion: &str) -> OxcDiagnostic {
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for MisrefactoredAssignOp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn missing_throw_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing throw")
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for MissingThrow {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };
@@ -43,7 +43,7 @@ impl Rule for MissingThrow {
 }
 
 impl MissingThrow {
-    fn has_missing_throw<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    fn has_missing_throw<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
         let mut node_ancestors = ctx.nodes().ancestors(node.id()).skip(1);
 
         let Some(node_id) = node_ancestors.next() else {

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -14,7 +14,7 @@ use crate::{
     ast_util::{call_expr_method_callee_info, is_method_call},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn reduce_likely_array_spread_diagnostic(spread_span: Span, reduce_span: Span) -> OxcDiagnostic {
@@ -123,7 +123,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAccumulatingSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // only check spreads on identifiers
         let AstKind::SpreadElement(spread) = node.kind() else {
             return;
@@ -160,7 +160,7 @@ impl Rule for NoAccumulatingSpread {
 }
 
 fn check_reduce_usage<'a>(
-    declaration: &AstNode<'a>,
+    declaration: &Node<'a>,
     referenced_symbol_id: SymbolId,
     spread_span: Span,
     ctx: &LintContext<'a>,
@@ -195,8 +195,8 @@ fn check_reduce_usage<'a>(
 }
 
 fn check_loop_usage<'a>(
-    declaration_node: &AstNode<'a>,
-    declarator: &AstNode<'a>,
+    declaration_node: &Node<'a>,
+    declarator: &Node<'a>,
     referenced_symbol_id: SymbolId,
     spread_node_id: NodeId,
     spread_span: Span,

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_async_await_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected async/await")
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(func_decl) => {
                 if func_decl.r#async {

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -9,7 +9,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, utils, AstNode};
+use crate::{context::LintContext, rule::Rule, utils, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoAsyncEndpointHandlers(Box<NoAsyncEndpointHandlersConfig>);
@@ -183,7 +183,7 @@ impl Rule for NoAsyncEndpointHandlers {
         Self(Box::new(NoAsyncEndpointHandlersConfig { allowed_names }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let kind = node.kind();
         let Some((_endpoint, args)) = utils::as_endpoint_registration(&kind) else {
             return;

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_const_enum_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected const enum")
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstEnum {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSEnumDeclaration(enum_decl) = node.kind() {
             if !enum_decl.r#const {
                 return;

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_optional_chaining_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
     if help.is_empty() {
@@ -76,7 +76,7 @@ impl Rule for NoOptionalChaining {
         Self(Box::new(NoOptionalChainingConfig { message: message.to_string() }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ChainExpression(expr) = node.kind() {
             ctx.diagnostic(no_optional_chaining_diagnostic(expr.span, &self.message));
         }

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_rest_spread_properties_diagnostic(
     span: Span,
@@ -83,7 +83,7 @@ impl Rule for NoRestSpreadProperties {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::SpreadElement(spread_element) => {
                 if ctx

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn number_arg_out_of_range_diagnostic(
     method_name: &str,
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumberArgOutOfRange {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    ast_util::get_function_like_declaration, context::LintContext, fixer::Fix, rule::Rule, AstNode,
+    ast_util::get_function_like_declaration, context::LintContext, fixer::Fix, rule::Rule, Node,
 };
 
 fn only_used_in_recursion_diagnostic(span: Span, param_name: &str) -> OxcDiagnostic {
@@ -65,7 +65,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for OnlyUsedInRecursion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (function_id, function_parameters, function_span) = match node.kind() {
             AstKind::Function(function) => {
                 if function.is_typescript_syntax() {

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn uninvoked_array_callback_diagnostic(cb_span: Span, arr_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Uninvoked array callback")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for UninvokedArrayCallback {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn avoid_new_promise_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid creating new promises").with_label(span)
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AvoidNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -6,9 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
 
-use crate::{
-    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_promise, AstNode,
-};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_promise, Node};
 
 fn catch_or_return_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -115,7 +113,7 @@ impl Rule for CatchOrReturn {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ExpressionStatement(expr_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, Node};
 
 fn static_promise_diagnostic(static_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{static_name}`"))
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewStatics {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_promise, Node};
 
 fn no_return_in_finally_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't return in a finally callback")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoReturnInFinally {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -75,7 +75,7 @@ impl Rule for ParamNames {
         Self(Box::new(cfg))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -7,7 +7,7 @@ fn prefer_wait_to_then_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer await to then()/catch()/finally()").with_label(span)
 }
 
-use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_promise, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferAwaitToThen;
@@ -29,12 +29,12 @@ declare_oxc_lint!(
     style,
 );
 
-fn is_inside_yield_or_await(node: &AstNode) -> bool {
+fn is_inside_yield_or_await(node: &Node) -> bool {
     matches!(node.kind(), AstKind::YieldExpression(_) | AstKind::AwaitExpression(_))
 }
 
 impl Rule for PreferAwaitToThen {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
-use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, Node};
 
 fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}`"))
@@ -64,7 +64,7 @@ impl Rule for SpecOnly {
         Self(Box::new(SpecOnlyConfig { allowed_methods }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(member_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_promise, Node};
 
 fn zero_or_one_argument_required_diagnostic(
     span: Span,
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ValidParams {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_prop_value, has_jsx_prop_ignore_case, is_create_element_call},
-    AstNode,
+    Node,
 };
 
 fn missing_type_prop(span: Span) -> OxcDiagnostic {
@@ -70,7 +70,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ButtonHasType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
                 let JSXElementName::Identifier(identifier) = &jsx_el.name else {

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_element_type, get_jsx_attribute_name, is_create_element_call},
-    AstNode,
+    Node,
 };
 
 fn missing_property(span: Span) -> OxcDiagnostic {
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for CheckedRequiresOnchangeOrReadonly {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_opening_el) => {
                 let Some(element_type) = get_element_type(ctx, jsx_opening_el) else {

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::get_prop_value, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_prop_value, Node};
 
 fn boolean_value_diagnostic(attr: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Value must be omitted for boolean attribute {attr:?}"))
@@ -102,7 +102,7 @@ impl Rule for JsxBooleanValue {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else { return };
 
         for attr in &jsx_opening_elem.attributes {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -12,7 +12,7 @@ use oxc_semantic::NodeId;
 use oxc_span::{GetSpan as _, Span};
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn jsx_curly_brace_presence_unnecessary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Curly braces are unnecessary here.").with_label(span)
@@ -330,7 +330,7 @@ impl Rule for JsxCurlyBracePresence {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(el) => {
                 el.opening_element.attributes.iter().for_each(|attr| {
@@ -360,7 +360,7 @@ impl JsxCurlyBracePresence {
         &self,
         ctx: &LintContext<'a>,
         children: &Vec<'a, JSXChild<'a>>,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
     ) {
         for child in children {
             match child {
@@ -384,7 +384,7 @@ impl JsxCurlyBracePresence {
         &self,
         ctx: &LintContext<'a>,
         attr: &JSXAttributeItem<'a>,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
     ) {
         let JSXAttributeItem::Attribute(attr) = attr else {
             return;
@@ -417,7 +417,7 @@ impl JsxCurlyBracePresence {
         &self,
         ctx: &LintContext<'a>,
         container: &JSXExpressionContainer<'a>,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         // true for JSX props, false for JSX children
         is_prop: bool,
     ) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -5,7 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn jsx_no_comment_textnodes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoCommentTextnodes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXText(jsx_text) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{Atom, Span};
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn jsx_no_duplicate_props_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No duplicate props allowed. The prop \"{x0}\" is duplicated."))
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoDuplicateProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -11,7 +11,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn target_blank_without_noreferrer(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` (which implies rel=`noopener`) is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
@@ -122,7 +122,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoTargetBlank {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_ele) = node.kind() {
             let Some(tag_name) = &jsx_ele.name.get_identifier_name() else {
                 return;

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn jsx_no_undef_diagnostic(ident_name: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow undeclared variables in JSX")
@@ -56,7 +56,7 @@ fn get_member_ident<'a>(mut expr: &'a JSXMemberExpression<'a>) -> Option<&'a Ide
 }
 
 impl Rule for JsxNoUndef {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(elem) = &node.kind() {
             if let Some(ident) = get_resolvable_ident(&elem.name) {
                 let reference = ctx.symbols().get_reference(ident.reference_id().unwrap());

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn needs_more_children(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span)
@@ -63,7 +63,7 @@ impl Rule for JsxNoUselessFragment {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
                 if !is_jsx_fragment(&jsx_elem.opening_element) {
@@ -84,7 +84,7 @@ impl Rule for JsxNoUselessFragment {
 }
 
 impl JsxNoUselessFragment {
-    fn check_element(&self, node: &AstNode, elem: &JSXElement, ctx: &LintContext) {
+    fn check_element(&self, node: &Node, elem: &JSXElement, ctx: &LintContext) {
         if jsx_elem_has_key_attr(elem) {
             return;
         }
@@ -103,7 +103,7 @@ impl JsxNoUselessFragment {
         }
     }
 
-    fn check_fragment(&self, node: &AstNode, elem: &JSXFragment, ctx: &LintContext) {
+    fn check_fragment(&self, node: &Node, elem: &JSXFragment, ctx: &LintContext) {
         if has_less_than_two_children(&elem.children)
             && !is_fragment_with_only_text_and_is_not_child(node.id(), &elem.children, ctx)
             && !(self.allow_expressions && is_fragment_with_single_expression(&elem.children))
@@ -147,7 +147,7 @@ fn is_padding_spaces(v: &JSXChild<'_>) -> bool {
     true
 }
 
-fn is_child_of_html_element(node: &AstNode, ctx: &LintContext) -> bool {
+fn is_child_of_html_element(node: &Node, ctx: &LintContext) -> bool {
     if let Some(AstKind::JSXElement(elem)) = ctx.nodes().parent_kind(node.id()) {
         if is_html_element(&elem.opening_element.name) {
             return true;

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -10,7 +10,7 @@ use crate::{
     fixer::{Fix, RuleFix},
     rule::Rule,
     utils::is_same_member_expression,
-    AstNode,
+    Node,
 };
 
 fn jsx_props_no_spread_multiple_identifiers_diagnostic(
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxPropsNoSpreadMulti {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() {
             let spread_attrs =
                 jsx_opening_el.attributes.iter().filter_map(JSXAttributeItem::as_spread);

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, Node};
 
 fn no_children_prop_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid passing children using a prop.")
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoChildrenProp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
                 let JSXAttributeName::Identifier(attr_ident) = &attr.name else {

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{has_jsx_prop, is_create_element_call},
-    AstNode,
+    Node,
 };
 
 fn no_danger_diagnostic(span: Span) -> OxcDiagnostic {
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDanger {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
                 if let Some(JSXAttributeItem::Attribute(prop)) =

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
-    AstNode,
+    Node,
 };
 
 fn no_direct_mutation_state_diagnostic(span: Span) -> OxcDiagnostic {
@@ -82,7 +82,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDirectMutationState {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::AssignmentExpression(assignment_expr) => {
                 if should_ignore_component(node, ctx) {
@@ -171,7 +171,7 @@ fn get_static_member_expression_obj<'a, 'b>(
     }
 }
 
-fn should_ignore_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn should_ignore_component<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let mut is_constructor = false;
     let mut is_call_expression = false;
     let mut is_component = false;

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_find_dom_node_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected call to `findDOMNode`.")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFindDomNode {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_is_mounted_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use isMounted")
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIsMounted {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_render_return_value_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not depend on the return value from ReactDOM.render.")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRenderReturnValue {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, utils::get_parent_component, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_parent_component, Node};
 
 fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use setState").with_label(span)
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetState {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, utils::get_parent_component, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_parent_component, Node};
 
 fn this_refs_deprecated(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using this.refs is deprecated.")
@@ -106,7 +106,7 @@ impl Rule for NoStringRefs {
         Self { no_template_literals }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
                 if is_literal_ref_attribute(attr, self.no_template_literals) {

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::{phf_map, Map};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unescaped_entities_diagnostic(span: Span, unescaped: char, escaped: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}")).with_label(span)
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnescapedEntities {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXText(jsx_text) = node.kind() {
             let source = jsx_text.span.source_text(ctx.source_text());
             for (i, char) in source.char_indices() {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 
-use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, Node};
 
 fn invalid_prop_on_tag(span: Span, prop: &str, tag: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid property found")
@@ -459,7 +459,7 @@ impl Rule for NoUnknownProperty {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         static HTML_TAG_CONVENTION: Lazy<Regex> = Lazy::new(|| Regex::new("^[a-z][^-]*$").unwrap());
 
         let AstKind::JSXOpeningElement(el) = &node.kind() else {

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -7,7 +7,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
-    AstNode,
+    Node,
 };
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
@@ -57,7 +57,7 @@ impl Rule for PreferEs6Class {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always) {
             if is_es5_component(node) {
                 let AstKind::CallExpression(call_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn react_in_jsx_scope_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'React' must be in scope when using JSX")
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ReactInJsxScope {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let node_span = match node.kind() {
             AstKind::JSXOpeningElement(v) => v.name.span(),
             AstKind::JSXFragment(v) => v.opening_fragment.span,

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -11,7 +11,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
-    AstNode,
+    Node,
 };
 
 fn require_render_return_diagnostic(span: Span) -> OxcDiagnostic {
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireRenderReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
             return;
         }
@@ -94,7 +94,7 @@ enum FoundReturn {
 const KEEP_WALKING_ON_THIS_PATH: bool = true;
 const STOP_WALKING_ON_THIS_PATH: bool = false;
 
-fn contains_return_statement(node: &AstNode, ctx: &LintContext) -> bool {
+fn contains_return_statement(node: &Node, ctx: &LintContext) -> bool {
     let cfg = ctx.cfg();
     let state = neighbors_filtered_by_edge_weight(
         cfg.graph(),
@@ -144,7 +144,7 @@ fn contains_return_statement(node: &AstNode, ctx: &LintContext) -> bool {
 
 const RENDER_METHOD_NAME: &str = "render";
 
-fn is_render_fn(node: &AstNode) -> bool {
+fn is_render_fn(node: &Node) -> bool {
     match node.kind() {
         AstKind::MethodDefinition(method) => {
             if method.key.is_specific_static_name(RENDER_METHOD_NAME) {
@@ -170,7 +170,7 @@ fn is_render_fn(node: &AstNode) -> bool {
     false
 }
 
-fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es5_component<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let Some(ancestors_0) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(ancestors_0.kind(), AstKind::ObjectExpression(_)) {
         return false;
@@ -186,7 +186,7 @@ fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
     is_es5_component(ancestors_2)
 }
 
-fn is_in_es6_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es6_component<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let Some(parent) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(parent.kind(), AstKind::ClassBody(_)) {
         return false;

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, globals::HTML_TAG, rule::Rule, AstNode};
+use crate::{context::LintContext, globals::HTML_TAG, rule::Rule, Node};
 
 fn self_closing_comp_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary closing tag")
@@ -73,7 +73,7 @@ impl Rule for SelfClosingComp {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::phf_set;
 
-use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, Node};
 
 fn void_dom_elements_no_children_diagnostic(tag: &str, span: Span) -> OxcDiagnostic {
     // TODO: use imperative phrasing
@@ -64,7 +64,7 @@ pub fn is_void_dom_element(element_name: &str) -> bool {
 }
 
 impl Rule for VoidDomElementsNoChildren {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_el) => {
                 let jsx_opening_el = &jsx_el.opening_element;

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -15,7 +15,7 @@ use oxc_ast::{
     },
     AstKind,
 };
-use oxc_semantic::{AstNode, NodeId};
+use oxc_semantic::{Node, NodeId};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{LogicalOperator, UnaryOperator};
 
@@ -217,10 +217,10 @@ impl<'a> ListenerMap for ExportSpecifier<'a> {
     }
 }
 
-// we don't need implement all AstNode
+// we don't need implement all Node
 // it's same as `reportSideEffectsInDefinitionWhenCalled` in eslint-plugin-tree-shaking
 // <https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/463fa1f0bef7caa2b231a38b9c3557051f506c92/src/rules/no-side-effects-in-initialization.ts#L1070-L1080>
-impl<'a> ListenerMap for AstNode<'a> {
+impl<'a> ListenerMap for Node<'a> {
     fn report_effects_when_called(&self, options: &NodeListenerOptions) {
         match self.kind() {
             AstKind::VariableDeclarator(decl) => {

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn adjacent_overload_signatures_diagnostic(
     fn_name: &str,
@@ -280,7 +280,7 @@ fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
 }
 
 impl Rule for AdjacentOverloadSignatures {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Class(class) => {
                 let members = &class.body.body;

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -115,7 +115,7 @@ impl Rule for ArrayType {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let default_config = &self.default;
         let readonly_config: &ArrayOption =
             &self.readonly.clone().unwrap_or_else(|| default_config.clone());

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn type_diagnostic(banned_type: &str, suggested_type: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTypes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSTypeReference(typ) => {
                 let name = match &typ.type_name {

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn consistent_indexed_object_style_diagnostic(a: &str, b: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("A {a} is preferred over an {b}."))
@@ -68,7 +68,7 @@ impl Rule for ConsistentIndexedObjectStyle {
         Self { is_record_mode: config == ConsistentIndexedObjectStyleConfig::Record }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if self.is_record_mode {
             match node.kind() {
                 AstKind::TSInterfaceDeclaration(inf) => {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn consistent_type_definitions_diagnostic(
     preferred_type_kind: &str,
@@ -68,7 +68,7 @@ impl Rule for ConsistentTypeDefinitions {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSTypeAliasDeclaration(decl) => match &decl.type_annotation {
                 TSType::TSTypeLiteral(_)

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -17,7 +17,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn no_import_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
@@ -137,7 +137,7 @@ impl Rule for ConsistentTypeImports {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if self.disallow_type_annotations.0 {
             //  `import()` type annotations are forbidden.
             // `type Foo = import('foo')`

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoConfusingNonNullAssertion;
@@ -75,7 +75,7 @@ fn is_confusable_operator(operator: BinaryOperator) -> bool {
 }
 
 impl Rule for NoConfusingNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BinaryExpression(binary_expr)
                 if is_confusable_operator(binary_expr.operator) =>

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_duplicate_enum_values_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow duplicate enum member values")
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateEnumValues {
     #[allow(clippy::float_cmp)]
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumDeclaration(enum_body) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoDynamicDelete;
@@ -34,7 +34,7 @@ fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoDynamicDelete {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::UnaryExpression(expr) = node.kind() else { return };
         if !matches!(expr.operator, UnaryOperator::Delete) {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_empty_interface_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span)
@@ -50,7 +50,7 @@ impl Rule for NoEmptyInterface {
         Self { allow_single_extends }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSInterfaceDeclaration(interface) = node.kind() {
             if interface.body.body.is_empty() {
                 match &interface.extends {

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_explicit_any_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected any. Specify a different type.")
@@ -87,7 +87,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExplicitAny {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSAnyKeyword(any) = node.kind() else {
             return;
         };
@@ -120,7 +120,7 @@ impl Rule for NoExplicitAny {
 }
 
 impl NoExplicitAny {
-    fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    fn is_in_rest<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
         debug_assert!(matches!(node.kind(), AstKind::TSAnyKeyword(_)));
         ctx.nodes()
             .iter_parents(node.id())

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_extra_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("extra non-null assertion").with_label(span)
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExtraNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let expr = match node.kind() {
             AstKind::TSNonNullExpression(expr) => {
                 if let Expression::TSNonNullExpression(expr) = expr.expression.without_parentheses()

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoExtraneousClass {
@@ -100,7 +100,7 @@ impl Rule for NoExtraneousClass {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::Class(class) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, fixer::Fix, rule::Rule, Node};
 
 fn no_import_type_side_effects_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
@@ -62,7 +62,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportTypeSideEffects {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ImportDeclaration(import_decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_misused_new_interface_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Interfaces cannot be constructed, only classes.")
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMisusedNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(interface_decl) => {
                 let decl_name = &interface_decl.id.name;

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("ES2015 module syntax is preferred over namespaces.")
@@ -57,7 +57,7 @@ impl Rule for NoNamespace {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSModuleDeclaration(declaration) = node.kind() else {
             return;
         };
@@ -104,7 +104,7 @@ impl Rule for NoNamespace {
     }
 }
 
-fn is_declaration(node: &AstNode, ctx: &LintContext) -> bool {
+fn is_declaration(node: &Node, ctx: &LintContext) -> bool {
     ctx.nodes().iter_parents(node.id()).any(|node| {
         let AstKind::TSModuleDeclaration(declaration) = node.kind() else {
             return false;

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertedNullishCoalescing;
@@ -34,7 +34,7 @@ fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnost
 }
 
 impl Rule for NoNonNullAssertedNullishCoalescing {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
         let Expression::TSNonNullExpression(ts_non_null_expr) = &expr.left else { return };
         if let Expression::Identifier(ident) = &ts_non_null_expr.expression {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_non_null_asserted_optional_chain_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("non-null assertions after an optional chain expression")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSNonNullExpression(non_null_expr) = node.kind() else {
             return;
         };
@@ -96,7 +96,7 @@ impl Rule for NoNonNullAssertedOptionalChain {
     }
 }
 
-fn is_parent_member_or_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn is_parent_member_or_call(node: &Node<'_>, ctx: &LintContext<'_>) -> bool {
     matches!(
         ctx.nodes().parent_kind(node.id()),
         Some(AstKind::MemberExpression(_) | AstKind::CallExpression(_))

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertion;
@@ -32,7 +32,7 @@ fn no_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSNonNullExpression(expr) = node.kind() else { return };
         ctx.diagnostic(no_non_null_assertion_diagnostic(expr.span));
     }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -8,7 +8,7 @@ use oxc_span::{CompactStr, GetSpan, Span};
 use rustc_hash::FxHashSet;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_this_alias_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
@@ -94,7 +94,7 @@ impl Rule for NoThisAlias {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(decl) => {
                 let Some(init) = &decl.init else { return };

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unnecessary_type_constraint_diagnostic(
     generic_type: &str,
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryTypeConstraint {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSTypeParameterDeclaration(decl) = node.kind() {
             for param in &decl.params {
                 if let Some(ty) = &param.constraint {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unsafe_declaration_merging_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe declaration merging between classes and interfaces.")
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeDeclarationMerging {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Class(decl) => {
                 if let Some(ident) = decl.id.as_ref() {

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_useless_empty_export_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty exports that don't change anything in a module file")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessEmptyExport {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ExportNamedDeclaration(decl) = node.kind() else { return };
         if decl.declaration.is_some() || !decl.specifiers.is_empty() {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, Node};
 
 fn no_var_requires_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require statement not part of import statement.")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVarRequires {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };
@@ -47,8 +47,8 @@ impl Rule for NoVarRequires {
                 let grandparent_node = parent_node.and_then(|x| ctx.nodes().parent_node(x.id()));
                 matches!(
                     (
-                        parent_node.map(oxc_semantic::AstNode::kind),
-                        grandparent_node.map(oxc_semantic::AstNode::kind)
+                        parent_node.map(oxc_semantic::Node::kind),
+                        grandparent_node.map(oxc_semantic::Node::kind)
                     ),
                     (Some(AstKind::ExpressionStatement(_)), _)
                         | (

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_wrapper_object_types(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use wrapper object types.").with_label(span)
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWrapperObjectTypes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (ident_name, ident_span, reference_id) = match node.kind() {
             AstKind::TSTypeReference(type_ref) => {
                 if let TSTypeName::IdentifierReference(type_name) = &type_ref.type_name {

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_as_const_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a `const` assertion instead of a literal type annotation.")
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAsConst {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_declarator) => {
                 let Some(type_annotation) = &variable_declarator.id.type_annotation else {

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_enum_initializers_diagnostic(
     member_name: &str,
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEnumInitializers {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumDeclaration(decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, UpdateOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_for_of_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -115,7 +115,7 @@ impl<'a> ExpressionExt for Expression<'a> {
 }
 
 impl Rule for PreferForOf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ForStatement(for_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, fixer::Fix, rule::Rule, Node};
 
 fn prefer_function_type_diagnostic(suggestion: &str, span: Span) -> OxcDiagnostic {
     // FIXME: use imperative message phrasing
@@ -103,7 +103,7 @@ fn has_one_super_type(decl: &TSInterfaceDeclaration) -> bool {
     true
 }
 
-fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>) {
+fn check_member(member: &TSSignature, node: &Node<'_>, ctx: &LintContext<'_>) {
     match member {
         TSSignature::TSCallSignatureDeclaration(decl) => {
             let start = decl.span.start;
@@ -313,7 +313,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 }
 
 impl Rule for PreferFunctionType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(decl) => {
                 let body: &oxc_allocator::Vec<'_, TSSignature<'_>> = &decl.body.body;

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_literal_enum_member_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -54,7 +54,7 @@ impl Rule for PreferLiteralEnumMember {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumMember(decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_namespace_keyword_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use 'namespace' instead of 'module' to declare custom TypeScript modules.")
@@ -34,13 +34,13 @@ declare_oxc_lint!(
     fix
 );
 
-fn is_nest_module(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+fn is_nest_module(node: &Node, ctx: &LintContext<'_>) -> bool {
     ctx.nodes()
         .parent_node(node.id())
         .map_or(false, |parent_node| is_valid_module_node(parent_node))
 }
 
-fn is_valid_module_node(node: &AstNode) -> bool {
+fn is_valid_module_node(node: &Node) -> bool {
     matches!(node.kind(), AstKind::TSModuleDeclaration(module) if is_valid_module(module))
 }
 
@@ -51,7 +51,7 @@ fn is_valid_module(module: &TSModuleDeclaration) -> bool {
 }
 
 impl Rule for PreferNamespaceKeyword {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSModuleDeclaration(module) = node.kind() else { return };
 
         if !is_valid_module(module) || is_nest_module(node, ctx) {

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{CompactStr, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn catch_error_name_diagnostic(
     caught_ident: &str,
@@ -90,7 +90,7 @@ impl Rule for CatchErrorName {
         Self(Box::new(CatchErrorNameConfig { ignore: ignored_names, name: allowed_name }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::CatchParameter(catch_param) = node.kind() {
             if let oxc_ast::ast::BindingPatternKind::BindingIdentifier(binding_ident) =
                 &catch_param.pattern.kind

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::is_react_hook,
-    AstNode,
+    Node,
 };
 
 fn consistent_function_scoping(span: Span) -> OxcDiagnostic {
@@ -158,7 +158,7 @@ impl Rule for ConsistentFunctionScoping {
         Self(Box::new(configuration))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (function_declaration_symbol_id, function_body, reporter_span) = match node.kind() {
             AstKind::Function(function) => {
                 if let Some(AstKind::AssignmentExpression(_)) = ctx.nodes().parent_kind(node.id()) {
@@ -214,7 +214,7 @@ impl Rule for ConsistentFunctionScoping {
         }
 
         if matches!(
-            outermost_paren_parent(node, ctx).map(AstNode::kind),
+            outermost_paren_parent(node, ctx).map(Node::kind),
             Some(AstKind::ReturnStatement(_) | AstKind::Argument(_))
         ) {
             return;
@@ -295,7 +295,7 @@ impl<'a> Visit<'a> for ReferencesFinder {
     }
 }
 
-fn is_parent_scope_iife<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+fn is_parent_scope_iife<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
     if let Some(parent_node) = outermost_paren_parent(node, ctx) {
         if let Some(parent_node) = outermost_paren_parent(parent_node, ctx) {
             if matches!(
@@ -312,7 +312,7 @@ fn is_parent_scope_iife<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
     false
 }
 
-fn is_in_react_hook<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+fn is_in_react_hook<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
     // we want the 3rd outermost parent
     // parents are: function body -> function -> argument -> call expression
     if let Some(parent) = nth_outermost_paren_parent(node, ctx, 3) {

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn empty_brace_spaces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No spaces inside empty pair of braces allowed")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for EmptyBraceSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StaticBlock(static_block) => {
                 let start = static_block.span.start;

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn missing_message(ctor_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Pass a message to the {ctor_name:1} constructor."))
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ErrorMessage {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (callee, span, args) = match &node.kind() {
             AstKind::NewExpression(NewExpression {
                 callee: Expression::Identifier(id),

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn escape_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use uppercase characters for the value of the escape sequence.")
@@ -127,7 +127,7 @@ fn check_case(value: &str, is_regex: bool) -> Option<String> {
     }
 }
 impl Rule for EscapeCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StringLiteral(StringLiteral { span, .. }) => {
                 let text = span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -13,7 +13,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{get_boolean_ancestor, is_boolean_node},
-    AstNode,
+    Node,
 };
 
 fn non_zero(span: Span, prop_name: &str, op_and_rhs: &str, help: Option<String>) -> OxcDiagnostic {
@@ -115,10 +115,10 @@ fn is_compare_right(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> 
     )
 }
 fn get_length_check_node<'a, 'b>(
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &'b LintContext<'a>,
     // (is_zero_length_check, length_check_node)
-) -> Option<(bool, &'b AstNode<'a>)> {
+) -> Option<(bool, &'b Node<'a>)> {
     let parent = ctx.nodes().parent_node(node.id());
     parent.and_then(|parent| {
         if let AstKind::BinaryExpression(binary_expr) = parent.kind() {
@@ -168,7 +168,7 @@ impl ExplicitLengthCheck {
     fn report<'a>(
         &self,
         ctx: &LintContext<'a>,
-        node: &AstNode<'a>,
+        node: &Node<'a>,
         is_zero_length_check: bool,
         static_member_expr: &StaticMemberExpression,
         auto_fix: bool,
@@ -242,7 +242,7 @@ impl ExplicitLengthCheck {
     }
 }
 impl Rule for ExplicitLengthCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(
             static_member_expr,
         )) = node.kind()
@@ -270,7 +270,7 @@ impl Rule for ExplicitLengthCheck {
                     return;
                 }
                 let parent = ctx.nodes().parent_node(node.id());
-                let kind = parent.map(AstNode::kind);
+                let kind = parent.map(Node::kind);
                 match kind {
                     Some(AstKind::LogicalExpression(LogicalExpression {
                         operator, right, ..

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -8,7 +8,7 @@ use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 use phf::phf_set;
 
-use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
+use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, Node};
 
 fn enforce(span: Span, fn_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `new {fn_name}()` instead of `{fn_name}()`")).with_label(span)
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NewForBuiltins {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::NewExpression(new_expr) => {
                 let callee = new_expr.callee.without_parentheses();

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_anonymous_default_export_diagnostic(span: Span, kind: ErrorNodeKind) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow anonymous functions and classes as the default export")
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAnonymousDefaultExport {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let problem_node = match node.kind() {
             // ESM: export default
             AstKind::ExportDefaultDeclaration(export_decl) => match &export_decl.declaration {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::phf_set;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn no_array_for_each_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `Array#forEach`")
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoArrayForEach {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -7,8 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
-    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_prototype_property,
-    AstNode,
+    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_prototype_property, Node,
 };
 
 fn no_array_reduce_diagnostic(span: Span) -> OxcDiagnostic {
@@ -61,7 +60,7 @@ impl Rule for NoArrayReduce {
         Self { allow_simple_operations }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_await_expression_member_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow member access from await expression")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAwaitExpressionMember {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(member_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn no_await_in_promise_methods_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Promise in `Promise.{method_name}()` should not be awaited."))
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAwaitInPromiseMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -9,7 +9,7 @@ use crate::{
     ast_util::{call_expr_method_callee_info, is_method_call},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn no_console_spaces_diagnostic(
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConsoleSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -8,7 +8,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     ast_util::get_declaration_of_variable, context::LintContext, globals::GLOBAL_OBJECT_NAMES,
-    rule::Rule, AstNode,
+    rule::Rule, Node,
 };
 
 fn no_document_cookie_diagnostic(span: Span) -> OxcDiagnostic {
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDocumentCookie {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_hex_escape_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use Unicode escapes instead of hexadecimal escapes.").with_label(span)
@@ -70,7 +70,7 @@ fn check_escape(value: &str) -> Option<String> {
 }
 
 impl Rule for NoHexEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StringLiteral(StringLiteral { span, .. }) => {
                 let text = span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_instanceof_array_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Array.isArray()` instead of `instanceof Array`.")
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoInstanceofArray {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_invalid_remove_event_listener_diagnostic(call_span: Span, arg_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid `removeEventListener` call.")
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoInvalidRemoveEventListener {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_reference, AstNode,
+    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_reference, Node,
 };
 
 fn no_length_as_slice_end_diagnostic(call_span: Span, arg_span: Span) -> OxcDiagnostic {
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLengthAsSliceEnd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_lonely_if_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected `if` as the only statement in a `if` block without `else`.")
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLonelyIf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::IfStatement(if_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn no_magic_array_flat_map_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Magic number for `Array.prototype.flat` depth is not allowed.")
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMagicArrayFlatDepth {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected negated condition.")
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNegatedCondition {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let stmt_test = match node.kind() {
             AstKind::IfStatement(if_stmt) => {
                 let Some(if_stmt_alternate) = &if_stmt.alternate else {

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_negation_in_equality_check_diagnostic(
     span: Span,
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNegationInEqualityCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::BinaryExpression(binary_expr) = node.kind() {
             let Expression::UnaryExpression(left_unary_expr) = &binary_expr.left else {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn unparenthesized_nested_ternary(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected nested ternary expression without parentheses.")
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNestedTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ConditionalExpression(cond_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_array_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `new Array(singleArgument)`.").with_help(r"It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.").with_label(span)
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewArray {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_new_buffer_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Buffer.alloc()` or `Buffer.from()` instead of the deprecated `new Buffer()` constructor.")
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewBuffer {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -16,7 +16,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn no_null_diagnostic(null: Span) -> OxcDiagnostic {
@@ -174,20 +174,20 @@ impl Rule for NoNull {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NullLiteral(null_literal) = node.kind() else {
             return;
         };
 
         let mut parents = iter_outer_expressions(ctx, node.id());
-        let Some(parent_kind) = parents.next().map(AstNode::kind) else {
+        let Some(parent_kind) = parents.next().map(Node::kind) else {
             ctx.diagnostic_with_fix(no_null_diagnostic(null_literal.span), |fixer| {
                 fix_null(fixer, null_literal)
             });
             return;
         };
 
-        let grandparent_kind = parents.next().map(AstNode::kind);
+        let grandparent_kind = parents.next().map(Node::kind);
         match (parent_kind, grandparent_kind) {
             (AstKind::Argument(_), Some(AstKind::CallExpression(call_expr)))
                 if match_call_expression_pass_case(null_literal, call_expr) =>

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn identifier(span: Span, param: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{param}`."))
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoObjectAsDefaultParameter {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentPattern(assignment_pat) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn no_process_exit_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `process.exit()`.")
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoProcessExit {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::CallExpression(expr) = node.kind() {
             if is_method_call(expr, Some(&["process"]), Some(&["exit"]), None, None) {
                 if has_hashbang(ctx)
@@ -66,7 +66,7 @@ fn has_hashbang(ctx: &LintContext) -> bool {
     program.hashbang.is_some()
 }
 
-fn is_inside_process_event_handler(ctx: &LintContext, node: &AstNode) -> bool {
+fn is_inside_process_event_handler(ctx: &LintContext, node: &Node) -> bool {
     for parent in ctx.nodes().iter_parents(node.id()) {
         if let AstKind::CallExpression(expr) = parent.kind() {
             if is_method_call(expr, Some(&["process"]), Some(&["on", "once"]), Some(1), None) {

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn no_single_promise_in_promise_methods_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSinglePromiseInPromiseMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_static_only_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow classes that only have static members.")
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoStaticOnlyClass {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::Class(class) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not add `then` to an object.")
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoThenable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ObjectExpression(expr) => {
                 expr.properties.iter().for_each(|prop| {

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_this_assignment_diagnostic(span: Span, ident_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not assign `this` to `{ident_name}`"))
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoThisAssignment {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_decl) => {
                 let Some(init) = &variable_decl.init else {

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, Node};
 
 fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.")
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTypeofUndefined {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(bin_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unnecessary_await_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow awaiting non-promise values")
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::AwaitExpression(expr) = node.kind() {
             if !not_promise(&expr.argument) {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unreadable_array_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow unreadable array destructuring")
@@ -53,7 +53,7 @@ fn is_unreadable_array_destructuring<T, U>(elements: &Vec<Option<T>>, rest: &Opt
 }
 
 impl Rule for NoUnreadableArrayDestructuring {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ArrayPattern(array_pattern) = node.kind() {
             if is_unreadable_array_destructuring(&array_pattern.elements, &array_pattern.rest) {
                 ctx.diagnostic(no_unreadable_array_destructuring_diagnostic(array_pattern.span));

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn no_unreadable_iife_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("IIFE with parenthesized arrow function body is considered unreadable.")
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnreadableIife {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::LogicalOperator;
 
-use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, Node};
 
 fn no_useless_fallback_in_spread_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow useless fallback when spreading in object literals")
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessFallbackInSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(logical_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn some(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Found a useless array length check")
@@ -153,7 +153,7 @@ fn is_useless_check<'a>(
 }
 
 impl Rule for NoUselessLengthCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::LogicalExpression(log_expr) = node.kind() {
             if ![LogicalOperator::And, LogicalOperator::Or].contains(&log_expr.operator) {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn spread_in_list(span: Span, arr_or_obj: &str) -> OxcDiagnostic {
@@ -147,7 +147,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if !matches!(node.kind(), AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_)) {
             return;
         }
@@ -179,7 +179,7 @@ impl Rule for NoUselessSpread {
     }
 }
 
-fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+fn check_useless_spread_in_list<'a>(node: &Node<'a>, ctx: &LintContext<'a>) -> bool {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return false;
     };
@@ -287,7 +287,7 @@ fn diagnose_array_in_array_spread<'a>(
 }
 
 fn check_useless_iterable_to_array<'a>(
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     array_expr: &ArrayExpression<'a>,
     spread_elem: &SpreadElement<'a>,
     ctx: &LintContext<'a>,

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::is_empty_stmt, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_empty_stmt, Node};
 
 fn no_useless_switch_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Useless case in switch statement.")
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessSwitchCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::SwitchStatement(switch_statement) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn warn() -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use useless `undefined`.")
@@ -131,7 +131,7 @@ fn is_undefined(arg: &Argument) -> bool {
     false
 }
 
-fn is_has_function_return_type(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+fn is_has_function_return_type(node: &Node, ctx: &LintContext<'_>) -> bool {
     let Some(parent_node) = ctx.nodes().parent_node(node.id()) else {
         return false;
     };
@@ -155,12 +155,12 @@ impl Rule for NoUselessUndefined {
         Self { check_arguments, check_arrow_function_body }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::IdentifierReference(undefined_literal)
                 if undefined_literal.name == "undefined" =>
             {
-                let mut parent_node: &AstNode<'a> = node;
+                let mut parent_node: &Node<'a> = node;
                 while let Some(parent) = ctx.nodes().parent_node(parent_node.id()) {
                     let parent_kind = parent.kind();
 

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn zero_fraction(span: Span, lit: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use a zero fraction in the number.")
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoZeroFractions {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::NumericLiteral(number_literal) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn uppercase_prefix(span: Span, prefix: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected number literal prefix in uppercase.")
@@ -78,7 +78,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumberLiteralCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (raw_literal, raw_span) = match node.kind() {
             AstKind::NumericLiteral(number) => (number.raw, number.span),
             AstKind::BigIntLiteral(number) => {

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -9,7 +9,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn numeric_separators_style_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid group length in numeric value.")
@@ -85,7 +85,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumericSeparatorsStyle {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::NumericLiteral(number) => {
                 if self.only_if_contains_separator && !number.raw.contains('_') {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_add_event_listener_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.")
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAddEventListener {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -16,7 +16,7 @@ use crate::{
         get_first_parameter_name, get_return_identifier_name, is_empty_array_expression,
         is_prototype_property,
     },
-    AstNode,
+    Node,
 };
 
 fn prefer_array_flat_diagnostic(span: Span) -> OxcDiagnostic {
@@ -65,7 +65,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArrayFlat {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_method_call, context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, fixer::Fix, rule::Rule, Node};
 
 fn prefer_array_flat_map_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`Array.flatMap` performs `Array.map` and `Array.flat` in one step.")
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArrayFlatMap {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(flat_call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -12,7 +12,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::is_boolean_node,
-    AstNode,
+    Node,
 };
 
 fn over_method(span: Span) -> OxcDiagnostic {
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArraySome {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 if !is_method_call(call_expr, None, Some(&["find", "findLast"]), Some(1), Some(2)) {
@@ -197,7 +197,7 @@ fn is_node_value_not_function(expr: &Expression) -> bool {
 }
 
 fn is_checking_undefined<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     _call_expr: &'b CallExpression<'a>,
     ctx: &'b LintContext<'a>,
 ) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_blob_reading_methods_diagnostic(
     span: Span,
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferBlobReadingMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_code_point_diagnostic(span: Span, good_method: &str, bad_method: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `{good_method}` over `{bad_method}`"))
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferCodePoint {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_date_now(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Date.now()` over `new Date()`")
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDateNow {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 // `new Date().{getTime,valueOf}()`

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_dom_node_append_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Node#append()` over `Node#appendChild()` for DOM nodes.")
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeAppend {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn set(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `setAttribute`.")
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeDataset {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -7,7 +7,7 @@ use crate::{
     ast_util::{call_expr_method_callee_info, is_method_call},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn prefer_dom_node_remove_diagnostic(span: Span) -> OxcDiagnostic {
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeRemove {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_dom_node_text_content_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `.textContent` over `.innerText`.")
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeTextContent {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         if let AstKind::MemberExpression(member_expr) = node.kind() {
             if let Some((span, name)) = member_expr.static_property_info() {
                 if name == "innerText" && !member_expr.is_computed() {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_event_target_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `EventTarget` over `EventEmitter`")
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEventTarget {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::IdentifierReference(ident) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -8,7 +8,7 @@ use crate::{
     ast_util::{call_expr_method_callee_info, is_method_call},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn prefer_includes_diagnostic(span: Span) -> OxcDiagnostic {
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferIncludes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::BinaryExpression(bin_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_same_reference, Node};
 
 fn prefer_logical_operator_over_ternary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using a logical operator over a ternary.")
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferLogicalOperatorOverTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ConditionalExpression(conditional_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_math_trunc_diagnostic(span: Span, bad_op: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{bad_op} 0`."))
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferMathTrunc {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let operator = match node.kind() {
             AstKind::UnaryExpression(unary_expr) => {
                 if !matches!(unary_expr.operator, UnaryOperator::BitwiseNot) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::phf_map;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn prefer_modern_dom_apis_diagnostic(
     good_method: &str,
@@ -66,7 +66,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferModernDomApis {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -8,7 +8,7 @@ use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 
 use crate::{
-    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_reference, AstNode,
+    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_reference, Node,
 };
 
 fn prefer_math_abs(span: Span) -> OxcDiagnostic {
@@ -59,7 +59,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferModernMathApis {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // there are two main cases to check:
         // Bin expression:
         //     `Math.log(x) * Math.LOG10E`

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::get_first_parameter_name, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::get_first_parameter_name, Node};
 
 fn function(span: Span, called_fn: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNativeCoercionFunctions {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ArrowFunctionExpression(arrow_expr) => {
                 if arrow_expr.r#async || arrow_expr.params.items.len() == 0 {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_resolver::NODEJS_BUILTINS;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_node_protocol_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using the `node:` protocol when importing Node.js builtin modules.")
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNodeProtocol {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let string_lit_value_with_span = match node.kind() {
             AstKind::ImportExpression(import) => match import.source {
                 Expression::StringLiteral(ref str_lit) => {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
+use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, Node};
 
 fn prefer_number_properties_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `Number.{method_name}` instead of the global `{method_name}`"))
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNumberProperties {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::MemberExpression(member_expr) => {
                 let Expression::Identifier(ident_name) = member_expr.object() else {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_optional_catch_binding_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer omitting the catch binding parameter if it is unused")
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferOptionalCatchBinding {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CatchParameter(catch_param) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -8,7 +8,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_empty_array_expression, is_empty_object_expression},
-    AstNode,
+    Node,
 };
 
 fn known_method(span: Span, obj_name: &str, method_name: &str) -> OxcDiagnostic {
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferPrototypeMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::phf_map;
 
-use crate::{context::LintContext, rule::Rule, utils::is_node_value_not_dom_node, AstNode};
+use crate::{context::LintContext, rule::Rule, utils::is_node_value_not_dom_node, Node};
 
 fn prefer_query_selector_diagnostic(
     good_method: &str,
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferQuerySelector {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_reflect_apply_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer Reflect.apply() over Function#apply()")
@@ -57,7 +57,7 @@ fn is_static_property_name_equal(expr: &MemberExpression, value: &str) -> bool {
 }
 
 impl Rule for PreferReflectApply {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, Node};
 
 fn prefer_regexp_test_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer RegExp#test() over String#match() and RegExp#exec()")
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferRegexpTest {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
-    ast_util::get_declaration_of_variable, context::LintContext, fixer::Fix, rule::Rule, AstNode,
+    ast_util::get_declaration_of_variable, context::LintContext, fixer::Fix, rule::Rule, Node,
 };
 
 fn prefer_set_size_diagnostic(span: Span) -> OxcDiagnostic {
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSetSize {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::MemberExpression(member_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::phf_set;
 
-use crate::{ast_util, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util, context::LintContext, rule::Rule, Node};
 
 fn prefer_spread_diagnostic(span: Span, bad_method: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer the spread operator (`...`) over {bad_method}"))
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Node};
 
 fn string_literal(span: Span, replacement: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("This pattern can be replaced with `{replacement}`."))
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringReplaceAll {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_string_slice_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer String#slice() over String#{method_name}()"))
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringSlice {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -10,7 +10,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn starts_with(span: Span) -> OxcDiagnostic {
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringStartsEndsWith {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_string_trim_start_end_diagnostic(
     span: Span,
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringTrimStartEnd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -5,7 +5,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, Node};
 
 fn prefer_structured_clone_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `structuredClone(…)` to create a deep clone.")
@@ -71,7 +71,7 @@ impl Rule for PreferStructuredClone {
         Self(Box::new(PreferStructuredCloneConfig { allowed_functions }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr): oxc_ast::AstKind<'a> = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn prefer_type_error_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferTypeError {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::ThrowStatement(throw_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -4,8 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_prototype_property,
-    AstNode,
+    ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_prototype_property, Node,
 };
 
 fn require_array_join_separator_diagnostic(span: Span) -> OxcDiagnostic {
@@ -48,7 +47,7 @@ fn is_array_prototype_property(member_expr: &MemberExpression, property: &str) -
 }
 
 impl Rule for RequireArrayJoinSeparator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn require_number_to_fixed_digits_argument_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Number method .toFixed() should have an argument")
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireNumberToFixedDigitsArgument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn switch_case_braces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for SwitchCaseBraces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, Node};
 
 fn text_encoding_identifier_case_diagnostic(
     span: Span,
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for TextEncodingIdentifierCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let (s, span) = match node.kind() {
             AstKind::StringLiteral(string_lit) => (&string_lit.value, string_lit.span),
             AstKind::JSXText(jsx_text) => (&jsx_text.value, jsx_text.span),

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -12,7 +12,7 @@ use crate::{
     ast_util::{outermost_paren, outermost_paren_parent},
     context::LintContext,
     rule::Rule,
-    AstNode,
+    Node,
 };
 
 fn throw_new_error_diagnostic(span: Span) -> OxcDiagnostic {
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ThrowNewError {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/vitest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_each.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, NodeId};
+use oxc_semantic::{Node, NodeId};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -78,7 +78,7 @@ impl Rule for PreferEach {
 }
 
 impl PreferEach {
-    fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, skip: &mut HashSet<NodeId>) {
+    fn run<'a>(node: &Node<'a>, ctx: &LintContext<'a>, skip: &mut HashSet<NodeId>) {
         let kind = node.kind();
 
         let AstKind::CallExpression(call_expr) = kind else { return };

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     },
     AstKind,
 };
-use oxc_semantic::{AstNode, ReferenceId};
+use oxc_semantic::{Node, ReferenceId};
 use phf::phf_set;
 
 use crate::LintContext;
@@ -139,7 +139,7 @@ pub fn parse_expect_jest_fn_call<'a>(
 }
 
 pub struct PossibleJestNode<'a, 'b> {
-    pub node: &'b AstNode<'a>,
+    pub node: &'b Node<'a>,
     pub original: Option<&'a str>, // if this node is imported from 'jest/globals', this field will be Some(original_name), otherwise None
 }
 

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
     },
     AstKind,
 };
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::Span;
 
 use crate::{
@@ -233,7 +233,7 @@ fn find_modifiers_and_matcher(
     Err(ExpectError::MatcherNotFound)
 }
 
-fn is_top_most_call_expr<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_top_most_call_expr<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let mut node = node;
 
     loop {
@@ -286,7 +286,7 @@ pub struct ExpectFnCallOptions<'a, 'b> {
     pub name: &'a str,
     pub local: &'a str,
     pub head: KnownMemberExpressionProperty<'a>,
-    pub node: &'b AstNode<'a>,
+    pub node: &'b Node<'a>,
     pub ctx: &'b LintContext<'a>,
 }
 

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -6,7 +6,7 @@ use oxc_semantic::JSDoc;
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
-use crate::{config::JSDocPluginSettings, context::LintContext, AstNode};
+use crate::{config::JSDocPluginSettings, context::LintContext, Node};
 
 /// JSDoc is often attached on the parent node of a function.
 ///
@@ -26,9 +26,9 @@ use crate::{config::JSDocPluginSettings, context::LintContext, AstNode};
 /// class Y { qux = () => {} }
 /// ```
 pub fn get_function_nearest_jsdoc_node<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     let mut current_node = node;
     // Whether the node has attached JSDoc or not is determined by `JSDocBuilder`
     while ctx.jsdoc().get_all_by_node(current_node).is_none() {

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     },
     match_member_expression, AstKind,
 };
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 
 use crate::{LintContext, OxlintSettings};
 
@@ -146,7 +146,7 @@ pub fn is_interactive_element(element_type: &str, jsx_opening_el: &JSXOpeningEle
 const PRAGMA: &str = "React";
 const CREATE_CLASS: &str = "createReactClass";
 
-pub fn is_es5_component(node: &AstNode) -> bool {
+pub fn is_es5_component(node: &Node) -> bool {
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return false;
     };
@@ -168,7 +168,7 @@ pub fn is_es5_component(node: &AstNode) -> bool {
 const COMPONENT: &str = "Component";
 const PURE_COMPONENT: &str = "PureComponent";
 
-pub fn is_es6_component(node: &AstNode) -> bool {
+pub fn is_es6_component(node: &Node) -> bool {
     let AstKind::Class(class_expr) = node.kind() else {
         return false;
     };
@@ -191,9 +191,9 @@ pub fn is_es6_component(node: &AstNode) -> bool {
 }
 
 pub fn get_parent_component<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
-) -> Option<&'b AstNode<'a>> {
+) -> Option<&'b Node<'a>> {
     for node_id in ctx.nodes().ancestors(node.id()) {
         let node = ctx.nodes().get_node(node_id);
         if is_es5_component(node) || is_es6_component(node) {

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -11,7 +11,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{rule::Rule, AstNode, LintContext};
+use crate::{rule::Rule, LintContext, Node};
 
 fn react_perf_inline_diagnostic(message: &'static str, attr_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(message)
@@ -60,7 +60,7 @@ impl<R> Rule for R
 where
     R: ReactPerfRule,
 {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
         // new objects/arrays/etc created at the root scope do not get
         // re-created on each render and thus do not affect performance.
         if node.scope_id() == ctx.scopes().root_scope_id() {

--- a/crates/oxc_linter/src/utils/tree_shaking.rs
+++ b/crates/oxc_linter/src/utils/tree_shaking.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     ast::{Expression, IdentifierReference, StaticMemberExpression},
     AstKind, CommentKind,
 };
-use oxc_semantic::{AstNode, NodeId, SymbolId};
+use oxc_semantic::{Node, NodeId, SymbolId};
 use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
 use rustc_hash::FxHashSet;
@@ -310,7 +310,7 @@ pub fn get_leading_tree_shaking_comment<'a>(span: Span, ctx: &LintContext<'a>) -
 }
 
 pub fn is_local_variable_a_whitelisted_module(
-    node: &AstNode,
+    node: &Node,
     name: &str,
     options: &NodeListenerOptions,
 ) -> bool {

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
     },
     AstKind,
 };
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_syntax::operator::LogicalOperator;
 
 pub use self::boolean::*;
@@ -96,7 +96,7 @@ pub fn is_empty_object_expression(expr: &Expression) -> bool {
     }
 }
 
-pub fn is_logical_expression(node: &AstNode) -> bool {
+pub fn is_logical_expression(node: &Node) -> bool {
     matches!(
         node.kind(),
         AstKind::LogicalExpression(LogicalExpression {

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     ast::{CallExpression, ConditionalExpression, Expression},
     AstKind,
 };
-use oxc_semantic::AstNode;
+use oxc_semantic::Node;
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
@@ -11,7 +11,7 @@ use crate::{ast_util::outermost_paren_parent, LintContext};
 pub fn is_logic_not(node: &AstKind) -> bool {
     matches!(node, AstKind::UnaryExpression(unary_expr) if unary_expr.operator == UnaryOperator::LogicalNot)
 }
-fn is_logic_not_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_logic_not_argument<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return false;
     };
@@ -27,14 +27,14 @@ pub fn is_boolean_call(kind: &AstKind) -> bool {
         }) if ident.name == "Boolean" && arguments.len() == 1
     )
 }
-pub fn is_boolean_call_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+pub fn is_boolean_call_argument<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let arg_id = ctx.nodes().parent_id(node.id());
     let parent = arg_id.and_then(|id| ctx.nodes().parent_kind(id));
     // println!("{parent:#?}");
     matches!(parent, Some(parent) if is_boolean_call(&parent))
 }
 
-pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+pub fn is_boolean_node<'a, 'b>(node: &'b Node<'a>, ctx: &'b LintContext<'a>) -> bool {
     let kind = node.kind();
 
     if is_logic_not(&kind)
@@ -75,10 +75,10 @@ pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
 }
 
 pub fn get_boolean_ancestor<'a, 'b>(
-    node: &'b AstNode<'a>,
+    node: &'b Node<'a>,
     ctx: &'b LintContext<'a>,
     // (node, is_negative)
-) -> (&'b AstNode<'a>, bool) {
+) -> (&'b Node<'a>, bool) {
     let mut is_negative = false;
     let mut cur = node;
     loop {

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -61,7 +61,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let expanded = quote! {
         #(pub use self::#use_stmts::#struct_names;)*
 
-        use crate::{context::LintContext, rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta}, AstNode};
+        use crate::{context::LintContext, rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta}, Node};
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -116,7 +116,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub(super) fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+            pub(super) fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run(node, ctx)),*
                 }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -26,7 +26,7 @@ use crate::{
     jsdoc::JSDocBuilder,
     label::UnusedLabels,
     module_record::ModuleRecordBuilder,
-    node::{AstNodes, NodeFlags, NodeId},
+    node::{NodeFlags, NodeId, Nodes},
     reference::{Reference, ReferenceFlags, ReferenceId},
     scope::{Bindings, ScopeFlags, ScopeId, ScopeTree},
     stats::Stats,
@@ -87,7 +87,7 @@ pub struct SemanticBuilder<'a> {
     pub(crate) hoisting_variables: FxHashMap<ScopeId, FxHashMap<Atom<'a>, SymbolId>>,
 
     // builders
-    pub(crate) nodes: AstNodes<'a>,
+    pub(crate) nodes: Nodes<'a>,
     pub(crate) scope: ScopeTree,
     pub(crate) symbols: SymbolTable,
 
@@ -136,7 +136,7 @@ impl<'a> SemanticBuilder<'a> {
             current_scope_id,
             function_stack: vec![],
             namespace_stack: vec![],
-            nodes: AstNodes::default(),
+            nodes: Nodes::default(),
             hoisting_variables: FxHashMap::default(),
             scope,
             symbols: SymbolTable::default(),
@@ -237,7 +237,7 @@ impl<'a> SemanticBuilder<'a> {
             program.scope_id.set(Some(scope_id));
         } else {
             // Use counts of nodes, scopes, symbols, and references to pre-allocate sufficient capacity
-            // in `AstNodes`, `ScopeTree` and `SymbolTable`.
+            // in `Nodes`, `ScopeTree` and `SymbolTable`.
             //
             // This means that as we traverse the AST and fill up these structures with data,
             // they never need to grow and reallocate - which is an expensive operation as it

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -15,7 +15,7 @@ use oxc_syntax::{
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
 };
 
-use crate::{builder::SemanticBuilder, diagnostics::redeclaration, scope::ScopeFlags, AstNode};
+use crate::{builder::SemanticBuilder, diagnostics::redeclaration, scope::ScopeFlags, Node};
 
 pub fn check_duplicate_class_elements(ctx: &SemanticBuilder<'_>) {
     let classes = &ctx.class_table_builder.classes;
@@ -128,7 +128,7 @@ pub const STRICT_MODE_NAMES: Set<&'static str> = phf_set! {
     "yield",
 };
 
-pub fn check_identifier<'a>(name: &str, span: Span, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+pub fn check_identifier<'a>(name: &str, span: Span, node: &Node<'a>, ctx: &SemanticBuilder<'a>) {
     // ts module block allows revered keywords
     if ctx.current_scope_flags().is_ts_module_block() {
         return;
@@ -163,7 +163,7 @@ fn invalid_let_declaration(x0: &str, span1: Span) -> OxcDiagnostic {
 
 pub fn check_binding_identifier<'a>(
     ident: &BindingIdentifier,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     let strict_mode = ctx.strict_mode();
@@ -195,7 +195,7 @@ fn unexpected_arguments(x0: &str, span1: Span) -> OxcDiagnostic {
 
 pub fn check_identifier_reference<'a>(
     ident: &IdentifierReference,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     //  Static Semantics: AssignmentTargetType
@@ -384,7 +384,7 @@ fn module_code(x0: &str, span1: Span) -> OxcDiagnostic {
 
 pub fn check_module_declaration<'a>(
     decl: &ModuleDeclaration,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     // It is ambiguous between script and module for `TypeScript`, skipping this check for now.
@@ -441,7 +441,7 @@ fn import_meta_property(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("The only valid meta property for import is import.meta").with_label(span)
 }
 
-pub fn check_meta_property<'a>(prop: &MetaProperty, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+pub fn check_meta_property<'a>(prop: &MetaProperty, node: &Node<'a>, ctx: &SemanticBuilder<'a>) {
     match prop.meta.name.as_str() {
         "import" => {
             if prop.property.name == "meta" {
@@ -567,7 +567,7 @@ fn invalid_break(span: Span) -> OxcDiagnostic {
 
 pub fn check_break_statement<'a>(
     stmt: &BreakStatement,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     // It is a Syntax Error if this BreakStatement is not nested, directly or indirectly (but not crossing function or static initialization block boundaries), within an IterationStatement or a SwitchStatement.
@@ -613,7 +613,7 @@ fn invalid_continue(span: Span) -> OxcDiagnostic {
 
 pub fn check_continue_statement<'a>(
     stmt: &ContinueStatement,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     // It is a Syntax Error if this ContinueStatement is not nested, directly or indirectly (but not crossing function or static initialization block boundaries), within an IterationStatement.
@@ -667,7 +667,7 @@ fn label_redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
 
 pub fn check_labeled_statement<'a>(
     stmt: &LabeledStatement,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     for node_id in ctx.nodes.ancestors(node.id()).skip(1) {
@@ -702,7 +702,7 @@ fn unexpected_initializer_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnost
 pub fn check_for_statement_left<'a>(
     left: &ForStatementLeft,
     is_for_in: bool,
-    _node: &AstNode<'a>,
+    _node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     let ForStatementLeft::VariableDeclaration(decl) = left else { return };
@@ -742,7 +742,7 @@ fn require_class_name(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("A class name is required.").with_label(span)
 }
 
-pub fn check_class(class: &Class, node: &AstNode<'_>, ctx: &SemanticBuilder<'_>) {
+pub fn check_class(class: &Class, node: &Node<'_>, ctx: &SemanticBuilder<'_>) {
     check_private_identifier(ctx);
 
     if class.is_declaration()
@@ -832,7 +832,7 @@ fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
 .with_label(span)
 }
 
-pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+pub fn check_super<'a>(sup: &Super, node: &Node<'a>, ctx: &SemanticBuilder<'a>) {
     let super_call_span = match ctx.nodes.parent_kind(node.id()) {
         Some(AstKind::CallExpression(expr)) => Some(expr.span),
         Some(AstKind::NewExpression(expr)) => Some(expr.span),
@@ -945,7 +945,7 @@ fn a_rest_parameter_cannot_have_an_initializer(span: Span) -> OxcDiagnostic {
 
 pub fn check_formal_parameters<'a>(
     params: &FormalParameters,
-    _node: &AstNode<'a>,
+    _node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     if let Some(rest) = &params.rest {
@@ -1072,7 +1072,7 @@ fn delete_private_field(span: Span) -> OxcDiagnostic {
 
 pub fn check_unary_expression<'a>(
     unary_expr: &'a UnaryExpression,
-    _node: &AstNode<'a>,
+    _node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     // https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors
@@ -1089,7 +1089,7 @@ pub fn check_unary_expression<'a>(
     }
 }
 
-fn is_in_formal_parameters<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) -> bool {
+fn is_in_formal_parameters<'a>(node: &Node<'a>, ctx: &SemanticBuilder<'a>) -> bool {
     for node_id in ctx.nodes.ancestors(node.id()).skip(1) {
         match ctx.nodes.kind(node_id) {
             AstKind::FormalParameter(_) => return true,
@@ -1109,7 +1109,7 @@ fn await_or_yield_in_parameter(x0: &str, span1: Span) -> OxcDiagnostic {
 
 pub fn check_await_expression<'a>(
     expr: &AwaitExpression,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     if is_in_formal_parameters(node, ctx) {
@@ -1124,7 +1124,7 @@ pub fn check_await_expression<'a>(
 
 pub fn check_yield_expression<'a>(
     expr: &YieldExpression,
-    node: &AstNode<'a>,
+    node: &Node<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
     if is_in_formal_parameters(node, ctx) {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -10,9 +10,9 @@ use javascript as js;
 pub use javascript::check_module_record;
 use typescript as ts;
 
-use crate::{builder::SemanticBuilder, AstNode};
+use crate::{builder::SemanticBuilder, Node};
 
-pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+pub fn check<'a>(node: &Node<'a>, ctx: &SemanticBuilder<'a>) {
     let kind = node.kind();
 
     match kind {

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
 use oxc_span::GetSpan;
 use oxc_syntax::class::{ClassId, ElementKind};
 
-use crate::{AstNodes, NodeId};
+use crate::{NodeId, Nodes};
 
 use super::{
     table::{Element, PrivateIdentifierReference},
@@ -34,7 +34,7 @@ impl ClassTableBuilder {
         &mut self,
         class: &ClassBody,
         current_node_id: NodeId,
-        nodes: &AstNodes,
+        nodes: &Nodes,
     ) {
         let parent_id = nodes.parent_id(current_node_id).unwrap_or_else(|| unreachable!());
         self.current_class_id = Some(self.classes.declare_class(self.current_class_id, parent_id));
@@ -99,7 +99,7 @@ impl ClassTableBuilder {
         &mut self,
         ident: &PrivateIdentifier,
         current_node_id: NodeId,
-        nodes: &AstNodes,
+        nodes: &Nodes,
     ) {
         let parent_kind = nodes.parent_kind(current_node_id);
         if let Some(parent_kind) = parent_kind {

--- a/crates/oxc_semantic/src/dot.rs
+++ b/crates/oxc_semantic/src/dot.rs
@@ -12,7 +12,7 @@ use oxc_cfg::{
 };
 use oxc_syntax::node::NodeId;
 
-use crate::{AstNode, AstNodes};
+use crate::{Node, Nodes};
 
 pub trait DisplayDot {
     fn display_dot(&self) -> String;
@@ -23,7 +23,7 @@ pub trait DebugDot {
 }
 
 #[derive(Clone, Copy)]
-pub struct DebugDotContext<'a, 'b>(&'b AstNodes<'a>);
+pub struct DebugDotContext<'a, 'b>(&'b Nodes<'a>);
 
 impl<'a, 'b> DebugDotContext<'a, 'b> {
     fn debug_ast_kind(self, id: NodeId) -> String {
@@ -42,8 +42,8 @@ impl<'a, 'b> DebugDotContext<'a, 'b> {
     }
 }
 
-impl<'a, 'b> From<&'b AstNodes<'a>> for DebugDotContext<'a, 'b> {
-    fn from(value: &'b AstNodes<'a>) -> Self {
+impl<'a, 'b> From<&'b Nodes<'a>> for DebugDotContext<'a, 'b> {
+    fn from(value: &'b Nodes<'a>) -> Self {
         Self(value)
     }
 }
@@ -118,7 +118,7 @@ impl DebugDot for Instruction {
             }
             InstructionKind::Break(LabeledInstruction::Labeled) => {
                 let Some(AstKind::BreakStatement(BreakStatement { label: Some(label), .. })) =
-                    self.node_id.map(|id| ctx.0.get_node(id)).map(AstNode::kind)
+                    self.node_id.map(|id| ctx.0.get_node(id)).map(Node::kind)
                 else {
                     unreachable!(
                         "Expected a label node to be associated with an labeled break instruction. {:?}",
@@ -131,7 +131,7 @@ impl DebugDot for Instruction {
             InstructionKind::Continue(LabeledInstruction::Labeled) => {
                 let Some(AstKind::ContinueStatement(ContinueStatement {
                     label: Some(label), ..
-                })) = self.node_id.map(|id| ctx.0.get_node(id)).map(AstNode::kind)
+                })) = self.node_id.map(|id| ctx.0.get_node(id)).map(Node::kind)
                 else {
                     unreachable!(
                         "Expected a label node to be associated with an labeled continue instruction. {:?}",

--- a/crates/oxc_semantic/src/jsdoc/finder.rs
+++ b/crates/oxc_semantic/src/jsdoc/finder.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use oxc_span::{GetSpan, Span};
 
-use crate::AstNode;
+use crate::Node;
 
 use super::parser::JSDoc;
 
@@ -18,7 +18,7 @@ impl<'a> JSDocFinder<'a> {
         Self { attached, not_attached }
     }
 
-    pub fn get_one_by_node<'b>(&'b self, node: &AstNode<'a>) -> Option<JSDoc<'a>> {
+    pub fn get_one_by_node<'b>(&'b self, node: &Node<'a>) -> Option<JSDoc<'a>> {
         let jsdocs = self.get_all_by_node(node)?;
 
         // If flagged, at least 1 JSDoc is attached
@@ -26,7 +26,7 @@ impl<'a> JSDocFinder<'a> {
         jsdocs.last().cloned()
     }
 
-    pub fn get_all_by_node<'b>(&'b self, node: &AstNode<'a>) -> Option<Vec<JSDoc<'a>>> {
+    pub fn get_all_by_node<'b>(&'b self, node: &Node<'a>) -> Option<Vec<JSDoc<'a>>> {
         if !node.flags().has_jsdoc() {
             return None;
         }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -37,7 +37,7 @@ mod unresolved_stack;
 pub use crate::{
     builder::{SemanticBuilder, SemanticBuilderReturn},
     jsdoc::{JSDoc, JSDocFinder, JSDocTag},
-    node::{AstNode, AstNodes, NodeId},
+    node::{Node, NodeId, Nodes},
     reference::{Reference, ReferenceFlags, ReferenceId},
     scope::ScopeTree,
     stats::Stats,
@@ -53,7 +53,7 @@ use class::ClassTable;
 ///
 /// Do not construct this struct directly; instead, use [`SemanticBuilder`].
 ///
-/// [`Abstract Syntax Tree (AST)`]: crate::AstNodes
+/// [`Abstract Syntax Tree (AST)`]: crate::Nodes
 /// [`scope tree`]: crate::ScopeTree
 /// [`symbol table`]: crate::SymbolTable
 /// [`control flow graph (CFG)`]: crate::ControlFlowGraph
@@ -65,7 +65,7 @@ pub struct Semantic<'a> {
     source_type: SourceType,
 
     /// The Abstract Syntax Tree (AST) nodes.
-    nodes: AstNodes<'a>,
+    nodes: Nodes<'a>,
 
     /// The scope tree containing scopes and what identifier names are bound in
     /// each one.
@@ -109,7 +109,7 @@ impl<'a> Semantic<'a> {
     }
 
     /// Nodes in the Abstract Syntax Tree (AST)
-    pub fn nodes(&self) -> &AstNodes<'a> {
+    pub fn nodes(&self) -> &Nodes<'a> {
         &self.nodes
     }
 
@@ -192,7 +192,7 @@ impl<'a> Semantic<'a> {
         self.symbols.get_resolved_references(symbol_id)
     }
 
-    pub fn symbol_declaration(&self, symbol_id: SymbolId) -> &AstNode<'a> {
+    pub fn symbol_declaration(&self, symbol_id: SymbolId) -> &Node<'a> {
         self.nodes.get_node(self.symbols.get_declaration(symbol_id))
     }
 

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -219,9 +219,9 @@ impl ScopeTree {
         &self.bindings[scope_id]
     }
 
-    /// Get the ID of the [`AstNode`] that created a scope.
+    /// Get the ID of the [`Node`] that created a scope.
     ///
-    /// [`AstNode`]: crate::AstNode
+    /// [`Node`]: crate::Node
     #[inline]
     pub fn get_node_id(&self, scope_id: ScopeId) -> NodeId {
         self.node_ids[scope_id]

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -43,7 +43,7 @@ macro_rules! assert_ge {
 ///
 /// Comprises number of AST nodes, scopes, symbols, and references.
 ///
-/// These counts can be used to pre-allocate sufficient capacity in `AstNodes`,
+/// These counts can be used to pre-allocate sufficient capacity in `Nodes`,
 /// `ScopeTree`, and `SymbolTable` to store info for all these items.
 ///
 /// * Obtain `Stats` from an existing [`Semantic`] with [`Semantic::stats`].

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -6,7 +6,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFixer, RuleFix},
     rule::Rule,
-    AstNode
+    Node
 };
 
 #[derive(Debug, Default, Clone)]
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for {{pascal_rule_name}} {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &Node<'a>, ctx: &LintContext<'a>) {
 
     }
 }


### PR DESCRIPTION
#5740 renamed `AstNodeId` to `NodeId`. To match this, also rename:

* `AstNode` -> `Node`
* `AstNodes` -> `Nodes`
