### PR TITLE
chore(transformer): a small `ast_helper` via `oxc_parser`.

### DIFF
--- a/crates/oxc_transformer/src/helpers/ast_helper.rs
+++ b/crates/oxc_transformer/src/helpers/ast_helper.rs
@@ -1,0 +1,41 @@
+#[macro_export]
+macro_rules! ast_helper {
+    ($allocator: expr, $source: ident) => {{
+        let source_type = oxc_span::SourceType::mjs();
+        let ret = oxc_parser::Parser::new($allocator, &$source, source_type).parse();
+        if !ret.errors.is_empty() {
+            // Since the code is only used in `oxc_transformer` crate, we can use `panic!` here.
+            panic!("Parser Errors: {:?} in using ast_helper", ret.errors);
+        }
+        ret
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+
+    #[test]
+    fn test_ast_helper() {
+        let allocator = Allocator::default();
+        let source = format!("const a = {}", 0);
+        let ast = ast_helper!(&allocator, source);
+        assert_eq!(ast.program.body.len(), 1);
+    }
+    
+    #[test]
+    fn test_more_complex_ast_helper() {
+        let allocator = Allocator::default();
+        let key = "key";
+        let src = format!(r#"Object.defineProperty(exports, {key}, {{
+    enumerable: true,
+    writable: true,
+    value: function () {{
+        return 0;
+    }}
+}})
+"#);
+        let ast = ast_helper!(&allocator, src);
+        assert_eq!(ast.program.body.len(), 1);
+    }
+}

--- a/crates/oxc_transformer/src/helpers/ast_helper.rs
+++ b/crates/oxc_transformer/src/helpers/ast_helper.rs
@@ -22,19 +22,21 @@ mod tests {
         let ast = ast_helper!(&allocator, source);
         assert_eq!(ast.program.body.len(), 1);
     }
-    
+
     #[test]
     fn test_more_complex_ast_helper() {
         let allocator = Allocator::default();
         let key = "key";
-        let src = format!(r#"Object.defineProperty(exports, {key}, {{
+        let src = format!(
+            r#"Object.defineProperty(exports, {key}, {{
     enumerable: true,
     writable: true,
     value: function () {{
         return 0;
     }}
 }})
-"#);
+"#
+        );
         let ast = ast_helper!(&allocator, src);
         assert_eq!(ast.program.body.len(), 1);
     }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -27,6 +27,8 @@ mod typescript;
 mod helpers {
     pub mod bindings;
     pub mod module_imports;
+    #[macro_use]
+    pub mod ast_helper;
 }
 
 use std::{path::Path, rc::Rc};


### PR DESCRIPTION
Related: https://github.com/oxc-project/backlog/issues/184.

I recently conceived the concept of a transitional phase. In my opinion, the current plan for `ast! { let Foo = ${a} }` syntax is overly complex for the time being. However, it appears that the Babel helper is somewhat indispensable for handling `commonjs` and `async/await`.