### PR TITLE
feat(ast): add a dummy `node_id` field to all visitable AST types.

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -6,6 +6,7 @@ src:
   - 'crates/oxc_ast/src/ast/js.rs'
   - 'crates/oxc_ast/src/ast/ts.rs'
   - 'crates/oxc_ast/src/ast/jsx.rs'
+  - 'crates/oxc_syntax/src/node.rs'
   - 'crates/oxc_syntax/src/number.rs'
   - 'crates/oxc_syntax/src/operator.rs'
   - 'crates/oxc_span/src/span/types.rs'

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -204,10 +204,8 @@ impl<'a> AstBuilder<'a> {
         extends: Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>,
     ) -> Vec<'a, TSInterfaceHeritage<'a>> {
         Vec::from_iter_in(
-            extends.into_iter().map(|(expression, type_parameters, span)| TSInterfaceHeritage {
-                span,
-                expression,
-                type_parameters,
+            extends.into_iter().map(|(expression, type_parameters, span)| {
+                self.ts_interface_heritage(span, expression, type_parameters)
             }),
             self.allocator,
         )

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -3,7 +3,8 @@ use std::{borrow::Cow, cell::Cell, fmt};
 use oxc_allocator::{Box, FromIn, Vec};
 use oxc_span::{Atom, GetSpan, SourceType, Span};
 use oxc_syntax::{
-    operator::UnaryOperator, reference::ReferenceId, scope::ScopeFlags, symbol::SymbolId,
+    node::NodeId, operator::UnaryOperator, reference::ReferenceId, scope::ScopeFlags,
+    symbol::SymbolId,
 };
 
 use crate::ast::*;
@@ -33,7 +34,15 @@ impl<'a> Program<'a> {
         hashbang: Option<Hashbang<'a>>,
         body: Vec<'a, Statement<'a>>,
     ) -> Self {
-        Self { span, source_type, directives, hashbang, body, scope_id: Cell::default() }
+        Self {
+            node_id: NodeId::DUMMY,
+            span,
+            source_type,
+            directives,
+            hashbang,
+            body,
+            scope_id: Cell::default(),
+        }
     }
 }
 
@@ -314,7 +323,7 @@ impl<'a> Expression<'a> {
 
 impl<'a> IdentifierName<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name }
+        Self { node_id: NodeId::DUMMY, span, name }
     }
 }
 
@@ -328,7 +337,7 @@ impl<'a> fmt::Display for IdentifierName<'a> {
 impl<'a> IdentifierReference<'a> {
     #[inline]
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name, reference_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, name, reference_id: Cell::default() }
     }
 
     #[inline]
@@ -337,7 +346,7 @@ impl<'a> IdentifierReference<'a> {
         name: Atom<'a>,
         reference_id: Option<ReferenceId>,
     ) -> Self {
-        Self { span, name, reference_id: Cell::new(reference_id) }
+        Self { node_id: NodeId::DUMMY, span, name, reference_id: Cell::new(reference_id) }
     }
 
     #[inline]
@@ -354,7 +363,7 @@ impl<'a> fmt::Display for IdentifierReference<'a> {
 
 impl<'a> BindingIdentifier<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name, symbol_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, name, symbol_id: Cell::default() }
     }
 }
 
@@ -669,7 +678,7 @@ impl<'a> ArrayAssignmentTarget<'a> {
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
     ) -> Self {
-        Self { span, elements, rest: None, trailing_comma: None }
+        Self { node_id: NodeId::DUMMY, span, elements, rest: None, trailing_comma: None }
     }
 }
 
@@ -678,7 +687,7 @@ impl<'a> ObjectAssignmentTarget<'a> {
         span: Span,
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
     ) -> Self {
-        Self { span, properties, rest: None }
+        Self { node_id: NodeId::DUMMY, span, properties, rest: None }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -734,7 +743,7 @@ impl<'a> Statement<'a> {
 impl<'a> FromIn<'a, Expression<'a>> for Statement<'a> {
     fn from_in(expression: Expression<'a>, allocator: &'a oxc_allocator::Allocator) -> Self {
         Statement::ExpressionStatement(Box::from_in(
-            ExpressionStatement { span: expression.span(), expression },
+            ExpressionStatement { node_id: NodeId::DUMMY, span: expression.span(), expression },
             allocator,
         ))
     }
@@ -751,7 +760,7 @@ impl<'a> Directive<'a> {
 
 impl<'a> BlockStatement<'a> {
     pub fn new(span: Span, body: Vec<'a, Statement<'a>>) -> Self {
-        Self { span, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, body, scope_id: Cell::default() }
     }
 }
 
@@ -844,7 +853,7 @@ impl<'a> ForStatement<'a> {
         update: Option<Expression<'a>>,
         body: Statement<'a>,
     ) -> Self {
-        Self { span, init, test, update, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, init, test, update, body, scope_id: Cell::default() }
     }
 }
 
@@ -863,7 +872,7 @@ impl<'a> ForInStatement<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> Self {
-        Self { span, left, right, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, left, right, body, scope_id: Cell::default() }
     }
 }
 
@@ -875,7 +884,7 @@ impl<'a> ForOfStatement<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> Self {
-        Self { span, r#await, left, right, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, r#await, left, right, body, scope_id: Cell::default() }
     }
 }
 
@@ -889,7 +898,7 @@ impl<'a> ForStatementLeft<'a> {
 
 impl<'a> SwitchStatement<'a> {
     pub fn new(span: Span, discriminant: Expression<'a>, cases: Vec<'a, SwitchCase<'a>>) -> Self {
-        Self { span, discriminant, cases, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, discriminant, cases, scope_id: Cell::default() }
     }
 }
 
@@ -905,13 +914,13 @@ impl<'a> CatchClause<'a> {
         param: Option<CatchParameter<'a>>,
         body: Box<'a, BlockStatement<'a>>,
     ) -> Self {
-        Self { span, param, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, param, body, scope_id: Cell::default() }
     }
 }
 
 impl<'a> BindingPattern<'a> {
     pub fn new_with_kind(kind: BindingPatternKind<'a>) -> Self {
-        Self { kind, type_annotation: None, optional: false }
+        Self { node_id: NodeId::DUMMY, kind, type_annotation: None, optional: false }
     }
 
     pub fn get_identifier(&self) -> Option<Atom<'a>> {
@@ -993,6 +1002,7 @@ impl<'a> Function<'a> {
         return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     ) -> Self {
         Self {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             id,
@@ -1113,6 +1123,7 @@ impl<'a> ArrowFunctionExpression<'a> {
         return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     ) -> Self {
         Self {
+            node_id: NodeId::DUMMY,
             span,
             expression,
             r#async,
@@ -1151,6 +1162,7 @@ impl<'a> Class<'a> {
         declare: bool,
     ) -> Self {
         Self {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             decorators,
@@ -1357,13 +1369,13 @@ impl MethodDefinitionType {
 
 impl<'a> PrivateIdentifier<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name }
+        Self { node_id: NodeId::DUMMY, span, name }
     }
 }
 
 impl<'a> StaticBlock<'a> {
     pub fn new(span: Span, body: Vec<'a, Statement<'a>>) -> Self {
-        Self { span, body, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, body, scope_id: Cell::default() }
     }
 }
 
@@ -1471,7 +1483,13 @@ impl<'a> ExportAllDeclaration<'a> {
 
 impl<'a> ExportSpecifier<'a> {
     pub fn new(span: Span, local: ModuleExportName<'a>, exported: ModuleExportName<'a>) -> Self {
-        Self { span, local, exported, export_kind: ImportOrExportKind::Value }
+        Self {
+            node_id: NodeId::DUMMY,
+            span,
+            local,
+            exported,
+            export_kind: ImportOrExportKind::Value,
+        }
     }
 }
 

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 use oxc_span::{Atom, Span};
+use oxc_syntax::node::NodeId;
 
 use crate::ast::*;
 
@@ -10,7 +11,7 @@ use crate::ast::*;
 
 impl<'a> JSXIdentifier<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name }
+        Self { node_id: NodeId::DUMMY, span, name }
     }
 }
 

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -12,13 +12,13 @@ use std::{
 use oxc_allocator::CloneIn;
 use oxc_regular_expression::ast::Pattern;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, Span};
-use oxc_syntax::number::NumberBase;
+use oxc_syntax::{node::NodeId, number::NumberBase};
 
 use crate::ast::*;
 
 impl BooleanLiteral {
     pub fn new(span: Span, value: bool) -> Self {
-        Self { span, value }
+        Self { node_id: NodeId::DUMMY, span, value }
     }
 
     pub fn as_str(&self) -> &'static str {
@@ -46,7 +46,7 @@ impl ContentHash for NullLiteral {
 
 impl NullLiteral {
     pub fn new(span: Span) -> Self {
-        Self { span }
+        Self { node_id: NodeId::DUMMY, span }
     }
 }
 
@@ -59,7 +59,7 @@ impl fmt::Display for NullLiteral {
 
 impl<'a> NumericLiteral<'a> {
     pub fn new(span: Span, value: f64, raw: &'a str, base: NumberBase) -> Self {
-        Self { span, value, raw, base }
+        Self { node_id: NodeId::DUMMY, span, value, raw, base }
     }
 
     /// port from [closure compiler](https://github.com/google/closure-compiler/blob/a4c880032fba961f7a6c06ef99daa3641810bfdd/src/com/google/javascript/jscomp/base/JSCompDoubles.java#L113)
@@ -261,7 +261,7 @@ impl fmt::Display for RegExpFlags {
 
 impl<'a> StringLiteral<'a> {
     pub fn new(span: Span, value: Atom<'a>) -> Self {
-        Self { span, value }
+        Self { node_id: NodeId::DUMMY, span, value }
     }
 
     /// Static Semantics: `IsStringWellFormedUnicode`

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -7,6 +7,7 @@ use std::{cell::Cell, fmt};
 
 use oxc_allocator::Vec;
 use oxc_span::{Atom, Span};
+use oxc_syntax::node::NodeId;
 
 use crate::ast::*;
 
@@ -18,7 +19,15 @@ impl<'a> TSEnumDeclaration<'a> {
         r#const: bool,
         declare: bool,
     ) -> Self {
-        Self { span, id, members, r#const, declare, scope_id: Cell::default() }
+        Self {
+            node_id: NodeId::DUMMY,
+            span,
+            id,
+            members,
+            r#const,
+            declare,
+            scope_id: Cell::default(),
+        }
     }
 }
 
@@ -151,7 +160,7 @@ impl<'a> TSModuleDeclaration<'a> {
         kind: TSModuleDeclarationKind,
         declare: bool,
     ) -> Self {
-        Self { span, id, body, kind, declare, scope_id: Cell::default() }
+        Self { node_id: NodeId::DUMMY, span, id, body, kind, declare, scope_id: Cell::default() }
     }
 
     pub fn is_strict(&self) -> bool {

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -8,36 +8,42 @@ use crate::ast::*;
 
 #[allow(clippy::wildcard_imports)]
 use oxc_regular_expression::ast::*;
+use oxc_syntax::node::NodeId;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    assert!(size_of::<BooleanLiteral>() == 12usize);
+    assert!(size_of::<BooleanLiteral>() == 16usize);
     assert!(align_of::<BooleanLiteral>() == 4usize);
-    assert!(offset_of!(BooleanLiteral, span) == 0usize);
-    assert!(offset_of!(BooleanLiteral, value) == 8usize);
+    assert!(offset_of!(BooleanLiteral, node_id) == 0usize);
+    assert!(offset_of!(BooleanLiteral, span) == 4usize);
+    assert!(offset_of!(BooleanLiteral, value) == 12usize);
 
-    assert!(size_of::<NullLiteral>() == 8usize);
+    assert!(size_of::<NullLiteral>() == 12usize);
     assert!(align_of::<NullLiteral>() == 4usize);
-    assert!(offset_of!(NullLiteral, span) == 0usize);
+    assert!(offset_of!(NullLiteral, node_id) == 0usize);
+    assert!(offset_of!(NullLiteral, span) == 4usize);
 
-    assert!(size_of::<NumericLiteral>() == 40usize);
+    assert!(size_of::<NumericLiteral>() == 48usize);
     assert!(align_of::<NumericLiteral>() == 8usize);
-    assert!(offset_of!(NumericLiteral, span) == 0usize);
-    assert!(offset_of!(NumericLiteral, value) == 8usize);
-    assert!(offset_of!(NumericLiteral, raw) == 16usize);
-    assert!(offset_of!(NumericLiteral, base) == 32usize);
+    assert!(offset_of!(NumericLiteral, node_id) == 0usize);
+    assert!(offset_of!(NumericLiteral, span) == 4usize);
+    assert!(offset_of!(NumericLiteral, value) == 16usize);
+    assert!(offset_of!(NumericLiteral, raw) == 24usize);
+    assert!(offset_of!(NumericLiteral, base) == 40usize);
 
-    assert!(size_of::<BigIntLiteral>() == 32usize);
+    assert!(size_of::<BigIntLiteral>() == 40usize);
     assert!(align_of::<BigIntLiteral>() == 8usize);
-    assert!(offset_of!(BigIntLiteral, span) == 0usize);
-    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
-    assert!(offset_of!(BigIntLiteral, base) == 24usize);
+    assert!(offset_of!(BigIntLiteral, node_id) == 0usize);
+    assert!(offset_of!(BigIntLiteral, span) == 4usize);
+    assert!(offset_of!(BigIntLiteral, raw) == 16usize);
+    assert!(offset_of!(BigIntLiteral, base) == 32usize);
 
-    assert!(size_of::<RegExpLiteral>() == 40usize);
+    assert!(size_of::<RegExpLiteral>() == 48usize);
     assert!(align_of::<RegExpLiteral>() == 8usize);
-    assert!(offset_of!(RegExpLiteral, span) == 0usize);
-    assert!(offset_of!(RegExpLiteral, value) == 8usize);
-    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
+    assert!(offset_of!(RegExpLiteral, node_id) == 0usize);
+    assert!(offset_of!(RegExpLiteral, span) == 4usize);
+    assert!(offset_of!(RegExpLiteral, value) == 12usize);
+    assert!(offset_of!(RegExpLiteral, regex) == 16usize);
 
     assert!(size_of::<RegExp>() == 32usize);
     assert!(align_of::<RegExp>() == 8usize);
@@ -50,75 +56,86 @@ const _: () = {
     assert!(size_of::<EmptyObject>() == 0usize);
     assert!(align_of::<EmptyObject>() == 1usize);
 
-    assert!(size_of::<StringLiteral>() == 24usize);
+    assert!(size_of::<StringLiteral>() == 32usize);
     assert!(align_of::<StringLiteral>() == 8usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
+    assert!(offset_of!(StringLiteral, node_id) == 0usize);
+    assert!(offset_of!(StringLiteral, span) == 4usize);
+    assert!(offset_of!(StringLiteral, value) == 16usize);
 
-    assert!(size_of::<Program>() == 112usize);
+    assert!(size_of::<Program>() == 120usize);
     assert!(align_of::<Program>() == 8usize);
-    assert!(offset_of!(Program, span) == 0usize);
-    assert!(offset_of!(Program, source_type) == 8usize);
+    assert!(offset_of!(Program, node_id) == 0usize);
+    assert!(offset_of!(Program, span) == 4usize);
+    assert!(offset_of!(Program, source_type) == 12usize);
     assert!(offset_of!(Program, hashbang) == 16usize);
-    assert!(offset_of!(Program, directives) == 40usize);
-    assert!(offset_of!(Program, body) == 72usize);
-    assert!(offset_of!(Program, scope_id) == 104usize);
+    assert!(offset_of!(Program, directives) == 48usize);
+    assert!(offset_of!(Program, body) == 80usize);
+    assert!(offset_of!(Program, scope_id) == 112usize);
 
     assert!(size_of::<Expression>() == 16usize);
     assert!(align_of::<Expression>() == 8usize);
 
-    assert!(size_of::<IdentifierName>() == 24usize);
+    assert!(size_of::<IdentifierName>() == 32usize);
     assert!(align_of::<IdentifierName>() == 8usize);
-    assert!(offset_of!(IdentifierName, span) == 0usize);
-    assert!(offset_of!(IdentifierName, name) == 8usize);
+    assert!(offset_of!(IdentifierName, node_id) == 0usize);
+    assert!(offset_of!(IdentifierName, span) == 4usize);
+    assert!(offset_of!(IdentifierName, name) == 16usize);
 
-    assert!(size_of::<IdentifierReference>() == 32usize);
+    assert!(size_of::<IdentifierReference>() == 40usize);
     assert!(align_of::<IdentifierReference>() == 8usize);
-    assert!(offset_of!(IdentifierReference, span) == 0usize);
-    assert!(offset_of!(IdentifierReference, name) == 8usize);
-    assert!(offset_of!(IdentifierReference, reference_id) == 24usize);
+    assert!(offset_of!(IdentifierReference, node_id) == 0usize);
+    assert!(offset_of!(IdentifierReference, span) == 4usize);
+    assert!(offset_of!(IdentifierReference, name) == 16usize);
+    assert!(offset_of!(IdentifierReference, reference_id) == 32usize);
 
-    assert!(size_of::<BindingIdentifier>() == 32usize);
+    assert!(size_of::<BindingIdentifier>() == 40usize);
     assert!(align_of::<BindingIdentifier>() == 8usize);
-    assert!(offset_of!(BindingIdentifier, span) == 0usize);
-    assert!(offset_of!(BindingIdentifier, name) == 8usize);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 24usize);
+    assert!(offset_of!(BindingIdentifier, node_id) == 0usize);
+    assert!(offset_of!(BindingIdentifier, span) == 4usize);
+    assert!(offset_of!(BindingIdentifier, name) == 16usize);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 32usize);
 
-    assert!(size_of::<LabelIdentifier>() == 24usize);
+    assert!(size_of::<LabelIdentifier>() == 32usize);
     assert!(align_of::<LabelIdentifier>() == 8usize);
-    assert!(offset_of!(LabelIdentifier, span) == 0usize);
-    assert!(offset_of!(LabelIdentifier, name) == 8usize);
+    assert!(offset_of!(LabelIdentifier, node_id) == 0usize);
+    assert!(offset_of!(LabelIdentifier, span) == 4usize);
+    assert!(offset_of!(LabelIdentifier, name) == 16usize);
 
-    assert!(size_of::<ThisExpression>() == 8usize);
+    assert!(size_of::<ThisExpression>() == 12usize);
     assert!(align_of::<ThisExpression>() == 4usize);
-    assert!(offset_of!(ThisExpression, span) == 0usize);
+    assert!(offset_of!(ThisExpression, node_id) == 0usize);
+    assert!(offset_of!(ThisExpression, span) == 4usize);
 
-    assert!(size_of::<ArrayExpression>() == 56usize);
+    assert!(size_of::<ArrayExpression>() == 64usize);
     assert!(align_of::<ArrayExpression>() == 8usize);
-    assert!(offset_of!(ArrayExpression, span) == 0usize);
-    assert!(offset_of!(ArrayExpression, elements) == 8usize);
-    assert!(offset_of!(ArrayExpression, trailing_comma) == 40usize);
+    assert!(offset_of!(ArrayExpression, node_id) == 0usize);
+    assert!(offset_of!(ArrayExpression, span) == 4usize);
+    assert!(offset_of!(ArrayExpression, elements) == 16usize);
+    assert!(offset_of!(ArrayExpression, trailing_comma) == 48usize);
 
-    assert!(size_of::<ArrayExpressionElement>() == 16usize);
+    assert!(size_of::<ArrayExpressionElement>() == 24usize);
     assert!(align_of::<ArrayExpressionElement>() == 8usize);
 
-    assert!(size_of::<Elision>() == 8usize);
+    assert!(size_of::<Elision>() == 12usize);
     assert!(align_of::<Elision>() == 4usize);
-    assert!(offset_of!(Elision, span) == 0usize);
+    assert!(offset_of!(Elision, node_id) == 0usize);
+    assert!(offset_of!(Elision, span) == 4usize);
 
-    assert!(size_of::<ObjectExpression>() == 56usize);
+    assert!(size_of::<ObjectExpression>() == 64usize);
     assert!(align_of::<ObjectExpression>() == 8usize);
-    assert!(offset_of!(ObjectExpression, span) == 0usize);
-    assert!(offset_of!(ObjectExpression, properties) == 8usize);
-    assert!(offset_of!(ObjectExpression, trailing_comma) == 40usize);
+    assert!(offset_of!(ObjectExpression, node_id) == 0usize);
+    assert!(offset_of!(ObjectExpression, span) == 4usize);
+    assert!(offset_of!(ObjectExpression, properties) == 16usize);
+    assert!(offset_of!(ObjectExpression, trailing_comma) == 48usize);
 
     assert!(size_of::<ObjectPropertyKind>() == 16usize);
     assert!(align_of::<ObjectPropertyKind>() == 8usize);
 
     assert!(size_of::<ObjectProperty>() == 72usize);
     assert!(align_of::<ObjectProperty>() == 8usize);
-    assert!(offset_of!(ObjectProperty, span) == 0usize);
-    assert!(offset_of!(ObjectProperty, kind) == 8usize);
+    assert!(offset_of!(ObjectProperty, node_id) == 0usize);
+    assert!(offset_of!(ObjectProperty, span) == 4usize);
+    assert!(offset_of!(ObjectProperty, kind) == 12usize);
     assert!(offset_of!(ObjectProperty, key) == 16usize);
     assert!(offset_of!(ObjectProperty, value) == 32usize);
     assert!(offset_of!(ObjectProperty, init) == 48usize);
@@ -132,23 +149,26 @@ const _: () = {
     assert!(size_of::<PropertyKind>() == 1usize);
     assert!(align_of::<PropertyKind>() == 1usize);
 
-    assert!(size_of::<TemplateLiteral>() == 72usize);
+    assert!(size_of::<TemplateLiteral>() == 80usize);
     assert!(align_of::<TemplateLiteral>() == 8usize);
-    assert!(offset_of!(TemplateLiteral, span) == 0usize);
-    assert!(offset_of!(TemplateLiteral, quasis) == 8usize);
-    assert!(offset_of!(TemplateLiteral, expressions) == 40usize);
+    assert!(offset_of!(TemplateLiteral, node_id) == 0usize);
+    assert!(offset_of!(TemplateLiteral, span) == 4usize);
+    assert!(offset_of!(TemplateLiteral, quasis) == 16usize);
+    assert!(offset_of!(TemplateLiteral, expressions) == 48usize);
 
-    assert!(size_of::<TaggedTemplateExpression>() == 104usize);
+    assert!(size_of::<TaggedTemplateExpression>() == 120usize);
     assert!(align_of::<TaggedTemplateExpression>() == 8usize);
-    assert!(offset_of!(TaggedTemplateExpression, span) == 0usize);
-    assert!(offset_of!(TaggedTemplateExpression, tag) == 8usize);
-    assert!(offset_of!(TaggedTemplateExpression, quasi) == 24usize);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 96usize);
+    assert!(offset_of!(TaggedTemplateExpression, node_id) == 0usize);
+    assert!(offset_of!(TaggedTemplateExpression, span) == 4usize);
+    assert!(offset_of!(TaggedTemplateExpression, tag) == 16usize);
+    assert!(offset_of!(TaggedTemplateExpression, quasi) == 32usize);
+    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 112usize);
 
     assert!(size_of::<TemplateElement>() == 48usize);
     assert!(align_of::<TemplateElement>() == 8usize);
-    assert!(offset_of!(TemplateElement, span) == 0usize);
-    assert!(offset_of!(TemplateElement, tail) == 8usize);
+    assert!(offset_of!(TemplateElement, node_id) == 0usize);
+    assert!(offset_of!(TemplateElement, span) == 4usize);
+    assert!(offset_of!(TemplateElement, tail) == 12usize);
     assert!(offset_of!(TemplateElement, value) == 16usize);
 
     assert!(size_of::<TemplateElementValue>() == 32usize);
@@ -159,101 +179,115 @@ const _: () = {
     assert!(size_of::<MemberExpression>() == 16usize);
     assert!(align_of::<MemberExpression>() == 8usize);
 
-    assert!(size_of::<ComputedMemberExpression>() == 48usize);
+    assert!(size_of::<ComputedMemberExpression>() == 56usize);
     assert!(align_of::<ComputedMemberExpression>() == 8usize);
-    assert!(offset_of!(ComputedMemberExpression, span) == 0usize);
-    assert!(offset_of!(ComputedMemberExpression, object) == 8usize);
-    assert!(offset_of!(ComputedMemberExpression, expression) == 24usize);
-    assert!(offset_of!(ComputedMemberExpression, optional) == 40usize);
+    assert!(offset_of!(ComputedMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(ComputedMemberExpression, span) == 4usize);
+    assert!(offset_of!(ComputedMemberExpression, object) == 16usize);
+    assert!(offset_of!(ComputedMemberExpression, expression) == 32usize);
+    assert!(offset_of!(ComputedMemberExpression, optional) == 48usize);
 
-    assert!(size_of::<StaticMemberExpression>() == 56usize);
+    assert!(size_of::<StaticMemberExpression>() == 72usize);
     assert!(align_of::<StaticMemberExpression>() == 8usize);
-    assert!(offset_of!(StaticMemberExpression, span) == 0usize);
-    assert!(offset_of!(StaticMemberExpression, object) == 8usize);
-    assert!(offset_of!(StaticMemberExpression, property) == 24usize);
-    assert!(offset_of!(StaticMemberExpression, optional) == 48usize);
+    assert!(offset_of!(StaticMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(StaticMemberExpression, span) == 4usize);
+    assert!(offset_of!(StaticMemberExpression, object) == 16usize);
+    assert!(offset_of!(StaticMemberExpression, property) == 32usize);
+    assert!(offset_of!(StaticMemberExpression, optional) == 64usize);
 
-    assert!(size_of::<PrivateFieldExpression>() == 56usize);
+    assert!(size_of::<PrivateFieldExpression>() == 72usize);
     assert!(align_of::<PrivateFieldExpression>() == 8usize);
-    assert!(offset_of!(PrivateFieldExpression, span) == 0usize);
-    assert!(offset_of!(PrivateFieldExpression, object) == 8usize);
-    assert!(offset_of!(PrivateFieldExpression, field) == 24usize);
-    assert!(offset_of!(PrivateFieldExpression, optional) == 48usize);
+    assert!(offset_of!(PrivateFieldExpression, node_id) == 0usize);
+    assert!(offset_of!(PrivateFieldExpression, span) == 4usize);
+    assert!(offset_of!(PrivateFieldExpression, object) == 16usize);
+    assert!(offset_of!(PrivateFieldExpression, field) == 32usize);
+    assert!(offset_of!(PrivateFieldExpression, optional) == 64usize);
 
-    assert!(size_of::<CallExpression>() == 72usize);
+    assert!(size_of::<CallExpression>() == 80usize);
     assert!(align_of::<CallExpression>() == 8usize);
-    assert!(offset_of!(CallExpression, span) == 0usize);
-    assert!(offset_of!(CallExpression, callee) == 8usize);
-    assert!(offset_of!(CallExpression, type_parameters) == 24usize);
-    assert!(offset_of!(CallExpression, arguments) == 32usize);
-    assert!(offset_of!(CallExpression, optional) == 64usize);
+    assert!(offset_of!(CallExpression, node_id) == 0usize);
+    assert!(offset_of!(CallExpression, span) == 4usize);
+    assert!(offset_of!(CallExpression, callee) == 16usize);
+    assert!(offset_of!(CallExpression, type_parameters) == 32usize);
+    assert!(offset_of!(CallExpression, arguments) == 40usize);
+    assert!(offset_of!(CallExpression, optional) == 72usize);
 
-    assert!(size_of::<NewExpression>() == 64usize);
+    assert!(size_of::<NewExpression>() == 72usize);
     assert!(align_of::<NewExpression>() == 8usize);
-    assert!(offset_of!(NewExpression, span) == 0usize);
-    assert!(offset_of!(NewExpression, callee) == 8usize);
-    assert!(offset_of!(NewExpression, arguments) == 24usize);
-    assert!(offset_of!(NewExpression, type_parameters) == 56usize);
+    assert!(offset_of!(NewExpression, node_id) == 0usize);
+    assert!(offset_of!(NewExpression, span) == 4usize);
+    assert!(offset_of!(NewExpression, callee) == 16usize);
+    assert!(offset_of!(NewExpression, arguments) == 32usize);
+    assert!(offset_of!(NewExpression, type_parameters) == 64usize);
 
-    assert!(size_of::<MetaProperty>() == 56usize);
+    assert!(size_of::<MetaProperty>() == 80usize);
     assert!(align_of::<MetaProperty>() == 8usize);
-    assert!(offset_of!(MetaProperty, span) == 0usize);
-    assert!(offset_of!(MetaProperty, meta) == 8usize);
-    assert!(offset_of!(MetaProperty, property) == 32usize);
+    assert!(offset_of!(MetaProperty, node_id) == 0usize);
+    assert!(offset_of!(MetaProperty, span) == 4usize);
+    assert!(offset_of!(MetaProperty, meta) == 16usize);
+    assert!(offset_of!(MetaProperty, property) == 48usize);
 
-    assert!(size_of::<SpreadElement>() == 24usize);
+    assert!(size_of::<SpreadElement>() == 32usize);
     assert!(align_of::<SpreadElement>() == 8usize);
-    assert!(offset_of!(SpreadElement, span) == 0usize);
-    assert!(offset_of!(SpreadElement, argument) == 8usize);
+    assert!(offset_of!(SpreadElement, node_id) == 0usize);
+    assert!(offset_of!(SpreadElement, span) == 4usize);
+    assert!(offset_of!(SpreadElement, argument) == 16usize);
 
     assert!(size_of::<Argument>() == 16usize);
     assert!(align_of::<Argument>() == 8usize);
 
     assert!(size_of::<UpdateExpression>() == 32usize);
     assert!(align_of::<UpdateExpression>() == 8usize);
-    assert!(offset_of!(UpdateExpression, span) == 0usize);
-    assert!(offset_of!(UpdateExpression, operator) == 8usize);
-    assert!(offset_of!(UpdateExpression, prefix) == 9usize);
+    assert!(offset_of!(UpdateExpression, node_id) == 0usize);
+    assert!(offset_of!(UpdateExpression, span) == 4usize);
+    assert!(offset_of!(UpdateExpression, operator) == 12usize);
+    assert!(offset_of!(UpdateExpression, prefix) == 13usize);
     assert!(offset_of!(UpdateExpression, argument) == 16usize);
 
     assert!(size_of::<UnaryExpression>() == 32usize);
     assert!(align_of::<UnaryExpression>() == 8usize);
-    assert!(offset_of!(UnaryExpression, span) == 0usize);
-    assert!(offset_of!(UnaryExpression, operator) == 8usize);
+    assert!(offset_of!(UnaryExpression, node_id) == 0usize);
+    assert!(offset_of!(UnaryExpression, span) == 4usize);
+    assert!(offset_of!(UnaryExpression, operator) == 12usize);
     assert!(offset_of!(UnaryExpression, argument) == 16usize);
 
-    assert!(size_of::<BinaryExpression>() == 48usize);
+    assert!(size_of::<BinaryExpression>() == 56usize);
     assert!(align_of::<BinaryExpression>() == 8usize);
-    assert!(offset_of!(BinaryExpression, span) == 0usize);
-    assert!(offset_of!(BinaryExpression, left) == 8usize);
-    assert!(offset_of!(BinaryExpression, operator) == 24usize);
-    assert!(offset_of!(BinaryExpression, right) == 32usize);
+    assert!(offset_of!(BinaryExpression, node_id) == 0usize);
+    assert!(offset_of!(BinaryExpression, span) == 4usize);
+    assert!(offset_of!(BinaryExpression, left) == 16usize);
+    assert!(offset_of!(BinaryExpression, operator) == 32usize);
+    assert!(offset_of!(BinaryExpression, right) == 40usize);
 
-    assert!(size_of::<PrivateInExpression>() == 56usize);
+    assert!(size_of::<PrivateInExpression>() == 72usize);
     assert!(align_of::<PrivateInExpression>() == 8usize);
-    assert!(offset_of!(PrivateInExpression, span) == 0usize);
-    assert!(offset_of!(PrivateInExpression, left) == 8usize);
-    assert!(offset_of!(PrivateInExpression, operator) == 32usize);
-    assert!(offset_of!(PrivateInExpression, right) == 40usize);
+    assert!(offset_of!(PrivateInExpression, node_id) == 0usize);
+    assert!(offset_of!(PrivateInExpression, span) == 4usize);
+    assert!(offset_of!(PrivateInExpression, left) == 16usize);
+    assert!(offset_of!(PrivateInExpression, operator) == 48usize);
+    assert!(offset_of!(PrivateInExpression, right) == 56usize);
 
-    assert!(size_of::<LogicalExpression>() == 48usize);
+    assert!(size_of::<LogicalExpression>() == 56usize);
     assert!(align_of::<LogicalExpression>() == 8usize);
-    assert!(offset_of!(LogicalExpression, span) == 0usize);
-    assert!(offset_of!(LogicalExpression, left) == 8usize);
-    assert!(offset_of!(LogicalExpression, operator) == 24usize);
-    assert!(offset_of!(LogicalExpression, right) == 32usize);
+    assert!(offset_of!(LogicalExpression, node_id) == 0usize);
+    assert!(offset_of!(LogicalExpression, span) == 4usize);
+    assert!(offset_of!(LogicalExpression, left) == 16usize);
+    assert!(offset_of!(LogicalExpression, operator) == 32usize);
+    assert!(offset_of!(LogicalExpression, right) == 40usize);
 
-    assert!(size_of::<ConditionalExpression>() == 56usize);
+    assert!(size_of::<ConditionalExpression>() == 64usize);
     assert!(align_of::<ConditionalExpression>() == 8usize);
-    assert!(offset_of!(ConditionalExpression, span) == 0usize);
-    assert!(offset_of!(ConditionalExpression, test) == 8usize);
-    assert!(offset_of!(ConditionalExpression, consequent) == 24usize);
-    assert!(offset_of!(ConditionalExpression, alternate) == 40usize);
+    assert!(offset_of!(ConditionalExpression, node_id) == 0usize);
+    assert!(offset_of!(ConditionalExpression, span) == 4usize);
+    assert!(offset_of!(ConditionalExpression, test) == 16usize);
+    assert!(offset_of!(ConditionalExpression, consequent) == 32usize);
+    assert!(offset_of!(ConditionalExpression, alternate) == 48usize);
 
     assert!(size_of::<AssignmentExpression>() == 48usize);
     assert!(align_of::<AssignmentExpression>() == 8usize);
-    assert!(offset_of!(AssignmentExpression, span) == 0usize);
-    assert!(offset_of!(AssignmentExpression, operator) == 8usize);
+    assert!(offset_of!(AssignmentExpression, node_id) == 0usize);
+    assert!(offset_of!(AssignmentExpression, span) == 4usize);
+    assert!(offset_of!(AssignmentExpression, operator) == 12usize);
     assert!(offset_of!(AssignmentExpression, left) == 16usize);
     assert!(offset_of!(AssignmentExpression, right) == 32usize);
 
@@ -266,332 +300,379 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 16usize);
     assert!(align_of::<AssignmentTargetPattern>() == 8usize);
 
-    assert!(size_of::<ArrayAssignmentTarget>() == 80usize);
+    assert!(size_of::<ArrayAssignmentTarget>() == 96usize);
     assert!(align_of::<ArrayAssignmentTarget>() == 8usize);
-    assert!(offset_of!(ArrayAssignmentTarget, span) == 0usize);
-    assert!(offset_of!(ArrayAssignmentTarget, elements) == 8usize);
-    assert!(offset_of!(ArrayAssignmentTarget, rest) == 40usize);
-    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 64usize);
+    assert!(offset_of!(ArrayAssignmentTarget, node_id) == 0usize);
+    assert!(offset_of!(ArrayAssignmentTarget, span) == 4usize);
+    assert!(offset_of!(ArrayAssignmentTarget, elements) == 16usize);
+    assert!(offset_of!(ArrayAssignmentTarget, rest) == 48usize);
+    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 80usize);
 
-    assert!(size_of::<ObjectAssignmentTarget>() == 64usize);
+    assert!(size_of::<ObjectAssignmentTarget>() == 80usize);
     assert!(align_of::<ObjectAssignmentTarget>() == 8usize);
-    assert!(offset_of!(ObjectAssignmentTarget, span) == 0usize);
-    assert!(offset_of!(ObjectAssignmentTarget, properties) == 8usize);
-    assert!(offset_of!(ObjectAssignmentTarget, rest) == 40usize);
+    assert!(offset_of!(ObjectAssignmentTarget, node_id) == 0usize);
+    assert!(offset_of!(ObjectAssignmentTarget, span) == 4usize);
+    assert!(offset_of!(ObjectAssignmentTarget, properties) == 16usize);
+    assert!(offset_of!(ObjectAssignmentTarget, rest) == 48usize);
 
-    assert!(size_of::<AssignmentTargetRest>() == 24usize);
+    assert!(size_of::<AssignmentTargetRest>() == 32usize);
     assert!(align_of::<AssignmentTargetRest>() == 8usize);
-    assert!(offset_of!(AssignmentTargetRest, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetRest, target) == 8usize);
+    assert!(offset_of!(AssignmentTargetRest, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetRest, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetRest, target) == 16usize);
 
     assert!(size_of::<AssignmentTargetMaybeDefault>() == 16usize);
     assert!(align_of::<AssignmentTargetMaybeDefault>() == 8usize);
 
-    assert!(size_of::<AssignmentTargetWithDefault>() == 40usize);
+    assert!(size_of::<AssignmentTargetWithDefault>() == 48usize);
     assert!(align_of::<AssignmentTargetWithDefault>() == 8usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, init) == 24usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, binding) == 16usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, init) == 32usize);
 
     assert!(size_of::<AssignmentTargetProperty>() == 16usize);
     assert!(align_of::<AssignmentTargetProperty>() == 8usize);
 
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 56usize);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 72usize);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 40usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 16usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 56usize);
 
-    assert!(size_of::<AssignmentTargetPropertyProperty>() == 40usize);
+    assert!(size_of::<AssignmentTargetPropertyProperty>() == 48usize);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, name) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 24usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, name) == 16usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 32usize);
 
-    assert!(size_of::<SequenceExpression>() == 40usize);
+    assert!(size_of::<SequenceExpression>() == 48usize);
     assert!(align_of::<SequenceExpression>() == 8usize);
-    assert!(offset_of!(SequenceExpression, span) == 0usize);
-    assert!(offset_of!(SequenceExpression, expressions) == 8usize);
+    assert!(offset_of!(SequenceExpression, node_id) == 0usize);
+    assert!(offset_of!(SequenceExpression, span) == 4usize);
+    assert!(offset_of!(SequenceExpression, expressions) == 16usize);
 
-    assert!(size_of::<Super>() == 8usize);
+    assert!(size_of::<Super>() == 12usize);
     assert!(align_of::<Super>() == 4usize);
-    assert!(offset_of!(Super, span) == 0usize);
+    assert!(offset_of!(Super, node_id) == 0usize);
+    assert!(offset_of!(Super, span) == 4usize);
 
-    assert!(size_of::<AwaitExpression>() == 24usize);
+    assert!(size_of::<AwaitExpression>() == 32usize);
     assert!(align_of::<AwaitExpression>() == 8usize);
-    assert!(offset_of!(AwaitExpression, span) == 0usize);
-    assert!(offset_of!(AwaitExpression, argument) == 8usize);
+    assert!(offset_of!(AwaitExpression, node_id) == 0usize);
+    assert!(offset_of!(AwaitExpression, span) == 4usize);
+    assert!(offset_of!(AwaitExpression, argument) == 16usize);
 
-    assert!(size_of::<ChainExpression>() == 24usize);
+    assert!(size_of::<ChainExpression>() == 32usize);
     assert!(align_of::<ChainExpression>() == 8usize);
-    assert!(offset_of!(ChainExpression, span) == 0usize);
-    assert!(offset_of!(ChainExpression, expression) == 8usize);
+    assert!(offset_of!(ChainExpression, node_id) == 0usize);
+    assert!(offset_of!(ChainExpression, span) == 4usize);
+    assert!(offset_of!(ChainExpression, expression) == 16usize);
 
     assert!(size_of::<ChainElement>() == 16usize);
     assert!(align_of::<ChainElement>() == 8usize);
 
-    assert!(size_of::<ParenthesizedExpression>() == 24usize);
+    assert!(size_of::<ParenthesizedExpression>() == 32usize);
     assert!(align_of::<ParenthesizedExpression>() == 8usize);
-    assert!(offset_of!(ParenthesizedExpression, span) == 0usize);
-    assert!(offset_of!(ParenthesizedExpression, expression) == 8usize);
+    assert!(offset_of!(ParenthesizedExpression, node_id) == 0usize);
+    assert!(offset_of!(ParenthesizedExpression, span) == 4usize);
+    assert!(offset_of!(ParenthesizedExpression, expression) == 16usize);
 
     assert!(size_of::<Statement>() == 16usize);
     assert!(align_of::<Statement>() == 8usize);
 
-    assert!(size_of::<Directive>() == 48usize);
+    assert!(size_of::<Directive>() == 64usize);
     assert!(align_of::<Directive>() == 8usize);
-    assert!(offset_of!(Directive, span) == 0usize);
-    assert!(offset_of!(Directive, expression) == 8usize);
-    assert!(offset_of!(Directive, directive) == 32usize);
+    assert!(offset_of!(Directive, node_id) == 0usize);
+    assert!(offset_of!(Directive, span) == 4usize);
+    assert!(offset_of!(Directive, expression) == 16usize);
+    assert!(offset_of!(Directive, directive) == 48usize);
 
-    assert!(size_of::<Hashbang>() == 24usize);
+    assert!(size_of::<Hashbang>() == 32usize);
     assert!(align_of::<Hashbang>() == 8usize);
-    assert!(offset_of!(Hashbang, span) == 0usize);
-    assert!(offset_of!(Hashbang, value) == 8usize);
+    assert!(offset_of!(Hashbang, node_id) == 0usize);
+    assert!(offset_of!(Hashbang, span) == 4usize);
+    assert!(offset_of!(Hashbang, value) == 16usize);
 
-    assert!(size_of::<BlockStatement>() == 48usize);
+    assert!(size_of::<BlockStatement>() == 56usize);
     assert!(align_of::<BlockStatement>() == 8usize);
-    assert!(offset_of!(BlockStatement, span) == 0usize);
-    assert!(offset_of!(BlockStatement, body) == 8usize);
-    assert!(offset_of!(BlockStatement, scope_id) == 40usize);
+    assert!(offset_of!(BlockStatement, node_id) == 0usize);
+    assert!(offset_of!(BlockStatement, span) == 4usize);
+    assert!(offset_of!(BlockStatement, body) == 16usize);
+    assert!(offset_of!(BlockStatement, scope_id) == 48usize);
 
     assert!(size_of::<Declaration>() == 16usize);
     assert!(align_of::<Declaration>() == 8usize);
 
     assert!(size_of::<VariableDeclaration>() == 56usize);
     assert!(align_of::<VariableDeclaration>() == 8usize);
-    assert!(offset_of!(VariableDeclaration, span) == 0usize);
-    assert!(offset_of!(VariableDeclaration, kind) == 8usize);
+    assert!(offset_of!(VariableDeclaration, node_id) == 0usize);
+    assert!(offset_of!(VariableDeclaration, span) == 4usize);
+    assert!(offset_of!(VariableDeclaration, kind) == 12usize);
     assert!(offset_of!(VariableDeclaration, declarations) == 16usize);
     assert!(offset_of!(VariableDeclaration, declare) == 48usize);
 
     assert!(size_of::<VariableDeclarationKind>() == 1usize);
     assert!(align_of::<VariableDeclarationKind>() == 1usize);
 
-    assert!(size_of::<VariableDeclarator>() == 72usize);
+    assert!(size_of::<VariableDeclarator>() == 80usize);
     assert!(align_of::<VariableDeclarator>() == 8usize);
-    assert!(offset_of!(VariableDeclarator, span) == 0usize);
-    assert!(offset_of!(VariableDeclarator, kind) == 8usize);
+    assert!(offset_of!(VariableDeclarator, node_id) == 0usize);
+    assert!(offset_of!(VariableDeclarator, span) == 4usize);
+    assert!(offset_of!(VariableDeclarator, kind) == 12usize);
     assert!(offset_of!(VariableDeclarator, id) == 16usize);
-    assert!(offset_of!(VariableDeclarator, init) == 48usize);
-    assert!(offset_of!(VariableDeclarator, definite) == 64usize);
+    assert!(offset_of!(VariableDeclarator, init) == 56usize);
+    assert!(offset_of!(VariableDeclarator, definite) == 72usize);
 
-    assert!(size_of::<EmptyStatement>() == 8usize);
+    assert!(size_of::<EmptyStatement>() == 12usize);
     assert!(align_of::<EmptyStatement>() == 4usize);
-    assert!(offset_of!(EmptyStatement, span) == 0usize);
+    assert!(offset_of!(EmptyStatement, node_id) == 0usize);
+    assert!(offset_of!(EmptyStatement, span) == 4usize);
 
-    assert!(size_of::<ExpressionStatement>() == 24usize);
+    assert!(size_of::<ExpressionStatement>() == 32usize);
     assert!(align_of::<ExpressionStatement>() == 8usize);
-    assert!(offset_of!(ExpressionStatement, span) == 0usize);
-    assert!(offset_of!(ExpressionStatement, expression) == 8usize);
+    assert!(offset_of!(ExpressionStatement, node_id) == 0usize);
+    assert!(offset_of!(ExpressionStatement, span) == 4usize);
+    assert!(offset_of!(ExpressionStatement, expression) == 16usize);
 
-    assert!(size_of::<IfStatement>() == 56usize);
+    assert!(size_of::<IfStatement>() == 64usize);
     assert!(align_of::<IfStatement>() == 8usize);
-    assert!(offset_of!(IfStatement, span) == 0usize);
-    assert!(offset_of!(IfStatement, test) == 8usize);
-    assert!(offset_of!(IfStatement, consequent) == 24usize);
-    assert!(offset_of!(IfStatement, alternate) == 40usize);
+    assert!(offset_of!(IfStatement, node_id) == 0usize);
+    assert!(offset_of!(IfStatement, span) == 4usize);
+    assert!(offset_of!(IfStatement, test) == 16usize);
+    assert!(offset_of!(IfStatement, consequent) == 32usize);
+    assert!(offset_of!(IfStatement, alternate) == 48usize);
 
-    assert!(size_of::<DoWhileStatement>() == 40usize);
+    assert!(size_of::<DoWhileStatement>() == 48usize);
     assert!(align_of::<DoWhileStatement>() == 8usize);
-    assert!(offset_of!(DoWhileStatement, span) == 0usize);
-    assert!(offset_of!(DoWhileStatement, body) == 8usize);
-    assert!(offset_of!(DoWhileStatement, test) == 24usize);
+    assert!(offset_of!(DoWhileStatement, node_id) == 0usize);
+    assert!(offset_of!(DoWhileStatement, span) == 4usize);
+    assert!(offset_of!(DoWhileStatement, body) == 16usize);
+    assert!(offset_of!(DoWhileStatement, test) == 32usize);
 
-    assert!(size_of::<WhileStatement>() == 40usize);
+    assert!(size_of::<WhileStatement>() == 48usize);
     assert!(align_of::<WhileStatement>() == 8usize);
-    assert!(offset_of!(WhileStatement, span) == 0usize);
-    assert!(offset_of!(WhileStatement, test) == 8usize);
-    assert!(offset_of!(WhileStatement, body) == 24usize);
+    assert!(offset_of!(WhileStatement, node_id) == 0usize);
+    assert!(offset_of!(WhileStatement, span) == 4usize);
+    assert!(offset_of!(WhileStatement, test) == 16usize);
+    assert!(offset_of!(WhileStatement, body) == 32usize);
 
-    assert!(size_of::<ForStatement>() == 80usize);
+    assert!(size_of::<ForStatement>() == 88usize);
     assert!(align_of::<ForStatement>() == 8usize);
-    assert!(offset_of!(ForStatement, span) == 0usize);
-    assert!(offset_of!(ForStatement, init) == 8usize);
-    assert!(offset_of!(ForStatement, test) == 24usize);
-    assert!(offset_of!(ForStatement, update) == 40usize);
-    assert!(offset_of!(ForStatement, body) == 56usize);
-    assert!(offset_of!(ForStatement, scope_id) == 72usize);
+    assert!(offset_of!(ForStatement, node_id) == 0usize);
+    assert!(offset_of!(ForStatement, span) == 4usize);
+    assert!(offset_of!(ForStatement, init) == 16usize);
+    assert!(offset_of!(ForStatement, test) == 32usize);
+    assert!(offset_of!(ForStatement, update) == 48usize);
+    assert!(offset_of!(ForStatement, body) == 64usize);
+    assert!(offset_of!(ForStatement, scope_id) == 80usize);
 
     assert!(size_of::<ForStatementInit>() == 16usize);
     assert!(align_of::<ForStatementInit>() == 8usize);
 
-    assert!(size_of::<ForInStatement>() == 64usize);
+    assert!(size_of::<ForInStatement>() == 72usize);
     assert!(align_of::<ForInStatement>() == 8usize);
-    assert!(offset_of!(ForInStatement, span) == 0usize);
-    assert!(offset_of!(ForInStatement, left) == 8usize);
-    assert!(offset_of!(ForInStatement, right) == 24usize);
-    assert!(offset_of!(ForInStatement, body) == 40usize);
-    assert!(offset_of!(ForInStatement, scope_id) == 56usize);
+    assert!(offset_of!(ForInStatement, node_id) == 0usize);
+    assert!(offset_of!(ForInStatement, span) == 4usize);
+    assert!(offset_of!(ForInStatement, left) == 16usize);
+    assert!(offset_of!(ForInStatement, right) == 32usize);
+    assert!(offset_of!(ForInStatement, body) == 48usize);
+    assert!(offset_of!(ForInStatement, scope_id) == 64usize);
 
     assert!(size_of::<ForStatementLeft>() == 16usize);
     assert!(align_of::<ForStatementLeft>() == 8usize);
 
     assert!(size_of::<ForOfStatement>() == 72usize);
     assert!(align_of::<ForOfStatement>() == 8usize);
-    assert!(offset_of!(ForOfStatement, span) == 0usize);
-    assert!(offset_of!(ForOfStatement, r#await) == 8usize);
+    assert!(offset_of!(ForOfStatement, node_id) == 0usize);
+    assert!(offset_of!(ForOfStatement, span) == 4usize);
+    assert!(offset_of!(ForOfStatement, r#await) == 12usize);
     assert!(offset_of!(ForOfStatement, left) == 16usize);
     assert!(offset_of!(ForOfStatement, right) == 32usize);
     assert!(offset_of!(ForOfStatement, body) == 48usize);
     assert!(offset_of!(ForOfStatement, scope_id) == 64usize);
 
-    assert!(size_of::<ContinueStatement>() == 32usize);
+    assert!(size_of::<ContinueStatement>() == 48usize);
     assert!(align_of::<ContinueStatement>() == 8usize);
-    assert!(offset_of!(ContinueStatement, span) == 0usize);
-    assert!(offset_of!(ContinueStatement, label) == 8usize);
+    assert!(offset_of!(ContinueStatement, node_id) == 0usize);
+    assert!(offset_of!(ContinueStatement, span) == 4usize);
+    assert!(offset_of!(ContinueStatement, label) == 16usize);
 
-    assert!(size_of::<BreakStatement>() == 32usize);
+    assert!(size_of::<BreakStatement>() == 48usize);
     assert!(align_of::<BreakStatement>() == 8usize);
-    assert!(offset_of!(BreakStatement, span) == 0usize);
-    assert!(offset_of!(BreakStatement, label) == 8usize);
+    assert!(offset_of!(BreakStatement, node_id) == 0usize);
+    assert!(offset_of!(BreakStatement, span) == 4usize);
+    assert!(offset_of!(BreakStatement, label) == 16usize);
 
-    assert!(size_of::<ReturnStatement>() == 24usize);
+    assert!(size_of::<ReturnStatement>() == 32usize);
     assert!(align_of::<ReturnStatement>() == 8usize);
-    assert!(offset_of!(ReturnStatement, span) == 0usize);
-    assert!(offset_of!(ReturnStatement, argument) == 8usize);
+    assert!(offset_of!(ReturnStatement, node_id) == 0usize);
+    assert!(offset_of!(ReturnStatement, span) == 4usize);
+    assert!(offset_of!(ReturnStatement, argument) == 16usize);
 
-    assert!(size_of::<WithStatement>() == 40usize);
+    assert!(size_of::<WithStatement>() == 48usize);
     assert!(align_of::<WithStatement>() == 8usize);
-    assert!(offset_of!(WithStatement, span) == 0usize);
-    assert!(offset_of!(WithStatement, object) == 8usize);
-    assert!(offset_of!(WithStatement, body) == 24usize);
+    assert!(offset_of!(WithStatement, node_id) == 0usize);
+    assert!(offset_of!(WithStatement, span) == 4usize);
+    assert!(offset_of!(WithStatement, object) == 16usize);
+    assert!(offset_of!(WithStatement, body) == 32usize);
 
-    assert!(size_of::<SwitchStatement>() == 64usize);
+    assert!(size_of::<SwitchStatement>() == 72usize);
     assert!(align_of::<SwitchStatement>() == 8usize);
-    assert!(offset_of!(SwitchStatement, span) == 0usize);
-    assert!(offset_of!(SwitchStatement, discriminant) == 8usize);
-    assert!(offset_of!(SwitchStatement, cases) == 24usize);
-    assert!(offset_of!(SwitchStatement, scope_id) == 56usize);
+    assert!(offset_of!(SwitchStatement, node_id) == 0usize);
+    assert!(offset_of!(SwitchStatement, span) == 4usize);
+    assert!(offset_of!(SwitchStatement, discriminant) == 16usize);
+    assert!(offset_of!(SwitchStatement, cases) == 32usize);
+    assert!(offset_of!(SwitchStatement, scope_id) == 64usize);
 
-    assert!(size_of::<SwitchCase>() == 56usize);
+    assert!(size_of::<SwitchCase>() == 64usize);
     assert!(align_of::<SwitchCase>() == 8usize);
-    assert!(offset_of!(SwitchCase, span) == 0usize);
-    assert!(offset_of!(SwitchCase, test) == 8usize);
-    assert!(offset_of!(SwitchCase, consequent) == 24usize);
+    assert!(offset_of!(SwitchCase, node_id) == 0usize);
+    assert!(offset_of!(SwitchCase, span) == 4usize);
+    assert!(offset_of!(SwitchCase, test) == 16usize);
+    assert!(offset_of!(SwitchCase, consequent) == 32usize);
 
-    assert!(size_of::<LabeledStatement>() == 48usize);
+    assert!(size_of::<LabeledStatement>() == 64usize);
     assert!(align_of::<LabeledStatement>() == 8usize);
-    assert!(offset_of!(LabeledStatement, span) == 0usize);
-    assert!(offset_of!(LabeledStatement, label) == 8usize);
-    assert!(offset_of!(LabeledStatement, body) == 32usize);
+    assert!(offset_of!(LabeledStatement, node_id) == 0usize);
+    assert!(offset_of!(LabeledStatement, span) == 4usize);
+    assert!(offset_of!(LabeledStatement, label) == 16usize);
+    assert!(offset_of!(LabeledStatement, body) == 48usize);
 
-    assert!(size_of::<ThrowStatement>() == 24usize);
+    assert!(size_of::<ThrowStatement>() == 32usize);
     assert!(align_of::<ThrowStatement>() == 8usize);
-    assert!(offset_of!(ThrowStatement, span) == 0usize);
-    assert!(offset_of!(ThrowStatement, argument) == 8usize);
+    assert!(offset_of!(ThrowStatement, node_id) == 0usize);
+    assert!(offset_of!(ThrowStatement, span) == 4usize);
+    assert!(offset_of!(ThrowStatement, argument) == 16usize);
 
-    assert!(size_of::<TryStatement>() == 32usize);
+    assert!(size_of::<TryStatement>() == 40usize);
     assert!(align_of::<TryStatement>() == 8usize);
-    assert!(offset_of!(TryStatement, span) == 0usize);
-    assert!(offset_of!(TryStatement, block) == 8usize);
-    assert!(offset_of!(TryStatement, handler) == 16usize);
-    assert!(offset_of!(TryStatement, finalizer) == 24usize);
+    assert!(offset_of!(TryStatement, node_id) == 0usize);
+    assert!(offset_of!(TryStatement, span) == 4usize);
+    assert!(offset_of!(TryStatement, block) == 16usize);
+    assert!(offset_of!(TryStatement, handler) == 24usize);
+    assert!(offset_of!(TryStatement, finalizer) == 32usize);
 
-    assert!(size_of::<CatchClause>() == 64usize);
+    assert!(size_of::<CatchClause>() == 88usize);
     assert!(align_of::<CatchClause>() == 8usize);
-    assert!(offset_of!(CatchClause, span) == 0usize);
-    assert!(offset_of!(CatchClause, param) == 8usize);
-    assert!(offset_of!(CatchClause, body) == 48usize);
-    assert!(offset_of!(CatchClause, scope_id) == 56usize);
+    assert!(offset_of!(CatchClause, node_id) == 0usize);
+    assert!(offset_of!(CatchClause, span) == 4usize);
+    assert!(offset_of!(CatchClause, param) == 16usize);
+    assert!(offset_of!(CatchClause, body) == 72usize);
+    assert!(offset_of!(CatchClause, scope_id) == 80usize);
 
-    assert!(size_of::<CatchParameter>() == 40usize);
+    assert!(size_of::<CatchParameter>() == 56usize);
     assert!(align_of::<CatchParameter>() == 8usize);
-    assert!(offset_of!(CatchParameter, span) == 0usize);
-    assert!(offset_of!(CatchParameter, pattern) == 8usize);
+    assert!(offset_of!(CatchParameter, node_id) == 0usize);
+    assert!(offset_of!(CatchParameter, span) == 4usize);
+    assert!(offset_of!(CatchParameter, pattern) == 16usize);
 
-    assert!(size_of::<DebuggerStatement>() == 8usize);
+    assert!(size_of::<DebuggerStatement>() == 12usize);
     assert!(align_of::<DebuggerStatement>() == 4usize);
-    assert!(offset_of!(DebuggerStatement, span) == 0usize);
+    assert!(offset_of!(DebuggerStatement, node_id) == 0usize);
+    assert!(offset_of!(DebuggerStatement, span) == 4usize);
 
-    assert!(size_of::<BindingPattern>() == 32usize);
+    assert!(size_of::<BindingPattern>() == 40usize);
     assert!(align_of::<BindingPattern>() == 8usize);
-    assert!(offset_of!(BindingPattern, kind) == 0usize);
-    assert!(offset_of!(BindingPattern, type_annotation) == 16usize);
-    assert!(offset_of!(BindingPattern, optional) == 24usize);
+    assert!(offset_of!(BindingPattern, node_id) == 0usize);
+    assert!(offset_of!(BindingPattern, kind) == 8usize);
+    assert!(offset_of!(BindingPattern, type_annotation) == 24usize);
+    assert!(offset_of!(BindingPattern, optional) == 32usize);
 
     assert!(size_of::<BindingPatternKind>() == 16usize);
     assert!(align_of::<BindingPatternKind>() == 8usize);
 
-    assert!(size_of::<AssignmentPattern>() == 56usize);
+    assert!(size_of::<AssignmentPattern>() == 72usize);
     assert!(align_of::<AssignmentPattern>() == 8usize);
-    assert!(offset_of!(AssignmentPattern, span) == 0usize);
-    assert!(offset_of!(AssignmentPattern, left) == 8usize);
-    assert!(offset_of!(AssignmentPattern, right) == 40usize);
+    assert!(offset_of!(AssignmentPattern, node_id) == 0usize);
+    assert!(offset_of!(AssignmentPattern, span) == 4usize);
+    assert!(offset_of!(AssignmentPattern, left) == 16usize);
+    assert!(offset_of!(AssignmentPattern, right) == 56usize);
 
-    assert!(size_of::<ObjectPattern>() == 48usize);
+    assert!(size_of::<ObjectPattern>() == 56usize);
     assert!(align_of::<ObjectPattern>() == 8usize);
-    assert!(offset_of!(ObjectPattern, span) == 0usize);
-    assert!(offset_of!(ObjectPattern, properties) == 8usize);
-    assert!(offset_of!(ObjectPattern, rest) == 40usize);
+    assert!(offset_of!(ObjectPattern, node_id) == 0usize);
+    assert!(offset_of!(ObjectPattern, span) == 4usize);
+    assert!(offset_of!(ObjectPattern, properties) == 16usize);
+    assert!(offset_of!(ObjectPattern, rest) == 48usize);
 
-    assert!(size_of::<BindingProperty>() == 64usize);
+    assert!(size_of::<BindingProperty>() == 80usize);
     assert!(align_of::<BindingProperty>() == 8usize);
-    assert!(offset_of!(BindingProperty, span) == 0usize);
-    assert!(offset_of!(BindingProperty, key) == 8usize);
-    assert!(offset_of!(BindingProperty, value) == 24usize);
-    assert!(offset_of!(BindingProperty, shorthand) == 56usize);
-    assert!(offset_of!(BindingProperty, computed) == 57usize);
+    assert!(offset_of!(BindingProperty, node_id) == 0usize);
+    assert!(offset_of!(BindingProperty, span) == 4usize);
+    assert!(offset_of!(BindingProperty, key) == 16usize);
+    assert!(offset_of!(BindingProperty, value) == 32usize);
+    assert!(offset_of!(BindingProperty, shorthand) == 72usize);
+    assert!(offset_of!(BindingProperty, computed) == 73usize);
 
-    assert!(size_of::<ArrayPattern>() == 48usize);
+    assert!(size_of::<ArrayPattern>() == 56usize);
     assert!(align_of::<ArrayPattern>() == 8usize);
-    assert!(offset_of!(ArrayPattern, span) == 0usize);
-    assert!(offset_of!(ArrayPattern, elements) == 8usize);
-    assert!(offset_of!(ArrayPattern, rest) == 40usize);
+    assert!(offset_of!(ArrayPattern, node_id) == 0usize);
+    assert!(offset_of!(ArrayPattern, span) == 4usize);
+    assert!(offset_of!(ArrayPattern, elements) == 16usize);
+    assert!(offset_of!(ArrayPattern, rest) == 48usize);
 
-    assert!(size_of::<BindingRestElement>() == 40usize);
+    assert!(size_of::<BindingRestElement>() == 56usize);
     assert!(align_of::<BindingRestElement>() == 8usize);
-    assert!(offset_of!(BindingRestElement, span) == 0usize);
-    assert!(offset_of!(BindingRestElement, argument) == 8usize);
+    assert!(offset_of!(BindingRestElement, node_id) == 0usize);
+    assert!(offset_of!(BindingRestElement, span) == 4usize);
+    assert!(offset_of!(BindingRestElement, argument) == 16usize);
 
-    assert!(size_of::<Function>() == 104usize);
+    assert!(size_of::<Function>() == 112usize);
     assert!(align_of::<Function>() == 8usize);
-    assert!(offset_of!(Function, r#type) == 0usize);
-    assert!(offset_of!(Function, span) == 4usize);
+    assert!(offset_of!(Function, node_id) == 0usize);
+    assert!(offset_of!(Function, r#type) == 4usize);
+    assert!(offset_of!(Function, span) == 8usize);
     assert!(offset_of!(Function, id) == 16usize);
-    assert!(offset_of!(Function, generator) == 48usize);
-    assert!(offset_of!(Function, r#async) == 49usize);
-    assert!(offset_of!(Function, declare) == 50usize);
-    assert!(offset_of!(Function, type_parameters) == 56usize);
-    assert!(offset_of!(Function, this_param) == 64usize);
-    assert!(offset_of!(Function, params) == 72usize);
-    assert!(offset_of!(Function, return_type) == 80usize);
-    assert!(offset_of!(Function, body) == 88usize);
-    assert!(offset_of!(Function, scope_id) == 96usize);
+    assert!(offset_of!(Function, generator) == 56usize);
+    assert!(offset_of!(Function, r#async) == 57usize);
+    assert!(offset_of!(Function, declare) == 58usize);
+    assert!(offset_of!(Function, type_parameters) == 64usize);
+    assert!(offset_of!(Function, this_param) == 72usize);
+    assert!(offset_of!(Function, params) == 80usize);
+    assert!(offset_of!(Function, return_type) == 88usize);
+    assert!(offset_of!(Function, body) == 96usize);
+    assert!(offset_of!(Function, scope_id) == 104usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
 
     assert!(size_of::<FormalParameters>() == 56usize);
     assert!(align_of::<FormalParameters>() == 8usize);
-    assert!(offset_of!(FormalParameters, span) == 0usize);
-    assert!(offset_of!(FormalParameters, kind) == 8usize);
+    assert!(offset_of!(FormalParameters, node_id) == 0usize);
+    assert!(offset_of!(FormalParameters, span) == 4usize);
+    assert!(offset_of!(FormalParameters, kind) == 12usize);
     assert!(offset_of!(FormalParameters, items) == 16usize);
     assert!(offset_of!(FormalParameters, rest) == 48usize);
 
-    assert!(size_of::<FormalParameter>() == 80usize);
+    assert!(size_of::<FormalParameter>() == 96usize);
     assert!(align_of::<FormalParameter>() == 8usize);
-    assert!(offset_of!(FormalParameter, span) == 0usize);
-    assert!(offset_of!(FormalParameter, decorators) == 8usize);
-    assert!(offset_of!(FormalParameter, pattern) == 40usize);
-    assert!(offset_of!(FormalParameter, accessibility) == 72usize);
-    assert!(offset_of!(FormalParameter, readonly) == 73usize);
-    assert!(offset_of!(FormalParameter, r#override) == 74usize);
+    assert!(offset_of!(FormalParameter, node_id) == 0usize);
+    assert!(offset_of!(FormalParameter, span) == 4usize);
+    assert!(offset_of!(FormalParameter, decorators) == 16usize);
+    assert!(offset_of!(FormalParameter, pattern) == 48usize);
+    assert!(offset_of!(FormalParameter, accessibility) == 88usize);
+    assert!(offset_of!(FormalParameter, readonly) == 89usize);
+    assert!(offset_of!(FormalParameter, r#override) == 90usize);
 
     assert!(size_of::<FormalParameterKind>() == 1usize);
     assert!(align_of::<FormalParameterKind>() == 1usize);
 
-    assert!(size_of::<FunctionBody>() == 72usize);
+    assert!(size_of::<FunctionBody>() == 80usize);
     assert!(align_of::<FunctionBody>() == 8usize);
-    assert!(offset_of!(FunctionBody, span) == 0usize);
-    assert!(offset_of!(FunctionBody, directives) == 8usize);
-    assert!(offset_of!(FunctionBody, statements) == 40usize);
+    assert!(offset_of!(FunctionBody, node_id) == 0usize);
+    assert!(offset_of!(FunctionBody, span) == 4usize);
+    assert!(offset_of!(FunctionBody, directives) == 16usize);
+    assert!(offset_of!(FunctionBody, statements) == 48usize);
 
     assert!(size_of::<ArrowFunctionExpression>() == 56usize);
     assert!(align_of::<ArrowFunctionExpression>() == 8usize);
-    assert!(offset_of!(ArrowFunctionExpression, span) == 0usize);
-    assert!(offset_of!(ArrowFunctionExpression, expression) == 8usize);
-    assert!(offset_of!(ArrowFunctionExpression, r#async) == 9usize);
+    assert!(offset_of!(ArrowFunctionExpression, node_id) == 0usize);
+    assert!(offset_of!(ArrowFunctionExpression, span) == 4usize);
+    assert!(offset_of!(ArrowFunctionExpression, expression) == 12usize);
+    assert!(offset_of!(ArrowFunctionExpression, r#async) == 13usize);
     assert!(offset_of!(ArrowFunctionExpression, type_parameters) == 16usize);
     assert!(offset_of!(ArrowFunctionExpression, params) == 24usize);
     assert!(offset_of!(ArrowFunctionExpression, return_type) == 32usize);
@@ -600,40 +681,44 @@ const _: () = {
 
     assert!(size_of::<YieldExpression>() == 32usize);
     assert!(align_of::<YieldExpression>() == 8usize);
-    assert!(offset_of!(YieldExpression, span) == 0usize);
-    assert!(offset_of!(YieldExpression, delegate) == 8usize);
+    assert!(offset_of!(YieldExpression, node_id) == 0usize);
+    assert!(offset_of!(YieldExpression, span) == 4usize);
+    assert!(offset_of!(YieldExpression, delegate) == 12usize);
     assert!(offset_of!(YieldExpression, argument) == 16usize);
 
-    assert!(size_of::<Class>() == 160usize);
+    assert!(size_of::<Class>() == 168usize);
     assert!(align_of::<Class>() == 8usize);
-    assert!(offset_of!(Class, r#type) == 0usize);
-    assert!(offset_of!(Class, span) == 4usize);
+    assert!(offset_of!(Class, node_id) == 0usize);
+    assert!(offset_of!(Class, r#type) == 4usize);
+    assert!(offset_of!(Class, span) == 8usize);
     assert!(offset_of!(Class, decorators) == 16usize);
     assert!(offset_of!(Class, id) == 48usize);
-    assert!(offset_of!(Class, type_parameters) == 80usize);
-    assert!(offset_of!(Class, super_class) == 88usize);
-    assert!(offset_of!(Class, super_type_parameters) == 104usize);
-    assert!(offset_of!(Class, implements) == 112usize);
-    assert!(offset_of!(Class, body) == 144usize);
-    assert!(offset_of!(Class, r#abstract) == 152usize);
-    assert!(offset_of!(Class, declare) == 153usize);
-    assert!(offset_of!(Class, scope_id) == 156usize);
+    assert!(offset_of!(Class, type_parameters) == 88usize);
+    assert!(offset_of!(Class, super_class) == 96usize);
+    assert!(offset_of!(Class, super_type_parameters) == 112usize);
+    assert!(offset_of!(Class, implements) == 120usize);
+    assert!(offset_of!(Class, body) == 152usize);
+    assert!(offset_of!(Class, r#abstract) == 160usize);
+    assert!(offset_of!(Class, declare) == 161usize);
+    assert!(offset_of!(Class, scope_id) == 164usize);
 
     assert!(size_of::<ClassType>() == 1usize);
     assert!(align_of::<ClassType>() == 1usize);
 
-    assert!(size_of::<ClassBody>() == 40usize);
+    assert!(size_of::<ClassBody>() == 48usize);
     assert!(align_of::<ClassBody>() == 8usize);
-    assert!(offset_of!(ClassBody, span) == 0usize);
-    assert!(offset_of!(ClassBody, body) == 8usize);
+    assert!(offset_of!(ClassBody, node_id) == 0usize);
+    assert!(offset_of!(ClassBody, span) == 4usize);
+    assert!(offset_of!(ClassBody, body) == 16usize);
 
     assert!(size_of::<ClassElement>() == 16usize);
     assert!(align_of::<ClassElement>() == 8usize);
 
     assert!(size_of::<MethodDefinition>() == 80usize);
     assert!(align_of::<MethodDefinition>() == 8usize);
-    assert!(offset_of!(MethodDefinition, r#type) == 0usize);
-    assert!(offset_of!(MethodDefinition, span) == 4usize);
+    assert!(offset_of!(MethodDefinition, node_id) == 0usize);
+    assert!(offset_of!(MethodDefinition, r#type) == 4usize);
+    assert!(offset_of!(MethodDefinition, span) == 8usize);
     assert!(offset_of!(MethodDefinition, decorators) == 16usize);
     assert!(offset_of!(MethodDefinition, key) == 48usize);
     assert!(offset_of!(MethodDefinition, value) == 64usize);
@@ -649,8 +734,9 @@ const _: () = {
 
     assert!(size_of::<PropertyDefinition>() == 104usize);
     assert!(align_of::<PropertyDefinition>() == 8usize);
-    assert!(offset_of!(PropertyDefinition, r#type) == 0usize);
-    assert!(offset_of!(PropertyDefinition, span) == 4usize);
+    assert!(offset_of!(PropertyDefinition, node_id) == 0usize);
+    assert!(offset_of!(PropertyDefinition, r#type) == 4usize);
+    assert!(offset_of!(PropertyDefinition, span) == 8usize);
     assert!(offset_of!(PropertyDefinition, decorators) == 16usize);
     assert!(offset_of!(PropertyDefinition, key) == 48usize);
     assert!(offset_of!(PropertyDefinition, value) == 64usize);
@@ -670,16 +756,18 @@ const _: () = {
     assert!(size_of::<MethodDefinitionKind>() == 1usize);
     assert!(align_of::<MethodDefinitionKind>() == 1usize);
 
-    assert!(size_of::<PrivateIdentifier>() == 24usize);
+    assert!(size_of::<PrivateIdentifier>() == 32usize);
     assert!(align_of::<PrivateIdentifier>() == 8usize);
-    assert!(offset_of!(PrivateIdentifier, span) == 0usize);
-    assert!(offset_of!(PrivateIdentifier, name) == 8usize);
+    assert!(offset_of!(PrivateIdentifier, node_id) == 0usize);
+    assert!(offset_of!(PrivateIdentifier, span) == 4usize);
+    assert!(offset_of!(PrivateIdentifier, name) == 16usize);
 
-    assert!(size_of::<StaticBlock>() == 48usize);
+    assert!(size_of::<StaticBlock>() == 56usize);
     assert!(align_of::<StaticBlock>() == 8usize);
-    assert!(offset_of!(StaticBlock, span) == 0usize);
-    assert!(offset_of!(StaticBlock, body) == 8usize);
-    assert!(offset_of!(StaticBlock, scope_id) == 40usize);
+    assert!(offset_of!(StaticBlock, node_id) == 0usize);
+    assert!(offset_of!(StaticBlock, span) == 4usize);
+    assert!(offset_of!(StaticBlock, body) == 16usize);
+    assert!(offset_of!(StaticBlock, scope_id) == 48usize);
 
     assert!(size_of::<ModuleDeclaration>() == 16usize);
     assert!(align_of::<ModuleDeclaration>() == 8usize);
@@ -689,8 +777,9 @@ const _: () = {
 
     assert!(size_of::<AccessorProperty>() == 104usize);
     assert!(align_of::<AccessorProperty>() == 8usize);
-    assert!(offset_of!(AccessorProperty, r#type) == 0usize);
-    assert!(offset_of!(AccessorProperty, span) == 4usize);
+    assert!(offset_of!(AccessorProperty, node_id) == 0usize);
+    assert!(offset_of!(AccessorProperty, r#type) == 4usize);
+    assert!(offset_of!(AccessorProperty, span) == 8usize);
     assert!(offset_of!(AccessorProperty, decorators) == 16usize);
     assert!(offset_of!(AccessorProperty, key) == 48usize);
     assert!(offset_of!(AccessorProperty, value) == 64usize);
@@ -700,124 +789,140 @@ const _: () = {
     assert!(offset_of!(AccessorProperty, type_annotation) == 88usize);
     assert!(offset_of!(AccessorProperty, accessibility) == 96usize);
 
-    assert!(size_of::<ImportExpression>() == 56usize);
+    assert!(size_of::<ImportExpression>() == 64usize);
     assert!(align_of::<ImportExpression>() == 8usize);
-    assert!(offset_of!(ImportExpression, span) == 0usize);
-    assert!(offset_of!(ImportExpression, source) == 8usize);
-    assert!(offset_of!(ImportExpression, arguments) == 24usize);
+    assert!(offset_of!(ImportExpression, node_id) == 0usize);
+    assert!(offset_of!(ImportExpression, span) == 4usize);
+    assert!(offset_of!(ImportExpression, source) == 16usize);
+    assert!(offset_of!(ImportExpression, arguments) == 32usize);
 
-    assert!(size_of::<ImportDeclaration>() == 80usize);
+    assert!(size_of::<ImportDeclaration>() == 96usize);
     assert!(align_of::<ImportDeclaration>() == 8usize);
-    assert!(offset_of!(ImportDeclaration, span) == 0usize);
-    assert!(offset_of!(ImportDeclaration, specifiers) == 8usize);
-    assert!(offset_of!(ImportDeclaration, source) == 40usize);
-    assert!(offset_of!(ImportDeclaration, with_clause) == 64usize);
-    assert!(offset_of!(ImportDeclaration, import_kind) == 72usize);
+    assert!(offset_of!(ImportDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ImportDeclaration, span) == 4usize);
+    assert!(offset_of!(ImportDeclaration, specifiers) == 16usize);
+    assert!(offset_of!(ImportDeclaration, source) == 48usize);
+    assert!(offset_of!(ImportDeclaration, with_clause) == 80usize);
+    assert!(offset_of!(ImportDeclaration, import_kind) == 88usize);
 
     assert!(size_of::<ImportDeclarationSpecifier>() == 16usize);
     assert!(align_of::<ImportDeclarationSpecifier>() == 8usize);
 
-    assert!(size_of::<ImportSpecifier>() == 88usize);
+    assert!(size_of::<ImportSpecifier>() == 112usize);
     assert!(align_of::<ImportSpecifier>() == 8usize);
-    assert!(offset_of!(ImportSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportSpecifier, imported) == 8usize);
-    assert!(offset_of!(ImportSpecifier, local) == 48usize);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 80usize);
+    assert!(offset_of!(ImportSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportSpecifier, imported) == 16usize);
+    assert!(offset_of!(ImportSpecifier, local) == 64usize);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 104usize);
 
-    assert!(size_of::<ImportDefaultSpecifier>() == 40usize);
+    assert!(size_of::<ImportDefaultSpecifier>() == 56usize);
     assert!(align_of::<ImportDefaultSpecifier>() == 8usize);
-    assert!(offset_of!(ImportDefaultSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportDefaultSpecifier, local) == 8usize);
+    assert!(offset_of!(ImportDefaultSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportDefaultSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportDefaultSpecifier, local) == 16usize);
 
-    assert!(size_of::<ImportNamespaceSpecifier>() == 40usize);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 56usize);
     assert!(align_of::<ImportNamespaceSpecifier>() == 8usize);
-    assert!(offset_of!(ImportNamespaceSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportNamespaceSpecifier, local) == 8usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, local) == 16usize);
 
-    assert!(size_of::<WithClause>() == 64usize);
+    assert!(size_of::<WithClause>() == 80usize);
     assert!(align_of::<WithClause>() == 8usize);
-    assert!(offset_of!(WithClause, span) == 0usize);
-    assert!(offset_of!(WithClause, attributes_keyword) == 8usize);
-    assert!(offset_of!(WithClause, with_entries) == 32usize);
+    assert!(offset_of!(WithClause, node_id) == 0usize);
+    assert!(offset_of!(WithClause, span) == 4usize);
+    assert!(offset_of!(WithClause, attributes_keyword) == 16usize);
+    assert!(offset_of!(WithClause, with_entries) == 48usize);
 
-    assert!(size_of::<ImportAttribute>() == 64usize);
+    assert!(size_of::<ImportAttribute>() == 88usize);
     assert!(align_of::<ImportAttribute>() == 8usize);
-    assert!(offset_of!(ImportAttribute, span) == 0usize);
-    assert!(offset_of!(ImportAttribute, key) == 8usize);
-    assert!(offset_of!(ImportAttribute, value) == 40usize);
+    assert!(offset_of!(ImportAttribute, node_id) == 0usize);
+    assert!(offset_of!(ImportAttribute, span) == 4usize);
+    assert!(offset_of!(ImportAttribute, key) == 16usize);
+    assert!(offset_of!(ImportAttribute, value) == 56usize);
 
-    assert!(size_of::<ImportAttributeKey>() == 32usize);
+    assert!(size_of::<ImportAttributeKey>() == 40usize);
     assert!(align_of::<ImportAttributeKey>() == 8usize);
 
-    assert!(size_of::<ExportNamedDeclaration>() == 96usize);
+    assert!(size_of::<ExportNamedDeclaration>() == 112usize);
     assert!(align_of::<ExportNamedDeclaration>() == 8usize);
-    assert!(offset_of!(ExportNamedDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportNamedDeclaration, declaration) == 8usize);
-    assert!(offset_of!(ExportNamedDeclaration, specifiers) == 24usize);
-    assert!(offset_of!(ExportNamedDeclaration, source) == 56usize);
-    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 80usize);
-    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 88usize);
+    assert!(offset_of!(ExportNamedDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportNamedDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportNamedDeclaration, declaration) == 16usize);
+    assert!(offset_of!(ExportNamedDeclaration, specifiers) == 32usize);
+    assert!(offset_of!(ExportNamedDeclaration, source) == 64usize);
+    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 96usize);
+    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 104usize);
 
-    assert!(size_of::<ExportDefaultDeclaration>() == 64usize);
+    assert!(size_of::<ExportDefaultDeclaration>() == 80usize);
     assert!(align_of::<ExportDefaultDeclaration>() == 8usize);
-    assert!(offset_of!(ExportDefaultDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8usize);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 24usize);
+    assert!(offset_of!(ExportDefaultDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportDefaultDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 16usize);
+    assert!(offset_of!(ExportDefaultDeclaration, exported) == 32usize);
 
-    assert!(size_of::<ExportAllDeclaration>() == 88usize);
+    assert!(size_of::<ExportAllDeclaration>() == 112usize);
     assert!(align_of::<ExportAllDeclaration>() == 8usize);
-    assert!(offset_of!(ExportAllDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportAllDeclaration, exported) == 8usize);
-    assert!(offset_of!(ExportAllDeclaration, source) == 48usize);
-    assert!(offset_of!(ExportAllDeclaration, with_clause) == 72usize);
-    assert!(offset_of!(ExportAllDeclaration, export_kind) == 80usize);
+    assert!(offset_of!(ExportAllDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportAllDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportAllDeclaration, exported) == 16usize);
+    assert!(offset_of!(ExportAllDeclaration, source) == 64usize);
+    assert!(offset_of!(ExportAllDeclaration, with_clause) == 96usize);
+    assert!(offset_of!(ExportAllDeclaration, export_kind) == 104usize);
 
-    assert!(size_of::<ExportSpecifier>() == 96usize);
+    assert!(size_of::<ExportSpecifier>() == 120usize);
     assert!(align_of::<ExportSpecifier>() == 8usize);
-    assert!(offset_of!(ExportSpecifier, span) == 0usize);
-    assert!(offset_of!(ExportSpecifier, local) == 8usize);
-    assert!(offset_of!(ExportSpecifier, exported) == 48usize);
-    assert!(offset_of!(ExportSpecifier, export_kind) == 88usize);
+    assert!(offset_of!(ExportSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ExportSpecifier, span) == 4usize);
+    assert!(offset_of!(ExportSpecifier, local) == 16usize);
+    assert!(offset_of!(ExportSpecifier, exported) == 64usize);
+    assert!(offset_of!(ExportSpecifier, export_kind) == 112usize);
 
     assert!(size_of::<ExportDefaultDeclarationKind>() == 16usize);
     assert!(align_of::<ExportDefaultDeclarationKind>() == 8usize);
 
-    assert!(size_of::<ModuleExportName>() == 40usize);
+    assert!(size_of::<ModuleExportName>() == 48usize);
     assert!(align_of::<ModuleExportName>() == 8usize);
 
-    assert!(size_of::<TSThisParameter>() == 24usize);
+    assert!(size_of::<TSThisParameter>() == 32usize);
     assert!(align_of::<TSThisParameter>() == 8usize);
-    assert!(offset_of!(TSThisParameter, span) == 0usize);
-    assert!(offset_of!(TSThisParameter, this_span) == 8usize);
-    assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
+    assert!(offset_of!(TSThisParameter, node_id) == 0usize);
+    assert!(offset_of!(TSThisParameter, span) == 4usize);
+    assert!(offset_of!(TSThisParameter, this_span) == 12usize);
+    assert!(offset_of!(TSThisParameter, type_annotation) == 24usize);
 
-    assert!(size_of::<TSEnumDeclaration>() == 80usize);
+    assert!(size_of::<TSEnumDeclaration>() == 96usize);
     assert!(align_of::<TSEnumDeclaration>() == 8usize);
-    assert!(offset_of!(TSEnumDeclaration, span) == 0usize);
-    assert!(offset_of!(TSEnumDeclaration, id) == 8usize);
-    assert!(offset_of!(TSEnumDeclaration, members) == 40usize);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 72usize);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 73usize);
-    assert!(offset_of!(TSEnumDeclaration, scope_id) == 76usize);
+    assert!(offset_of!(TSEnumDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSEnumDeclaration, span) == 4usize);
+    assert!(offset_of!(TSEnumDeclaration, id) == 16usize);
+    assert!(offset_of!(TSEnumDeclaration, members) == 56usize);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 88usize);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 89usize);
+    assert!(offset_of!(TSEnumDeclaration, scope_id) == 92usize);
 
-    assert!(size_of::<TSEnumMember>() == 40usize);
+    assert!(size_of::<TSEnumMember>() == 48usize);
     assert!(align_of::<TSEnumMember>() == 8usize);
-    assert!(offset_of!(TSEnumMember, span) == 0usize);
-    assert!(offset_of!(TSEnumMember, id) == 8usize);
-    assert!(offset_of!(TSEnumMember, initializer) == 24usize);
+    assert!(offset_of!(TSEnumMember, node_id) == 0usize);
+    assert!(offset_of!(TSEnumMember, span) == 4usize);
+    assert!(offset_of!(TSEnumMember, id) == 16usize);
+    assert!(offset_of!(TSEnumMember, initializer) == 32usize);
 
     assert!(size_of::<TSEnumMemberName>() == 16usize);
     assert!(align_of::<TSEnumMemberName>() == 8usize);
 
-    assert!(size_of::<TSTypeAnnotation>() == 24usize);
+    assert!(size_of::<TSTypeAnnotation>() == 32usize);
     assert!(align_of::<TSTypeAnnotation>() == 8usize);
-    assert!(offset_of!(TSTypeAnnotation, span) == 0usize);
-    assert!(offset_of!(TSTypeAnnotation, type_annotation) == 8usize);
+    assert!(offset_of!(TSTypeAnnotation, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAnnotation, span) == 4usize);
+    assert!(offset_of!(TSTypeAnnotation, type_annotation) == 16usize);
 
-    assert!(size_of::<TSLiteralType>() == 24usize);
+    assert!(size_of::<TSLiteralType>() == 32usize);
     assert!(align_of::<TSLiteralType>() == 8usize);
-    assert!(offset_of!(TSLiteralType, span) == 0usize);
-    assert!(offset_of!(TSLiteralType, literal) == 8usize);
+    assert!(offset_of!(TSLiteralType, node_id) == 0usize);
+    assert!(offset_of!(TSLiteralType, span) == 4usize);
+    assert!(offset_of!(TSLiteralType, literal) == 16usize);
 
     assert!(size_of::<TSLiteral>() == 16usize);
     assert!(align_of::<TSLiteral>() == 8usize);
@@ -825,478 +930,549 @@ const _: () = {
     assert!(size_of::<TSType>() == 16usize);
     assert!(align_of::<TSType>() == 8usize);
 
-    assert!(size_of::<TSConditionalType>() == 80usize);
+    assert!(size_of::<TSConditionalType>() == 88usize);
     assert!(align_of::<TSConditionalType>() == 8usize);
-    assert!(offset_of!(TSConditionalType, span) == 0usize);
-    assert!(offset_of!(TSConditionalType, check_type) == 8usize);
-    assert!(offset_of!(TSConditionalType, extends_type) == 24usize);
-    assert!(offset_of!(TSConditionalType, true_type) == 40usize);
-    assert!(offset_of!(TSConditionalType, false_type) == 56usize);
-    assert!(offset_of!(TSConditionalType, scope_id) == 72usize);
+    assert!(offset_of!(TSConditionalType, node_id) == 0usize);
+    assert!(offset_of!(TSConditionalType, span) == 4usize);
+    assert!(offset_of!(TSConditionalType, check_type) == 16usize);
+    assert!(offset_of!(TSConditionalType, extends_type) == 32usize);
+    assert!(offset_of!(TSConditionalType, true_type) == 48usize);
+    assert!(offset_of!(TSConditionalType, false_type) == 64usize);
+    assert!(offset_of!(TSConditionalType, scope_id) == 80usize);
 
-    assert!(size_of::<TSUnionType>() == 40usize);
+    assert!(size_of::<TSUnionType>() == 48usize);
     assert!(align_of::<TSUnionType>() == 8usize);
-    assert!(offset_of!(TSUnionType, span) == 0usize);
-    assert!(offset_of!(TSUnionType, types) == 8usize);
+    assert!(offset_of!(TSUnionType, node_id) == 0usize);
+    assert!(offset_of!(TSUnionType, span) == 4usize);
+    assert!(offset_of!(TSUnionType, types) == 16usize);
 
-    assert!(size_of::<TSIntersectionType>() == 40usize);
+    assert!(size_of::<TSIntersectionType>() == 48usize);
     assert!(align_of::<TSIntersectionType>() == 8usize);
-    assert!(offset_of!(TSIntersectionType, span) == 0usize);
-    assert!(offset_of!(TSIntersectionType, types) == 8usize);
+    assert!(offset_of!(TSIntersectionType, node_id) == 0usize);
+    assert!(offset_of!(TSIntersectionType, span) == 4usize);
+    assert!(offset_of!(TSIntersectionType, types) == 16usize);
 
-    assert!(size_of::<TSParenthesizedType>() == 24usize);
+    assert!(size_of::<TSParenthesizedType>() == 32usize);
     assert!(align_of::<TSParenthesizedType>() == 8usize);
-    assert!(offset_of!(TSParenthesizedType, span) == 0usize);
-    assert!(offset_of!(TSParenthesizedType, type_annotation) == 8usize);
+    assert!(offset_of!(TSParenthesizedType, node_id) == 0usize);
+    assert!(offset_of!(TSParenthesizedType, span) == 4usize);
+    assert!(offset_of!(TSParenthesizedType, type_annotation) == 16usize);
 
     assert!(size_of::<TSTypeOperator>() == 32usize);
     assert!(align_of::<TSTypeOperator>() == 8usize);
-    assert!(offset_of!(TSTypeOperator, span) == 0usize);
-    assert!(offset_of!(TSTypeOperator, operator) == 8usize);
+    assert!(offset_of!(TSTypeOperator, node_id) == 0usize);
+    assert!(offset_of!(TSTypeOperator, span) == 4usize);
+    assert!(offset_of!(TSTypeOperator, operator) == 12usize);
     assert!(offset_of!(TSTypeOperator, type_annotation) == 16usize);
 
     assert!(size_of::<TSTypeOperatorOperator>() == 1usize);
     assert!(align_of::<TSTypeOperatorOperator>() == 1usize);
 
-    assert!(size_of::<TSArrayType>() == 24usize);
+    assert!(size_of::<TSArrayType>() == 32usize);
     assert!(align_of::<TSArrayType>() == 8usize);
-    assert!(offset_of!(TSArrayType, span) == 0usize);
-    assert!(offset_of!(TSArrayType, element_type) == 8usize);
+    assert!(offset_of!(TSArrayType, node_id) == 0usize);
+    assert!(offset_of!(TSArrayType, span) == 4usize);
+    assert!(offset_of!(TSArrayType, element_type) == 16usize);
 
-    assert!(size_of::<TSIndexedAccessType>() == 40usize);
+    assert!(size_of::<TSIndexedAccessType>() == 48usize);
     assert!(align_of::<TSIndexedAccessType>() == 8usize);
-    assert!(offset_of!(TSIndexedAccessType, span) == 0usize);
-    assert!(offset_of!(TSIndexedAccessType, object_type) == 8usize);
-    assert!(offset_of!(TSIndexedAccessType, index_type) == 24usize);
+    assert!(offset_of!(TSIndexedAccessType, node_id) == 0usize);
+    assert!(offset_of!(TSIndexedAccessType, span) == 4usize);
+    assert!(offset_of!(TSIndexedAccessType, object_type) == 16usize);
+    assert!(offset_of!(TSIndexedAccessType, index_type) == 32usize);
 
-    assert!(size_of::<TSTupleType>() == 40usize);
+    assert!(size_of::<TSTupleType>() == 48usize);
     assert!(align_of::<TSTupleType>() == 8usize);
-    assert!(offset_of!(TSTupleType, span) == 0usize);
-    assert!(offset_of!(TSTupleType, element_types) == 8usize);
+    assert!(offset_of!(TSTupleType, node_id) == 0usize);
+    assert!(offset_of!(TSTupleType, span) == 4usize);
+    assert!(offset_of!(TSTupleType, element_types) == 16usize);
 
-    assert!(size_of::<TSNamedTupleMember>() == 56usize);
+    assert!(size_of::<TSNamedTupleMember>() == 72usize);
     assert!(align_of::<TSNamedTupleMember>() == 8usize);
-    assert!(offset_of!(TSNamedTupleMember, span) == 0usize);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 8usize);
-    assert!(offset_of!(TSNamedTupleMember, label) == 24usize);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 48usize);
+    assert!(offset_of!(TSNamedTupleMember, node_id) == 0usize);
+    assert!(offset_of!(TSNamedTupleMember, span) == 4usize);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 16usize);
+    assert!(offset_of!(TSNamedTupleMember, label) == 32usize);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 64usize);
 
-    assert!(size_of::<TSOptionalType>() == 24usize);
+    assert!(size_of::<TSOptionalType>() == 32usize);
     assert!(align_of::<TSOptionalType>() == 8usize);
-    assert!(offset_of!(TSOptionalType, span) == 0usize);
-    assert!(offset_of!(TSOptionalType, type_annotation) == 8usize);
+    assert!(offset_of!(TSOptionalType, node_id) == 0usize);
+    assert!(offset_of!(TSOptionalType, span) == 4usize);
+    assert!(offset_of!(TSOptionalType, type_annotation) == 16usize);
 
-    assert!(size_of::<TSRestType>() == 24usize);
+    assert!(size_of::<TSRestType>() == 32usize);
     assert!(align_of::<TSRestType>() == 8usize);
-    assert!(offset_of!(TSRestType, span) == 0usize);
-    assert!(offset_of!(TSRestType, type_annotation) == 8usize);
+    assert!(offset_of!(TSRestType, node_id) == 0usize);
+    assert!(offset_of!(TSRestType, span) == 4usize);
+    assert!(offset_of!(TSRestType, type_annotation) == 16usize);
 
     assert!(size_of::<TSTupleElement>() == 16usize);
     assert!(align_of::<TSTupleElement>() == 8usize);
 
-    assert!(size_of::<TSAnyKeyword>() == 8usize);
+    assert!(size_of::<TSAnyKeyword>() == 12usize);
     assert!(align_of::<TSAnyKeyword>() == 4usize);
-    assert!(offset_of!(TSAnyKeyword, span) == 0usize);
+    assert!(offset_of!(TSAnyKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSAnyKeyword, span) == 4usize);
 
-    assert!(size_of::<TSStringKeyword>() == 8usize);
+    assert!(size_of::<TSStringKeyword>() == 12usize);
     assert!(align_of::<TSStringKeyword>() == 4usize);
-    assert!(offset_of!(TSStringKeyword, span) == 0usize);
+    assert!(offset_of!(TSStringKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSStringKeyword, span) == 4usize);
 
-    assert!(size_of::<TSBooleanKeyword>() == 8usize);
+    assert!(size_of::<TSBooleanKeyword>() == 12usize);
     assert!(align_of::<TSBooleanKeyword>() == 4usize);
-    assert!(offset_of!(TSBooleanKeyword, span) == 0usize);
+    assert!(offset_of!(TSBooleanKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSBooleanKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNumberKeyword>() == 8usize);
+    assert!(size_of::<TSNumberKeyword>() == 12usize);
     assert!(align_of::<TSNumberKeyword>() == 4usize);
-    assert!(offset_of!(TSNumberKeyword, span) == 0usize);
+    assert!(offset_of!(TSNumberKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNumberKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNeverKeyword>() == 8usize);
+    assert!(size_of::<TSNeverKeyword>() == 12usize);
     assert!(align_of::<TSNeverKeyword>() == 4usize);
-    assert!(offset_of!(TSNeverKeyword, span) == 0usize);
+    assert!(offset_of!(TSNeverKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNeverKeyword, span) == 4usize);
 
-    assert!(size_of::<TSIntrinsicKeyword>() == 8usize);
+    assert!(size_of::<TSIntrinsicKeyword>() == 12usize);
     assert!(align_of::<TSIntrinsicKeyword>() == 4usize);
-    assert!(offset_of!(TSIntrinsicKeyword, span) == 0usize);
+    assert!(offset_of!(TSIntrinsicKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSIntrinsicKeyword, span) == 4usize);
 
-    assert!(size_of::<TSUnknownKeyword>() == 8usize);
+    assert!(size_of::<TSUnknownKeyword>() == 12usize);
     assert!(align_of::<TSUnknownKeyword>() == 4usize);
-    assert!(offset_of!(TSUnknownKeyword, span) == 0usize);
+    assert!(offset_of!(TSUnknownKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSUnknownKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNullKeyword>() == 8usize);
+    assert!(size_of::<TSNullKeyword>() == 12usize);
     assert!(align_of::<TSNullKeyword>() == 4usize);
-    assert!(offset_of!(TSNullKeyword, span) == 0usize);
+    assert!(offset_of!(TSNullKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNullKeyword, span) == 4usize);
 
-    assert!(size_of::<TSUndefinedKeyword>() == 8usize);
+    assert!(size_of::<TSUndefinedKeyword>() == 12usize);
     assert!(align_of::<TSUndefinedKeyword>() == 4usize);
-    assert!(offset_of!(TSUndefinedKeyword, span) == 0usize);
+    assert!(offset_of!(TSUndefinedKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSUndefinedKeyword, span) == 4usize);
 
-    assert!(size_of::<TSVoidKeyword>() == 8usize);
+    assert!(size_of::<TSVoidKeyword>() == 12usize);
     assert!(align_of::<TSVoidKeyword>() == 4usize);
-    assert!(offset_of!(TSVoidKeyword, span) == 0usize);
+    assert!(offset_of!(TSVoidKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSVoidKeyword, span) == 4usize);
 
-    assert!(size_of::<TSSymbolKeyword>() == 8usize);
+    assert!(size_of::<TSSymbolKeyword>() == 12usize);
     assert!(align_of::<TSSymbolKeyword>() == 4usize);
-    assert!(offset_of!(TSSymbolKeyword, span) == 0usize);
+    assert!(offset_of!(TSSymbolKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSSymbolKeyword, span) == 4usize);
 
-    assert!(size_of::<TSThisType>() == 8usize);
+    assert!(size_of::<TSThisType>() == 12usize);
     assert!(align_of::<TSThisType>() == 4usize);
-    assert!(offset_of!(TSThisType, span) == 0usize);
+    assert!(offset_of!(TSThisType, node_id) == 0usize);
+    assert!(offset_of!(TSThisType, span) == 4usize);
 
-    assert!(size_of::<TSObjectKeyword>() == 8usize);
+    assert!(size_of::<TSObjectKeyword>() == 12usize);
     assert!(align_of::<TSObjectKeyword>() == 4usize);
-    assert!(offset_of!(TSObjectKeyword, span) == 0usize);
+    assert!(offset_of!(TSObjectKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSObjectKeyword, span) == 4usize);
 
-    assert!(size_of::<TSBigIntKeyword>() == 8usize);
+    assert!(size_of::<TSBigIntKeyword>() == 12usize);
     assert!(align_of::<TSBigIntKeyword>() == 4usize);
-    assert!(offset_of!(TSBigIntKeyword, span) == 0usize);
+    assert!(offset_of!(TSBigIntKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSBigIntKeyword, span) == 4usize);
 
-    assert!(size_of::<TSTypeReference>() == 32usize);
+    assert!(size_of::<TSTypeReference>() == 40usize);
     assert!(align_of::<TSTypeReference>() == 8usize);
-    assert!(offset_of!(TSTypeReference, span) == 0usize);
-    assert!(offset_of!(TSTypeReference, type_name) == 8usize);
-    assert!(offset_of!(TSTypeReference, type_parameters) == 24usize);
+    assert!(offset_of!(TSTypeReference, node_id) == 0usize);
+    assert!(offset_of!(TSTypeReference, span) == 4usize);
+    assert!(offset_of!(TSTypeReference, type_name) == 16usize);
+    assert!(offset_of!(TSTypeReference, type_parameters) == 32usize);
 
     assert!(size_of::<TSTypeName>() == 16usize);
     assert!(align_of::<TSTypeName>() == 8usize);
 
-    assert!(size_of::<TSQualifiedName>() == 48usize);
+    assert!(size_of::<TSQualifiedName>() == 64usize);
     assert!(align_of::<TSQualifiedName>() == 8usize);
-    assert!(offset_of!(TSQualifiedName, span) == 0usize);
-    assert!(offset_of!(TSQualifiedName, left) == 8usize);
-    assert!(offset_of!(TSQualifiedName, right) == 24usize);
+    assert!(offset_of!(TSQualifiedName, node_id) == 0usize);
+    assert!(offset_of!(TSQualifiedName, span) == 4usize);
+    assert!(offset_of!(TSQualifiedName, left) == 16usize);
+    assert!(offset_of!(TSQualifiedName, right) == 32usize);
 
-    assert!(size_of::<TSTypeParameterInstantiation>() == 40usize);
+    assert!(size_of::<TSTypeParameterInstantiation>() == 48usize);
     assert!(align_of::<TSTypeParameterInstantiation>() == 8usize);
-    assert!(offset_of!(TSTypeParameterInstantiation, span) == 0usize);
-    assert!(offset_of!(TSTypeParameterInstantiation, params) == 8usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, span) == 4usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, params) == 16usize);
 
-    assert!(size_of::<TSTypeParameter>() == 80usize);
+    assert!(size_of::<TSTypeParameter>() == 96usize);
     assert!(align_of::<TSTypeParameter>() == 8usize);
-    assert!(offset_of!(TSTypeParameter, span) == 0usize);
-    assert!(offset_of!(TSTypeParameter, name) == 8usize);
-    assert!(offset_of!(TSTypeParameter, constraint) == 40usize);
-    assert!(offset_of!(TSTypeParameter, default) == 56usize);
-    assert!(offset_of!(TSTypeParameter, r#in) == 72usize);
-    assert!(offset_of!(TSTypeParameter, out) == 73usize);
-    assert!(offset_of!(TSTypeParameter, r#const) == 74usize);
+    assert!(offset_of!(TSTypeParameter, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameter, span) == 4usize);
+    assert!(offset_of!(TSTypeParameter, name) == 16usize);
+    assert!(offset_of!(TSTypeParameter, constraint) == 56usize);
+    assert!(offset_of!(TSTypeParameter, default) == 72usize);
+    assert!(offset_of!(TSTypeParameter, r#in) == 88usize);
+    assert!(offset_of!(TSTypeParameter, out) == 89usize);
+    assert!(offset_of!(TSTypeParameter, r#const) == 90usize);
 
-    assert!(size_of::<TSTypeParameterDeclaration>() == 40usize);
+    assert!(size_of::<TSTypeParameterDeclaration>() == 48usize);
     assert!(align_of::<TSTypeParameterDeclaration>() == 8usize);
-    assert!(offset_of!(TSTypeParameterDeclaration, span) == 0usize);
-    assert!(offset_of!(TSTypeParameterDeclaration, params) == 8usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, span) == 4usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, params) == 16usize);
 
-    assert!(size_of::<TSTypeAliasDeclaration>() == 72usize);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 88usize);
     assert!(align_of::<TSTypeAliasDeclaration>() == 8usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, span) == 0usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, id) == 8usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 40usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 48usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 64usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 68usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, span) == 4usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, id) == 16usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 56usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 64usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 80usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 84usize);
 
     assert!(size_of::<TSAccessibility>() == 1usize);
     assert!(align_of::<TSAccessibility>() == 1usize);
 
-    assert!(size_of::<TSClassImplements>() == 32usize);
+    assert!(size_of::<TSClassImplements>() == 40usize);
     assert!(align_of::<TSClassImplements>() == 8usize);
-    assert!(offset_of!(TSClassImplements, span) == 0usize);
-    assert!(offset_of!(TSClassImplements, expression) == 8usize);
-    assert!(offset_of!(TSClassImplements, type_parameters) == 24usize);
+    assert!(offset_of!(TSClassImplements, node_id) == 0usize);
+    assert!(offset_of!(TSClassImplements, span) == 4usize);
+    assert!(offset_of!(TSClassImplements, expression) == 16usize);
+    assert!(offset_of!(TSClassImplements, type_parameters) == 32usize);
 
-    assert!(size_of::<TSInterfaceDeclaration>() == 96usize);
+    assert!(size_of::<TSInterfaceDeclaration>() == 112usize);
     assert!(align_of::<TSInterfaceDeclaration>() == 8usize);
-    assert!(offset_of!(TSInterfaceDeclaration, span) == 0usize);
-    assert!(offset_of!(TSInterfaceDeclaration, id) == 8usize);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 40usize);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 72usize);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 80usize);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 88usize);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 92usize);
+    assert!(offset_of!(TSInterfaceDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceDeclaration, span) == 4usize);
+    assert!(offset_of!(TSInterfaceDeclaration, id) == 16usize);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 56usize);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 88usize);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 96usize);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 104usize);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 108usize);
 
-    assert!(size_of::<TSInterfaceBody>() == 40usize);
+    assert!(size_of::<TSInterfaceBody>() == 48usize);
     assert!(align_of::<TSInterfaceBody>() == 8usize);
-    assert!(offset_of!(TSInterfaceBody, span) == 0usize);
-    assert!(offset_of!(TSInterfaceBody, body) == 8usize);
+    assert!(offset_of!(TSInterfaceBody, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceBody, span) == 4usize);
+    assert!(offset_of!(TSInterfaceBody, body) == 16usize);
 
     assert!(size_of::<TSPropertySignature>() == 40usize);
     assert!(align_of::<TSPropertySignature>() == 8usize);
-    assert!(offset_of!(TSPropertySignature, span) == 0usize);
-    assert!(offset_of!(TSPropertySignature, computed) == 8usize);
-    assert!(offset_of!(TSPropertySignature, optional) == 9usize);
-    assert!(offset_of!(TSPropertySignature, readonly) == 10usize);
+    assert!(offset_of!(TSPropertySignature, node_id) == 0usize);
+    assert!(offset_of!(TSPropertySignature, span) == 4usize);
+    assert!(offset_of!(TSPropertySignature, computed) == 12usize);
+    assert!(offset_of!(TSPropertySignature, optional) == 13usize);
+    assert!(offset_of!(TSPropertySignature, readonly) == 14usize);
     assert!(offset_of!(TSPropertySignature, key) == 16usize);
     assert!(offset_of!(TSPropertySignature, type_annotation) == 32usize);
 
     assert!(size_of::<TSSignature>() == 16usize);
     assert!(align_of::<TSSignature>() == 8usize);
 
-    assert!(size_of::<TSIndexSignature>() == 56usize);
+    assert!(size_of::<TSIndexSignature>() == 64usize);
     assert!(align_of::<TSIndexSignature>() == 8usize);
-    assert!(offset_of!(TSIndexSignature, span) == 0usize);
-    assert!(offset_of!(TSIndexSignature, parameters) == 8usize);
-    assert!(offset_of!(TSIndexSignature, type_annotation) == 40usize);
-    assert!(offset_of!(TSIndexSignature, readonly) == 48usize);
+    assert!(offset_of!(TSIndexSignature, node_id) == 0usize);
+    assert!(offset_of!(TSIndexSignature, span) == 4usize);
+    assert!(offset_of!(TSIndexSignature, parameters) == 16usize);
+    assert!(offset_of!(TSIndexSignature, type_annotation) == 48usize);
+    assert!(offset_of!(TSIndexSignature, readonly) == 56usize);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 64usize);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 72usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 40usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 48usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 56usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, span) == 4usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 16usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 48usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 56usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 64usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
 
-    assert!(size_of::<TSMethodSignature>() == 72usize);
+    assert!(size_of::<TSMethodSignature>() == 80usize);
     assert!(align_of::<TSMethodSignature>() == 8usize);
-    assert!(offset_of!(TSMethodSignature, span) == 0usize);
-    assert!(offset_of!(TSMethodSignature, key) == 8usize);
-    assert!(offset_of!(TSMethodSignature, computed) == 24usize);
-    assert!(offset_of!(TSMethodSignature, optional) == 25usize);
-    assert!(offset_of!(TSMethodSignature, kind) == 26usize);
-    assert!(offset_of!(TSMethodSignature, this_param) == 32usize);
-    assert!(offset_of!(TSMethodSignature, params) == 40usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 48usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 56usize);
-    assert!(offset_of!(TSMethodSignature, scope_id) == 64usize);
+    assert!(offset_of!(TSMethodSignature, node_id) == 0usize);
+    assert!(offset_of!(TSMethodSignature, span) == 4usize);
+    assert!(offset_of!(TSMethodSignature, key) == 16usize);
+    assert!(offset_of!(TSMethodSignature, computed) == 32usize);
+    assert!(offset_of!(TSMethodSignature, optional) == 33usize);
+    assert!(offset_of!(TSMethodSignature, kind) == 34usize);
+    assert!(offset_of!(TSMethodSignature, this_param) == 40usize);
+    assert!(offset_of!(TSMethodSignature, params) == 48usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 56usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 64usize);
+    assert!(offset_of!(TSMethodSignature, scope_id) == 72usize);
 
-    assert!(size_of::<TSConstructSignatureDeclaration>() == 40usize);
+    assert!(size_of::<TSConstructSignatureDeclaration>() == 48usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 8usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 8usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 16usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 24usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 32usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, span) == 4usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 16usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 24usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 32usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 40usize);
 
-    assert!(size_of::<TSIndexSignatureName>() == 32usize);
+    assert!(size_of::<TSIndexSignatureName>() == 40usize);
     assert!(align_of::<TSIndexSignatureName>() == 8usize);
-    assert!(offset_of!(TSIndexSignatureName, span) == 0usize);
-    assert!(offset_of!(TSIndexSignatureName, name) == 8usize);
-    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 24usize);
+    assert!(offset_of!(TSIndexSignatureName, node_id) == 0usize);
+    assert!(offset_of!(TSIndexSignatureName, span) == 4usize);
+    assert!(offset_of!(TSIndexSignatureName, name) == 16usize);
+    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 32usize);
 
-    assert!(size_of::<TSInterfaceHeritage>() == 32usize);
+    assert!(size_of::<TSInterfaceHeritage>() == 40usize);
     assert!(align_of::<TSInterfaceHeritage>() == 8usize);
-    assert!(offset_of!(TSInterfaceHeritage, span) == 0usize);
-    assert!(offset_of!(TSInterfaceHeritage, expression) == 8usize);
-    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 24usize);
+    assert!(offset_of!(TSInterfaceHeritage, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceHeritage, span) == 4usize);
+    assert!(offset_of!(TSInterfaceHeritage, expression) == 16usize);
+    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 32usize);
 
-    assert!(size_of::<TSTypePredicate>() == 40usize);
+    assert!(size_of::<TSTypePredicate>() == 56usize);
     assert!(align_of::<TSTypePredicate>() == 8usize);
-    assert!(offset_of!(TSTypePredicate, span) == 0usize);
-    assert!(offset_of!(TSTypePredicate, parameter_name) == 8usize);
-    assert!(offset_of!(TSTypePredicate, asserts) == 24usize);
-    assert!(offset_of!(TSTypePredicate, type_annotation) == 32usize);
+    assert!(offset_of!(TSTypePredicate, node_id) == 0usize);
+    assert!(offset_of!(TSTypePredicate, span) == 4usize);
+    assert!(offset_of!(TSTypePredicate, parameter_name) == 16usize);
+    assert!(offset_of!(TSTypePredicate, asserts) == 40usize);
+    assert!(offset_of!(TSTypePredicate, type_annotation) == 48usize);
 
-    assert!(size_of::<TSTypePredicateName>() == 16usize);
+    assert!(size_of::<TSTypePredicateName>() == 24usize);
     assert!(align_of::<TSTypePredicateName>() == 8usize);
 
-    assert!(size_of::<TSModuleDeclaration>() == 64usize);
+    assert!(size_of::<TSModuleDeclaration>() == 80usize);
     assert!(align_of::<TSModuleDeclaration>() == 8usize);
-    assert!(offset_of!(TSModuleDeclaration, span) == 0usize);
-    assert!(offset_of!(TSModuleDeclaration, id) == 8usize);
-    assert!(offset_of!(TSModuleDeclaration, body) == 40usize);
-    assert!(offset_of!(TSModuleDeclaration, kind) == 56usize);
-    assert!(offset_of!(TSModuleDeclaration, declare) == 57usize);
-    assert!(offset_of!(TSModuleDeclaration, scope_id) == 60usize);
+    assert!(offset_of!(TSModuleDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSModuleDeclaration, span) == 4usize);
+    assert!(offset_of!(TSModuleDeclaration, id) == 16usize);
+    assert!(offset_of!(TSModuleDeclaration, body) == 56usize);
+    assert!(offset_of!(TSModuleDeclaration, kind) == 72usize);
+    assert!(offset_of!(TSModuleDeclaration, declare) == 73usize);
+    assert!(offset_of!(TSModuleDeclaration, scope_id) == 76usize);
 
     assert!(size_of::<TSModuleDeclarationKind>() == 1usize);
     assert!(align_of::<TSModuleDeclarationKind>() == 1usize);
 
-    assert!(size_of::<TSModuleDeclarationName>() == 32usize);
+    assert!(size_of::<TSModuleDeclarationName>() == 40usize);
     assert!(align_of::<TSModuleDeclarationName>() == 8usize);
 
     assert!(size_of::<TSModuleDeclarationBody>() == 16usize);
     assert!(align_of::<TSModuleDeclarationBody>() == 8usize);
 
-    assert!(size_of::<TSModuleBlock>() == 72usize);
+    assert!(size_of::<TSModuleBlock>() == 80usize);
     assert!(align_of::<TSModuleBlock>() == 8usize);
-    assert!(offset_of!(TSModuleBlock, span) == 0usize);
-    assert!(offset_of!(TSModuleBlock, directives) == 8usize);
-    assert!(offset_of!(TSModuleBlock, body) == 40usize);
+    assert!(offset_of!(TSModuleBlock, node_id) == 0usize);
+    assert!(offset_of!(TSModuleBlock, span) == 4usize);
+    assert!(offset_of!(TSModuleBlock, directives) == 16usize);
+    assert!(offset_of!(TSModuleBlock, body) == 48usize);
 
-    assert!(size_of::<TSTypeLiteral>() == 40usize);
+    assert!(size_of::<TSTypeLiteral>() == 48usize);
     assert!(align_of::<TSTypeLiteral>() == 8usize);
-    assert!(offset_of!(TSTypeLiteral, span) == 0usize);
-    assert!(offset_of!(TSTypeLiteral, members) == 8usize);
+    assert!(offset_of!(TSTypeLiteral, node_id) == 0usize);
+    assert!(offset_of!(TSTypeLiteral, span) == 4usize);
+    assert!(offset_of!(TSTypeLiteral, members) == 16usize);
 
-    assert!(size_of::<TSInferType>() == 16usize);
+    assert!(size_of::<TSInferType>() == 24usize);
     assert!(align_of::<TSInferType>() == 8usize);
-    assert!(offset_of!(TSInferType, span) == 0usize);
-    assert!(offset_of!(TSInferType, type_parameter) == 8usize);
+    assert!(offset_of!(TSInferType, node_id) == 0usize);
+    assert!(offset_of!(TSInferType, span) == 4usize);
+    assert!(offset_of!(TSInferType, type_parameter) == 16usize);
 
-    assert!(size_of::<TSTypeQuery>() == 32usize);
+    assert!(size_of::<TSTypeQuery>() == 40usize);
     assert!(align_of::<TSTypeQuery>() == 8usize);
-    assert!(offset_of!(TSTypeQuery, span) == 0usize);
-    assert!(offset_of!(TSTypeQuery, expr_name) == 8usize);
-    assert!(offset_of!(TSTypeQuery, type_parameters) == 24usize);
+    assert!(offset_of!(TSTypeQuery, node_id) == 0usize);
+    assert!(offset_of!(TSTypeQuery, span) == 4usize);
+    assert!(offset_of!(TSTypeQuery, expr_name) == 16usize);
+    assert!(offset_of!(TSTypeQuery, type_parameters) == 32usize);
 
     assert!(size_of::<TSTypeQueryExprName>() == 16usize);
     assert!(align_of::<TSTypeQueryExprName>() == 8usize);
 
     assert!(size_of::<TSImportType>() == 64usize);
     assert!(align_of::<TSImportType>() == 8usize);
-    assert!(offset_of!(TSImportType, span) == 0usize);
-    assert!(offset_of!(TSImportType, is_type_of) == 8usize);
+    assert!(offset_of!(TSImportType, node_id) == 0usize);
+    assert!(offset_of!(TSImportType, span) == 4usize);
+    assert!(offset_of!(TSImportType, is_type_of) == 12usize);
     assert!(offset_of!(TSImportType, parameter) == 16usize);
     assert!(offset_of!(TSImportType, qualifier) == 32usize);
     assert!(offset_of!(TSImportType, attributes) == 48usize);
     assert!(offset_of!(TSImportType, type_parameters) == 56usize);
 
-    assert!(size_of::<TSImportAttributes>() == 64usize);
+    assert!(size_of::<TSImportAttributes>() == 80usize);
     assert!(align_of::<TSImportAttributes>() == 8usize);
-    assert!(offset_of!(TSImportAttributes, span) == 0usize);
-    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 32usize);
+    assert!(offset_of!(TSImportAttributes, node_id) == 0usize);
+    assert!(offset_of!(TSImportAttributes, span) == 4usize);
+    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 16usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 48usize);
 
-    assert!(size_of::<TSImportAttribute>() == 56usize);
+    assert!(size_of::<TSImportAttribute>() == 72usize);
     assert!(align_of::<TSImportAttribute>() == 8usize);
-    assert!(offset_of!(TSImportAttribute, span) == 0usize);
-    assert!(offset_of!(TSImportAttribute, name) == 8usize);
-    assert!(offset_of!(TSImportAttribute, value) == 40usize);
+    assert!(offset_of!(TSImportAttribute, node_id) == 0usize);
+    assert!(offset_of!(TSImportAttribute, span) == 4usize);
+    assert!(offset_of!(TSImportAttribute, name) == 16usize);
+    assert!(offset_of!(TSImportAttribute, value) == 56usize);
 
-    assert!(size_of::<TSImportAttributeName>() == 32usize);
+    assert!(size_of::<TSImportAttributeName>() == 40usize);
     assert!(align_of::<TSImportAttributeName>() == 8usize);
 
-    assert!(size_of::<TSFunctionType>() == 40usize);
+    assert!(size_of::<TSFunctionType>() == 48usize);
     assert!(align_of::<TSFunctionType>() == 8usize);
-    assert!(offset_of!(TSFunctionType, span) == 0usize);
-    assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 16usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 24usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 32usize);
+    assert!(offset_of!(TSFunctionType, node_id) == 0usize);
+    assert!(offset_of!(TSFunctionType, span) == 4usize);
+    assert!(offset_of!(TSFunctionType, this_param) == 16usize);
+    assert!(offset_of!(TSFunctionType, params) == 24usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 32usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 40usize);
 
     assert!(size_of::<TSConstructorType>() == 40usize);
     assert!(align_of::<TSConstructorType>() == 8usize);
-    assert!(offset_of!(TSConstructorType, span) == 0usize);
-    assert!(offset_of!(TSConstructorType, r#abstract) == 8usize);
+    assert!(offset_of!(TSConstructorType, node_id) == 0usize);
+    assert!(offset_of!(TSConstructorType, span) == 4usize);
+    assert!(offset_of!(TSConstructorType, r#abstract) == 12usize);
     assert!(offset_of!(TSConstructorType, params) == 16usize);
     assert!(offset_of!(TSConstructorType, return_type) == 24usize);
     assert!(offset_of!(TSConstructorType, type_parameters) == 32usize);
 
-    assert!(size_of::<TSMappedType>() == 56usize);
+    assert!(size_of::<TSMappedType>() == 64usize);
     assert!(align_of::<TSMappedType>() == 8usize);
-    assert!(offset_of!(TSMappedType, span) == 0usize);
-    assert!(offset_of!(TSMappedType, type_parameter) == 8usize);
-    assert!(offset_of!(TSMappedType, name_type) == 16usize);
-    assert!(offset_of!(TSMappedType, type_annotation) == 32usize);
-    assert!(offset_of!(TSMappedType, optional) == 48usize);
-    assert!(offset_of!(TSMappedType, readonly) == 49usize);
-    assert!(offset_of!(TSMappedType, scope_id) == 52usize);
+    assert!(offset_of!(TSMappedType, node_id) == 0usize);
+    assert!(offset_of!(TSMappedType, span) == 4usize);
+    assert!(offset_of!(TSMappedType, type_parameter) == 16usize);
+    assert!(offset_of!(TSMappedType, name_type) == 24usize);
+    assert!(offset_of!(TSMappedType, type_annotation) == 40usize);
+    assert!(offset_of!(TSMappedType, optional) == 56usize);
+    assert!(offset_of!(TSMappedType, readonly) == 57usize);
+    assert!(offset_of!(TSMappedType, scope_id) == 60usize);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1usize);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1usize);
 
-    assert!(size_of::<TSTemplateLiteralType>() == 72usize);
+    assert!(size_of::<TSTemplateLiteralType>() == 80usize);
     assert!(align_of::<TSTemplateLiteralType>() == 8usize);
-    assert!(offset_of!(TSTemplateLiteralType, span) == 0usize);
-    assert!(offset_of!(TSTemplateLiteralType, quasis) == 8usize);
-    assert!(offset_of!(TSTemplateLiteralType, types) == 40usize);
+    assert!(offset_of!(TSTemplateLiteralType, node_id) == 0usize);
+    assert!(offset_of!(TSTemplateLiteralType, span) == 4usize);
+    assert!(offset_of!(TSTemplateLiteralType, quasis) == 16usize);
+    assert!(offset_of!(TSTemplateLiteralType, types) == 48usize);
 
-    assert!(size_of::<TSAsExpression>() == 40usize);
+    assert!(size_of::<TSAsExpression>() == 48usize);
     assert!(align_of::<TSAsExpression>() == 8usize);
-    assert!(offset_of!(TSAsExpression, span) == 0usize);
-    assert!(offset_of!(TSAsExpression, expression) == 8usize);
-    assert!(offset_of!(TSAsExpression, type_annotation) == 24usize);
+    assert!(offset_of!(TSAsExpression, node_id) == 0usize);
+    assert!(offset_of!(TSAsExpression, span) == 4usize);
+    assert!(offset_of!(TSAsExpression, expression) == 16usize);
+    assert!(offset_of!(TSAsExpression, type_annotation) == 32usize);
 
-    assert!(size_of::<TSSatisfiesExpression>() == 40usize);
+    assert!(size_of::<TSSatisfiesExpression>() == 48usize);
     assert!(align_of::<TSSatisfiesExpression>() == 8usize);
-    assert!(offset_of!(TSSatisfiesExpression, span) == 0usize);
-    assert!(offset_of!(TSSatisfiesExpression, expression) == 8usize);
-    assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 24usize);
+    assert!(offset_of!(TSSatisfiesExpression, node_id) == 0usize);
+    assert!(offset_of!(TSSatisfiesExpression, span) == 4usize);
+    assert!(offset_of!(TSSatisfiesExpression, expression) == 16usize);
+    assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 32usize);
 
-    assert!(size_of::<TSTypeAssertion>() == 40usize);
+    assert!(size_of::<TSTypeAssertion>() == 48usize);
     assert!(align_of::<TSTypeAssertion>() == 8usize);
-    assert!(offset_of!(TSTypeAssertion, span) == 0usize);
-    assert!(offset_of!(TSTypeAssertion, expression) == 8usize);
-    assert!(offset_of!(TSTypeAssertion, type_annotation) == 24usize);
+    assert!(offset_of!(TSTypeAssertion, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAssertion, span) == 4usize);
+    assert!(offset_of!(TSTypeAssertion, expression) == 16usize);
+    assert!(offset_of!(TSTypeAssertion, type_annotation) == 32usize);
 
-    assert!(size_of::<TSImportEqualsDeclaration>() == 64usize);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 80usize);
     assert!(align_of::<TSImportEqualsDeclaration>() == 8usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, span) == 0usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, id) == 8usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 40usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 56usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, span) == 4usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, id) == 16usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 56usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 72usize);
 
     assert!(size_of::<TSModuleReference>() == 16usize);
     assert!(align_of::<TSModuleReference>() == 8usize);
 
-    assert!(size_of::<TSExternalModuleReference>() == 32usize);
+    assert!(size_of::<TSExternalModuleReference>() == 48usize);
     assert!(align_of::<TSExternalModuleReference>() == 8usize);
-    assert!(offset_of!(TSExternalModuleReference, span) == 0usize);
-    assert!(offset_of!(TSExternalModuleReference, expression) == 8usize);
+    assert!(offset_of!(TSExternalModuleReference, node_id) == 0usize);
+    assert!(offset_of!(TSExternalModuleReference, span) == 4usize);
+    assert!(offset_of!(TSExternalModuleReference, expression) == 16usize);
 
-    assert!(size_of::<TSNonNullExpression>() == 24usize);
+    assert!(size_of::<TSNonNullExpression>() == 32usize);
     assert!(align_of::<TSNonNullExpression>() == 8usize);
-    assert!(offset_of!(TSNonNullExpression, span) == 0usize);
-    assert!(offset_of!(TSNonNullExpression, expression) == 8usize);
+    assert!(offset_of!(TSNonNullExpression, node_id) == 0usize);
+    assert!(offset_of!(TSNonNullExpression, span) == 4usize);
+    assert!(offset_of!(TSNonNullExpression, expression) == 16usize);
 
-    assert!(size_of::<Decorator>() == 24usize);
+    assert!(size_of::<Decorator>() == 32usize);
     assert!(align_of::<Decorator>() == 8usize);
-    assert!(offset_of!(Decorator, span) == 0usize);
-    assert!(offset_of!(Decorator, expression) == 8usize);
+    assert!(offset_of!(Decorator, node_id) == 0usize);
+    assert!(offset_of!(Decorator, span) == 4usize);
+    assert!(offset_of!(Decorator, expression) == 16usize);
 
-    assert!(size_of::<TSExportAssignment>() == 24usize);
+    assert!(size_of::<TSExportAssignment>() == 32usize);
     assert!(align_of::<TSExportAssignment>() == 8usize);
-    assert!(offset_of!(TSExportAssignment, span) == 0usize);
-    assert!(offset_of!(TSExportAssignment, expression) == 8usize);
+    assert!(offset_of!(TSExportAssignment, node_id) == 0usize);
+    assert!(offset_of!(TSExportAssignment, span) == 4usize);
+    assert!(offset_of!(TSExportAssignment, expression) == 16usize);
 
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 32usize);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 48usize);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 8usize);
-    assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0usize);
-    assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, span) == 4usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, id) == 16usize);
 
-    assert!(size_of::<TSInstantiationExpression>() == 32usize);
+    assert!(size_of::<TSInstantiationExpression>() == 40usize);
     assert!(align_of::<TSInstantiationExpression>() == 8usize);
-    assert!(offset_of!(TSInstantiationExpression, span) == 0usize);
-    assert!(offset_of!(TSInstantiationExpression, expression) == 8usize);
-    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 24usize);
+    assert!(offset_of!(TSInstantiationExpression, node_id) == 0usize);
+    assert!(offset_of!(TSInstantiationExpression, span) == 4usize);
+    assert!(offset_of!(TSInstantiationExpression, expression) == 16usize);
+    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 32usize);
 
     assert!(size_of::<ImportOrExportKind>() == 1usize);
     assert!(align_of::<ImportOrExportKind>() == 1usize);
 
-    assert!(size_of::<JSDocNullableType>() == 32usize);
+    assert!(size_of::<JSDocNullableType>() == 40usize);
     assert!(align_of::<JSDocNullableType>() == 8usize);
-    assert!(offset_of!(JSDocNullableType, span) == 0usize);
-    assert!(offset_of!(JSDocNullableType, type_annotation) == 8usize);
-    assert!(offset_of!(JSDocNullableType, postfix) == 24usize);
+    assert!(offset_of!(JSDocNullableType, node_id) == 0usize);
+    assert!(offset_of!(JSDocNullableType, span) == 4usize);
+    assert!(offset_of!(JSDocNullableType, type_annotation) == 16usize);
+    assert!(offset_of!(JSDocNullableType, postfix) == 32usize);
 
-    assert!(size_of::<JSDocNonNullableType>() == 32usize);
+    assert!(size_of::<JSDocNonNullableType>() == 40usize);
     assert!(align_of::<JSDocNonNullableType>() == 8usize);
-    assert!(offset_of!(JSDocNonNullableType, span) == 0usize);
-    assert!(offset_of!(JSDocNonNullableType, type_annotation) == 8usize);
-    assert!(offset_of!(JSDocNonNullableType, postfix) == 24usize);
+    assert!(offset_of!(JSDocNonNullableType, node_id) == 0usize);
+    assert!(offset_of!(JSDocNonNullableType, span) == 4usize);
+    assert!(offset_of!(JSDocNonNullableType, type_annotation) == 16usize);
+    assert!(offset_of!(JSDocNonNullableType, postfix) == 32usize);
 
-    assert!(size_of::<JSDocUnknownType>() == 8usize);
+    assert!(size_of::<JSDocUnknownType>() == 12usize);
     assert!(align_of::<JSDocUnknownType>() == 4usize);
-    assert!(offset_of!(JSDocUnknownType, span) == 0usize);
+    assert!(offset_of!(JSDocUnknownType, node_id) == 0usize);
+    assert!(offset_of!(JSDocUnknownType, span) == 4usize);
 
-    assert!(size_of::<JSXElement>() == 56usize);
+    assert!(size_of::<JSXElement>() == 64usize);
     assert!(align_of::<JSXElement>() == 8usize);
-    assert!(offset_of!(JSXElement, span) == 0usize);
-    assert!(offset_of!(JSXElement, opening_element) == 8usize);
-    assert!(offset_of!(JSXElement, closing_element) == 16usize);
-    assert!(offset_of!(JSXElement, children) == 24usize);
+    assert!(offset_of!(JSXElement, node_id) == 0usize);
+    assert!(offset_of!(JSXElement, span) == 4usize);
+    assert!(offset_of!(JSXElement, opening_element) == 16usize);
+    assert!(offset_of!(JSXElement, closing_element) == 24usize);
+    assert!(offset_of!(JSXElement, children) == 32usize);
 
     assert!(size_of::<JSXOpeningElement>() == 72usize);
     assert!(align_of::<JSXOpeningElement>() == 8usize);
-    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
+    assert!(offset_of!(JSXOpeningElement, node_id) == 0usize);
+    assert!(offset_of!(JSXOpeningElement, span) == 4usize);
+    assert!(offset_of!(JSXOpeningElement, self_closing) == 12usize);
     assert!(offset_of!(JSXOpeningElement, name) == 16usize);
     assert!(offset_of!(JSXOpeningElement, attributes) == 32usize);
     assert!(offset_of!(JSXOpeningElement, type_parameters) == 64usize);
 
-    assert!(size_of::<JSXClosingElement>() == 24usize);
+    assert!(size_of::<JSXClosingElement>() == 32usize);
     assert!(align_of::<JSXClosingElement>() == 8usize);
-    assert!(offset_of!(JSXClosingElement, span) == 0usize);
-    assert!(offset_of!(JSXClosingElement, name) == 8usize);
+    assert!(offset_of!(JSXClosingElement, node_id) == 0usize);
+    assert!(offset_of!(JSXClosingElement, span) == 4usize);
+    assert!(offset_of!(JSXClosingElement, name) == 16usize);
 
-    assert!(size_of::<JSXFragment>() == 56usize);
+    assert!(size_of::<JSXFragment>() == 64usize);
     assert!(align_of::<JSXFragment>() == 8usize);
-    assert!(offset_of!(JSXFragment, span) == 0usize);
-    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
-    assert!(offset_of!(JSXFragment, children) == 24usize);
+    assert!(offset_of!(JSXFragment, node_id) == 0usize);
+    assert!(offset_of!(JSXFragment, span) == 4usize);
+    assert!(offset_of!(JSXFragment, opening_fragment) == 12usize);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 20usize);
+    assert!(offset_of!(JSXFragment, children) == 32usize);
 
     assert!(size_of::<JSXOpeningFragment>() == 8usize);
     assert!(align_of::<JSXOpeningFragment>() == 4usize);
@@ -1309,46 +1485,52 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 16usize);
     assert!(align_of::<JSXElementName>() == 8usize);
 
-    assert!(size_of::<JSXNamespacedName>() == 56usize);
+    assert!(size_of::<JSXNamespacedName>() == 80usize);
     assert!(align_of::<JSXNamespacedName>() == 8usize);
-    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
-    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 32usize);
+    assert!(offset_of!(JSXNamespacedName, node_id) == 0usize);
+    assert!(offset_of!(JSXNamespacedName, span) == 4usize);
+    assert!(offset_of!(JSXNamespacedName, namespace) == 16usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 48usize);
 
-    assert!(size_of::<JSXMemberExpression>() == 48usize);
+    assert!(size_of::<JSXMemberExpression>() == 64usize);
     assert!(align_of::<JSXMemberExpression>() == 8usize);
-    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
-    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
-    assert!(offset_of!(JSXMemberExpression, property) == 24usize);
+    assert!(offset_of!(JSXMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(JSXMemberExpression, span) == 4usize);
+    assert!(offset_of!(JSXMemberExpression, object) == 16usize);
+    assert!(offset_of!(JSXMemberExpression, property) == 32usize);
 
     assert!(size_of::<JSXMemberExpressionObject>() == 16usize);
     assert!(align_of::<JSXMemberExpressionObject>() == 8usize);
 
-    assert!(size_of::<JSXExpressionContainer>() == 24usize);
+    assert!(size_of::<JSXExpressionContainer>() == 40usize);
     assert!(align_of::<JSXExpressionContainer>() == 8usize);
-    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
-    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
+    assert!(offset_of!(JSXExpressionContainer, node_id) == 0usize);
+    assert!(offset_of!(JSXExpressionContainer, span) == 4usize);
+    assert!(offset_of!(JSXExpressionContainer, expression) == 16usize);
 
-    assert!(size_of::<JSXExpression>() == 16usize);
+    assert!(size_of::<JSXExpression>() == 24usize);
     assert!(align_of::<JSXExpression>() == 8usize);
 
-    assert!(size_of::<JSXEmptyExpression>() == 8usize);
+    assert!(size_of::<JSXEmptyExpression>() == 12usize);
     assert!(align_of::<JSXEmptyExpression>() == 4usize);
-    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
+    assert!(offset_of!(JSXEmptyExpression, node_id) == 0usize);
+    assert!(offset_of!(JSXEmptyExpression, span) == 4usize);
 
     assert!(size_of::<JSXAttributeItem>() == 16usize);
     assert!(align_of::<JSXAttributeItem>() == 8usize);
 
-    assert!(size_of::<JSXAttribute>() == 40usize);
+    assert!(size_of::<JSXAttribute>() == 48usize);
     assert!(align_of::<JSXAttribute>() == 8usize);
-    assert!(offset_of!(JSXAttribute, span) == 0usize);
-    assert!(offset_of!(JSXAttribute, name) == 8usize);
-    assert!(offset_of!(JSXAttribute, value) == 24usize);
+    assert!(offset_of!(JSXAttribute, node_id) == 0usize);
+    assert!(offset_of!(JSXAttribute, span) == 4usize);
+    assert!(offset_of!(JSXAttribute, name) == 16usize);
+    assert!(offset_of!(JSXAttribute, value) == 32usize);
 
-    assert!(size_of::<JSXSpreadAttribute>() == 24usize);
+    assert!(size_of::<JSXSpreadAttribute>() == 32usize);
     assert!(align_of::<JSXSpreadAttribute>() == 8usize);
-    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
-    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
+    assert!(offset_of!(JSXSpreadAttribute, node_id) == 0usize);
+    assert!(offset_of!(JSXSpreadAttribute, span) == 4usize);
+    assert!(offset_of!(JSXSpreadAttribute, argument) == 16usize);
 
     assert!(size_of::<JSXAttributeName>() == 16usize);
     assert!(align_of::<JSXAttributeName>() == 8usize);
@@ -1356,23 +1538,29 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 16usize);
     assert!(align_of::<JSXAttributeValue>() == 8usize);
 
-    assert!(size_of::<JSXIdentifier>() == 24usize);
+    assert!(size_of::<JSXIdentifier>() == 32usize);
     assert!(align_of::<JSXIdentifier>() == 8usize);
-    assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
+    assert!(offset_of!(JSXIdentifier, node_id) == 0usize);
+    assert!(offset_of!(JSXIdentifier, span) == 4usize);
+    assert!(offset_of!(JSXIdentifier, name) == 16usize);
 
     assert!(size_of::<JSXChild>() == 16usize);
     assert!(align_of::<JSXChild>() == 8usize);
 
-    assert!(size_of::<JSXSpreadChild>() == 24usize);
+    assert!(size_of::<JSXSpreadChild>() == 32usize);
     assert!(align_of::<JSXSpreadChild>() == 8usize);
-    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
-    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
+    assert!(offset_of!(JSXSpreadChild, node_id) == 0usize);
+    assert!(offset_of!(JSXSpreadChild, span) == 4usize);
+    assert!(offset_of!(JSXSpreadChild, expression) == 16usize);
 
-    assert!(size_of::<JSXText>() == 24usize);
+    assert!(size_of::<JSXText>() == 32usize);
     assert!(align_of::<JSXText>() == 8usize);
-    assert!(offset_of!(JSXText, span) == 0usize);
-    assert!(offset_of!(JSXText, value) == 8usize);
+    assert!(offset_of!(JSXText, node_id) == 0usize);
+    assert!(offset_of!(JSXText, span) == 4usize);
+    assert!(offset_of!(JSXText, value) == 16usize);
+
+    assert!(size_of::<NodeId>() == 4usize);
+    assert!(align_of::<NodeId>() == 4usize);
 
     assert!(size_of::<NumberBase>() == 1usize);
     assert!(align_of::<NumberBase>() == 1usize);
@@ -1566,33 +1754,38 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
-    assert!(size_of::<BooleanLiteral>() == 12usize);
+    assert!(size_of::<BooleanLiteral>() == 16usize);
     assert!(align_of::<BooleanLiteral>() == 4usize);
-    assert!(offset_of!(BooleanLiteral, span) == 0usize);
-    assert!(offset_of!(BooleanLiteral, value) == 8usize);
+    assert!(offset_of!(BooleanLiteral, node_id) == 0usize);
+    assert!(offset_of!(BooleanLiteral, span) == 4usize);
+    assert!(offset_of!(BooleanLiteral, value) == 12usize);
 
-    assert!(size_of::<NullLiteral>() == 8usize);
+    assert!(size_of::<NullLiteral>() == 12usize);
     assert!(align_of::<NullLiteral>() == 4usize);
-    assert!(offset_of!(NullLiteral, span) == 0usize);
+    assert!(offset_of!(NullLiteral, node_id) == 0usize);
+    assert!(offset_of!(NullLiteral, span) == 4usize);
 
-    assert!(size_of::<NumericLiteral>() == 32usize);
+    assert!(size_of::<NumericLiteral>() == 40usize);
     assert!(align_of::<NumericLiteral>() == 8usize);
-    assert!(offset_of!(NumericLiteral, span) == 0usize);
-    assert!(offset_of!(NumericLiteral, value) == 8usize);
-    assert!(offset_of!(NumericLiteral, raw) == 16usize);
-    assert!(offset_of!(NumericLiteral, base) == 24usize);
+    assert!(offset_of!(NumericLiteral, node_id) == 0usize);
+    assert!(offset_of!(NumericLiteral, span) == 4usize);
+    assert!(offset_of!(NumericLiteral, value) == 16usize);
+    assert!(offset_of!(NumericLiteral, raw) == 24usize);
+    assert!(offset_of!(NumericLiteral, base) == 32usize);
 
-    assert!(size_of::<BigIntLiteral>() == 20usize);
+    assert!(size_of::<BigIntLiteral>() == 24usize);
     assert!(align_of::<BigIntLiteral>() == 4usize);
-    assert!(offset_of!(BigIntLiteral, span) == 0usize);
-    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
-    assert!(offset_of!(BigIntLiteral, base) == 16usize);
+    assert!(offset_of!(BigIntLiteral, node_id) == 0usize);
+    assert!(offset_of!(BigIntLiteral, span) == 4usize);
+    assert!(offset_of!(BigIntLiteral, raw) == 12usize);
+    assert!(offset_of!(BigIntLiteral, base) == 20usize);
 
-    assert!(size_of::<RegExpLiteral>() == 24usize);
+    assert!(size_of::<RegExpLiteral>() == 28usize);
     assert!(align_of::<RegExpLiteral>() == 4usize);
-    assert!(offset_of!(RegExpLiteral, span) == 0usize);
-    assert!(offset_of!(RegExpLiteral, value) == 8usize);
-    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
+    assert!(offset_of!(RegExpLiteral, node_id) == 0usize);
+    assert!(offset_of!(RegExpLiteral, span) == 4usize);
+    assert!(offset_of!(RegExpLiteral, value) == 12usize);
+    assert!(offset_of!(RegExpLiteral, regex) == 12usize);
 
     assert!(size_of::<RegExp>() == 16usize);
     assert!(align_of::<RegExp>() == 4usize);
@@ -1605,81 +1798,92 @@ const _: () = {
     assert!(size_of::<EmptyObject>() == 0usize);
     assert!(align_of::<EmptyObject>() == 1usize);
 
-    assert!(size_of::<StringLiteral>() == 16usize);
+    assert!(size_of::<StringLiteral>() == 20usize);
     assert!(align_of::<StringLiteral>() == 4usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
+    assert!(offset_of!(StringLiteral, node_id) == 0usize);
+    assert!(offset_of!(StringLiteral, span) == 4usize);
+    assert!(offset_of!(StringLiteral, value) == 12usize);
 
-    assert!(size_of::<Program>() == 64usize);
+    assert!(size_of::<Program>() == 72usize);
     assert!(align_of::<Program>() == 4usize);
-    assert!(offset_of!(Program, span) == 0usize);
-    assert!(offset_of!(Program, source_type) == 8usize);
-    assert!(offset_of!(Program, hashbang) == 12usize);
-    assert!(offset_of!(Program, directives) == 28usize);
-    assert!(offset_of!(Program, body) == 44usize);
-    assert!(offset_of!(Program, scope_id) == 60usize);
+    assert!(offset_of!(Program, node_id) == 0usize);
+    assert!(offset_of!(Program, span) == 4usize);
+    assert!(offset_of!(Program, source_type) == 12usize);
+    assert!(offset_of!(Program, hashbang) == 16usize);
+    assert!(offset_of!(Program, directives) == 36usize);
+    assert!(offset_of!(Program, body) == 52usize);
+    assert!(offset_of!(Program, scope_id) == 68usize);
 
     assert!(size_of::<Expression>() == 8usize);
     assert!(align_of::<Expression>() == 4usize);
 
-    assert!(size_of::<IdentifierName>() == 16usize);
+    assert!(size_of::<IdentifierName>() == 20usize);
     assert!(align_of::<IdentifierName>() == 4usize);
-    assert!(offset_of!(IdentifierName, span) == 0usize);
-    assert!(offset_of!(IdentifierName, name) == 8usize);
+    assert!(offset_of!(IdentifierName, node_id) == 0usize);
+    assert!(offset_of!(IdentifierName, span) == 4usize);
+    assert!(offset_of!(IdentifierName, name) == 12usize);
 
-    assert!(size_of::<IdentifierReference>() == 20usize);
+    assert!(size_of::<IdentifierReference>() == 24usize);
     assert!(align_of::<IdentifierReference>() == 4usize);
-    assert!(offset_of!(IdentifierReference, span) == 0usize);
-    assert!(offset_of!(IdentifierReference, name) == 8usize);
-    assert!(offset_of!(IdentifierReference, reference_id) == 16usize);
+    assert!(offset_of!(IdentifierReference, node_id) == 0usize);
+    assert!(offset_of!(IdentifierReference, span) == 4usize);
+    assert!(offset_of!(IdentifierReference, name) == 12usize);
+    assert!(offset_of!(IdentifierReference, reference_id) == 20usize);
 
-    assert!(size_of::<BindingIdentifier>() == 20usize);
+    assert!(size_of::<BindingIdentifier>() == 24usize);
     assert!(align_of::<BindingIdentifier>() == 4usize);
-    assert!(offset_of!(BindingIdentifier, span) == 0usize);
-    assert!(offset_of!(BindingIdentifier, name) == 8usize);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 16usize);
+    assert!(offset_of!(BindingIdentifier, node_id) == 0usize);
+    assert!(offset_of!(BindingIdentifier, span) == 4usize);
+    assert!(offset_of!(BindingIdentifier, name) == 12usize);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 20usize);
 
-    assert!(size_of::<LabelIdentifier>() == 16usize);
+    assert!(size_of::<LabelIdentifier>() == 20usize);
     assert!(align_of::<LabelIdentifier>() == 4usize);
-    assert!(offset_of!(LabelIdentifier, span) == 0usize);
-    assert!(offset_of!(LabelIdentifier, name) == 8usize);
+    assert!(offset_of!(LabelIdentifier, node_id) == 0usize);
+    assert!(offset_of!(LabelIdentifier, span) == 4usize);
+    assert!(offset_of!(LabelIdentifier, name) == 12usize);
 
-    assert!(size_of::<ThisExpression>() == 8usize);
+    assert!(size_of::<ThisExpression>() == 12usize);
     assert!(align_of::<ThisExpression>() == 4usize);
-    assert!(offset_of!(ThisExpression, span) == 0usize);
+    assert!(offset_of!(ThisExpression, node_id) == 0usize);
+    assert!(offset_of!(ThisExpression, span) == 4usize);
 
-    assert!(size_of::<ArrayExpression>() == 36usize);
+    assert!(size_of::<ArrayExpression>() == 40usize);
     assert!(align_of::<ArrayExpression>() == 4usize);
-    assert!(offset_of!(ArrayExpression, span) == 0usize);
-    assert!(offset_of!(ArrayExpression, elements) == 8usize);
-    assert!(offset_of!(ArrayExpression, trailing_comma) == 24usize);
+    assert!(offset_of!(ArrayExpression, node_id) == 0usize);
+    assert!(offset_of!(ArrayExpression, span) == 4usize);
+    assert!(offset_of!(ArrayExpression, elements) == 12usize);
+    assert!(offset_of!(ArrayExpression, trailing_comma) == 28usize);
 
-    assert!(size_of::<ArrayExpressionElement>() == 12usize);
+    assert!(size_of::<ArrayExpressionElement>() == 16usize);
     assert!(align_of::<ArrayExpressionElement>() == 4usize);
 
-    assert!(size_of::<Elision>() == 8usize);
+    assert!(size_of::<Elision>() == 12usize);
     assert!(align_of::<Elision>() == 4usize);
-    assert!(offset_of!(Elision, span) == 0usize);
+    assert!(offset_of!(Elision, node_id) == 0usize);
+    assert!(offset_of!(Elision, span) == 4usize);
 
-    assert!(size_of::<ObjectExpression>() == 36usize);
+    assert!(size_of::<ObjectExpression>() == 40usize);
     assert!(align_of::<ObjectExpression>() == 4usize);
-    assert!(offset_of!(ObjectExpression, span) == 0usize);
-    assert!(offset_of!(ObjectExpression, properties) == 8usize);
-    assert!(offset_of!(ObjectExpression, trailing_comma) == 24usize);
+    assert!(offset_of!(ObjectExpression, node_id) == 0usize);
+    assert!(offset_of!(ObjectExpression, span) == 4usize);
+    assert!(offset_of!(ObjectExpression, properties) == 12usize);
+    assert!(offset_of!(ObjectExpression, trailing_comma) == 28usize);
 
     assert!(size_of::<ObjectPropertyKind>() == 8usize);
     assert!(align_of::<ObjectPropertyKind>() == 4usize);
 
-    assert!(size_of::<ObjectProperty>() == 40usize);
+    assert!(size_of::<ObjectProperty>() == 44usize);
     assert!(align_of::<ObjectProperty>() == 4usize);
-    assert!(offset_of!(ObjectProperty, span) == 0usize);
-    assert!(offset_of!(ObjectProperty, kind) == 8usize);
-    assert!(offset_of!(ObjectProperty, key) == 12usize);
-    assert!(offset_of!(ObjectProperty, value) == 20usize);
-    assert!(offset_of!(ObjectProperty, init) == 28usize);
-    assert!(offset_of!(ObjectProperty, method) == 36usize);
-    assert!(offset_of!(ObjectProperty, shorthand) == 37usize);
-    assert!(offset_of!(ObjectProperty, computed) == 38usize);
+    assert!(offset_of!(ObjectProperty, node_id) == 0usize);
+    assert!(offset_of!(ObjectProperty, span) == 4usize);
+    assert!(offset_of!(ObjectProperty, kind) == 12usize);
+    assert!(offset_of!(ObjectProperty, key) == 16usize);
+    assert!(offset_of!(ObjectProperty, value) == 24usize);
+    assert!(offset_of!(ObjectProperty, init) == 32usize);
+    assert!(offset_of!(ObjectProperty, method) == 40usize);
+    assert!(offset_of!(ObjectProperty, shorthand) == 41usize);
+    assert!(offset_of!(ObjectProperty, computed) == 42usize);
 
     assert!(size_of::<PropertyKey>() == 8usize);
     assert!(align_of::<PropertyKey>() == 4usize);
@@ -1687,24 +1891,27 @@ const _: () = {
     assert!(size_of::<PropertyKind>() == 1usize);
     assert!(align_of::<PropertyKind>() == 1usize);
 
-    assert!(size_of::<TemplateLiteral>() == 40usize);
+    assert!(size_of::<TemplateLiteral>() == 44usize);
     assert!(align_of::<TemplateLiteral>() == 4usize);
-    assert!(offset_of!(TemplateLiteral, span) == 0usize);
-    assert!(offset_of!(TemplateLiteral, quasis) == 8usize);
-    assert!(offset_of!(TemplateLiteral, expressions) == 24usize);
+    assert!(offset_of!(TemplateLiteral, node_id) == 0usize);
+    assert!(offset_of!(TemplateLiteral, span) == 4usize);
+    assert!(offset_of!(TemplateLiteral, quasis) == 12usize);
+    assert!(offset_of!(TemplateLiteral, expressions) == 28usize);
 
-    assert!(size_of::<TaggedTemplateExpression>() == 60usize);
+    assert!(size_of::<TaggedTemplateExpression>() == 68usize);
     assert!(align_of::<TaggedTemplateExpression>() == 4usize);
-    assert!(offset_of!(TaggedTemplateExpression, span) == 0usize);
-    assert!(offset_of!(TaggedTemplateExpression, tag) == 8usize);
-    assert!(offset_of!(TaggedTemplateExpression, quasi) == 16usize);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 56usize);
+    assert!(offset_of!(TaggedTemplateExpression, node_id) == 0usize);
+    assert!(offset_of!(TaggedTemplateExpression, span) == 4usize);
+    assert!(offset_of!(TaggedTemplateExpression, tag) == 12usize);
+    assert!(offset_of!(TaggedTemplateExpression, quasi) == 20usize);
+    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 64usize);
 
-    assert!(size_of::<TemplateElement>() == 28usize);
+    assert!(size_of::<TemplateElement>() == 32usize);
     assert!(align_of::<TemplateElement>() == 4usize);
-    assert!(offset_of!(TemplateElement, span) == 0usize);
-    assert!(offset_of!(TemplateElement, tail) == 8usize);
-    assert!(offset_of!(TemplateElement, value) == 12usize);
+    assert!(offset_of!(TemplateElement, node_id) == 0usize);
+    assert!(offset_of!(TemplateElement, span) == 4usize);
+    assert!(offset_of!(TemplateElement, tail) == 12usize);
+    assert!(offset_of!(TemplateElement, value) == 16usize);
 
     assert!(size_of::<TemplateElementValue>() == 16usize);
     assert!(align_of::<TemplateElementValue>() == 4usize);
@@ -1714,103 +1921,117 @@ const _: () = {
     assert!(size_of::<MemberExpression>() == 8usize);
     assert!(align_of::<MemberExpression>() == 4usize);
 
-    assert!(size_of::<ComputedMemberExpression>() == 28usize);
+    assert!(size_of::<ComputedMemberExpression>() == 32usize);
     assert!(align_of::<ComputedMemberExpression>() == 4usize);
-    assert!(offset_of!(ComputedMemberExpression, span) == 0usize);
-    assert!(offset_of!(ComputedMemberExpression, object) == 8usize);
-    assert!(offset_of!(ComputedMemberExpression, expression) == 16usize);
-    assert!(offset_of!(ComputedMemberExpression, optional) == 24usize);
+    assert!(offset_of!(ComputedMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(ComputedMemberExpression, span) == 4usize);
+    assert!(offset_of!(ComputedMemberExpression, object) == 12usize);
+    assert!(offset_of!(ComputedMemberExpression, expression) == 20usize);
+    assert!(offset_of!(ComputedMemberExpression, optional) == 28usize);
 
-    assert!(size_of::<StaticMemberExpression>() == 36usize);
+    assert!(size_of::<StaticMemberExpression>() == 44usize);
     assert!(align_of::<StaticMemberExpression>() == 4usize);
-    assert!(offset_of!(StaticMemberExpression, span) == 0usize);
-    assert!(offset_of!(StaticMemberExpression, object) == 8usize);
-    assert!(offset_of!(StaticMemberExpression, property) == 16usize);
-    assert!(offset_of!(StaticMemberExpression, optional) == 32usize);
+    assert!(offset_of!(StaticMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(StaticMemberExpression, span) == 4usize);
+    assert!(offset_of!(StaticMemberExpression, object) == 12usize);
+    assert!(offset_of!(StaticMemberExpression, property) == 20usize);
+    assert!(offset_of!(StaticMemberExpression, optional) == 40usize);
 
-    assert!(size_of::<PrivateFieldExpression>() == 36usize);
+    assert!(size_of::<PrivateFieldExpression>() == 44usize);
     assert!(align_of::<PrivateFieldExpression>() == 4usize);
-    assert!(offset_of!(PrivateFieldExpression, span) == 0usize);
-    assert!(offset_of!(PrivateFieldExpression, object) == 8usize);
-    assert!(offset_of!(PrivateFieldExpression, field) == 16usize);
-    assert!(offset_of!(PrivateFieldExpression, optional) == 32usize);
+    assert!(offset_of!(PrivateFieldExpression, node_id) == 0usize);
+    assert!(offset_of!(PrivateFieldExpression, span) == 4usize);
+    assert!(offset_of!(PrivateFieldExpression, object) == 12usize);
+    assert!(offset_of!(PrivateFieldExpression, field) == 20usize);
+    assert!(offset_of!(PrivateFieldExpression, optional) == 40usize);
 
-    assert!(size_of::<CallExpression>() == 40usize);
+    assert!(size_of::<CallExpression>() == 44usize);
     assert!(align_of::<CallExpression>() == 4usize);
-    assert!(offset_of!(CallExpression, span) == 0usize);
-    assert!(offset_of!(CallExpression, callee) == 8usize);
-    assert!(offset_of!(CallExpression, type_parameters) == 16usize);
-    assert!(offset_of!(CallExpression, arguments) == 20usize);
-    assert!(offset_of!(CallExpression, optional) == 36usize);
+    assert!(offset_of!(CallExpression, node_id) == 0usize);
+    assert!(offset_of!(CallExpression, span) == 4usize);
+    assert!(offset_of!(CallExpression, callee) == 12usize);
+    assert!(offset_of!(CallExpression, type_parameters) == 20usize);
+    assert!(offset_of!(CallExpression, arguments) == 24usize);
+    assert!(offset_of!(CallExpression, optional) == 40usize);
 
-    assert!(size_of::<NewExpression>() == 36usize);
+    assert!(size_of::<NewExpression>() == 40usize);
     assert!(align_of::<NewExpression>() == 4usize);
-    assert!(offset_of!(NewExpression, span) == 0usize);
-    assert!(offset_of!(NewExpression, callee) == 8usize);
-    assert!(offset_of!(NewExpression, arguments) == 16usize);
-    assert!(offset_of!(NewExpression, type_parameters) == 32usize);
+    assert!(offset_of!(NewExpression, node_id) == 0usize);
+    assert!(offset_of!(NewExpression, span) == 4usize);
+    assert!(offset_of!(NewExpression, callee) == 12usize);
+    assert!(offset_of!(NewExpression, arguments) == 20usize);
+    assert!(offset_of!(NewExpression, type_parameters) == 36usize);
 
-    assert!(size_of::<MetaProperty>() == 40usize);
+    assert!(size_of::<MetaProperty>() == 52usize);
     assert!(align_of::<MetaProperty>() == 4usize);
-    assert!(offset_of!(MetaProperty, span) == 0usize);
-    assert!(offset_of!(MetaProperty, meta) == 8usize);
-    assert!(offset_of!(MetaProperty, property) == 24usize);
+    assert!(offset_of!(MetaProperty, node_id) == 0usize);
+    assert!(offset_of!(MetaProperty, span) == 4usize);
+    assert!(offset_of!(MetaProperty, meta) == 12usize);
+    assert!(offset_of!(MetaProperty, property) == 32usize);
 
-    assert!(size_of::<SpreadElement>() == 16usize);
+    assert!(size_of::<SpreadElement>() == 20usize);
     assert!(align_of::<SpreadElement>() == 4usize);
-    assert!(offset_of!(SpreadElement, span) == 0usize);
-    assert!(offset_of!(SpreadElement, argument) == 8usize);
+    assert!(offset_of!(SpreadElement, node_id) == 0usize);
+    assert!(offset_of!(SpreadElement, span) == 4usize);
+    assert!(offset_of!(SpreadElement, argument) == 12usize);
 
     assert!(size_of::<Argument>() == 8usize);
     assert!(align_of::<Argument>() == 4usize);
 
-    assert!(size_of::<UpdateExpression>() == 20usize);
+    assert!(size_of::<UpdateExpression>() == 24usize);
     assert!(align_of::<UpdateExpression>() == 4usize);
-    assert!(offset_of!(UpdateExpression, span) == 0usize);
-    assert!(offset_of!(UpdateExpression, operator) == 8usize);
-    assert!(offset_of!(UpdateExpression, prefix) == 9usize);
-    assert!(offset_of!(UpdateExpression, argument) == 12usize);
+    assert!(offset_of!(UpdateExpression, node_id) == 0usize);
+    assert!(offset_of!(UpdateExpression, span) == 4usize);
+    assert!(offset_of!(UpdateExpression, operator) == 12usize);
+    assert!(offset_of!(UpdateExpression, prefix) == 13usize);
+    assert!(offset_of!(UpdateExpression, argument) == 16usize);
 
-    assert!(size_of::<UnaryExpression>() == 20usize);
+    assert!(size_of::<UnaryExpression>() == 24usize);
     assert!(align_of::<UnaryExpression>() == 4usize);
-    assert!(offset_of!(UnaryExpression, span) == 0usize);
-    assert!(offset_of!(UnaryExpression, operator) == 8usize);
-    assert!(offset_of!(UnaryExpression, argument) == 12usize);
+    assert!(offset_of!(UnaryExpression, node_id) == 0usize);
+    assert!(offset_of!(UnaryExpression, span) == 4usize);
+    assert!(offset_of!(UnaryExpression, operator) == 12usize);
+    assert!(offset_of!(UnaryExpression, argument) == 16usize);
 
-    assert!(size_of::<BinaryExpression>() == 28usize);
+    assert!(size_of::<BinaryExpression>() == 32usize);
     assert!(align_of::<BinaryExpression>() == 4usize);
-    assert!(offset_of!(BinaryExpression, span) == 0usize);
-    assert!(offset_of!(BinaryExpression, left) == 8usize);
-    assert!(offset_of!(BinaryExpression, operator) == 16usize);
-    assert!(offset_of!(BinaryExpression, right) == 20usize);
+    assert!(offset_of!(BinaryExpression, node_id) == 0usize);
+    assert!(offset_of!(BinaryExpression, span) == 4usize);
+    assert!(offset_of!(BinaryExpression, left) == 12usize);
+    assert!(offset_of!(BinaryExpression, operator) == 20usize);
+    assert!(offset_of!(BinaryExpression, right) == 24usize);
 
-    assert!(size_of::<PrivateInExpression>() == 36usize);
+    assert!(size_of::<PrivateInExpression>() == 44usize);
     assert!(align_of::<PrivateInExpression>() == 4usize);
-    assert!(offset_of!(PrivateInExpression, span) == 0usize);
-    assert!(offset_of!(PrivateInExpression, left) == 8usize);
-    assert!(offset_of!(PrivateInExpression, operator) == 24usize);
-    assert!(offset_of!(PrivateInExpression, right) == 28usize);
+    assert!(offset_of!(PrivateInExpression, node_id) == 0usize);
+    assert!(offset_of!(PrivateInExpression, span) == 4usize);
+    assert!(offset_of!(PrivateInExpression, left) == 12usize);
+    assert!(offset_of!(PrivateInExpression, operator) == 32usize);
+    assert!(offset_of!(PrivateInExpression, right) == 36usize);
 
-    assert!(size_of::<LogicalExpression>() == 28usize);
+    assert!(size_of::<LogicalExpression>() == 32usize);
     assert!(align_of::<LogicalExpression>() == 4usize);
-    assert!(offset_of!(LogicalExpression, span) == 0usize);
-    assert!(offset_of!(LogicalExpression, left) == 8usize);
-    assert!(offset_of!(LogicalExpression, operator) == 16usize);
-    assert!(offset_of!(LogicalExpression, right) == 20usize);
+    assert!(offset_of!(LogicalExpression, node_id) == 0usize);
+    assert!(offset_of!(LogicalExpression, span) == 4usize);
+    assert!(offset_of!(LogicalExpression, left) == 12usize);
+    assert!(offset_of!(LogicalExpression, operator) == 20usize);
+    assert!(offset_of!(LogicalExpression, right) == 24usize);
 
-    assert!(size_of::<ConditionalExpression>() == 32usize);
+    assert!(size_of::<ConditionalExpression>() == 36usize);
     assert!(align_of::<ConditionalExpression>() == 4usize);
-    assert!(offset_of!(ConditionalExpression, span) == 0usize);
-    assert!(offset_of!(ConditionalExpression, test) == 8usize);
-    assert!(offset_of!(ConditionalExpression, consequent) == 16usize);
-    assert!(offset_of!(ConditionalExpression, alternate) == 24usize);
+    assert!(offset_of!(ConditionalExpression, node_id) == 0usize);
+    assert!(offset_of!(ConditionalExpression, span) == 4usize);
+    assert!(offset_of!(ConditionalExpression, test) == 12usize);
+    assert!(offset_of!(ConditionalExpression, consequent) == 20usize);
+    assert!(offset_of!(ConditionalExpression, alternate) == 28usize);
 
-    assert!(size_of::<AssignmentExpression>() == 28usize);
+    assert!(size_of::<AssignmentExpression>() == 32usize);
     assert!(align_of::<AssignmentExpression>() == 4usize);
-    assert!(offset_of!(AssignmentExpression, span) == 0usize);
-    assert!(offset_of!(AssignmentExpression, operator) == 8usize);
-    assert!(offset_of!(AssignmentExpression, left) == 12usize);
-    assert!(offset_of!(AssignmentExpression, right) == 20usize);
+    assert!(offset_of!(AssignmentExpression, node_id) == 0usize);
+    assert!(offset_of!(AssignmentExpression, span) == 4usize);
+    assert!(offset_of!(AssignmentExpression, operator) == 12usize);
+    assert!(offset_of!(AssignmentExpression, left) == 16usize);
+    assert!(offset_of!(AssignmentExpression, right) == 24usize);
 
     assert!(size_of::<AssignmentTarget>() == 8usize);
     assert!(align_of::<AssignmentTarget>() == 4usize);
@@ -1821,403 +2042,455 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 8usize);
     assert!(align_of::<AssignmentTargetPattern>() == 4usize);
 
-    assert!(size_of::<ArrayAssignmentTarget>() == 52usize);
+    assert!(size_of::<ArrayAssignmentTarget>() == 60usize);
     assert!(align_of::<ArrayAssignmentTarget>() == 4usize);
-    assert!(offset_of!(ArrayAssignmentTarget, span) == 0usize);
-    assert!(offset_of!(ArrayAssignmentTarget, elements) == 8usize);
-    assert!(offset_of!(ArrayAssignmentTarget, rest) == 24usize);
-    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 40usize);
+    assert!(offset_of!(ArrayAssignmentTarget, node_id) == 0usize);
+    assert!(offset_of!(ArrayAssignmentTarget, span) == 4usize);
+    assert!(offset_of!(ArrayAssignmentTarget, elements) == 12usize);
+    assert!(offset_of!(ArrayAssignmentTarget, rest) == 28usize);
+    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 48usize);
 
-    assert!(size_of::<ObjectAssignmentTarget>() == 40usize);
+    assert!(size_of::<ObjectAssignmentTarget>() == 48usize);
     assert!(align_of::<ObjectAssignmentTarget>() == 4usize);
-    assert!(offset_of!(ObjectAssignmentTarget, span) == 0usize);
-    assert!(offset_of!(ObjectAssignmentTarget, properties) == 8usize);
-    assert!(offset_of!(ObjectAssignmentTarget, rest) == 24usize);
+    assert!(offset_of!(ObjectAssignmentTarget, node_id) == 0usize);
+    assert!(offset_of!(ObjectAssignmentTarget, span) == 4usize);
+    assert!(offset_of!(ObjectAssignmentTarget, properties) == 12usize);
+    assert!(offset_of!(ObjectAssignmentTarget, rest) == 28usize);
 
-    assert!(size_of::<AssignmentTargetRest>() == 16usize);
+    assert!(size_of::<AssignmentTargetRest>() == 20usize);
     assert!(align_of::<AssignmentTargetRest>() == 4usize);
-    assert!(offset_of!(AssignmentTargetRest, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetRest, target) == 8usize);
+    assert!(offset_of!(AssignmentTargetRest, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetRest, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetRest, target) == 12usize);
 
     assert!(size_of::<AssignmentTargetMaybeDefault>() == 8usize);
     assert!(align_of::<AssignmentTargetMaybeDefault>() == 4usize);
 
-    assert!(size_of::<AssignmentTargetWithDefault>() == 24usize);
+    assert!(size_of::<AssignmentTargetWithDefault>() == 28usize);
     assert!(align_of::<AssignmentTargetWithDefault>() == 4usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetWithDefault, init) == 16usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, binding) == 12usize);
+    assert!(offset_of!(AssignmentTargetWithDefault, init) == 20usize);
 
     assert!(size_of::<AssignmentTargetProperty>() == 8usize);
     assert!(align_of::<AssignmentTargetProperty>() == 4usize);
 
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 36usize);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 44usize);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 4usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 28usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 12usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 36usize);
 
-    assert!(size_of::<AssignmentTargetPropertyProperty>() == 24usize);
+    assert!(size_of::<AssignmentTargetPropertyProperty>() == 28usize);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 4usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 0usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, name) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 16usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, node_id) == 0usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, span) == 4usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, name) == 12usize);
+    assert!(offset_of!(AssignmentTargetPropertyProperty, binding) == 20usize);
 
-    assert!(size_of::<SequenceExpression>() == 24usize);
+    assert!(size_of::<SequenceExpression>() == 28usize);
     assert!(align_of::<SequenceExpression>() == 4usize);
-    assert!(offset_of!(SequenceExpression, span) == 0usize);
-    assert!(offset_of!(SequenceExpression, expressions) == 8usize);
+    assert!(offset_of!(SequenceExpression, node_id) == 0usize);
+    assert!(offset_of!(SequenceExpression, span) == 4usize);
+    assert!(offset_of!(SequenceExpression, expressions) == 12usize);
 
-    assert!(size_of::<Super>() == 8usize);
+    assert!(size_of::<Super>() == 12usize);
     assert!(align_of::<Super>() == 4usize);
-    assert!(offset_of!(Super, span) == 0usize);
+    assert!(offset_of!(Super, node_id) == 0usize);
+    assert!(offset_of!(Super, span) == 4usize);
 
-    assert!(size_of::<AwaitExpression>() == 16usize);
+    assert!(size_of::<AwaitExpression>() == 20usize);
     assert!(align_of::<AwaitExpression>() == 4usize);
-    assert!(offset_of!(AwaitExpression, span) == 0usize);
-    assert!(offset_of!(AwaitExpression, argument) == 8usize);
+    assert!(offset_of!(AwaitExpression, node_id) == 0usize);
+    assert!(offset_of!(AwaitExpression, span) == 4usize);
+    assert!(offset_of!(AwaitExpression, argument) == 12usize);
 
-    assert!(size_of::<ChainExpression>() == 16usize);
+    assert!(size_of::<ChainExpression>() == 20usize);
     assert!(align_of::<ChainExpression>() == 4usize);
-    assert!(offset_of!(ChainExpression, span) == 0usize);
-    assert!(offset_of!(ChainExpression, expression) == 8usize);
+    assert!(offset_of!(ChainExpression, node_id) == 0usize);
+    assert!(offset_of!(ChainExpression, span) == 4usize);
+    assert!(offset_of!(ChainExpression, expression) == 12usize);
 
     assert!(size_of::<ChainElement>() == 8usize);
     assert!(align_of::<ChainElement>() == 4usize);
 
-    assert!(size_of::<ParenthesizedExpression>() == 16usize);
+    assert!(size_of::<ParenthesizedExpression>() == 20usize);
     assert!(align_of::<ParenthesizedExpression>() == 4usize);
-    assert!(offset_of!(ParenthesizedExpression, span) == 0usize);
-    assert!(offset_of!(ParenthesizedExpression, expression) == 8usize);
+    assert!(offset_of!(ParenthesizedExpression, node_id) == 0usize);
+    assert!(offset_of!(ParenthesizedExpression, span) == 4usize);
+    assert!(offset_of!(ParenthesizedExpression, expression) == 12usize);
 
     assert!(size_of::<Statement>() == 8usize);
     assert!(align_of::<Statement>() == 4usize);
 
-    assert!(size_of::<Directive>() == 32usize);
+    assert!(size_of::<Directive>() == 40usize);
     assert!(align_of::<Directive>() == 4usize);
-    assert!(offset_of!(Directive, span) == 0usize);
-    assert!(offset_of!(Directive, expression) == 8usize);
-    assert!(offset_of!(Directive, directive) == 24usize);
+    assert!(offset_of!(Directive, node_id) == 0usize);
+    assert!(offset_of!(Directive, span) == 4usize);
+    assert!(offset_of!(Directive, expression) == 12usize);
+    assert!(offset_of!(Directive, directive) == 32usize);
 
-    assert!(size_of::<Hashbang>() == 16usize);
+    assert!(size_of::<Hashbang>() == 20usize);
     assert!(align_of::<Hashbang>() == 4usize);
-    assert!(offset_of!(Hashbang, span) == 0usize);
-    assert!(offset_of!(Hashbang, value) == 8usize);
+    assert!(offset_of!(Hashbang, node_id) == 0usize);
+    assert!(offset_of!(Hashbang, span) == 4usize);
+    assert!(offset_of!(Hashbang, value) == 12usize);
 
-    assert!(size_of::<BlockStatement>() == 28usize);
+    assert!(size_of::<BlockStatement>() == 32usize);
     assert!(align_of::<BlockStatement>() == 4usize);
-    assert!(offset_of!(BlockStatement, span) == 0usize);
-    assert!(offset_of!(BlockStatement, body) == 8usize);
-    assert!(offset_of!(BlockStatement, scope_id) == 24usize);
+    assert!(offset_of!(BlockStatement, node_id) == 0usize);
+    assert!(offset_of!(BlockStatement, span) == 4usize);
+    assert!(offset_of!(BlockStatement, body) == 12usize);
+    assert!(offset_of!(BlockStatement, scope_id) == 28usize);
 
     assert!(size_of::<Declaration>() == 8usize);
     assert!(align_of::<Declaration>() == 4usize);
 
-    assert!(size_of::<VariableDeclaration>() == 32usize);
+    assert!(size_of::<VariableDeclaration>() == 36usize);
     assert!(align_of::<VariableDeclaration>() == 4usize);
-    assert!(offset_of!(VariableDeclaration, span) == 0usize);
-    assert!(offset_of!(VariableDeclaration, kind) == 8usize);
-    assert!(offset_of!(VariableDeclaration, declarations) == 12usize);
-    assert!(offset_of!(VariableDeclaration, declare) == 28usize);
+    assert!(offset_of!(VariableDeclaration, node_id) == 0usize);
+    assert!(offset_of!(VariableDeclaration, span) == 4usize);
+    assert!(offset_of!(VariableDeclaration, kind) == 12usize);
+    assert!(offset_of!(VariableDeclaration, declarations) == 16usize);
+    assert!(offset_of!(VariableDeclaration, declare) == 32usize);
 
     assert!(size_of::<VariableDeclarationKind>() == 1usize);
     assert!(align_of::<VariableDeclarationKind>() == 1usize);
 
-    assert!(size_of::<VariableDeclarator>() == 40usize);
+    assert!(size_of::<VariableDeclarator>() == 48usize);
     assert!(align_of::<VariableDeclarator>() == 4usize);
-    assert!(offset_of!(VariableDeclarator, span) == 0usize);
-    assert!(offset_of!(VariableDeclarator, kind) == 8usize);
-    assert!(offset_of!(VariableDeclarator, id) == 12usize);
-    assert!(offset_of!(VariableDeclarator, init) == 28usize);
-    assert!(offset_of!(VariableDeclarator, definite) == 36usize);
+    assert!(offset_of!(VariableDeclarator, node_id) == 0usize);
+    assert!(offset_of!(VariableDeclarator, span) == 4usize);
+    assert!(offset_of!(VariableDeclarator, kind) == 12usize);
+    assert!(offset_of!(VariableDeclarator, id) == 16usize);
+    assert!(offset_of!(VariableDeclarator, init) == 36usize);
+    assert!(offset_of!(VariableDeclarator, definite) == 44usize);
 
-    assert!(size_of::<EmptyStatement>() == 8usize);
+    assert!(size_of::<EmptyStatement>() == 12usize);
     assert!(align_of::<EmptyStatement>() == 4usize);
-    assert!(offset_of!(EmptyStatement, span) == 0usize);
+    assert!(offset_of!(EmptyStatement, node_id) == 0usize);
+    assert!(offset_of!(EmptyStatement, span) == 4usize);
 
-    assert!(size_of::<ExpressionStatement>() == 16usize);
+    assert!(size_of::<ExpressionStatement>() == 20usize);
     assert!(align_of::<ExpressionStatement>() == 4usize);
-    assert!(offset_of!(ExpressionStatement, span) == 0usize);
-    assert!(offset_of!(ExpressionStatement, expression) == 8usize);
+    assert!(offset_of!(ExpressionStatement, node_id) == 0usize);
+    assert!(offset_of!(ExpressionStatement, span) == 4usize);
+    assert!(offset_of!(ExpressionStatement, expression) == 12usize);
 
-    assert!(size_of::<IfStatement>() == 32usize);
+    assert!(size_of::<IfStatement>() == 36usize);
     assert!(align_of::<IfStatement>() == 4usize);
-    assert!(offset_of!(IfStatement, span) == 0usize);
-    assert!(offset_of!(IfStatement, test) == 8usize);
-    assert!(offset_of!(IfStatement, consequent) == 16usize);
-    assert!(offset_of!(IfStatement, alternate) == 24usize);
+    assert!(offset_of!(IfStatement, node_id) == 0usize);
+    assert!(offset_of!(IfStatement, span) == 4usize);
+    assert!(offset_of!(IfStatement, test) == 12usize);
+    assert!(offset_of!(IfStatement, consequent) == 20usize);
+    assert!(offset_of!(IfStatement, alternate) == 28usize);
 
-    assert!(size_of::<DoWhileStatement>() == 24usize);
+    assert!(size_of::<DoWhileStatement>() == 28usize);
     assert!(align_of::<DoWhileStatement>() == 4usize);
-    assert!(offset_of!(DoWhileStatement, span) == 0usize);
-    assert!(offset_of!(DoWhileStatement, body) == 8usize);
-    assert!(offset_of!(DoWhileStatement, test) == 16usize);
+    assert!(offset_of!(DoWhileStatement, node_id) == 0usize);
+    assert!(offset_of!(DoWhileStatement, span) == 4usize);
+    assert!(offset_of!(DoWhileStatement, body) == 12usize);
+    assert!(offset_of!(DoWhileStatement, test) == 20usize);
 
-    assert!(size_of::<WhileStatement>() == 24usize);
+    assert!(size_of::<WhileStatement>() == 28usize);
     assert!(align_of::<WhileStatement>() == 4usize);
-    assert!(offset_of!(WhileStatement, span) == 0usize);
-    assert!(offset_of!(WhileStatement, test) == 8usize);
-    assert!(offset_of!(WhileStatement, body) == 16usize);
+    assert!(offset_of!(WhileStatement, node_id) == 0usize);
+    assert!(offset_of!(WhileStatement, span) == 4usize);
+    assert!(offset_of!(WhileStatement, test) == 12usize);
+    assert!(offset_of!(WhileStatement, body) == 20usize);
 
-    assert!(size_of::<ForStatement>() == 44usize);
+    assert!(size_of::<ForStatement>() == 48usize);
     assert!(align_of::<ForStatement>() == 4usize);
-    assert!(offset_of!(ForStatement, span) == 0usize);
-    assert!(offset_of!(ForStatement, init) == 8usize);
-    assert!(offset_of!(ForStatement, test) == 16usize);
-    assert!(offset_of!(ForStatement, update) == 24usize);
-    assert!(offset_of!(ForStatement, body) == 32usize);
-    assert!(offset_of!(ForStatement, scope_id) == 40usize);
+    assert!(offset_of!(ForStatement, node_id) == 0usize);
+    assert!(offset_of!(ForStatement, span) == 4usize);
+    assert!(offset_of!(ForStatement, init) == 12usize);
+    assert!(offset_of!(ForStatement, test) == 20usize);
+    assert!(offset_of!(ForStatement, update) == 28usize);
+    assert!(offset_of!(ForStatement, body) == 36usize);
+    assert!(offset_of!(ForStatement, scope_id) == 44usize);
 
     assert!(size_of::<ForStatementInit>() == 8usize);
     assert!(align_of::<ForStatementInit>() == 4usize);
 
-    assert!(size_of::<ForInStatement>() == 36usize);
+    assert!(size_of::<ForInStatement>() == 40usize);
     assert!(align_of::<ForInStatement>() == 4usize);
-    assert!(offset_of!(ForInStatement, span) == 0usize);
-    assert!(offset_of!(ForInStatement, left) == 8usize);
-    assert!(offset_of!(ForInStatement, right) == 16usize);
-    assert!(offset_of!(ForInStatement, body) == 24usize);
-    assert!(offset_of!(ForInStatement, scope_id) == 32usize);
+    assert!(offset_of!(ForInStatement, node_id) == 0usize);
+    assert!(offset_of!(ForInStatement, span) == 4usize);
+    assert!(offset_of!(ForInStatement, left) == 12usize);
+    assert!(offset_of!(ForInStatement, right) == 20usize);
+    assert!(offset_of!(ForInStatement, body) == 28usize);
+    assert!(offset_of!(ForInStatement, scope_id) == 36usize);
 
     assert!(size_of::<ForStatementLeft>() == 8usize);
     assert!(align_of::<ForStatementLeft>() == 4usize);
 
-    assert!(size_of::<ForOfStatement>() == 40usize);
+    assert!(size_of::<ForOfStatement>() == 44usize);
     assert!(align_of::<ForOfStatement>() == 4usize);
-    assert!(offset_of!(ForOfStatement, span) == 0usize);
-    assert!(offset_of!(ForOfStatement, r#await) == 8usize);
-    assert!(offset_of!(ForOfStatement, left) == 12usize);
-    assert!(offset_of!(ForOfStatement, right) == 20usize);
-    assert!(offset_of!(ForOfStatement, body) == 28usize);
-    assert!(offset_of!(ForOfStatement, scope_id) == 36usize);
+    assert!(offset_of!(ForOfStatement, node_id) == 0usize);
+    assert!(offset_of!(ForOfStatement, span) == 4usize);
+    assert!(offset_of!(ForOfStatement, r#await) == 12usize);
+    assert!(offset_of!(ForOfStatement, left) == 16usize);
+    assert!(offset_of!(ForOfStatement, right) == 24usize);
+    assert!(offset_of!(ForOfStatement, body) == 32usize);
+    assert!(offset_of!(ForOfStatement, scope_id) == 40usize);
 
-    assert!(size_of::<ContinueStatement>() == 24usize);
+    assert!(size_of::<ContinueStatement>() == 32usize);
     assert!(align_of::<ContinueStatement>() == 4usize);
-    assert!(offset_of!(ContinueStatement, span) == 0usize);
-    assert!(offset_of!(ContinueStatement, label) == 8usize);
+    assert!(offset_of!(ContinueStatement, node_id) == 0usize);
+    assert!(offset_of!(ContinueStatement, span) == 4usize);
+    assert!(offset_of!(ContinueStatement, label) == 12usize);
 
-    assert!(size_of::<BreakStatement>() == 24usize);
+    assert!(size_of::<BreakStatement>() == 32usize);
     assert!(align_of::<BreakStatement>() == 4usize);
-    assert!(offset_of!(BreakStatement, span) == 0usize);
-    assert!(offset_of!(BreakStatement, label) == 8usize);
+    assert!(offset_of!(BreakStatement, node_id) == 0usize);
+    assert!(offset_of!(BreakStatement, span) == 4usize);
+    assert!(offset_of!(BreakStatement, label) == 12usize);
 
-    assert!(size_of::<ReturnStatement>() == 16usize);
+    assert!(size_of::<ReturnStatement>() == 20usize);
     assert!(align_of::<ReturnStatement>() == 4usize);
-    assert!(offset_of!(ReturnStatement, span) == 0usize);
-    assert!(offset_of!(ReturnStatement, argument) == 8usize);
+    assert!(offset_of!(ReturnStatement, node_id) == 0usize);
+    assert!(offset_of!(ReturnStatement, span) == 4usize);
+    assert!(offset_of!(ReturnStatement, argument) == 12usize);
 
-    assert!(size_of::<WithStatement>() == 24usize);
+    assert!(size_of::<WithStatement>() == 28usize);
     assert!(align_of::<WithStatement>() == 4usize);
-    assert!(offset_of!(WithStatement, span) == 0usize);
-    assert!(offset_of!(WithStatement, object) == 8usize);
-    assert!(offset_of!(WithStatement, body) == 16usize);
+    assert!(offset_of!(WithStatement, node_id) == 0usize);
+    assert!(offset_of!(WithStatement, span) == 4usize);
+    assert!(offset_of!(WithStatement, object) == 12usize);
+    assert!(offset_of!(WithStatement, body) == 20usize);
 
-    assert!(size_of::<SwitchStatement>() == 36usize);
+    assert!(size_of::<SwitchStatement>() == 40usize);
     assert!(align_of::<SwitchStatement>() == 4usize);
-    assert!(offset_of!(SwitchStatement, span) == 0usize);
-    assert!(offset_of!(SwitchStatement, discriminant) == 8usize);
-    assert!(offset_of!(SwitchStatement, cases) == 16usize);
-    assert!(offset_of!(SwitchStatement, scope_id) == 32usize);
+    assert!(offset_of!(SwitchStatement, node_id) == 0usize);
+    assert!(offset_of!(SwitchStatement, span) == 4usize);
+    assert!(offset_of!(SwitchStatement, discriminant) == 12usize);
+    assert!(offset_of!(SwitchStatement, cases) == 20usize);
+    assert!(offset_of!(SwitchStatement, scope_id) == 36usize);
 
-    assert!(size_of::<SwitchCase>() == 32usize);
+    assert!(size_of::<SwitchCase>() == 36usize);
     assert!(align_of::<SwitchCase>() == 4usize);
-    assert!(offset_of!(SwitchCase, span) == 0usize);
-    assert!(offset_of!(SwitchCase, test) == 8usize);
-    assert!(offset_of!(SwitchCase, consequent) == 16usize);
+    assert!(offset_of!(SwitchCase, node_id) == 0usize);
+    assert!(offset_of!(SwitchCase, span) == 4usize);
+    assert!(offset_of!(SwitchCase, test) == 12usize);
+    assert!(offset_of!(SwitchCase, consequent) == 20usize);
 
-    assert!(size_of::<LabeledStatement>() == 32usize);
+    assert!(size_of::<LabeledStatement>() == 40usize);
     assert!(align_of::<LabeledStatement>() == 4usize);
-    assert!(offset_of!(LabeledStatement, span) == 0usize);
-    assert!(offset_of!(LabeledStatement, label) == 8usize);
-    assert!(offset_of!(LabeledStatement, body) == 24usize);
+    assert!(offset_of!(LabeledStatement, node_id) == 0usize);
+    assert!(offset_of!(LabeledStatement, span) == 4usize);
+    assert!(offset_of!(LabeledStatement, label) == 12usize);
+    assert!(offset_of!(LabeledStatement, body) == 32usize);
 
-    assert!(size_of::<ThrowStatement>() == 16usize);
+    assert!(size_of::<ThrowStatement>() == 20usize);
     assert!(align_of::<ThrowStatement>() == 4usize);
-    assert!(offset_of!(ThrowStatement, span) == 0usize);
-    assert!(offset_of!(ThrowStatement, argument) == 8usize);
+    assert!(offset_of!(ThrowStatement, node_id) == 0usize);
+    assert!(offset_of!(ThrowStatement, span) == 4usize);
+    assert!(offset_of!(ThrowStatement, argument) == 12usize);
 
-    assert!(size_of::<TryStatement>() == 20usize);
+    assert!(size_of::<TryStatement>() == 24usize);
     assert!(align_of::<TryStatement>() == 4usize);
-    assert!(offset_of!(TryStatement, span) == 0usize);
-    assert!(offset_of!(TryStatement, block) == 8usize);
-    assert!(offset_of!(TryStatement, handler) == 12usize);
-    assert!(offset_of!(TryStatement, finalizer) == 16usize);
+    assert!(offset_of!(TryStatement, node_id) == 0usize);
+    assert!(offset_of!(TryStatement, span) == 4usize);
+    assert!(offset_of!(TryStatement, block) == 12usize);
+    assert!(offset_of!(TryStatement, handler) == 16usize);
+    assert!(offset_of!(TryStatement, finalizer) == 20usize);
 
-    assert!(size_of::<CatchClause>() == 40usize);
+    assert!(size_of::<CatchClause>() == 52usize);
     assert!(align_of::<CatchClause>() == 4usize);
-    assert!(offset_of!(CatchClause, span) == 0usize);
-    assert!(offset_of!(CatchClause, param) == 8usize);
-    assert!(offset_of!(CatchClause, body) == 32usize);
-    assert!(offset_of!(CatchClause, scope_id) == 36usize);
+    assert!(offset_of!(CatchClause, node_id) == 0usize);
+    assert!(offset_of!(CatchClause, span) == 4usize);
+    assert!(offset_of!(CatchClause, param) == 12usize);
+    assert!(offset_of!(CatchClause, body) == 44usize);
+    assert!(offset_of!(CatchClause, scope_id) == 48usize);
 
-    assert!(size_of::<CatchParameter>() == 24usize);
+    assert!(size_of::<CatchParameter>() == 32usize);
     assert!(align_of::<CatchParameter>() == 4usize);
-    assert!(offset_of!(CatchParameter, span) == 0usize);
-    assert!(offset_of!(CatchParameter, pattern) == 8usize);
+    assert!(offset_of!(CatchParameter, node_id) == 0usize);
+    assert!(offset_of!(CatchParameter, span) == 4usize);
+    assert!(offset_of!(CatchParameter, pattern) == 12usize);
 
-    assert!(size_of::<DebuggerStatement>() == 8usize);
+    assert!(size_of::<DebuggerStatement>() == 12usize);
     assert!(align_of::<DebuggerStatement>() == 4usize);
-    assert!(offset_of!(DebuggerStatement, span) == 0usize);
+    assert!(offset_of!(DebuggerStatement, node_id) == 0usize);
+    assert!(offset_of!(DebuggerStatement, span) == 4usize);
 
-    assert!(size_of::<BindingPattern>() == 16usize);
+    assert!(size_of::<BindingPattern>() == 20usize);
     assert!(align_of::<BindingPattern>() == 4usize);
-    assert!(offset_of!(BindingPattern, kind) == 0usize);
-    assert!(offset_of!(BindingPattern, type_annotation) == 8usize);
-    assert!(offset_of!(BindingPattern, optional) == 12usize);
+    assert!(offset_of!(BindingPattern, node_id) == 0usize);
+    assert!(offset_of!(BindingPattern, kind) == 4usize);
+    assert!(offset_of!(BindingPattern, type_annotation) == 12usize);
+    assert!(offset_of!(BindingPattern, optional) == 16usize);
 
     assert!(size_of::<BindingPatternKind>() == 8usize);
     assert!(align_of::<BindingPatternKind>() == 4usize);
 
-    assert!(size_of::<AssignmentPattern>() == 32usize);
+    assert!(size_of::<AssignmentPattern>() == 40usize);
     assert!(align_of::<AssignmentPattern>() == 4usize);
-    assert!(offset_of!(AssignmentPattern, span) == 0usize);
-    assert!(offset_of!(AssignmentPattern, left) == 8usize);
-    assert!(offset_of!(AssignmentPattern, right) == 24usize);
+    assert!(offset_of!(AssignmentPattern, node_id) == 0usize);
+    assert!(offset_of!(AssignmentPattern, span) == 4usize);
+    assert!(offset_of!(AssignmentPattern, left) == 12usize);
+    assert!(offset_of!(AssignmentPattern, right) == 32usize);
 
-    assert!(size_of::<ObjectPattern>() == 28usize);
+    assert!(size_of::<ObjectPattern>() == 32usize);
     assert!(align_of::<ObjectPattern>() == 4usize);
-    assert!(offset_of!(ObjectPattern, span) == 0usize);
-    assert!(offset_of!(ObjectPattern, properties) == 8usize);
-    assert!(offset_of!(ObjectPattern, rest) == 24usize);
+    assert!(offset_of!(ObjectPattern, node_id) == 0usize);
+    assert!(offset_of!(ObjectPattern, span) == 4usize);
+    assert!(offset_of!(ObjectPattern, properties) == 12usize);
+    assert!(offset_of!(ObjectPattern, rest) == 28usize);
 
-    assert!(size_of::<BindingProperty>() == 36usize);
+    assert!(size_of::<BindingProperty>() == 44usize);
     assert!(align_of::<BindingProperty>() == 4usize);
-    assert!(offset_of!(BindingProperty, span) == 0usize);
-    assert!(offset_of!(BindingProperty, key) == 8usize);
-    assert!(offset_of!(BindingProperty, value) == 16usize);
-    assert!(offset_of!(BindingProperty, shorthand) == 32usize);
-    assert!(offset_of!(BindingProperty, computed) == 33usize);
+    assert!(offset_of!(BindingProperty, node_id) == 0usize);
+    assert!(offset_of!(BindingProperty, span) == 4usize);
+    assert!(offset_of!(BindingProperty, key) == 12usize);
+    assert!(offset_of!(BindingProperty, value) == 20usize);
+    assert!(offset_of!(BindingProperty, shorthand) == 40usize);
+    assert!(offset_of!(BindingProperty, computed) == 41usize);
 
-    assert!(size_of::<ArrayPattern>() == 28usize);
+    assert!(size_of::<ArrayPattern>() == 32usize);
     assert!(align_of::<ArrayPattern>() == 4usize);
-    assert!(offset_of!(ArrayPattern, span) == 0usize);
-    assert!(offset_of!(ArrayPattern, elements) == 8usize);
-    assert!(offset_of!(ArrayPattern, rest) == 24usize);
+    assert!(offset_of!(ArrayPattern, node_id) == 0usize);
+    assert!(offset_of!(ArrayPattern, span) == 4usize);
+    assert!(offset_of!(ArrayPattern, elements) == 12usize);
+    assert!(offset_of!(ArrayPattern, rest) == 28usize);
 
-    assert!(size_of::<BindingRestElement>() == 24usize);
+    assert!(size_of::<BindingRestElement>() == 32usize);
     assert!(align_of::<BindingRestElement>() == 4usize);
-    assert!(offset_of!(BindingRestElement, span) == 0usize);
-    assert!(offset_of!(BindingRestElement, argument) == 8usize);
+    assert!(offset_of!(BindingRestElement, node_id) == 0usize);
+    assert!(offset_of!(BindingRestElement, span) == 4usize);
+    assert!(offset_of!(BindingRestElement, argument) == 12usize);
 
-    assert!(size_of::<Function>() == 60usize);
+    assert!(size_of::<Function>() == 68usize);
     assert!(align_of::<Function>() == 4usize);
-    assert!(offset_of!(Function, r#type) == 0usize);
-    assert!(offset_of!(Function, span) == 4usize);
-    assert!(offset_of!(Function, id) == 12usize);
-    assert!(offset_of!(Function, generator) == 32usize);
-    assert!(offset_of!(Function, r#async) == 33usize);
-    assert!(offset_of!(Function, declare) == 34usize);
-    assert!(offset_of!(Function, type_parameters) == 36usize);
-    assert!(offset_of!(Function, this_param) == 40usize);
-    assert!(offset_of!(Function, params) == 44usize);
-    assert!(offset_of!(Function, return_type) == 48usize);
-    assert!(offset_of!(Function, body) == 52usize);
-    assert!(offset_of!(Function, scope_id) == 56usize);
+    assert!(offset_of!(Function, node_id) == 0usize);
+    assert!(offset_of!(Function, r#type) == 4usize);
+    assert!(offset_of!(Function, span) == 8usize);
+    assert!(offset_of!(Function, id) == 16usize);
+    assert!(offset_of!(Function, generator) == 40usize);
+    assert!(offset_of!(Function, r#async) == 41usize);
+    assert!(offset_of!(Function, declare) == 42usize);
+    assert!(offset_of!(Function, type_parameters) == 44usize);
+    assert!(offset_of!(Function, this_param) == 48usize);
+    assert!(offset_of!(Function, params) == 52usize);
+    assert!(offset_of!(Function, return_type) == 56usize);
+    assert!(offset_of!(Function, body) == 60usize);
+    assert!(offset_of!(Function, scope_id) == 64usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
 
-    assert!(size_of::<FormalParameters>() == 32usize);
+    assert!(size_of::<FormalParameters>() == 36usize);
     assert!(align_of::<FormalParameters>() == 4usize);
-    assert!(offset_of!(FormalParameters, span) == 0usize);
-    assert!(offset_of!(FormalParameters, kind) == 8usize);
-    assert!(offset_of!(FormalParameters, items) == 12usize);
-    assert!(offset_of!(FormalParameters, rest) == 28usize);
+    assert!(offset_of!(FormalParameters, node_id) == 0usize);
+    assert!(offset_of!(FormalParameters, span) == 4usize);
+    assert!(offset_of!(FormalParameters, kind) == 12usize);
+    assert!(offset_of!(FormalParameters, items) == 16usize);
+    assert!(offset_of!(FormalParameters, rest) == 32usize);
 
-    assert!(size_of::<FormalParameter>() == 44usize);
+    assert!(size_of::<FormalParameter>() == 52usize);
     assert!(align_of::<FormalParameter>() == 4usize);
-    assert!(offset_of!(FormalParameter, span) == 0usize);
-    assert!(offset_of!(FormalParameter, decorators) == 8usize);
-    assert!(offset_of!(FormalParameter, pattern) == 24usize);
-    assert!(offset_of!(FormalParameter, accessibility) == 40usize);
-    assert!(offset_of!(FormalParameter, readonly) == 41usize);
-    assert!(offset_of!(FormalParameter, r#override) == 42usize);
+    assert!(offset_of!(FormalParameter, node_id) == 0usize);
+    assert!(offset_of!(FormalParameter, span) == 4usize);
+    assert!(offset_of!(FormalParameter, decorators) == 12usize);
+    assert!(offset_of!(FormalParameter, pattern) == 28usize);
+    assert!(offset_of!(FormalParameter, accessibility) == 48usize);
+    assert!(offset_of!(FormalParameter, readonly) == 49usize);
+    assert!(offset_of!(FormalParameter, r#override) == 50usize);
 
     assert!(size_of::<FormalParameterKind>() == 1usize);
     assert!(align_of::<FormalParameterKind>() == 1usize);
 
-    assert!(size_of::<FunctionBody>() == 40usize);
+    assert!(size_of::<FunctionBody>() == 44usize);
     assert!(align_of::<FunctionBody>() == 4usize);
-    assert!(offset_of!(FunctionBody, span) == 0usize);
-    assert!(offset_of!(FunctionBody, directives) == 8usize);
-    assert!(offset_of!(FunctionBody, statements) == 24usize);
+    assert!(offset_of!(FunctionBody, node_id) == 0usize);
+    assert!(offset_of!(FunctionBody, span) == 4usize);
+    assert!(offset_of!(FunctionBody, directives) == 12usize);
+    assert!(offset_of!(FunctionBody, statements) == 28usize);
 
-    assert!(size_of::<ArrowFunctionExpression>() == 32usize);
+    assert!(size_of::<ArrowFunctionExpression>() == 36usize);
     assert!(align_of::<ArrowFunctionExpression>() == 4usize);
-    assert!(offset_of!(ArrowFunctionExpression, span) == 0usize);
-    assert!(offset_of!(ArrowFunctionExpression, expression) == 8usize);
-    assert!(offset_of!(ArrowFunctionExpression, r#async) == 9usize);
-    assert!(offset_of!(ArrowFunctionExpression, type_parameters) == 12usize);
-    assert!(offset_of!(ArrowFunctionExpression, params) == 16usize);
-    assert!(offset_of!(ArrowFunctionExpression, return_type) == 20usize);
-    assert!(offset_of!(ArrowFunctionExpression, body) == 24usize);
-    assert!(offset_of!(ArrowFunctionExpression, scope_id) == 28usize);
+    assert!(offset_of!(ArrowFunctionExpression, node_id) == 0usize);
+    assert!(offset_of!(ArrowFunctionExpression, span) == 4usize);
+    assert!(offset_of!(ArrowFunctionExpression, expression) == 12usize);
+    assert!(offset_of!(ArrowFunctionExpression, r#async) == 13usize);
+    assert!(offset_of!(ArrowFunctionExpression, type_parameters) == 16usize);
+    assert!(offset_of!(ArrowFunctionExpression, params) == 20usize);
+    assert!(offset_of!(ArrowFunctionExpression, return_type) == 24usize);
+    assert!(offset_of!(ArrowFunctionExpression, body) == 28usize);
+    assert!(offset_of!(ArrowFunctionExpression, scope_id) == 32usize);
 
-    assert!(size_of::<YieldExpression>() == 20usize);
+    assert!(size_of::<YieldExpression>() == 24usize);
     assert!(align_of::<YieldExpression>() == 4usize);
-    assert!(offset_of!(YieldExpression, span) == 0usize);
-    assert!(offset_of!(YieldExpression, delegate) == 8usize);
-    assert!(offset_of!(YieldExpression, argument) == 12usize);
+    assert!(offset_of!(YieldExpression, node_id) == 0usize);
+    assert!(offset_of!(YieldExpression, span) == 4usize);
+    assert!(offset_of!(YieldExpression, delegate) == 12usize);
+    assert!(offset_of!(YieldExpression, argument) == 16usize);
 
-    assert!(size_of::<Class>() == 92usize);
+    assert!(size_of::<Class>() == 100usize);
     assert!(align_of::<Class>() == 4usize);
-    assert!(offset_of!(Class, r#type) == 0usize);
-    assert!(offset_of!(Class, span) == 4usize);
-    assert!(offset_of!(Class, decorators) == 12usize);
-    assert!(offset_of!(Class, id) == 28usize);
-    assert!(offset_of!(Class, type_parameters) == 48usize);
-    assert!(offset_of!(Class, super_class) == 52usize);
-    assert!(offset_of!(Class, super_type_parameters) == 60usize);
-    assert!(offset_of!(Class, implements) == 64usize);
-    assert!(offset_of!(Class, body) == 80usize);
-    assert!(offset_of!(Class, r#abstract) == 84usize);
-    assert!(offset_of!(Class, declare) == 85usize);
-    assert!(offset_of!(Class, scope_id) == 88usize);
+    assert!(offset_of!(Class, node_id) == 0usize);
+    assert!(offset_of!(Class, r#type) == 4usize);
+    assert!(offset_of!(Class, span) == 8usize);
+    assert!(offset_of!(Class, decorators) == 16usize);
+    assert!(offset_of!(Class, id) == 32usize);
+    assert!(offset_of!(Class, type_parameters) == 56usize);
+    assert!(offset_of!(Class, super_class) == 60usize);
+    assert!(offset_of!(Class, super_type_parameters) == 68usize);
+    assert!(offset_of!(Class, implements) == 72usize);
+    assert!(offset_of!(Class, body) == 88usize);
+    assert!(offset_of!(Class, r#abstract) == 92usize);
+    assert!(offset_of!(Class, declare) == 93usize);
+    assert!(offset_of!(Class, scope_id) == 96usize);
 
     assert!(size_of::<ClassType>() == 1usize);
     assert!(align_of::<ClassType>() == 1usize);
 
-    assert!(size_of::<ClassBody>() == 24usize);
+    assert!(size_of::<ClassBody>() == 28usize);
     assert!(align_of::<ClassBody>() == 4usize);
-    assert!(offset_of!(ClassBody, span) == 0usize);
-    assert!(offset_of!(ClassBody, body) == 8usize);
+    assert!(offset_of!(ClassBody, node_id) == 0usize);
+    assert!(offset_of!(ClassBody, span) == 4usize);
+    assert!(offset_of!(ClassBody, body) == 12usize);
 
     assert!(size_of::<ClassElement>() == 8usize);
     assert!(align_of::<ClassElement>() == 4usize);
 
-    assert!(size_of::<MethodDefinition>() == 48usize);
+    assert!(size_of::<MethodDefinition>() == 52usize);
     assert!(align_of::<MethodDefinition>() == 4usize);
-    assert!(offset_of!(MethodDefinition, r#type) == 0usize);
-    assert!(offset_of!(MethodDefinition, span) == 4usize);
-    assert!(offset_of!(MethodDefinition, decorators) == 12usize);
-    assert!(offset_of!(MethodDefinition, key) == 28usize);
-    assert!(offset_of!(MethodDefinition, value) == 36usize);
-    assert!(offset_of!(MethodDefinition, kind) == 40usize);
-    assert!(offset_of!(MethodDefinition, computed) == 41usize);
-    assert!(offset_of!(MethodDefinition, r#static) == 42usize);
-    assert!(offset_of!(MethodDefinition, r#override) == 43usize);
-    assert!(offset_of!(MethodDefinition, optional) == 44usize);
-    assert!(offset_of!(MethodDefinition, accessibility) == 45usize);
+    assert!(offset_of!(MethodDefinition, node_id) == 0usize);
+    assert!(offset_of!(MethodDefinition, r#type) == 4usize);
+    assert!(offset_of!(MethodDefinition, span) == 8usize);
+    assert!(offset_of!(MethodDefinition, decorators) == 16usize);
+    assert!(offset_of!(MethodDefinition, key) == 32usize);
+    assert!(offset_of!(MethodDefinition, value) == 40usize);
+    assert!(offset_of!(MethodDefinition, kind) == 44usize);
+    assert!(offset_of!(MethodDefinition, computed) == 45usize);
+    assert!(offset_of!(MethodDefinition, r#static) == 46usize);
+    assert!(offset_of!(MethodDefinition, r#override) == 47usize);
+    assert!(offset_of!(MethodDefinition, optional) == 48usize);
+    assert!(offset_of!(MethodDefinition, accessibility) == 49usize);
 
     assert!(size_of::<MethodDefinitionType>() == 1usize);
     assert!(align_of::<MethodDefinitionType>() == 1usize);
 
-    assert!(size_of::<PropertyDefinition>() == 60usize);
+    assert!(size_of::<PropertyDefinition>() == 64usize);
     assert!(align_of::<PropertyDefinition>() == 4usize);
-    assert!(offset_of!(PropertyDefinition, r#type) == 0usize);
-    assert!(offset_of!(PropertyDefinition, span) == 4usize);
-    assert!(offset_of!(PropertyDefinition, decorators) == 12usize);
-    assert!(offset_of!(PropertyDefinition, key) == 28usize);
-    assert!(offset_of!(PropertyDefinition, value) == 36usize);
-    assert!(offset_of!(PropertyDefinition, computed) == 44usize);
-    assert!(offset_of!(PropertyDefinition, r#static) == 45usize);
-    assert!(offset_of!(PropertyDefinition, declare) == 46usize);
-    assert!(offset_of!(PropertyDefinition, r#override) == 47usize);
-    assert!(offset_of!(PropertyDefinition, optional) == 48usize);
-    assert!(offset_of!(PropertyDefinition, definite) == 49usize);
-    assert!(offset_of!(PropertyDefinition, readonly) == 50usize);
-    assert!(offset_of!(PropertyDefinition, type_annotation) == 52usize);
-    assert!(offset_of!(PropertyDefinition, accessibility) == 56usize);
+    assert!(offset_of!(PropertyDefinition, node_id) == 0usize);
+    assert!(offset_of!(PropertyDefinition, r#type) == 4usize);
+    assert!(offset_of!(PropertyDefinition, span) == 8usize);
+    assert!(offset_of!(PropertyDefinition, decorators) == 16usize);
+    assert!(offset_of!(PropertyDefinition, key) == 32usize);
+    assert!(offset_of!(PropertyDefinition, value) == 40usize);
+    assert!(offset_of!(PropertyDefinition, computed) == 48usize);
+    assert!(offset_of!(PropertyDefinition, r#static) == 49usize);
+    assert!(offset_of!(PropertyDefinition, declare) == 50usize);
+    assert!(offset_of!(PropertyDefinition, r#override) == 51usize);
+    assert!(offset_of!(PropertyDefinition, optional) == 52usize);
+    assert!(offset_of!(PropertyDefinition, definite) == 53usize);
+    assert!(offset_of!(PropertyDefinition, readonly) == 54usize);
+    assert!(offset_of!(PropertyDefinition, type_annotation) == 56usize);
+    assert!(offset_of!(PropertyDefinition, accessibility) == 60usize);
 
     assert!(size_of::<PropertyDefinitionType>() == 1usize);
     assert!(align_of::<PropertyDefinitionType>() == 1usize);
@@ -2225,16 +2498,18 @@ const _: () = {
     assert!(size_of::<MethodDefinitionKind>() == 1usize);
     assert!(align_of::<MethodDefinitionKind>() == 1usize);
 
-    assert!(size_of::<PrivateIdentifier>() == 16usize);
+    assert!(size_of::<PrivateIdentifier>() == 20usize);
     assert!(align_of::<PrivateIdentifier>() == 4usize);
-    assert!(offset_of!(PrivateIdentifier, span) == 0usize);
-    assert!(offset_of!(PrivateIdentifier, name) == 8usize);
+    assert!(offset_of!(PrivateIdentifier, node_id) == 0usize);
+    assert!(offset_of!(PrivateIdentifier, span) == 4usize);
+    assert!(offset_of!(PrivateIdentifier, name) == 12usize);
 
-    assert!(size_of::<StaticBlock>() == 28usize);
+    assert!(size_of::<StaticBlock>() == 32usize);
     assert!(align_of::<StaticBlock>() == 4usize);
-    assert!(offset_of!(StaticBlock, span) == 0usize);
-    assert!(offset_of!(StaticBlock, body) == 8usize);
-    assert!(offset_of!(StaticBlock, scope_id) == 24usize);
+    assert!(offset_of!(StaticBlock, node_id) == 0usize);
+    assert!(offset_of!(StaticBlock, span) == 4usize);
+    assert!(offset_of!(StaticBlock, body) == 12usize);
+    assert!(offset_of!(StaticBlock, scope_id) == 28usize);
 
     assert!(size_of::<ModuleDeclaration>() == 8usize);
     assert!(align_of::<ModuleDeclaration>() == 4usize);
@@ -2242,137 +2517,154 @@ const _: () = {
     assert!(size_of::<AccessorPropertyType>() == 1usize);
     assert!(align_of::<AccessorPropertyType>() == 1usize);
 
-    assert!(size_of::<AccessorProperty>() == 56usize);
+    assert!(size_of::<AccessorProperty>() == 60usize);
     assert!(align_of::<AccessorProperty>() == 4usize);
-    assert!(offset_of!(AccessorProperty, r#type) == 0usize);
-    assert!(offset_of!(AccessorProperty, span) == 4usize);
-    assert!(offset_of!(AccessorProperty, decorators) == 12usize);
-    assert!(offset_of!(AccessorProperty, key) == 28usize);
-    assert!(offset_of!(AccessorProperty, value) == 36usize);
-    assert!(offset_of!(AccessorProperty, computed) == 44usize);
-    assert!(offset_of!(AccessorProperty, r#static) == 45usize);
-    assert!(offset_of!(AccessorProperty, definite) == 46usize);
-    assert!(offset_of!(AccessorProperty, type_annotation) == 48usize);
-    assert!(offset_of!(AccessorProperty, accessibility) == 52usize);
+    assert!(offset_of!(AccessorProperty, node_id) == 0usize);
+    assert!(offset_of!(AccessorProperty, r#type) == 4usize);
+    assert!(offset_of!(AccessorProperty, span) == 8usize);
+    assert!(offset_of!(AccessorProperty, decorators) == 16usize);
+    assert!(offset_of!(AccessorProperty, key) == 32usize);
+    assert!(offset_of!(AccessorProperty, value) == 40usize);
+    assert!(offset_of!(AccessorProperty, computed) == 48usize);
+    assert!(offset_of!(AccessorProperty, r#static) == 49usize);
+    assert!(offset_of!(AccessorProperty, definite) == 50usize);
+    assert!(offset_of!(AccessorProperty, type_annotation) == 52usize);
+    assert!(offset_of!(AccessorProperty, accessibility) == 56usize);
 
-    assert!(size_of::<ImportExpression>() == 32usize);
+    assert!(size_of::<ImportExpression>() == 36usize);
     assert!(align_of::<ImportExpression>() == 4usize);
-    assert!(offset_of!(ImportExpression, span) == 0usize);
-    assert!(offset_of!(ImportExpression, source) == 8usize);
-    assert!(offset_of!(ImportExpression, arguments) == 16usize);
+    assert!(offset_of!(ImportExpression, node_id) == 0usize);
+    assert!(offset_of!(ImportExpression, span) == 4usize);
+    assert!(offset_of!(ImportExpression, source) == 12usize);
+    assert!(offset_of!(ImportExpression, arguments) == 20usize);
 
-    assert!(size_of::<ImportDeclaration>() == 48usize);
+    assert!(size_of::<ImportDeclaration>() == 56usize);
     assert!(align_of::<ImportDeclaration>() == 4usize);
-    assert!(offset_of!(ImportDeclaration, span) == 0usize);
-    assert!(offset_of!(ImportDeclaration, specifiers) == 8usize);
-    assert!(offset_of!(ImportDeclaration, source) == 24usize);
-    assert!(offset_of!(ImportDeclaration, with_clause) == 40usize);
-    assert!(offset_of!(ImportDeclaration, import_kind) == 44usize);
+    assert!(offset_of!(ImportDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ImportDeclaration, span) == 4usize);
+    assert!(offset_of!(ImportDeclaration, specifiers) == 12usize);
+    assert!(offset_of!(ImportDeclaration, source) == 28usize);
+    assert!(offset_of!(ImportDeclaration, with_clause) == 48usize);
+    assert!(offset_of!(ImportDeclaration, import_kind) == 52usize);
 
     assert!(size_of::<ImportDeclarationSpecifier>() == 8usize);
     assert!(align_of::<ImportDeclarationSpecifier>() == 4usize);
 
-    assert!(size_of::<ImportSpecifier>() == 56usize);
+    assert!(size_of::<ImportSpecifier>() == 68usize);
     assert!(align_of::<ImportSpecifier>() == 4usize);
-    assert!(offset_of!(ImportSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportSpecifier, imported) == 8usize);
-    assert!(offset_of!(ImportSpecifier, local) == 32usize);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 52usize);
+    assert!(offset_of!(ImportSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportSpecifier, imported) == 12usize);
+    assert!(offset_of!(ImportSpecifier, local) == 40usize);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 64usize);
 
-    assert!(size_of::<ImportDefaultSpecifier>() == 28usize);
+    assert!(size_of::<ImportDefaultSpecifier>() == 36usize);
     assert!(align_of::<ImportDefaultSpecifier>() == 4usize);
-    assert!(offset_of!(ImportDefaultSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportDefaultSpecifier, local) == 8usize);
+    assert!(offset_of!(ImportDefaultSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportDefaultSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportDefaultSpecifier, local) == 12usize);
 
-    assert!(size_of::<ImportNamespaceSpecifier>() == 28usize);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 36usize);
     assert!(align_of::<ImportNamespaceSpecifier>() == 4usize);
-    assert!(offset_of!(ImportNamespaceSpecifier, span) == 0usize);
-    assert!(offset_of!(ImportNamespaceSpecifier, local) == 8usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, span) == 4usize);
+    assert!(offset_of!(ImportNamespaceSpecifier, local) == 12usize);
 
-    assert!(size_of::<WithClause>() == 40usize);
+    assert!(size_of::<WithClause>() == 48usize);
     assert!(align_of::<WithClause>() == 4usize);
-    assert!(offset_of!(WithClause, span) == 0usize);
-    assert!(offset_of!(WithClause, attributes_keyword) == 8usize);
-    assert!(offset_of!(WithClause, with_entries) == 24usize);
+    assert!(offset_of!(WithClause, node_id) == 0usize);
+    assert!(offset_of!(WithClause, span) == 4usize);
+    assert!(offset_of!(WithClause, attributes_keyword) == 12usize);
+    assert!(offset_of!(WithClause, with_entries) == 32usize);
 
-    assert!(size_of::<ImportAttribute>() == 44usize);
+    assert!(size_of::<ImportAttribute>() == 56usize);
     assert!(align_of::<ImportAttribute>() == 4usize);
-    assert!(offset_of!(ImportAttribute, span) == 0usize);
-    assert!(offset_of!(ImportAttribute, key) == 8usize);
-    assert!(offset_of!(ImportAttribute, value) == 28usize);
+    assert!(offset_of!(ImportAttribute, node_id) == 0usize);
+    assert!(offset_of!(ImportAttribute, span) == 4usize);
+    assert!(offset_of!(ImportAttribute, key) == 12usize);
+    assert!(offset_of!(ImportAttribute, value) == 36usize);
 
-    assert!(size_of::<ImportAttributeKey>() == 20usize);
+    assert!(size_of::<ImportAttributeKey>() == 24usize);
     assert!(align_of::<ImportAttributeKey>() == 4usize);
 
-    assert!(size_of::<ExportNamedDeclaration>() == 56usize);
+    assert!(size_of::<ExportNamedDeclaration>() == 64usize);
     assert!(align_of::<ExportNamedDeclaration>() == 4usize);
-    assert!(offset_of!(ExportNamedDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportNamedDeclaration, declaration) == 8usize);
-    assert!(offset_of!(ExportNamedDeclaration, specifiers) == 16usize);
-    assert!(offset_of!(ExportNamedDeclaration, source) == 32usize);
-    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 48usize);
-    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 52usize);
+    assert!(offset_of!(ExportNamedDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportNamedDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportNamedDeclaration, declaration) == 12usize);
+    assert!(offset_of!(ExportNamedDeclaration, specifiers) == 20usize);
+    assert!(offset_of!(ExportNamedDeclaration, source) == 36usize);
+    assert!(offset_of!(ExportNamedDeclaration, export_kind) == 56usize);
+    assert!(offset_of!(ExportNamedDeclaration, with_clause) == 60usize);
 
-    assert!(size_of::<ExportDefaultDeclaration>() == 40usize);
+    assert!(size_of::<ExportDefaultDeclaration>() == 48usize);
     assert!(align_of::<ExportDefaultDeclaration>() == 4usize);
-    assert!(offset_of!(ExportDefaultDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8usize);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 16usize);
+    assert!(offset_of!(ExportDefaultDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportDefaultDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 12usize);
+    assert!(offset_of!(ExportDefaultDeclaration, exported) == 20usize);
 
-    assert!(size_of::<ExportAllDeclaration>() == 56usize);
+    assert!(size_of::<ExportAllDeclaration>() == 68usize);
     assert!(align_of::<ExportAllDeclaration>() == 4usize);
-    assert!(offset_of!(ExportAllDeclaration, span) == 0usize);
-    assert!(offset_of!(ExportAllDeclaration, exported) == 8usize);
-    assert!(offset_of!(ExportAllDeclaration, source) == 32usize);
-    assert!(offset_of!(ExportAllDeclaration, with_clause) == 48usize);
-    assert!(offset_of!(ExportAllDeclaration, export_kind) == 52usize);
+    assert!(offset_of!(ExportAllDeclaration, node_id) == 0usize);
+    assert!(offset_of!(ExportAllDeclaration, span) == 4usize);
+    assert!(offset_of!(ExportAllDeclaration, exported) == 12usize);
+    assert!(offset_of!(ExportAllDeclaration, source) == 40usize);
+    assert!(offset_of!(ExportAllDeclaration, with_clause) == 60usize);
+    assert!(offset_of!(ExportAllDeclaration, export_kind) == 64usize);
 
-    assert!(size_of::<ExportSpecifier>() == 60usize);
+    assert!(size_of::<ExportSpecifier>() == 72usize);
     assert!(align_of::<ExportSpecifier>() == 4usize);
-    assert!(offset_of!(ExportSpecifier, span) == 0usize);
-    assert!(offset_of!(ExportSpecifier, local) == 8usize);
-    assert!(offset_of!(ExportSpecifier, exported) == 32usize);
-    assert!(offset_of!(ExportSpecifier, export_kind) == 56usize);
+    assert!(offset_of!(ExportSpecifier, node_id) == 0usize);
+    assert!(offset_of!(ExportSpecifier, span) == 4usize);
+    assert!(offset_of!(ExportSpecifier, local) == 12usize);
+    assert!(offset_of!(ExportSpecifier, exported) == 40usize);
+    assert!(offset_of!(ExportSpecifier, export_kind) == 68usize);
 
     assert!(size_of::<ExportDefaultDeclarationKind>() == 8usize);
     assert!(align_of::<ExportDefaultDeclarationKind>() == 4usize);
 
-    assert!(size_of::<ModuleExportName>() == 24usize);
+    assert!(size_of::<ModuleExportName>() == 28usize);
     assert!(align_of::<ModuleExportName>() == 4usize);
 
-    assert!(size_of::<TSThisParameter>() == 20usize);
+    assert!(size_of::<TSThisParameter>() == 24usize);
     assert!(align_of::<TSThisParameter>() == 4usize);
-    assert!(offset_of!(TSThisParameter, span) == 0usize);
-    assert!(offset_of!(TSThisParameter, this_span) == 8usize);
-    assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
+    assert!(offset_of!(TSThisParameter, node_id) == 0usize);
+    assert!(offset_of!(TSThisParameter, span) == 4usize);
+    assert!(offset_of!(TSThisParameter, this_span) == 12usize);
+    assert!(offset_of!(TSThisParameter, type_annotation) == 20usize);
 
-    assert!(size_of::<TSEnumDeclaration>() == 52usize);
+    assert!(size_of::<TSEnumDeclaration>() == 60usize);
     assert!(align_of::<TSEnumDeclaration>() == 4usize);
-    assert!(offset_of!(TSEnumDeclaration, span) == 0usize);
-    assert!(offset_of!(TSEnumDeclaration, id) == 8usize);
-    assert!(offset_of!(TSEnumDeclaration, members) == 28usize);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 44usize);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 45usize);
-    assert!(offset_of!(TSEnumDeclaration, scope_id) == 48usize);
+    assert!(offset_of!(TSEnumDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSEnumDeclaration, span) == 4usize);
+    assert!(offset_of!(TSEnumDeclaration, id) == 12usize);
+    assert!(offset_of!(TSEnumDeclaration, members) == 36usize);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 52usize);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 53usize);
+    assert!(offset_of!(TSEnumDeclaration, scope_id) == 56usize);
 
-    assert!(size_of::<TSEnumMember>() == 24usize);
+    assert!(size_of::<TSEnumMember>() == 28usize);
     assert!(align_of::<TSEnumMember>() == 4usize);
-    assert!(offset_of!(TSEnumMember, span) == 0usize);
-    assert!(offset_of!(TSEnumMember, id) == 8usize);
-    assert!(offset_of!(TSEnumMember, initializer) == 16usize);
+    assert!(offset_of!(TSEnumMember, node_id) == 0usize);
+    assert!(offset_of!(TSEnumMember, span) == 4usize);
+    assert!(offset_of!(TSEnumMember, id) == 12usize);
+    assert!(offset_of!(TSEnumMember, initializer) == 20usize);
 
     assert!(size_of::<TSEnumMemberName>() == 8usize);
     assert!(align_of::<TSEnumMemberName>() == 4usize);
 
-    assert!(size_of::<TSTypeAnnotation>() == 16usize);
+    assert!(size_of::<TSTypeAnnotation>() == 20usize);
     assert!(align_of::<TSTypeAnnotation>() == 4usize);
-    assert!(offset_of!(TSTypeAnnotation, span) == 0usize);
-    assert!(offset_of!(TSTypeAnnotation, type_annotation) == 8usize);
+    assert!(offset_of!(TSTypeAnnotation, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAnnotation, span) == 4usize);
+    assert!(offset_of!(TSTypeAnnotation, type_annotation) == 12usize);
 
-    assert!(size_of::<TSLiteralType>() == 16usize);
+    assert!(size_of::<TSLiteralType>() == 20usize);
     assert!(align_of::<TSLiteralType>() == 4usize);
-    assert!(offset_of!(TSLiteralType, span) == 0usize);
-    assert!(offset_of!(TSLiteralType, literal) == 8usize);
+    assert!(offset_of!(TSLiteralType, node_id) == 0usize);
+    assert!(offset_of!(TSLiteralType, span) == 4usize);
+    assert!(offset_of!(TSLiteralType, literal) == 12usize);
 
     assert!(size_of::<TSLiteral>() == 8usize);
     assert!(align_of::<TSLiteral>() == 4usize);
@@ -2380,478 +2672,549 @@ const _: () = {
     assert!(size_of::<TSType>() == 8usize);
     assert!(align_of::<TSType>() == 4usize);
 
-    assert!(size_of::<TSConditionalType>() == 44usize);
+    assert!(size_of::<TSConditionalType>() == 48usize);
     assert!(align_of::<TSConditionalType>() == 4usize);
-    assert!(offset_of!(TSConditionalType, span) == 0usize);
-    assert!(offset_of!(TSConditionalType, check_type) == 8usize);
-    assert!(offset_of!(TSConditionalType, extends_type) == 16usize);
-    assert!(offset_of!(TSConditionalType, true_type) == 24usize);
-    assert!(offset_of!(TSConditionalType, false_type) == 32usize);
-    assert!(offset_of!(TSConditionalType, scope_id) == 40usize);
+    assert!(offset_of!(TSConditionalType, node_id) == 0usize);
+    assert!(offset_of!(TSConditionalType, span) == 4usize);
+    assert!(offset_of!(TSConditionalType, check_type) == 12usize);
+    assert!(offset_of!(TSConditionalType, extends_type) == 20usize);
+    assert!(offset_of!(TSConditionalType, true_type) == 28usize);
+    assert!(offset_of!(TSConditionalType, false_type) == 36usize);
+    assert!(offset_of!(TSConditionalType, scope_id) == 44usize);
 
-    assert!(size_of::<TSUnionType>() == 24usize);
+    assert!(size_of::<TSUnionType>() == 28usize);
     assert!(align_of::<TSUnionType>() == 4usize);
-    assert!(offset_of!(TSUnionType, span) == 0usize);
-    assert!(offset_of!(TSUnionType, types) == 8usize);
+    assert!(offset_of!(TSUnionType, node_id) == 0usize);
+    assert!(offset_of!(TSUnionType, span) == 4usize);
+    assert!(offset_of!(TSUnionType, types) == 12usize);
 
-    assert!(size_of::<TSIntersectionType>() == 24usize);
+    assert!(size_of::<TSIntersectionType>() == 28usize);
     assert!(align_of::<TSIntersectionType>() == 4usize);
-    assert!(offset_of!(TSIntersectionType, span) == 0usize);
-    assert!(offset_of!(TSIntersectionType, types) == 8usize);
+    assert!(offset_of!(TSIntersectionType, node_id) == 0usize);
+    assert!(offset_of!(TSIntersectionType, span) == 4usize);
+    assert!(offset_of!(TSIntersectionType, types) == 12usize);
 
-    assert!(size_of::<TSParenthesizedType>() == 16usize);
+    assert!(size_of::<TSParenthesizedType>() == 20usize);
     assert!(align_of::<TSParenthesizedType>() == 4usize);
-    assert!(offset_of!(TSParenthesizedType, span) == 0usize);
-    assert!(offset_of!(TSParenthesizedType, type_annotation) == 8usize);
+    assert!(offset_of!(TSParenthesizedType, node_id) == 0usize);
+    assert!(offset_of!(TSParenthesizedType, span) == 4usize);
+    assert!(offset_of!(TSParenthesizedType, type_annotation) == 12usize);
 
-    assert!(size_of::<TSTypeOperator>() == 20usize);
+    assert!(size_of::<TSTypeOperator>() == 24usize);
     assert!(align_of::<TSTypeOperator>() == 4usize);
-    assert!(offset_of!(TSTypeOperator, span) == 0usize);
-    assert!(offset_of!(TSTypeOperator, operator) == 8usize);
-    assert!(offset_of!(TSTypeOperator, type_annotation) == 12usize);
+    assert!(offset_of!(TSTypeOperator, node_id) == 0usize);
+    assert!(offset_of!(TSTypeOperator, span) == 4usize);
+    assert!(offset_of!(TSTypeOperator, operator) == 12usize);
+    assert!(offset_of!(TSTypeOperator, type_annotation) == 16usize);
 
     assert!(size_of::<TSTypeOperatorOperator>() == 1usize);
     assert!(align_of::<TSTypeOperatorOperator>() == 1usize);
 
-    assert!(size_of::<TSArrayType>() == 16usize);
+    assert!(size_of::<TSArrayType>() == 20usize);
     assert!(align_of::<TSArrayType>() == 4usize);
-    assert!(offset_of!(TSArrayType, span) == 0usize);
-    assert!(offset_of!(TSArrayType, element_type) == 8usize);
+    assert!(offset_of!(TSArrayType, node_id) == 0usize);
+    assert!(offset_of!(TSArrayType, span) == 4usize);
+    assert!(offset_of!(TSArrayType, element_type) == 12usize);
 
-    assert!(size_of::<TSIndexedAccessType>() == 24usize);
+    assert!(size_of::<TSIndexedAccessType>() == 28usize);
     assert!(align_of::<TSIndexedAccessType>() == 4usize);
-    assert!(offset_of!(TSIndexedAccessType, span) == 0usize);
-    assert!(offset_of!(TSIndexedAccessType, object_type) == 8usize);
-    assert!(offset_of!(TSIndexedAccessType, index_type) == 16usize);
+    assert!(offset_of!(TSIndexedAccessType, node_id) == 0usize);
+    assert!(offset_of!(TSIndexedAccessType, span) == 4usize);
+    assert!(offset_of!(TSIndexedAccessType, object_type) == 12usize);
+    assert!(offset_of!(TSIndexedAccessType, index_type) == 20usize);
 
-    assert!(size_of::<TSTupleType>() == 24usize);
+    assert!(size_of::<TSTupleType>() == 28usize);
     assert!(align_of::<TSTupleType>() == 4usize);
-    assert!(offset_of!(TSTupleType, span) == 0usize);
-    assert!(offset_of!(TSTupleType, element_types) == 8usize);
+    assert!(offset_of!(TSTupleType, node_id) == 0usize);
+    assert!(offset_of!(TSTupleType, span) == 4usize);
+    assert!(offset_of!(TSTupleType, element_types) == 12usize);
 
-    assert!(size_of::<TSNamedTupleMember>() == 36usize);
+    assert!(size_of::<TSNamedTupleMember>() == 44usize);
     assert!(align_of::<TSNamedTupleMember>() == 4usize);
-    assert!(offset_of!(TSNamedTupleMember, span) == 0usize);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 8usize);
-    assert!(offset_of!(TSNamedTupleMember, label) == 16usize);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 32usize);
+    assert!(offset_of!(TSNamedTupleMember, node_id) == 0usize);
+    assert!(offset_of!(TSNamedTupleMember, span) == 4usize);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 12usize);
+    assert!(offset_of!(TSNamedTupleMember, label) == 20usize);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 40usize);
 
-    assert!(size_of::<TSOptionalType>() == 16usize);
+    assert!(size_of::<TSOptionalType>() == 20usize);
     assert!(align_of::<TSOptionalType>() == 4usize);
-    assert!(offset_of!(TSOptionalType, span) == 0usize);
-    assert!(offset_of!(TSOptionalType, type_annotation) == 8usize);
+    assert!(offset_of!(TSOptionalType, node_id) == 0usize);
+    assert!(offset_of!(TSOptionalType, span) == 4usize);
+    assert!(offset_of!(TSOptionalType, type_annotation) == 12usize);
 
-    assert!(size_of::<TSRestType>() == 16usize);
+    assert!(size_of::<TSRestType>() == 20usize);
     assert!(align_of::<TSRestType>() == 4usize);
-    assert!(offset_of!(TSRestType, span) == 0usize);
-    assert!(offset_of!(TSRestType, type_annotation) == 8usize);
+    assert!(offset_of!(TSRestType, node_id) == 0usize);
+    assert!(offset_of!(TSRestType, span) == 4usize);
+    assert!(offset_of!(TSRestType, type_annotation) == 12usize);
 
     assert!(size_of::<TSTupleElement>() == 8usize);
     assert!(align_of::<TSTupleElement>() == 4usize);
 
-    assert!(size_of::<TSAnyKeyword>() == 8usize);
+    assert!(size_of::<TSAnyKeyword>() == 12usize);
     assert!(align_of::<TSAnyKeyword>() == 4usize);
-    assert!(offset_of!(TSAnyKeyword, span) == 0usize);
+    assert!(offset_of!(TSAnyKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSAnyKeyword, span) == 4usize);
 
-    assert!(size_of::<TSStringKeyword>() == 8usize);
+    assert!(size_of::<TSStringKeyword>() == 12usize);
     assert!(align_of::<TSStringKeyword>() == 4usize);
-    assert!(offset_of!(TSStringKeyword, span) == 0usize);
+    assert!(offset_of!(TSStringKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSStringKeyword, span) == 4usize);
 
-    assert!(size_of::<TSBooleanKeyword>() == 8usize);
+    assert!(size_of::<TSBooleanKeyword>() == 12usize);
     assert!(align_of::<TSBooleanKeyword>() == 4usize);
-    assert!(offset_of!(TSBooleanKeyword, span) == 0usize);
+    assert!(offset_of!(TSBooleanKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSBooleanKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNumberKeyword>() == 8usize);
+    assert!(size_of::<TSNumberKeyword>() == 12usize);
     assert!(align_of::<TSNumberKeyword>() == 4usize);
-    assert!(offset_of!(TSNumberKeyword, span) == 0usize);
+    assert!(offset_of!(TSNumberKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNumberKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNeverKeyword>() == 8usize);
+    assert!(size_of::<TSNeverKeyword>() == 12usize);
     assert!(align_of::<TSNeverKeyword>() == 4usize);
-    assert!(offset_of!(TSNeverKeyword, span) == 0usize);
+    assert!(offset_of!(TSNeverKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNeverKeyword, span) == 4usize);
 
-    assert!(size_of::<TSIntrinsicKeyword>() == 8usize);
+    assert!(size_of::<TSIntrinsicKeyword>() == 12usize);
     assert!(align_of::<TSIntrinsicKeyword>() == 4usize);
-    assert!(offset_of!(TSIntrinsicKeyword, span) == 0usize);
+    assert!(offset_of!(TSIntrinsicKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSIntrinsicKeyword, span) == 4usize);
 
-    assert!(size_of::<TSUnknownKeyword>() == 8usize);
+    assert!(size_of::<TSUnknownKeyword>() == 12usize);
     assert!(align_of::<TSUnknownKeyword>() == 4usize);
-    assert!(offset_of!(TSUnknownKeyword, span) == 0usize);
+    assert!(offset_of!(TSUnknownKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSUnknownKeyword, span) == 4usize);
 
-    assert!(size_of::<TSNullKeyword>() == 8usize);
+    assert!(size_of::<TSNullKeyword>() == 12usize);
     assert!(align_of::<TSNullKeyword>() == 4usize);
-    assert!(offset_of!(TSNullKeyword, span) == 0usize);
+    assert!(offset_of!(TSNullKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSNullKeyword, span) == 4usize);
 
-    assert!(size_of::<TSUndefinedKeyword>() == 8usize);
+    assert!(size_of::<TSUndefinedKeyword>() == 12usize);
     assert!(align_of::<TSUndefinedKeyword>() == 4usize);
-    assert!(offset_of!(TSUndefinedKeyword, span) == 0usize);
+    assert!(offset_of!(TSUndefinedKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSUndefinedKeyword, span) == 4usize);
 
-    assert!(size_of::<TSVoidKeyword>() == 8usize);
+    assert!(size_of::<TSVoidKeyword>() == 12usize);
     assert!(align_of::<TSVoidKeyword>() == 4usize);
-    assert!(offset_of!(TSVoidKeyword, span) == 0usize);
+    assert!(offset_of!(TSVoidKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSVoidKeyword, span) == 4usize);
 
-    assert!(size_of::<TSSymbolKeyword>() == 8usize);
+    assert!(size_of::<TSSymbolKeyword>() == 12usize);
     assert!(align_of::<TSSymbolKeyword>() == 4usize);
-    assert!(offset_of!(TSSymbolKeyword, span) == 0usize);
+    assert!(offset_of!(TSSymbolKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSSymbolKeyword, span) == 4usize);
 
-    assert!(size_of::<TSThisType>() == 8usize);
+    assert!(size_of::<TSThisType>() == 12usize);
     assert!(align_of::<TSThisType>() == 4usize);
-    assert!(offset_of!(TSThisType, span) == 0usize);
+    assert!(offset_of!(TSThisType, node_id) == 0usize);
+    assert!(offset_of!(TSThisType, span) == 4usize);
 
-    assert!(size_of::<TSObjectKeyword>() == 8usize);
+    assert!(size_of::<TSObjectKeyword>() == 12usize);
     assert!(align_of::<TSObjectKeyword>() == 4usize);
-    assert!(offset_of!(TSObjectKeyword, span) == 0usize);
+    assert!(offset_of!(TSObjectKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSObjectKeyword, span) == 4usize);
 
-    assert!(size_of::<TSBigIntKeyword>() == 8usize);
+    assert!(size_of::<TSBigIntKeyword>() == 12usize);
     assert!(align_of::<TSBigIntKeyword>() == 4usize);
-    assert!(offset_of!(TSBigIntKeyword, span) == 0usize);
+    assert!(offset_of!(TSBigIntKeyword, node_id) == 0usize);
+    assert!(offset_of!(TSBigIntKeyword, span) == 4usize);
 
-    assert!(size_of::<TSTypeReference>() == 20usize);
+    assert!(size_of::<TSTypeReference>() == 24usize);
     assert!(align_of::<TSTypeReference>() == 4usize);
-    assert!(offset_of!(TSTypeReference, span) == 0usize);
-    assert!(offset_of!(TSTypeReference, type_name) == 8usize);
-    assert!(offset_of!(TSTypeReference, type_parameters) == 16usize);
+    assert!(offset_of!(TSTypeReference, node_id) == 0usize);
+    assert!(offset_of!(TSTypeReference, span) == 4usize);
+    assert!(offset_of!(TSTypeReference, type_name) == 12usize);
+    assert!(offset_of!(TSTypeReference, type_parameters) == 20usize);
 
     assert!(size_of::<TSTypeName>() == 8usize);
     assert!(align_of::<TSTypeName>() == 4usize);
 
-    assert!(size_of::<TSQualifiedName>() == 32usize);
+    assert!(size_of::<TSQualifiedName>() == 40usize);
     assert!(align_of::<TSQualifiedName>() == 4usize);
-    assert!(offset_of!(TSQualifiedName, span) == 0usize);
-    assert!(offset_of!(TSQualifiedName, left) == 8usize);
-    assert!(offset_of!(TSQualifiedName, right) == 16usize);
+    assert!(offset_of!(TSQualifiedName, node_id) == 0usize);
+    assert!(offset_of!(TSQualifiedName, span) == 4usize);
+    assert!(offset_of!(TSQualifiedName, left) == 12usize);
+    assert!(offset_of!(TSQualifiedName, right) == 20usize);
 
-    assert!(size_of::<TSTypeParameterInstantiation>() == 24usize);
+    assert!(size_of::<TSTypeParameterInstantiation>() == 28usize);
     assert!(align_of::<TSTypeParameterInstantiation>() == 4usize);
-    assert!(offset_of!(TSTypeParameterInstantiation, span) == 0usize);
-    assert!(offset_of!(TSTypeParameterInstantiation, params) == 8usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, span) == 4usize);
+    assert!(offset_of!(TSTypeParameterInstantiation, params) == 12usize);
 
-    assert!(size_of::<TSTypeParameter>() == 48usize);
+    assert!(size_of::<TSTypeParameter>() == 56usize);
     assert!(align_of::<TSTypeParameter>() == 4usize);
-    assert!(offset_of!(TSTypeParameter, span) == 0usize);
-    assert!(offset_of!(TSTypeParameter, name) == 8usize);
-    assert!(offset_of!(TSTypeParameter, constraint) == 28usize);
-    assert!(offset_of!(TSTypeParameter, default) == 36usize);
-    assert!(offset_of!(TSTypeParameter, r#in) == 44usize);
-    assert!(offset_of!(TSTypeParameter, out) == 45usize);
-    assert!(offset_of!(TSTypeParameter, r#const) == 46usize);
+    assert!(offset_of!(TSTypeParameter, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameter, span) == 4usize);
+    assert!(offset_of!(TSTypeParameter, name) == 12usize);
+    assert!(offset_of!(TSTypeParameter, constraint) == 36usize);
+    assert!(offset_of!(TSTypeParameter, default) == 44usize);
+    assert!(offset_of!(TSTypeParameter, r#in) == 52usize);
+    assert!(offset_of!(TSTypeParameter, out) == 53usize);
+    assert!(offset_of!(TSTypeParameter, r#const) == 54usize);
 
-    assert!(size_of::<TSTypeParameterDeclaration>() == 24usize);
+    assert!(size_of::<TSTypeParameterDeclaration>() == 28usize);
     assert!(align_of::<TSTypeParameterDeclaration>() == 4usize);
-    assert!(offset_of!(TSTypeParameterDeclaration, span) == 0usize);
-    assert!(offset_of!(TSTypeParameterDeclaration, params) == 8usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, span) == 4usize);
+    assert!(offset_of!(TSTypeParameterDeclaration, params) == 12usize);
 
-    assert!(size_of::<TSTypeAliasDeclaration>() == 48usize);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 56usize);
     assert!(align_of::<TSTypeAliasDeclaration>() == 4usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, span) == 0usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, id) == 8usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 28usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 32usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 40usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 44usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, span) == 4usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, id) == 12usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 36usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 40usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 48usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 52usize);
 
     assert!(size_of::<TSAccessibility>() == 1usize);
     assert!(align_of::<TSAccessibility>() == 1usize);
 
-    assert!(size_of::<TSClassImplements>() == 20usize);
+    assert!(size_of::<TSClassImplements>() == 24usize);
     assert!(align_of::<TSClassImplements>() == 4usize);
-    assert!(offset_of!(TSClassImplements, span) == 0usize);
-    assert!(offset_of!(TSClassImplements, expression) == 8usize);
-    assert!(offset_of!(TSClassImplements, type_parameters) == 16usize);
+    assert!(offset_of!(TSClassImplements, node_id) == 0usize);
+    assert!(offset_of!(TSClassImplements, span) == 4usize);
+    assert!(offset_of!(TSClassImplements, expression) == 12usize);
+    assert!(offset_of!(TSClassImplements, type_parameters) == 20usize);
 
-    assert!(size_of::<TSInterfaceDeclaration>() == 60usize);
+    assert!(size_of::<TSInterfaceDeclaration>() == 68usize);
     assert!(align_of::<TSInterfaceDeclaration>() == 4usize);
-    assert!(offset_of!(TSInterfaceDeclaration, span) == 0usize);
-    assert!(offset_of!(TSInterfaceDeclaration, id) == 8usize);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 28usize);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 44usize);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 48usize);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 52usize);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56usize);
+    assert!(offset_of!(TSInterfaceDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceDeclaration, span) == 4usize);
+    assert!(offset_of!(TSInterfaceDeclaration, id) == 12usize);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 36usize);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 52usize);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 56usize);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 60usize);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 64usize);
 
-    assert!(size_of::<TSInterfaceBody>() == 24usize);
+    assert!(size_of::<TSInterfaceBody>() == 28usize);
     assert!(align_of::<TSInterfaceBody>() == 4usize);
-    assert!(offset_of!(TSInterfaceBody, span) == 0usize);
-    assert!(offset_of!(TSInterfaceBody, body) == 8usize);
+    assert!(offset_of!(TSInterfaceBody, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceBody, span) == 4usize);
+    assert!(offset_of!(TSInterfaceBody, body) == 12usize);
 
-    assert!(size_of::<TSPropertySignature>() == 24usize);
+    assert!(size_of::<TSPropertySignature>() == 28usize);
     assert!(align_of::<TSPropertySignature>() == 4usize);
-    assert!(offset_of!(TSPropertySignature, span) == 0usize);
-    assert!(offset_of!(TSPropertySignature, computed) == 8usize);
-    assert!(offset_of!(TSPropertySignature, optional) == 9usize);
-    assert!(offset_of!(TSPropertySignature, readonly) == 10usize);
-    assert!(offset_of!(TSPropertySignature, key) == 12usize);
-    assert!(offset_of!(TSPropertySignature, type_annotation) == 20usize);
+    assert!(offset_of!(TSPropertySignature, node_id) == 0usize);
+    assert!(offset_of!(TSPropertySignature, span) == 4usize);
+    assert!(offset_of!(TSPropertySignature, computed) == 12usize);
+    assert!(offset_of!(TSPropertySignature, optional) == 13usize);
+    assert!(offset_of!(TSPropertySignature, readonly) == 14usize);
+    assert!(offset_of!(TSPropertySignature, key) == 16usize);
+    assert!(offset_of!(TSPropertySignature, type_annotation) == 24usize);
 
     assert!(size_of::<TSSignature>() == 8usize);
     assert!(align_of::<TSSignature>() == 4usize);
 
-    assert!(size_of::<TSIndexSignature>() == 32usize);
+    assert!(size_of::<TSIndexSignature>() == 36usize);
     assert!(align_of::<TSIndexSignature>() == 4usize);
-    assert!(offset_of!(TSIndexSignature, span) == 0usize);
-    assert!(offset_of!(TSIndexSignature, parameters) == 8usize);
-    assert!(offset_of!(TSIndexSignature, type_annotation) == 24usize);
-    assert!(offset_of!(TSIndexSignature, readonly) == 28usize);
+    assert!(offset_of!(TSIndexSignature, node_id) == 0usize);
+    assert!(offset_of!(TSIndexSignature, span) == 4usize);
+    assert!(offset_of!(TSIndexSignature, parameters) == 12usize);
+    assert!(offset_of!(TSIndexSignature, type_annotation) == 28usize);
+    assert!(offset_of!(TSIndexSignature, readonly) == 32usize);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 44usize);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 48usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 32usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 36usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 40usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, span) == 4usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 12usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 36usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 40usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 44usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
 
-    assert!(size_of::<TSMethodSignature>() == 40usize);
+    assert!(size_of::<TSMethodSignature>() == 44usize);
     assert!(align_of::<TSMethodSignature>() == 4usize);
-    assert!(offset_of!(TSMethodSignature, span) == 0usize);
-    assert!(offset_of!(TSMethodSignature, key) == 8usize);
-    assert!(offset_of!(TSMethodSignature, computed) == 16usize);
-    assert!(offset_of!(TSMethodSignature, optional) == 17usize);
-    assert!(offset_of!(TSMethodSignature, kind) == 18usize);
-    assert!(offset_of!(TSMethodSignature, this_param) == 20usize);
-    assert!(offset_of!(TSMethodSignature, params) == 24usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 28usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 32usize);
-    assert!(offset_of!(TSMethodSignature, scope_id) == 36usize);
+    assert!(offset_of!(TSMethodSignature, node_id) == 0usize);
+    assert!(offset_of!(TSMethodSignature, span) == 4usize);
+    assert!(offset_of!(TSMethodSignature, key) == 12usize);
+    assert!(offset_of!(TSMethodSignature, computed) == 20usize);
+    assert!(offset_of!(TSMethodSignature, optional) == 21usize);
+    assert!(offset_of!(TSMethodSignature, kind) == 22usize);
+    assert!(offset_of!(TSMethodSignature, this_param) == 24usize);
+    assert!(offset_of!(TSMethodSignature, params) == 28usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 32usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 36usize);
+    assert!(offset_of!(TSMethodSignature, scope_id) == 40usize);
 
-    assert!(size_of::<TSConstructSignatureDeclaration>() == 24usize);
+    assert!(size_of::<TSConstructSignatureDeclaration>() == 28usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 4usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 8usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 12usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 16usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 20usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, span) == 4usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 12usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 16usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 20usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 24usize);
 
-    assert!(size_of::<TSIndexSignatureName>() == 20usize);
+    assert!(size_of::<TSIndexSignatureName>() == 24usize);
     assert!(align_of::<TSIndexSignatureName>() == 4usize);
-    assert!(offset_of!(TSIndexSignatureName, span) == 0usize);
-    assert!(offset_of!(TSIndexSignatureName, name) == 8usize);
-    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 16usize);
+    assert!(offset_of!(TSIndexSignatureName, node_id) == 0usize);
+    assert!(offset_of!(TSIndexSignatureName, span) == 4usize);
+    assert!(offset_of!(TSIndexSignatureName, name) == 12usize);
+    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 20usize);
 
-    assert!(size_of::<TSInterfaceHeritage>() == 20usize);
+    assert!(size_of::<TSInterfaceHeritage>() == 24usize);
     assert!(align_of::<TSInterfaceHeritage>() == 4usize);
-    assert!(offset_of!(TSInterfaceHeritage, span) == 0usize);
-    assert!(offset_of!(TSInterfaceHeritage, expression) == 8usize);
-    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 16usize);
+    assert!(offset_of!(TSInterfaceHeritage, node_id) == 0usize);
+    assert!(offset_of!(TSInterfaceHeritage, span) == 4usize);
+    assert!(offset_of!(TSInterfaceHeritage, expression) == 12usize);
+    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 20usize);
 
-    assert!(size_of::<TSTypePredicate>() == 28usize);
+    assert!(size_of::<TSTypePredicate>() == 36usize);
     assert!(align_of::<TSTypePredicate>() == 4usize);
-    assert!(offset_of!(TSTypePredicate, span) == 0usize);
-    assert!(offset_of!(TSTypePredicate, parameter_name) == 8usize);
-    assert!(offset_of!(TSTypePredicate, asserts) == 20usize);
-    assert!(offset_of!(TSTypePredicate, type_annotation) == 24usize);
+    assert!(offset_of!(TSTypePredicate, node_id) == 0usize);
+    assert!(offset_of!(TSTypePredicate, span) == 4usize);
+    assert!(offset_of!(TSTypePredicate, parameter_name) == 12usize);
+    assert!(offset_of!(TSTypePredicate, asserts) == 28usize);
+    assert!(offset_of!(TSTypePredicate, type_annotation) == 32usize);
 
-    assert!(size_of::<TSTypePredicateName>() == 12usize);
+    assert!(size_of::<TSTypePredicateName>() == 16usize);
     assert!(align_of::<TSTypePredicateName>() == 4usize);
 
-    assert!(size_of::<TSModuleDeclaration>() == 44usize);
+    assert!(size_of::<TSModuleDeclaration>() == 52usize);
     assert!(align_of::<TSModuleDeclaration>() == 4usize);
-    assert!(offset_of!(TSModuleDeclaration, span) == 0usize);
-    assert!(offset_of!(TSModuleDeclaration, id) == 8usize);
-    assert!(offset_of!(TSModuleDeclaration, body) == 28usize);
-    assert!(offset_of!(TSModuleDeclaration, kind) == 36usize);
-    assert!(offset_of!(TSModuleDeclaration, declare) == 37usize);
-    assert!(offset_of!(TSModuleDeclaration, scope_id) == 40usize);
+    assert!(offset_of!(TSModuleDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSModuleDeclaration, span) == 4usize);
+    assert!(offset_of!(TSModuleDeclaration, id) == 12usize);
+    assert!(offset_of!(TSModuleDeclaration, body) == 36usize);
+    assert!(offset_of!(TSModuleDeclaration, kind) == 44usize);
+    assert!(offset_of!(TSModuleDeclaration, declare) == 45usize);
+    assert!(offset_of!(TSModuleDeclaration, scope_id) == 48usize);
 
     assert!(size_of::<TSModuleDeclarationKind>() == 1usize);
     assert!(align_of::<TSModuleDeclarationKind>() == 1usize);
 
-    assert!(size_of::<TSModuleDeclarationName>() == 20usize);
+    assert!(size_of::<TSModuleDeclarationName>() == 24usize);
     assert!(align_of::<TSModuleDeclarationName>() == 4usize);
 
     assert!(size_of::<TSModuleDeclarationBody>() == 8usize);
     assert!(align_of::<TSModuleDeclarationBody>() == 4usize);
 
-    assert!(size_of::<TSModuleBlock>() == 40usize);
+    assert!(size_of::<TSModuleBlock>() == 44usize);
     assert!(align_of::<TSModuleBlock>() == 4usize);
-    assert!(offset_of!(TSModuleBlock, span) == 0usize);
-    assert!(offset_of!(TSModuleBlock, directives) == 8usize);
-    assert!(offset_of!(TSModuleBlock, body) == 24usize);
+    assert!(offset_of!(TSModuleBlock, node_id) == 0usize);
+    assert!(offset_of!(TSModuleBlock, span) == 4usize);
+    assert!(offset_of!(TSModuleBlock, directives) == 12usize);
+    assert!(offset_of!(TSModuleBlock, body) == 28usize);
 
-    assert!(size_of::<TSTypeLiteral>() == 24usize);
+    assert!(size_of::<TSTypeLiteral>() == 28usize);
     assert!(align_of::<TSTypeLiteral>() == 4usize);
-    assert!(offset_of!(TSTypeLiteral, span) == 0usize);
-    assert!(offset_of!(TSTypeLiteral, members) == 8usize);
+    assert!(offset_of!(TSTypeLiteral, node_id) == 0usize);
+    assert!(offset_of!(TSTypeLiteral, span) == 4usize);
+    assert!(offset_of!(TSTypeLiteral, members) == 12usize);
 
-    assert!(size_of::<TSInferType>() == 12usize);
+    assert!(size_of::<TSInferType>() == 16usize);
     assert!(align_of::<TSInferType>() == 4usize);
-    assert!(offset_of!(TSInferType, span) == 0usize);
-    assert!(offset_of!(TSInferType, type_parameter) == 8usize);
+    assert!(offset_of!(TSInferType, node_id) == 0usize);
+    assert!(offset_of!(TSInferType, span) == 4usize);
+    assert!(offset_of!(TSInferType, type_parameter) == 12usize);
 
-    assert!(size_of::<TSTypeQuery>() == 20usize);
+    assert!(size_of::<TSTypeQuery>() == 24usize);
     assert!(align_of::<TSTypeQuery>() == 4usize);
-    assert!(offset_of!(TSTypeQuery, span) == 0usize);
-    assert!(offset_of!(TSTypeQuery, expr_name) == 8usize);
-    assert!(offset_of!(TSTypeQuery, type_parameters) == 16usize);
+    assert!(offset_of!(TSTypeQuery, node_id) == 0usize);
+    assert!(offset_of!(TSTypeQuery, span) == 4usize);
+    assert!(offset_of!(TSTypeQuery, expr_name) == 12usize);
+    assert!(offset_of!(TSTypeQuery, type_parameters) == 20usize);
 
     assert!(size_of::<TSTypeQueryExprName>() == 8usize);
     assert!(align_of::<TSTypeQueryExprName>() == 4usize);
 
-    assert!(size_of::<TSImportType>() == 36usize);
+    assert!(size_of::<TSImportType>() == 40usize);
     assert!(align_of::<TSImportType>() == 4usize);
-    assert!(offset_of!(TSImportType, span) == 0usize);
-    assert!(offset_of!(TSImportType, is_type_of) == 8usize);
-    assert!(offset_of!(TSImportType, parameter) == 12usize);
-    assert!(offset_of!(TSImportType, qualifier) == 20usize);
-    assert!(offset_of!(TSImportType, attributes) == 28usize);
-    assert!(offset_of!(TSImportType, type_parameters) == 32usize);
+    assert!(offset_of!(TSImportType, node_id) == 0usize);
+    assert!(offset_of!(TSImportType, span) == 4usize);
+    assert!(offset_of!(TSImportType, is_type_of) == 12usize);
+    assert!(offset_of!(TSImportType, parameter) == 16usize);
+    assert!(offset_of!(TSImportType, qualifier) == 24usize);
+    assert!(offset_of!(TSImportType, attributes) == 32usize);
+    assert!(offset_of!(TSImportType, type_parameters) == 36usize);
 
-    assert!(size_of::<TSImportAttributes>() == 40usize);
+    assert!(size_of::<TSImportAttributes>() == 48usize);
     assert!(align_of::<TSImportAttributes>() == 4usize);
-    assert!(offset_of!(TSImportAttributes, span) == 0usize);
-    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 24usize);
+    assert!(offset_of!(TSImportAttributes, node_id) == 0usize);
+    assert!(offset_of!(TSImportAttributes, span) == 4usize);
+    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 12usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 32usize);
 
-    assert!(size_of::<TSImportAttribute>() == 36usize);
+    assert!(size_of::<TSImportAttribute>() == 44usize);
     assert!(align_of::<TSImportAttribute>() == 4usize);
-    assert!(offset_of!(TSImportAttribute, span) == 0usize);
-    assert!(offset_of!(TSImportAttribute, name) == 8usize);
-    assert!(offset_of!(TSImportAttribute, value) == 28usize);
+    assert!(offset_of!(TSImportAttribute, node_id) == 0usize);
+    assert!(offset_of!(TSImportAttribute, span) == 4usize);
+    assert!(offset_of!(TSImportAttribute, name) == 12usize);
+    assert!(offset_of!(TSImportAttribute, value) == 36usize);
 
-    assert!(size_of::<TSImportAttributeName>() == 20usize);
+    assert!(size_of::<TSImportAttributeName>() == 24usize);
     assert!(align_of::<TSImportAttributeName>() == 4usize);
 
-    assert!(size_of::<TSFunctionType>() == 24usize);
+    assert!(size_of::<TSFunctionType>() == 28usize);
     assert!(align_of::<TSFunctionType>() == 4usize);
-    assert!(offset_of!(TSFunctionType, span) == 0usize);
-    assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 12usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 16usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 20usize);
+    assert!(offset_of!(TSFunctionType, node_id) == 0usize);
+    assert!(offset_of!(TSFunctionType, span) == 4usize);
+    assert!(offset_of!(TSFunctionType, this_param) == 12usize);
+    assert!(offset_of!(TSFunctionType, params) == 16usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 20usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 24usize);
 
-    assert!(size_of::<TSConstructorType>() == 24usize);
+    assert!(size_of::<TSConstructorType>() == 28usize);
     assert!(align_of::<TSConstructorType>() == 4usize);
-    assert!(offset_of!(TSConstructorType, span) == 0usize);
-    assert!(offset_of!(TSConstructorType, r#abstract) == 8usize);
-    assert!(offset_of!(TSConstructorType, params) == 12usize);
-    assert!(offset_of!(TSConstructorType, return_type) == 16usize);
-    assert!(offset_of!(TSConstructorType, type_parameters) == 20usize);
+    assert!(offset_of!(TSConstructorType, node_id) == 0usize);
+    assert!(offset_of!(TSConstructorType, span) == 4usize);
+    assert!(offset_of!(TSConstructorType, r#abstract) == 12usize);
+    assert!(offset_of!(TSConstructorType, params) == 16usize);
+    assert!(offset_of!(TSConstructorType, return_type) == 20usize);
+    assert!(offset_of!(TSConstructorType, type_parameters) == 24usize);
 
-    assert!(size_of::<TSMappedType>() == 36usize);
+    assert!(size_of::<TSMappedType>() == 40usize);
     assert!(align_of::<TSMappedType>() == 4usize);
-    assert!(offset_of!(TSMappedType, span) == 0usize);
-    assert!(offset_of!(TSMappedType, type_parameter) == 8usize);
-    assert!(offset_of!(TSMappedType, name_type) == 12usize);
-    assert!(offset_of!(TSMappedType, type_annotation) == 20usize);
-    assert!(offset_of!(TSMappedType, optional) == 28usize);
-    assert!(offset_of!(TSMappedType, readonly) == 29usize);
-    assert!(offset_of!(TSMappedType, scope_id) == 32usize);
+    assert!(offset_of!(TSMappedType, node_id) == 0usize);
+    assert!(offset_of!(TSMappedType, span) == 4usize);
+    assert!(offset_of!(TSMappedType, type_parameter) == 12usize);
+    assert!(offset_of!(TSMappedType, name_type) == 16usize);
+    assert!(offset_of!(TSMappedType, type_annotation) == 24usize);
+    assert!(offset_of!(TSMappedType, optional) == 32usize);
+    assert!(offset_of!(TSMappedType, readonly) == 33usize);
+    assert!(offset_of!(TSMappedType, scope_id) == 36usize);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1usize);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1usize);
 
-    assert!(size_of::<TSTemplateLiteralType>() == 40usize);
+    assert!(size_of::<TSTemplateLiteralType>() == 44usize);
     assert!(align_of::<TSTemplateLiteralType>() == 4usize);
-    assert!(offset_of!(TSTemplateLiteralType, span) == 0usize);
-    assert!(offset_of!(TSTemplateLiteralType, quasis) == 8usize);
-    assert!(offset_of!(TSTemplateLiteralType, types) == 24usize);
+    assert!(offset_of!(TSTemplateLiteralType, node_id) == 0usize);
+    assert!(offset_of!(TSTemplateLiteralType, span) == 4usize);
+    assert!(offset_of!(TSTemplateLiteralType, quasis) == 12usize);
+    assert!(offset_of!(TSTemplateLiteralType, types) == 28usize);
 
-    assert!(size_of::<TSAsExpression>() == 24usize);
+    assert!(size_of::<TSAsExpression>() == 28usize);
     assert!(align_of::<TSAsExpression>() == 4usize);
-    assert!(offset_of!(TSAsExpression, span) == 0usize);
-    assert!(offset_of!(TSAsExpression, expression) == 8usize);
-    assert!(offset_of!(TSAsExpression, type_annotation) == 16usize);
+    assert!(offset_of!(TSAsExpression, node_id) == 0usize);
+    assert!(offset_of!(TSAsExpression, span) == 4usize);
+    assert!(offset_of!(TSAsExpression, expression) == 12usize);
+    assert!(offset_of!(TSAsExpression, type_annotation) == 20usize);
 
-    assert!(size_of::<TSSatisfiesExpression>() == 24usize);
+    assert!(size_of::<TSSatisfiesExpression>() == 28usize);
     assert!(align_of::<TSSatisfiesExpression>() == 4usize);
-    assert!(offset_of!(TSSatisfiesExpression, span) == 0usize);
-    assert!(offset_of!(TSSatisfiesExpression, expression) == 8usize);
-    assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 16usize);
+    assert!(offset_of!(TSSatisfiesExpression, node_id) == 0usize);
+    assert!(offset_of!(TSSatisfiesExpression, span) == 4usize);
+    assert!(offset_of!(TSSatisfiesExpression, expression) == 12usize);
+    assert!(offset_of!(TSSatisfiesExpression, type_annotation) == 20usize);
 
-    assert!(size_of::<TSTypeAssertion>() == 24usize);
+    assert!(size_of::<TSTypeAssertion>() == 28usize);
     assert!(align_of::<TSTypeAssertion>() == 4usize);
-    assert!(offset_of!(TSTypeAssertion, span) == 0usize);
-    assert!(offset_of!(TSTypeAssertion, expression) == 8usize);
-    assert!(offset_of!(TSTypeAssertion, type_annotation) == 16usize);
+    assert!(offset_of!(TSTypeAssertion, node_id) == 0usize);
+    assert!(offset_of!(TSTypeAssertion, span) == 4usize);
+    assert!(offset_of!(TSTypeAssertion, expression) == 12usize);
+    assert!(offset_of!(TSTypeAssertion, type_annotation) == 20usize);
 
-    assert!(size_of::<TSImportEqualsDeclaration>() == 40usize);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 48usize);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, span) == 0usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, id) == 8usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 28usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 36usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, span) == 4usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, id) == 12usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 36usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 44usize);
 
     assert!(size_of::<TSModuleReference>() == 8usize);
     assert!(align_of::<TSModuleReference>() == 4usize);
 
-    assert!(size_of::<TSExternalModuleReference>() == 24usize);
+    assert!(size_of::<TSExternalModuleReference>() == 32usize);
     assert!(align_of::<TSExternalModuleReference>() == 4usize);
-    assert!(offset_of!(TSExternalModuleReference, span) == 0usize);
-    assert!(offset_of!(TSExternalModuleReference, expression) == 8usize);
+    assert!(offset_of!(TSExternalModuleReference, node_id) == 0usize);
+    assert!(offset_of!(TSExternalModuleReference, span) == 4usize);
+    assert!(offset_of!(TSExternalModuleReference, expression) == 12usize);
 
-    assert!(size_of::<TSNonNullExpression>() == 16usize);
+    assert!(size_of::<TSNonNullExpression>() == 20usize);
     assert!(align_of::<TSNonNullExpression>() == 4usize);
-    assert!(offset_of!(TSNonNullExpression, span) == 0usize);
-    assert!(offset_of!(TSNonNullExpression, expression) == 8usize);
+    assert!(offset_of!(TSNonNullExpression, node_id) == 0usize);
+    assert!(offset_of!(TSNonNullExpression, span) == 4usize);
+    assert!(offset_of!(TSNonNullExpression, expression) == 12usize);
 
-    assert!(size_of::<Decorator>() == 16usize);
+    assert!(size_of::<Decorator>() == 20usize);
     assert!(align_of::<Decorator>() == 4usize);
-    assert!(offset_of!(Decorator, span) == 0usize);
-    assert!(offset_of!(Decorator, expression) == 8usize);
+    assert!(offset_of!(Decorator, node_id) == 0usize);
+    assert!(offset_of!(Decorator, span) == 4usize);
+    assert!(offset_of!(Decorator, expression) == 12usize);
 
-    assert!(size_of::<TSExportAssignment>() == 16usize);
+    assert!(size_of::<TSExportAssignment>() == 20usize);
     assert!(align_of::<TSExportAssignment>() == 4usize);
-    assert!(offset_of!(TSExportAssignment, span) == 0usize);
-    assert!(offset_of!(TSExportAssignment, expression) == 8usize);
+    assert!(offset_of!(TSExportAssignment, node_id) == 0usize);
+    assert!(offset_of!(TSExportAssignment, span) == 4usize);
+    assert!(offset_of!(TSExportAssignment, expression) == 12usize);
 
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 24usize);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 32usize);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 4usize);
-    assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0usize);
-    assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, node_id) == 0usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, span) == 4usize);
+    assert!(offset_of!(TSNamespaceExportDeclaration, id) == 12usize);
 
-    assert!(size_of::<TSInstantiationExpression>() == 20usize);
+    assert!(size_of::<TSInstantiationExpression>() == 24usize);
     assert!(align_of::<TSInstantiationExpression>() == 4usize);
-    assert!(offset_of!(TSInstantiationExpression, span) == 0usize);
-    assert!(offset_of!(TSInstantiationExpression, expression) == 8usize);
-    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 16usize);
+    assert!(offset_of!(TSInstantiationExpression, node_id) == 0usize);
+    assert!(offset_of!(TSInstantiationExpression, span) == 4usize);
+    assert!(offset_of!(TSInstantiationExpression, expression) == 12usize);
+    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 20usize);
 
     assert!(size_of::<ImportOrExportKind>() == 1usize);
     assert!(align_of::<ImportOrExportKind>() == 1usize);
 
-    assert!(size_of::<JSDocNullableType>() == 20usize);
+    assert!(size_of::<JSDocNullableType>() == 24usize);
     assert!(align_of::<JSDocNullableType>() == 4usize);
-    assert!(offset_of!(JSDocNullableType, span) == 0usize);
-    assert!(offset_of!(JSDocNullableType, type_annotation) == 8usize);
-    assert!(offset_of!(JSDocNullableType, postfix) == 16usize);
+    assert!(offset_of!(JSDocNullableType, node_id) == 0usize);
+    assert!(offset_of!(JSDocNullableType, span) == 4usize);
+    assert!(offset_of!(JSDocNullableType, type_annotation) == 12usize);
+    assert!(offset_of!(JSDocNullableType, postfix) == 20usize);
 
-    assert!(size_of::<JSDocNonNullableType>() == 20usize);
+    assert!(size_of::<JSDocNonNullableType>() == 24usize);
     assert!(align_of::<JSDocNonNullableType>() == 4usize);
-    assert!(offset_of!(JSDocNonNullableType, span) == 0usize);
-    assert!(offset_of!(JSDocNonNullableType, type_annotation) == 8usize);
-    assert!(offset_of!(JSDocNonNullableType, postfix) == 16usize);
+    assert!(offset_of!(JSDocNonNullableType, node_id) == 0usize);
+    assert!(offset_of!(JSDocNonNullableType, span) == 4usize);
+    assert!(offset_of!(JSDocNonNullableType, type_annotation) == 12usize);
+    assert!(offset_of!(JSDocNonNullableType, postfix) == 20usize);
 
-    assert!(size_of::<JSDocUnknownType>() == 8usize);
+    assert!(size_of::<JSDocUnknownType>() == 12usize);
     assert!(align_of::<JSDocUnknownType>() == 4usize);
-    assert!(offset_of!(JSDocUnknownType, span) == 0usize);
+    assert!(offset_of!(JSDocUnknownType, node_id) == 0usize);
+    assert!(offset_of!(JSDocUnknownType, span) == 4usize);
 
-    assert!(size_of::<JSXElement>() == 32usize);
+    assert!(size_of::<JSXElement>() == 36usize);
     assert!(align_of::<JSXElement>() == 4usize);
-    assert!(offset_of!(JSXElement, span) == 0usize);
-    assert!(offset_of!(JSXElement, opening_element) == 8usize);
-    assert!(offset_of!(JSXElement, closing_element) == 12usize);
-    assert!(offset_of!(JSXElement, children) == 16usize);
+    assert!(offset_of!(JSXElement, node_id) == 0usize);
+    assert!(offset_of!(JSXElement, span) == 4usize);
+    assert!(offset_of!(JSXElement, opening_element) == 12usize);
+    assert!(offset_of!(JSXElement, closing_element) == 16usize);
+    assert!(offset_of!(JSXElement, children) == 20usize);
 
-    assert!(size_of::<JSXOpeningElement>() == 40usize);
+    assert!(size_of::<JSXOpeningElement>() == 44usize);
     assert!(align_of::<JSXOpeningElement>() == 4usize);
-    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
-    assert!(offset_of!(JSXOpeningElement, name) == 12usize);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 20usize);
-    assert!(offset_of!(JSXOpeningElement, type_parameters) == 36usize);
+    assert!(offset_of!(JSXOpeningElement, node_id) == 0usize);
+    assert!(offset_of!(JSXOpeningElement, span) == 4usize);
+    assert!(offset_of!(JSXOpeningElement, self_closing) == 12usize);
+    assert!(offset_of!(JSXOpeningElement, name) == 16usize);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 24usize);
+    assert!(offset_of!(JSXOpeningElement, type_parameters) == 40usize);
 
-    assert!(size_of::<JSXClosingElement>() == 16usize);
+    assert!(size_of::<JSXClosingElement>() == 20usize);
     assert!(align_of::<JSXClosingElement>() == 4usize);
-    assert!(offset_of!(JSXClosingElement, span) == 0usize);
-    assert!(offset_of!(JSXClosingElement, name) == 8usize);
+    assert!(offset_of!(JSXClosingElement, node_id) == 0usize);
+    assert!(offset_of!(JSXClosingElement, span) == 4usize);
+    assert!(offset_of!(JSXClosingElement, name) == 12usize);
 
-    assert!(size_of::<JSXFragment>() == 40usize);
+    assert!(size_of::<JSXFragment>() == 44usize);
     assert!(align_of::<JSXFragment>() == 4usize);
-    assert!(offset_of!(JSXFragment, span) == 0usize);
-    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
-    assert!(offset_of!(JSXFragment, children) == 24usize);
+    assert!(offset_of!(JSXFragment, node_id) == 0usize);
+    assert!(offset_of!(JSXFragment, span) == 4usize);
+    assert!(offset_of!(JSXFragment, opening_fragment) == 12usize);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 20usize);
+    assert!(offset_of!(JSXFragment, children) == 28usize);
 
     assert!(size_of::<JSXOpeningFragment>() == 8usize);
     assert!(align_of::<JSXOpeningFragment>() == 4usize);
@@ -2864,46 +3227,52 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 8usize);
     assert!(align_of::<JSXElementName>() == 4usize);
 
-    assert!(size_of::<JSXNamespacedName>() == 40usize);
+    assert!(size_of::<JSXNamespacedName>() == 52usize);
     assert!(align_of::<JSXNamespacedName>() == 4usize);
-    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
-    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 24usize);
+    assert!(offset_of!(JSXNamespacedName, node_id) == 0usize);
+    assert!(offset_of!(JSXNamespacedName, span) == 4usize);
+    assert!(offset_of!(JSXNamespacedName, namespace) == 12usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 32usize);
 
-    assert!(size_of::<JSXMemberExpression>() == 32usize);
+    assert!(size_of::<JSXMemberExpression>() == 40usize);
     assert!(align_of::<JSXMemberExpression>() == 4usize);
-    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
-    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
-    assert!(offset_of!(JSXMemberExpression, property) == 16usize);
+    assert!(offset_of!(JSXMemberExpression, node_id) == 0usize);
+    assert!(offset_of!(JSXMemberExpression, span) == 4usize);
+    assert!(offset_of!(JSXMemberExpression, object) == 12usize);
+    assert!(offset_of!(JSXMemberExpression, property) == 20usize);
 
     assert!(size_of::<JSXMemberExpressionObject>() == 8usize);
     assert!(align_of::<JSXMemberExpressionObject>() == 4usize);
 
-    assert!(size_of::<JSXExpressionContainer>() == 20usize);
+    assert!(size_of::<JSXExpressionContainer>() == 28usize);
     assert!(align_of::<JSXExpressionContainer>() == 4usize);
-    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
-    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
+    assert!(offset_of!(JSXExpressionContainer, node_id) == 0usize);
+    assert!(offset_of!(JSXExpressionContainer, span) == 4usize);
+    assert!(offset_of!(JSXExpressionContainer, expression) == 12usize);
 
-    assert!(size_of::<JSXExpression>() == 12usize);
+    assert!(size_of::<JSXExpression>() == 16usize);
     assert!(align_of::<JSXExpression>() == 4usize);
 
-    assert!(size_of::<JSXEmptyExpression>() == 8usize);
+    assert!(size_of::<JSXEmptyExpression>() == 12usize);
     assert!(align_of::<JSXEmptyExpression>() == 4usize);
-    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
+    assert!(offset_of!(JSXEmptyExpression, node_id) == 0usize);
+    assert!(offset_of!(JSXEmptyExpression, span) == 4usize);
 
     assert!(size_of::<JSXAttributeItem>() == 8usize);
     assert!(align_of::<JSXAttributeItem>() == 4usize);
 
-    assert!(size_of::<JSXAttribute>() == 24usize);
+    assert!(size_of::<JSXAttribute>() == 28usize);
     assert!(align_of::<JSXAttribute>() == 4usize);
-    assert!(offset_of!(JSXAttribute, span) == 0usize);
-    assert!(offset_of!(JSXAttribute, name) == 8usize);
-    assert!(offset_of!(JSXAttribute, value) == 16usize);
+    assert!(offset_of!(JSXAttribute, node_id) == 0usize);
+    assert!(offset_of!(JSXAttribute, span) == 4usize);
+    assert!(offset_of!(JSXAttribute, name) == 12usize);
+    assert!(offset_of!(JSXAttribute, value) == 20usize);
 
-    assert!(size_of::<JSXSpreadAttribute>() == 16usize);
+    assert!(size_of::<JSXSpreadAttribute>() == 20usize);
     assert!(align_of::<JSXSpreadAttribute>() == 4usize);
-    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
-    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
+    assert!(offset_of!(JSXSpreadAttribute, node_id) == 0usize);
+    assert!(offset_of!(JSXSpreadAttribute, span) == 4usize);
+    assert!(offset_of!(JSXSpreadAttribute, argument) == 12usize);
 
     assert!(size_of::<JSXAttributeName>() == 8usize);
     assert!(align_of::<JSXAttributeName>() == 4usize);
@@ -2911,23 +3280,29 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 8usize);
     assert!(align_of::<JSXAttributeValue>() == 4usize);
 
-    assert!(size_of::<JSXIdentifier>() == 16usize);
+    assert!(size_of::<JSXIdentifier>() == 20usize);
     assert!(align_of::<JSXIdentifier>() == 4usize);
-    assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
+    assert!(offset_of!(JSXIdentifier, node_id) == 0usize);
+    assert!(offset_of!(JSXIdentifier, span) == 4usize);
+    assert!(offset_of!(JSXIdentifier, name) == 12usize);
 
     assert!(size_of::<JSXChild>() == 8usize);
     assert!(align_of::<JSXChild>() == 4usize);
 
-    assert!(size_of::<JSXSpreadChild>() == 16usize);
+    assert!(size_of::<JSXSpreadChild>() == 20usize);
     assert!(align_of::<JSXSpreadChild>() == 4usize);
-    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
-    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
+    assert!(offset_of!(JSXSpreadChild, node_id) == 0usize);
+    assert!(offset_of!(JSXSpreadChild, span) == 4usize);
+    assert!(offset_of!(JSXSpreadChild, expression) == 12usize);
 
-    assert!(size_of::<JSXText>() == 16usize);
+    assert!(size_of::<JSXText>() == 20usize);
     assert!(align_of::<JSXText>() == 4usize);
-    assert!(offset_of!(JSXText, span) == 0usize);
-    assert!(offset_of!(JSXText, value) == 8usize);
+    assert!(offset_of!(JSXText, node_id) == 0usize);
+    assert!(offset_of!(JSXText, span) == 4usize);
+    assert!(offset_of!(JSXText, value) == 12usize);
+
+    assert!(size_of::<NodeId>() == 4usize);
+    assert!(align_of::<NodeId>() == 4usize);
 
     assert!(size_of::<NumberBase>() == 1usize);
     assert!(align_of::<NumberBase>() == 1usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8,6 +8,7 @@
 )]
 
 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
+use oxc_syntax::node::NodeId;
 
 #[allow(clippy::wildcard_imports)]
 use crate::ast::*;
@@ -28,7 +29,7 @@ impl<'a> AstBuilder<'a> {
     /// - value
     #[inline]
     pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
-        BooleanLiteral { span, value }
+        BooleanLiteral { node_id: NodeId::DUMMY, span, value }
     }
 
     /// Builds a [`BooleanLiteral`] and stores it in the memory arena.
@@ -51,7 +52,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn null_literal(self, span: Span) -> NullLiteral {
-        NullLiteral { span }
+        NullLiteral { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`NullLiteral`] and stores it in the memory arena.
@@ -85,7 +86,13 @@ impl<'a> AstBuilder<'a> {
     where
         S: IntoIn<'a, &'a str>,
     {
-        NumericLiteral { span, value, raw: raw.into_in(self.allocator), base }
+        NumericLiteral {
+            node_id: NodeId::DUMMY,
+            span,
+            value,
+            raw: raw.into_in(self.allocator),
+            base,
+        }
     }
 
     /// Builds a [`NumericLiteral`] and stores it in the memory arena.
@@ -124,7 +131,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        BigIntLiteral { span, raw: raw.into_in(self.allocator), base }
+        BigIntLiteral { node_id: NodeId::DUMMY, span, raw: raw.into_in(self.allocator), base }
     }
 
     /// Builds a [`BigIntLiteral`] and stores it in the memory arena.
@@ -163,7 +170,7 @@ impl<'a> AstBuilder<'a> {
         value: EmptyObject,
         regex: RegExp<'a>,
     ) -> RegExpLiteral<'a> {
-        RegExpLiteral { span, value, regex }
+        RegExpLiteral { node_id: NodeId::DUMMY, span, value, regex }
     }
 
     /// Builds a [`RegExpLiteral`] and stores it in the memory arena.
@@ -196,7 +203,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        StringLiteral { span, value: value.into_in(self.allocator) }
+        StringLiteral { node_id: NodeId::DUMMY, span, value: value.into_in(self.allocator) }
     }
 
     /// Builds a [`StringLiteral`] and stores it in the memory arena.
@@ -233,7 +240,15 @@ impl<'a> AstBuilder<'a> {
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
     ) -> Program<'a> {
-        Program { span, source_type, hashbang, directives, body, scope_id: Default::default() }
+        Program {
+            node_id: NodeId::DUMMY,
+            span,
+            source_type,
+            hashbang,
+            directives,
+            body,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`Program`] and stores it in the memory arena.
@@ -1475,7 +1490,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        IdentifierName { span, name: name.into_in(self.allocator) }
+        IdentifierName { node_id: NodeId::DUMMY, span, name: name.into_in(self.allocator) }
     }
 
     /// Builds a [`IdentifierName`] and stores it in the memory arena.
@@ -1506,6 +1521,7 @@ impl<'a> AstBuilder<'a> {
         A: IntoIn<'a, Atom<'a>>,
     {
         IdentifierReference {
+            node_id: NodeId::DUMMY,
             span,
             name: name.into_in(self.allocator),
             reference_id: Default::default(),
@@ -1544,6 +1560,7 @@ impl<'a> AstBuilder<'a> {
         A: IntoIn<'a, Atom<'a>>,
     {
         BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span,
             name: name.into_in(self.allocator),
             symbol_id: Default::default(),
@@ -1577,7 +1594,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        LabelIdentifier { span, name: name.into_in(self.allocator) }
+        LabelIdentifier { node_id: NodeId::DUMMY, span, name: name.into_in(self.allocator) }
     }
 
     /// Builds a [`LabelIdentifier`] and stores it in the memory arena.
@@ -1603,7 +1620,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn this_expression(self, span: Span) -> ThisExpression {
-        ThisExpression { span }
+        ThisExpression { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`ThisExpression`] and stores it in the memory arena.
@@ -1632,7 +1649,7 @@ impl<'a> AstBuilder<'a> {
         elements: Vec<'a, ArrayExpressionElement<'a>>,
         trailing_comma: Option<Span>,
     ) -> ArrayExpression<'a> {
-        ArrayExpression { span, elements, trailing_comma }
+        ArrayExpression { node_id: NodeId::DUMMY, span, elements, trailing_comma }
     }
 
     /// Builds a [`ArrayExpression`] and stores it in the memory arena.
@@ -1715,7 +1732,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn elision(self, span: Span) -> Elision {
-        Elision { span }
+        Elision { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`Elision`] and stores it in the memory arena.
@@ -1744,7 +1761,7 @@ impl<'a> AstBuilder<'a> {
         properties: Vec<'a, ObjectPropertyKind<'a>>,
         trailing_comma: Option<Span>,
     ) -> ObjectExpression<'a> {
-        ObjectExpression { span, properties, trailing_comma }
+        ObjectExpression { node_id: NodeId::DUMMY, span, properties, trailing_comma }
     }
 
     /// Builds a [`ObjectExpression`] and stores it in the memory arena.
@@ -1856,7 +1873,17 @@ impl<'a> AstBuilder<'a> {
         shorthand: bool,
         computed: bool,
     ) -> ObjectProperty<'a> {
-        ObjectProperty { span, kind, key, value, init, method, shorthand, computed }
+        ObjectProperty {
+            node_id: NodeId::DUMMY,
+            span,
+            kind,
+            key,
+            value,
+            init,
+            method,
+            shorthand,
+            computed,
+        }
     }
 
     /// Builds a [`ObjectProperty`] and stores it in the memory arena.
@@ -1958,7 +1985,7 @@ impl<'a> AstBuilder<'a> {
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
     ) -> TemplateLiteral<'a> {
-        TemplateLiteral { span, quasis, expressions }
+        TemplateLiteral { node_id: NodeId::DUMMY, span, quasis, expressions }
     }
 
     /// Builds a [`TemplateLiteral`] and stores it in the memory arena.
@@ -2000,6 +2027,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TaggedTemplateExpression {
+            node_id: NodeId::DUMMY,
             span,
             tag,
             quasi,
@@ -2048,7 +2076,7 @@ impl<'a> AstBuilder<'a> {
         tail: bool,
         value: TemplateElementValue<'a>,
     ) -> TemplateElement<'a> {
-        TemplateElement { span, tail, value }
+        TemplateElement { node_id: NodeId::DUMMY, span, tail, value }
     }
 
     /// Builds a [`TemplateElement`] and stores it in the memory arena.
@@ -2182,7 +2210,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         optional: bool,
     ) -> ComputedMemberExpression<'a> {
-        ComputedMemberExpression { span, object, expression, optional }
+        ComputedMemberExpression { node_id: NodeId::DUMMY, span, object, expression, optional }
     }
 
     /// Builds a [`ComputedMemberExpression`] and stores it in the memory arena.
@@ -2225,7 +2253,7 @@ impl<'a> AstBuilder<'a> {
         property: IdentifierName<'a>,
         optional: bool,
     ) -> StaticMemberExpression<'a> {
-        StaticMemberExpression { span, object, property, optional }
+        StaticMemberExpression { node_id: NodeId::DUMMY, span, object, property, optional }
     }
 
     /// Builds a [`StaticMemberExpression`] and stores it in the memory arena.
@@ -2265,7 +2293,7 @@ impl<'a> AstBuilder<'a> {
         field: PrivateIdentifier<'a>,
         optional: bool,
     ) -> PrivateFieldExpression<'a> {
-        PrivateFieldExpression { span, object, field, optional }
+        PrivateFieldExpression { node_id: NodeId::DUMMY, span, object, field, optional }
     }
 
     /// Builds a [`PrivateFieldExpression`] and stores it in the memory arena.
@@ -2311,6 +2339,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         CallExpression {
+            node_id: NodeId::DUMMY,
             span,
             callee,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -2368,6 +2397,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         NewExpression {
+            node_id: NodeId::DUMMY,
             span,
             callee,
             arguments,
@@ -2413,7 +2443,7 @@ impl<'a> AstBuilder<'a> {
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
     ) -> MetaProperty<'a> {
-        MetaProperty { span, meta, property }
+        MetaProperty { node_id: NodeId::DUMMY, span, meta, property }
     }
 
     /// Builds a [`MetaProperty`] and stores it in the memory arena.
@@ -2443,7 +2473,7 @@ impl<'a> AstBuilder<'a> {
     /// - argument: The expression being spread.
     #[inline]
     pub fn spread_element(self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
-        SpreadElement { span, argument }
+        SpreadElement { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`SpreadElement`] and stores it in the memory arena.
@@ -2505,7 +2535,7 @@ impl<'a> AstBuilder<'a> {
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
     ) -> UpdateExpression<'a> {
-        UpdateExpression { span, operator, prefix, argument }
+        UpdateExpression { node_id: NodeId::DUMMY, span, operator, prefix, argument }
     }
 
     /// Builds a [`UpdateExpression`] and stores it in the memory arena.
@@ -2543,7 +2573,7 @@ impl<'a> AstBuilder<'a> {
         operator: UnaryOperator,
         argument: Expression<'a>,
     ) -> UnaryExpression<'a> {
-        UnaryExpression { span, operator, argument }
+        UnaryExpression { node_id: NodeId::DUMMY, span, operator, argument }
     }
 
     /// Builds a [`UnaryExpression`] and stores it in the memory arena.
@@ -2581,7 +2611,7 @@ impl<'a> AstBuilder<'a> {
         operator: BinaryOperator,
         right: Expression<'a>,
     ) -> BinaryExpression<'a> {
-        BinaryExpression { span, left, operator, right }
+        BinaryExpression { node_id: NodeId::DUMMY, span, left, operator, right }
     }
 
     /// Builds a [`BinaryExpression`] and stores it in the memory arena.
@@ -2621,7 +2651,7 @@ impl<'a> AstBuilder<'a> {
         operator: BinaryOperator,
         right: Expression<'a>,
     ) -> PrivateInExpression<'a> {
-        PrivateInExpression { span, left, operator, right }
+        PrivateInExpression { node_id: NodeId::DUMMY, span, left, operator, right }
     }
 
     /// Builds a [`PrivateInExpression`] and stores it in the memory arena.
@@ -2661,7 +2691,7 @@ impl<'a> AstBuilder<'a> {
         operator: LogicalOperator,
         right: Expression<'a>,
     ) -> LogicalExpression<'a> {
-        LogicalExpression { span, left, operator, right }
+        LogicalExpression { node_id: NodeId::DUMMY, span, left, operator, right }
     }
 
     /// Builds a [`LogicalExpression`] and stores it in the memory arena.
@@ -2701,7 +2731,7 @@ impl<'a> AstBuilder<'a> {
         consequent: Expression<'a>,
         alternate: Expression<'a>,
     ) -> ConditionalExpression<'a> {
-        ConditionalExpression { span, test, consequent, alternate }
+        ConditionalExpression { node_id: NodeId::DUMMY, span, test, consequent, alternate }
     }
 
     /// Builds a [`ConditionalExpression`] and stores it in the memory arena.
@@ -2741,7 +2771,7 @@ impl<'a> AstBuilder<'a> {
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
     ) -> AssignmentExpression<'a> {
-        AssignmentExpression { span, operator, left, right }
+        AssignmentExpression { node_id: NodeId::DUMMY, span, operator, left, right }
     }
 
     /// Builds a [`AssignmentExpression`] and stores it in the memory arena.
@@ -3074,7 +3104,7 @@ impl<'a> AstBuilder<'a> {
         rest: Option<AssignmentTargetRest<'a>>,
         trailing_comma: Option<Span>,
     ) -> ArrayAssignmentTarget<'a> {
-        ArrayAssignmentTarget { span, elements, rest, trailing_comma }
+        ArrayAssignmentTarget { node_id: NodeId::DUMMY, span, elements, rest, trailing_comma }
     }
 
     /// Builds a [`ArrayAssignmentTarget`] and stores it in the memory arena.
@@ -3115,7 +3145,7 @@ impl<'a> AstBuilder<'a> {
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
         rest: Option<AssignmentTargetRest<'a>>,
     ) -> ObjectAssignmentTarget<'a> {
-        ObjectAssignmentTarget { span, properties, rest }
+        ObjectAssignmentTarget { node_id: NodeId::DUMMY, span, properties, rest }
     }
 
     /// Builds a [`ObjectAssignmentTarget`] and stores it in the memory arena.
@@ -3149,7 +3179,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         target: AssignmentTarget<'a>,
     ) -> AssignmentTargetRest<'a> {
-        AssignmentTargetRest { span, target }
+        AssignmentTargetRest { node_id: NodeId::DUMMY, span, target }
     }
 
     /// Builds a [`AssignmentTargetRest`] and stores it in the memory arena.
@@ -3223,7 +3253,7 @@ impl<'a> AstBuilder<'a> {
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
     ) -> AssignmentTargetWithDefault<'a> {
-        AssignmentTargetWithDefault { span, binding, init }
+        AssignmentTargetWithDefault { node_id: NodeId::DUMMY, span, binding, init }
     }
 
     /// Builds a [`AssignmentTargetWithDefault`] and stores it in the memory arena.
@@ -3323,7 +3353,7 @@ impl<'a> AstBuilder<'a> {
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
     ) -> AssignmentTargetPropertyIdentifier<'a> {
-        AssignmentTargetPropertyIdentifier { span, binding, init }
+        AssignmentTargetPropertyIdentifier { node_id: NodeId::DUMMY, span, binding, init }
     }
 
     /// Builds a [`AssignmentTargetPropertyIdentifier`] and stores it in the memory arena.
@@ -3359,7 +3389,7 @@ impl<'a> AstBuilder<'a> {
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
     ) -> AssignmentTargetPropertyProperty<'a> {
-        AssignmentTargetPropertyProperty { span, name, binding }
+        AssignmentTargetPropertyProperty { node_id: NodeId::DUMMY, span, name, binding }
     }
 
     /// Builds a [`AssignmentTargetPropertyProperty`] and stores it in the memory arena.
@@ -3393,7 +3423,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expressions: Vec<'a, Expression<'a>>,
     ) -> SequenceExpression<'a> {
-        SequenceExpression { span, expressions }
+        SequenceExpression { node_id: NodeId::DUMMY, span, expressions }
     }
 
     /// Builds a [`SequenceExpression`] and stores it in the memory arena.
@@ -3420,7 +3450,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn super_(self, span: Span) -> Super {
-        Super { span }
+        Super { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`Super`] and stores it in the memory arena.
@@ -3443,7 +3473,7 @@ impl<'a> AstBuilder<'a> {
     /// - argument
     #[inline]
     pub fn await_expression(self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
-        AwaitExpression { span, argument }
+        AwaitExpression { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`AwaitExpression`] and stores it in the memory arena.
@@ -3471,7 +3501,7 @@ impl<'a> AstBuilder<'a> {
     /// - expression
     #[inline]
     pub fn chain_expression(self, span: Span, expression: ChainElement<'a>) -> ChainExpression<'a> {
-        ChainExpression { span, expression }
+        ChainExpression { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`ChainExpression`] and stores it in the memory arena.
@@ -3548,7 +3578,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> ParenthesizedExpression<'a> {
-        ParenthesizedExpression { span, expression }
+        ParenthesizedExpression { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`ParenthesizedExpression`] and stores it in the memory arena.
@@ -4056,7 +4086,12 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        Directive { span, expression, directive: directive.into_in(self.allocator) }
+        Directive {
+            node_id: NodeId::DUMMY,
+            span,
+            expression,
+            directive: directive.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`Directive`] and stores it in the memory arena.
@@ -4092,7 +4127,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        Hashbang { span, value: value.into_in(self.allocator) }
+        Hashbang { node_id: NodeId::DUMMY, span, value: value.into_in(self.allocator) }
     }
 
     /// Builds a [`Hashbang`] and stores it in the memory arena.
@@ -4119,7 +4154,7 @@ impl<'a> AstBuilder<'a> {
     /// - body
     #[inline]
     pub fn block_statement(self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
-        BlockStatement { span, body, scope_id: Default::default() }
+        BlockStatement { node_id: NodeId::DUMMY, span, body, scope_id: Default::default() }
     }
 
     /// Builds a [`BlockStatement`] and stores it in the memory arena.
@@ -4495,7 +4530,7 @@ impl<'a> AstBuilder<'a> {
         declarations: Vec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> VariableDeclaration<'a> {
-        VariableDeclaration { span, kind, declarations, declare }
+        VariableDeclaration { node_id: NodeId::DUMMY, span, kind, declarations, declare }
     }
 
     /// Builds a [`VariableDeclaration`] and stores it in the memory arena.
@@ -4537,7 +4572,7 @@ impl<'a> AstBuilder<'a> {
         init: Option<Expression<'a>>,
         definite: bool,
     ) -> VariableDeclarator<'a> {
-        VariableDeclarator { span, kind, id, init, definite }
+        VariableDeclarator { node_id: NodeId::DUMMY, span, kind, id, init, definite }
     }
 
     /// Builds a [`VariableDeclarator`] and stores it in the memory arena.
@@ -4570,7 +4605,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn empty_statement(self, span: Span) -> EmptyStatement {
-        EmptyStatement { span }
+        EmptyStatement { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`EmptyStatement`] and stores it in the memory arena.
@@ -4597,7 +4632,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> ExpressionStatement<'a> {
-        ExpressionStatement { span, expression }
+        ExpressionStatement { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`ExpressionStatement`] and stores it in the memory arena.
@@ -4633,7 +4668,7 @@ impl<'a> AstBuilder<'a> {
         consequent: Statement<'a>,
         alternate: Option<Statement<'a>>,
     ) -> IfStatement<'a> {
-        IfStatement { span, test, consequent, alternate }
+        IfStatement { node_id: NodeId::DUMMY, span, test, consequent, alternate }
     }
 
     /// Builds a [`IfStatement`] and stores it in the memory arena.
@@ -4671,7 +4706,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
         test: Expression<'a>,
     ) -> DoWhileStatement<'a> {
-        DoWhileStatement { span, body, test }
+        DoWhileStatement { node_id: NodeId::DUMMY, span, body, test }
     }
 
     /// Builds a [`DoWhileStatement`] and stores it in the memory arena.
@@ -4707,7 +4742,7 @@ impl<'a> AstBuilder<'a> {
         test: Expression<'a>,
         body: Statement<'a>,
     ) -> WhileStatement<'a> {
-        WhileStatement { span, test, body }
+        WhileStatement { node_id: NodeId::DUMMY, span, test, body }
     }
 
     /// Builds a [`WhileStatement`] and stores it in the memory arena.
@@ -4747,7 +4782,15 @@ impl<'a> AstBuilder<'a> {
         update: Option<Expression<'a>>,
         body: Statement<'a>,
     ) -> ForStatement<'a> {
-        ForStatement { span, init, test, update, body, scope_id: Default::default() }
+        ForStatement {
+            node_id: NodeId::DUMMY,
+            span,
+            init,
+            test,
+            update,
+            body,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`ForStatement`] and stores it in the memory arena.
@@ -4828,7 +4871,14 @@ impl<'a> AstBuilder<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> ForInStatement<'a> {
-        ForInStatement { span, left, right, body, scope_id: Default::default() }
+        ForInStatement {
+            node_id: NodeId::DUMMY,
+            span,
+            left,
+            right,
+            body,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`ForInStatement`] and stores it in the memory arena.
@@ -4912,7 +4962,15 @@ impl<'a> AstBuilder<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> ForOfStatement<'a> {
-        ForOfStatement { span, r#await, left, right, body, scope_id: Default::default() }
+        ForOfStatement {
+            node_id: NodeId::DUMMY,
+            span,
+            r#await,
+            left,
+            right,
+            body,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`ForOfStatement`] and stores it in the memory arena.
@@ -4950,7 +5008,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ContinueStatement<'a> {
-        ContinueStatement { span, label }
+        ContinueStatement { node_id: NodeId::DUMMY, span, label }
     }
 
     /// Builds a [`ContinueStatement`] and stores it in the memory arena.
@@ -4982,7 +5040,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> BreakStatement<'a> {
-        BreakStatement { span, label }
+        BreakStatement { node_id: NodeId::DUMMY, span, label }
     }
 
     /// Builds a [`BreakStatement`] and stores it in the memory arena.
@@ -5014,7 +5072,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> ReturnStatement<'a> {
-        ReturnStatement { span, argument }
+        ReturnStatement { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`ReturnStatement`] and stores it in the memory arena.
@@ -5048,7 +5106,7 @@ impl<'a> AstBuilder<'a> {
         object: Expression<'a>,
         body: Statement<'a>,
     ) -> WithStatement<'a> {
-        WithStatement { span, object, body }
+        WithStatement { node_id: NodeId::DUMMY, span, object, body }
     }
 
     /// Builds a [`WithStatement`] and stores it in the memory arena.
@@ -5084,7 +5142,13 @@ impl<'a> AstBuilder<'a> {
         discriminant: Expression<'a>,
         cases: Vec<'a, SwitchCase<'a>>,
     ) -> SwitchStatement<'a> {
-        SwitchStatement { span, discriminant, cases, scope_id: Default::default() }
+        SwitchStatement {
+            node_id: NodeId::DUMMY,
+            span,
+            discriminant,
+            cases,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`SwitchStatement`] and stores it in the memory arena.
@@ -5120,7 +5184,7 @@ impl<'a> AstBuilder<'a> {
         test: Option<Expression<'a>>,
         consequent: Vec<'a, Statement<'a>>,
     ) -> SwitchCase<'a> {
-        SwitchCase { span, test, consequent }
+        SwitchCase { node_id: NodeId::DUMMY, span, test, consequent }
     }
 
     /// Builds a [`SwitchCase`] and stores it in the memory arena.
@@ -5156,7 +5220,7 @@ impl<'a> AstBuilder<'a> {
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
     ) -> LabeledStatement<'a> {
-        LabeledStatement { span, label, body }
+        LabeledStatement { node_id: NodeId::DUMMY, span, label, body }
     }
 
     /// Builds a [`LabeledStatement`] and stores it in the memory arena.
@@ -5186,7 +5250,7 @@ impl<'a> AstBuilder<'a> {
     /// - argument
     #[inline]
     pub fn throw_statement(self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
-        ThrowStatement { span, argument }
+        ThrowStatement { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`ThrowStatement`] and stores it in the memory arena.
@@ -5228,6 +5292,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, BlockStatement<'a>>>>,
     {
         TryStatement {
+            node_id: NodeId::DUMMY,
             span,
             block: block.into_in(self.allocator),
             handler: handler.into_in(self.allocator),
@@ -5279,6 +5344,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
     {
         CatchClause {
+            node_id: NodeId::DUMMY,
             span,
             param,
             body: body.into_in(self.allocator),
@@ -5316,7 +5382,7 @@ impl<'a> AstBuilder<'a> {
     /// - pattern
     #[inline]
     pub fn catch_parameter(self, span: Span, pattern: BindingPattern<'a>) -> CatchParameter<'a> {
-        CatchParameter { span, pattern }
+        CatchParameter { node_id: NodeId::DUMMY, span, pattern }
     }
 
     /// Builds a [`CatchParameter`] and stores it in the memory arena.
@@ -5343,7 +5409,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn debugger_statement(self, span: Span) -> DebuggerStatement {
-        DebuggerStatement { span }
+        DebuggerStatement { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`DebuggerStatement`] and stores it in the memory arena.
@@ -5375,7 +5441,12 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
-        BindingPattern { kind, type_annotation: type_annotation.into_in(self.allocator), optional }
+        BindingPattern {
+            node_id: NodeId::DUMMY,
+            kind,
+            type_annotation: type_annotation.into_in(self.allocator),
+            optional,
+        }
     }
 
     /// Builds a [`BindingPattern`] and stores it in the memory arena.
@@ -5531,7 +5602,7 @@ impl<'a> AstBuilder<'a> {
         left: BindingPattern<'a>,
         right: Expression<'a>,
     ) -> AssignmentPattern<'a> {
-        AssignmentPattern { span, left, right }
+        AssignmentPattern { node_id: NodeId::DUMMY, span, left, right }
     }
 
     /// Builds a [`AssignmentPattern`] and stores it in the memory arena.
@@ -5570,7 +5641,12 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
     {
-        ObjectPattern { span, properties, rest: rest.into_in(self.allocator) }
+        ObjectPattern {
+            node_id: NodeId::DUMMY,
+            span,
+            properties,
+            rest: rest.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`ObjectPattern`] and stores it in the memory arena.
@@ -5613,7 +5689,7 @@ impl<'a> AstBuilder<'a> {
         shorthand: bool,
         computed: bool,
     ) -> BindingProperty<'a> {
-        BindingProperty { span, key, value, shorthand, computed }
+        BindingProperty { node_id: NodeId::DUMMY, span, key, value, shorthand, computed }
     }
 
     /// Builds a [`BindingProperty`] and stores it in the memory arena.
@@ -5656,7 +5732,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
     {
-        ArrayPattern { span, elements, rest: rest.into_in(self.allocator) }
+        ArrayPattern { node_id: NodeId::DUMMY, span, elements, rest: rest.into_in(self.allocator) }
     }
 
     /// Builds a [`ArrayPattern`] and stores it in the memory arena.
@@ -5693,7 +5769,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: BindingPattern<'a>,
     ) -> BindingRestElement<'a> {
-        BindingRestElement { span, argument }
+        BindingRestElement { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`BindingRestElement`] and stores it in the memory arena.
@@ -5751,6 +5827,7 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             id,
@@ -5842,7 +5919,13 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
     {
-        FormalParameters { span, kind, items, rest: rest.into_in(self.allocator) }
+        FormalParameters {
+            node_id: NodeId::DUMMY,
+            span,
+            kind,
+            items,
+            rest: rest.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`FormalParameters`] and stores it in the memory arena.
@@ -5889,7 +5972,15 @@ impl<'a> AstBuilder<'a> {
         readonly: bool,
         r#override: bool,
     ) -> FormalParameter<'a> {
-        FormalParameter { span, decorators, pattern, accessibility, readonly, r#override }
+        FormalParameter {
+            node_id: NodeId::DUMMY,
+            span,
+            decorators,
+            pattern,
+            accessibility,
+            readonly,
+            r#override,
+        }
     }
 
     /// Builds a [`FormalParameter`] and stores it in the memory arena.
@@ -5934,7 +6025,7 @@ impl<'a> AstBuilder<'a> {
         directives: Vec<'a, Directive<'a>>,
         statements: Vec<'a, Statement<'a>>,
     ) -> FunctionBody<'a> {
-        FunctionBody { span, directives, statements }
+        FunctionBody { node_id: NodeId::DUMMY, span, directives, statements }
     }
 
     /// Builds a [`FunctionBody`] and stores it in the memory arena.
@@ -5985,6 +6076,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
+            node_id: NodeId::DUMMY,
             span,
             expression,
             r#async,
@@ -6054,7 +6146,7 @@ impl<'a> AstBuilder<'a> {
         delegate: bool,
         argument: Option<Expression<'a>>,
     ) -> YieldExpression<'a> {
-        YieldExpression { span, delegate, argument }
+        YieldExpression { node_id: NodeId::DUMMY, span, delegate, argument }
     }
 
     /// Builds a [`YieldExpression`] and stores it in the memory arena.
@@ -6112,6 +6204,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Class {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             decorators,
@@ -6190,7 +6283,7 @@ impl<'a> AstBuilder<'a> {
     /// - body
     #[inline]
     pub fn class_body(self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
-        ClassBody { span, body }
+        ClassBody { node_id: NodeId::DUMMY, span, body }
     }
 
     /// Builds a [`ClassBody`] and stores it in the memory arena.
@@ -6486,6 +6579,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, Function<'a>>>,
     {
         MethodDefinition {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             decorators,
@@ -6593,6 +6687,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         PropertyDefinition {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             decorators,
@@ -6683,7 +6778,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        PrivateIdentifier { span, name: name.into_in(self.allocator) }
+        PrivateIdentifier { node_id: NodeId::DUMMY, span, name: name.into_in(self.allocator) }
     }
 
     /// Builds a [`PrivateIdentifier`] and stores it in the memory arena.
@@ -6710,7 +6805,7 @@ impl<'a> AstBuilder<'a> {
     /// - body
     #[inline]
     pub fn static_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
-        StaticBlock { span, body, scope_id: Default::default() }
+        StaticBlock { node_id: NodeId::DUMMY, span, body, scope_id: Default::default() }
     }
 
     /// Builds a [`StaticBlock`] and stores it in the memory arena.
@@ -6982,6 +7077,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         AccessorProperty {
+            node_id: NodeId::DUMMY,
             r#type,
             span,
             decorators,
@@ -7059,7 +7155,7 @@ impl<'a> AstBuilder<'a> {
         source: Expression<'a>,
         arguments: Vec<'a, Expression<'a>>,
     ) -> ImportExpression<'a> {
-        ImportExpression { span, source, arguments }
+        ImportExpression { node_id: NodeId::DUMMY, span, source, arguments }
     }
 
     /// Builds a [`ImportExpression`] and stores it in the memory arena.
@@ -7103,6 +7199,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ImportDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             specifiers,
             source,
@@ -7253,7 +7350,7 @@ impl<'a> AstBuilder<'a> {
         local: BindingIdentifier<'a>,
         import_kind: ImportOrExportKind,
     ) -> ImportSpecifier<'a> {
-        ImportSpecifier { span, imported, local, import_kind }
+        ImportSpecifier { node_id: NodeId::DUMMY, span, imported, local, import_kind }
     }
 
     /// Builds a [`ImportSpecifier`] and stores it in the memory arena.
@@ -7289,7 +7386,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDefaultSpecifier<'a> {
-        ImportDefaultSpecifier { span, local }
+        ImportDefaultSpecifier { node_id: NodeId::DUMMY, span, local }
     }
 
     /// Builds a [`ImportDefaultSpecifier`] and stores it in the memory arena.
@@ -7321,7 +7418,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportNamespaceSpecifier<'a> {
-        ImportNamespaceSpecifier { span, local }
+        ImportNamespaceSpecifier { node_id: NodeId::DUMMY, span, local }
     }
 
     /// Builds a [`ImportNamespaceSpecifier`] and stores it in the memory arena.
@@ -7355,7 +7452,7 @@ impl<'a> AstBuilder<'a> {
         attributes_keyword: IdentifierName<'a>,
         with_entries: Vec<'a, ImportAttribute<'a>>,
     ) -> WithClause<'a> {
-        WithClause { span, attributes_keyword, with_entries }
+        WithClause { node_id: NodeId::DUMMY, span, attributes_keyword, with_entries }
     }
 
     /// Builds a [`WithClause`] and stores it in the memory arena.
@@ -7391,7 +7488,7 @@ impl<'a> AstBuilder<'a> {
         key: ImportAttributeKey<'a>,
         value: StringLiteral<'a>,
     ) -> ImportAttribute<'a> {
-        ImportAttribute { span, key, value }
+        ImportAttribute { node_id: NodeId::DUMMY, span, key, value }
     }
 
     /// Builds a [`ImportAttribute`] and stores it in the memory arena.
@@ -7489,6 +7586,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ExportNamedDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             declaration,
             specifiers,
@@ -7550,7 +7648,7 @@ impl<'a> AstBuilder<'a> {
         declaration: ExportDefaultDeclarationKind<'a>,
         exported: ModuleExportName<'a>,
     ) -> ExportDefaultDeclaration<'a> {
-        ExportDefaultDeclaration { span, declaration, exported }
+        ExportDefaultDeclaration { node_id: NodeId::DUMMY, span, declaration, exported }
     }
 
     /// Builds a [`ExportDefaultDeclaration`] and stores it in the memory arena.
@@ -7594,6 +7692,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ExportAllDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             exported,
             source,
@@ -7647,7 +7746,7 @@ impl<'a> AstBuilder<'a> {
         exported: ModuleExportName<'a>,
         export_kind: ImportOrExportKind,
     ) -> ExportSpecifier<'a> {
-        ExportSpecifier { span, local, exported, export_kind }
+        ExportSpecifier { node_id: NodeId::DUMMY, span, local, exported, export_kind }
     }
 
     /// Builds a [`ExportSpecifier`] and stores it in the memory arena.
@@ -7937,6 +8036,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSThisParameter {
+            node_id: NodeId::DUMMY,
             span,
             this_span,
             type_annotation: type_annotation.into_in(self.allocator),
@@ -7983,7 +8083,15 @@ impl<'a> AstBuilder<'a> {
         r#const: bool,
         declare: bool,
     ) -> TSEnumDeclaration<'a> {
-        TSEnumDeclaration { span, id, members, r#const, declare, scope_id: Default::default() }
+        TSEnumDeclaration {
+            node_id: NodeId::DUMMY,
+            span,
+            id,
+            members,
+            r#const,
+            declare,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`TSEnumDeclaration`] and stores it in the memory arena.
@@ -8023,7 +8131,7 @@ impl<'a> AstBuilder<'a> {
         id: TSEnumMemberName<'a>,
         initializer: Option<Expression<'a>>,
     ) -> TSEnumMember<'a> {
-        TSEnumMember { span, id, initializer }
+        TSEnumMember { node_id: NodeId::DUMMY, span, id, initializer }
     }
 
     /// Builds a [`TSEnumMember`] and stores it in the memory arena.
@@ -8175,7 +8283,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTypeAnnotation<'a> {
-        TSTypeAnnotation { span, type_annotation }
+        TSTypeAnnotation { node_id: NodeId::DUMMY, span, type_annotation }
     }
 
     /// Builds a [`TSTypeAnnotation`] and stores it in the memory arena.
@@ -8203,7 +8311,7 @@ impl<'a> AstBuilder<'a> {
     /// - literal
     #[inline]
     pub fn ts_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
-        TSLiteralType { span, literal }
+        TSLiteralType { node_id: NodeId::DUMMY, span, literal }
     }
 
     /// Builds a [`TSLiteralType`] and stores it in the memory arena.
@@ -9449,6 +9557,7 @@ impl<'a> AstBuilder<'a> {
         false_type: TSType<'a>,
     ) -> TSConditionalType<'a> {
         TSConditionalType {
+            node_id: NodeId::DUMMY,
             span,
             check_type,
             extends_type,
@@ -9492,7 +9601,7 @@ impl<'a> AstBuilder<'a> {
     /// - types
     #[inline]
     pub fn ts_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
-        TSUnionType { span, types }
+        TSUnionType { node_id: NodeId::DUMMY, span, types }
     }
 
     /// Builds a [`TSUnionType`] and stores it in the memory arena.
@@ -9524,7 +9633,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         types: Vec<'a, TSType<'a>>,
     ) -> TSIntersectionType<'a> {
-        TSIntersectionType { span, types }
+        TSIntersectionType { node_id: NodeId::DUMMY, span, types }
     }
 
     /// Builds a [`TSIntersectionType`] and stores it in the memory arena.
@@ -9556,7 +9665,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSParenthesizedType<'a> {
-        TSParenthesizedType { span, type_annotation }
+        TSParenthesizedType { node_id: NodeId::DUMMY, span, type_annotation }
     }
 
     /// Builds a [`TSParenthesizedType`] and stores it in the memory arena.
@@ -9590,7 +9699,7 @@ impl<'a> AstBuilder<'a> {
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
     ) -> TSTypeOperator<'a> {
-        TSTypeOperator { span, operator, type_annotation }
+        TSTypeOperator { node_id: NodeId::DUMMY, span, operator, type_annotation }
     }
 
     /// Builds a [`TSTypeOperator`] and stores it in the memory arena.
@@ -9620,7 +9729,7 @@ impl<'a> AstBuilder<'a> {
     /// - element_type
     #[inline]
     pub fn ts_array_type(self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
-        TSArrayType { span, element_type }
+        TSArrayType { node_id: NodeId::DUMMY, span, element_type }
     }
 
     /// Builds a [`TSArrayType`] and stores it in the memory arena.
@@ -9654,7 +9763,7 @@ impl<'a> AstBuilder<'a> {
         object_type: TSType<'a>,
         index_type: TSType<'a>,
     ) -> TSIndexedAccessType<'a> {
-        TSIndexedAccessType { span, object_type, index_type }
+        TSIndexedAccessType { node_id: NodeId::DUMMY, span, object_type, index_type }
     }
 
     /// Builds a [`TSIndexedAccessType`] and stores it in the memory arena.
@@ -9688,7 +9797,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         element_types: Vec<'a, TSTupleElement<'a>>,
     ) -> TSTupleType<'a> {
-        TSTupleType { span, element_types }
+        TSTupleType { node_id: NodeId::DUMMY, span, element_types }
     }
 
     /// Builds a [`TSTupleType`] and stores it in the memory arena.
@@ -9724,7 +9833,7 @@ impl<'a> AstBuilder<'a> {
         label: IdentifierName<'a>,
         optional: bool,
     ) -> TSNamedTupleMember<'a> {
-        TSNamedTupleMember { span, element_type, label, optional }
+        TSNamedTupleMember { node_id: NodeId::DUMMY, span, element_type, label, optional }
     }
 
     /// Builds a [`TSNamedTupleMember`] and stores it in the memory arena.
@@ -9756,7 +9865,7 @@ impl<'a> AstBuilder<'a> {
     /// - type_annotation
     #[inline]
     pub fn ts_optional_type(self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
-        TSOptionalType { span, type_annotation }
+        TSOptionalType { node_id: NodeId::DUMMY, span, type_annotation }
     }
 
     /// Builds a [`TSOptionalType`] and stores it in the memory arena.
@@ -9784,7 +9893,7 @@ impl<'a> AstBuilder<'a> {
     /// - type_annotation
     #[inline]
     pub fn ts_rest_type(self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
-        TSRestType { span, type_annotation }
+        TSRestType { node_id: NodeId::DUMMY, span, type_annotation }
     }
 
     /// Builds a [`TSRestType`] and stores it in the memory arena.
@@ -9866,7 +9975,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_any_keyword(self, span: Span) -> TSAnyKeyword {
-        TSAnyKeyword { span }
+        TSAnyKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSAnyKeyword`] and stores it in the memory arena.
@@ -9888,7 +9997,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_string_keyword(self, span: Span) -> TSStringKeyword {
-        TSStringKeyword { span }
+        TSStringKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSStringKeyword`] and stores it in the memory arena.
@@ -9910,7 +10019,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_boolean_keyword(self, span: Span) -> TSBooleanKeyword {
-        TSBooleanKeyword { span }
+        TSBooleanKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSBooleanKeyword`] and stores it in the memory arena.
@@ -9932,7 +10041,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_number_keyword(self, span: Span) -> TSNumberKeyword {
-        TSNumberKeyword { span }
+        TSNumberKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSNumberKeyword`] and stores it in the memory arena.
@@ -9954,7 +10063,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_never_keyword(self, span: Span) -> TSNeverKeyword {
-        TSNeverKeyword { span }
+        TSNeverKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSNeverKeyword`] and stores it in the memory arena.
@@ -9976,7 +10085,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_intrinsic_keyword(self, span: Span) -> TSIntrinsicKeyword {
-        TSIntrinsicKeyword { span }
+        TSIntrinsicKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSIntrinsicKeyword`] and stores it in the memory arena.
@@ -9998,7 +10107,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_unknown_keyword(self, span: Span) -> TSUnknownKeyword {
-        TSUnknownKeyword { span }
+        TSUnknownKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSUnknownKeyword`] and stores it in the memory arena.
@@ -10020,7 +10129,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_null_keyword(self, span: Span) -> TSNullKeyword {
-        TSNullKeyword { span }
+        TSNullKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSNullKeyword`] and stores it in the memory arena.
@@ -10042,7 +10151,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_undefined_keyword(self, span: Span) -> TSUndefinedKeyword {
-        TSUndefinedKeyword { span }
+        TSUndefinedKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSUndefinedKeyword`] and stores it in the memory arena.
@@ -10064,7 +10173,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_void_keyword(self, span: Span) -> TSVoidKeyword {
-        TSVoidKeyword { span }
+        TSVoidKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSVoidKeyword`] and stores it in the memory arena.
@@ -10086,7 +10195,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_symbol_keyword(self, span: Span) -> TSSymbolKeyword {
-        TSSymbolKeyword { span }
+        TSSymbolKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSSymbolKeyword`] and stores it in the memory arena.
@@ -10108,7 +10217,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_this_type(self, span: Span) -> TSThisType {
-        TSThisType { span }
+        TSThisType { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSThisType`] and stores it in the memory arena.
@@ -10130,7 +10239,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_object_keyword(self, span: Span) -> TSObjectKeyword {
-        TSObjectKeyword { span }
+        TSObjectKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSObjectKeyword`] and stores it in the memory arena.
@@ -10152,7 +10261,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_big_int_keyword(self, span: Span) -> TSBigIntKeyword {
-        TSBigIntKeyword { span }
+        TSBigIntKeyword { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`TSBigIntKeyword`] and stores it in the memory arena.
@@ -10185,6 +10294,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeReference {
+            node_id: NodeId::DUMMY,
             span,
             type_name,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -10278,7 +10388,7 @@ impl<'a> AstBuilder<'a> {
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
     ) -> TSQualifiedName<'a> {
-        TSQualifiedName { span, left, right }
+        TSQualifiedName { node_id: NodeId::DUMMY, span, left, right }
     }
 
     /// Builds a [`TSQualifiedName`] and stores it in the memory arena.
@@ -10312,7 +10422,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         params: Vec<'a, TSType<'a>>,
     ) -> TSTypeParameterInstantiation<'a> {
-        TSTypeParameterInstantiation { span, params }
+        TSTypeParameterInstantiation { node_id: NodeId::DUMMY, span, params }
     }
 
     /// Builds a [`TSTypeParameterInstantiation`] and stores it in the memory arena.
@@ -10354,7 +10464,16 @@ impl<'a> AstBuilder<'a> {
         out: bool,
         r#const: bool,
     ) -> TSTypeParameter<'a> {
-        TSTypeParameter { span, name, constraint, default, r#in, out, r#const }
+        TSTypeParameter {
+            node_id: NodeId::DUMMY,
+            span,
+            name,
+            constraint,
+            default,
+            r#in,
+            out,
+            r#const,
+        }
     }
 
     /// Builds a [`TSTypeParameter`] and stores it in the memory arena.
@@ -10399,7 +10518,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         params: Vec<'a, TSTypeParameter<'a>>,
     ) -> TSTypeParameterDeclaration<'a> {
-        TSTypeParameterDeclaration { span, params }
+        TSTypeParameterDeclaration { node_id: NodeId::DUMMY, span, params }
     }
 
     /// Builds a [`TSTypeParameterDeclaration`] and stores it in the memory arena.
@@ -10441,6 +10560,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSTypeAliasDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -10497,6 +10617,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSClassImplements {
+            node_id: NodeId::DUMMY,
             span,
             expression,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -10550,6 +10671,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
     {
         TSInterfaceDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             id,
             extends,
@@ -10604,7 +10726,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         body: Vec<'a, TSSignature<'a>>,
     ) -> TSInterfaceBody<'a> {
-        TSInterfaceBody { span, body }
+        TSInterfaceBody { node_id: NodeId::DUMMY, span, body }
     }
 
     /// Builds a [`TSInterfaceBody`] and stores it in the memory arena.
@@ -10648,6 +10770,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSPropertySignature {
+            node_id: NodeId::DUMMY,
             span,
             computed,
             optional,
@@ -10924,6 +11047,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignature {
+            node_id: NodeId::DUMMY,
             span,
             parameters,
             type_annotation: type_annotation.into_in(self.allocator),
@@ -10982,6 +11106,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSCallSignatureDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             this_param,
             params: params.into_in(self.allocator),
@@ -11060,6 +11185,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSMethodSignature {
+            node_id: NodeId::DUMMY,
             span,
             key,
             computed,
@@ -11145,6 +11271,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSConstructSignatureDeclaration {
+            node_id: NodeId::DUMMY,
             span,
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
@@ -11201,6 +11328,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
+            node_id: NodeId::DUMMY,
             span,
             name: name.into_in(self.allocator),
             type_annotation: type_annotation.into_in(self.allocator),
@@ -11248,6 +11376,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSInterfaceHeritage {
+            node_id: NodeId::DUMMY,
             span,
             expression,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -11296,6 +11425,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSTypePredicate {
+            node_id: NodeId::DUMMY,
             span,
             parameter_name,
             asserts,
@@ -11394,7 +11524,15 @@ impl<'a> AstBuilder<'a> {
         kind: TSModuleDeclarationKind,
         declare: bool,
     ) -> TSModuleDeclaration<'a> {
-        TSModuleDeclaration { span, id, body, kind, declare, scope_id: Default::default() }
+        TSModuleDeclaration {
+            node_id: NodeId::DUMMY,
+            span,
+            id,
+            body,
+            kind,
+            declare,
+            scope_id: Default::default(),
+        }
     }
 
     /// Builds a [`TSModuleDeclaration`] and stores it in the memory arena.
@@ -11560,7 +11698,7 @@ impl<'a> AstBuilder<'a> {
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
     ) -> TSModuleBlock<'a> {
-        TSModuleBlock { span, directives, body }
+        TSModuleBlock { node_id: NodeId::DUMMY, span, directives, body }
     }
 
     /// Builds a [`TSModuleBlock`] and stores it in the memory arena.
@@ -11594,7 +11732,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         members: Vec<'a, TSSignature<'a>>,
     ) -> TSTypeLiteral<'a> {
-        TSTypeLiteral { span, members }
+        TSTypeLiteral { node_id: NodeId::DUMMY, span, members }
     }
 
     /// Builds a [`TSTypeLiteral`] and stores it in the memory arena.
@@ -11625,7 +11763,11 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
-        TSInferType { span, type_parameter: type_parameter.into_in(self.allocator) }
+        TSInferType {
+            node_id: NodeId::DUMMY,
+            span,
+            type_parameter: type_parameter.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`TSInferType`] and stores it in the memory arena.
@@ -11661,7 +11803,12 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        TSTypeQuery { span, expr_name, type_parameters: type_parameters.into_in(self.allocator) }
+        TSTypeQuery {
+            node_id: NodeId::DUMMY,
+            span,
+            expr_name,
+            type_parameters: type_parameters.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`TSTypeQuery`] and stores it in the memory arena.
@@ -11763,6 +11910,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSImportType {
+            node_id: NodeId::DUMMY,
             span,
             is_type_of,
             parameter,
@@ -11825,7 +11973,7 @@ impl<'a> AstBuilder<'a> {
         attributes_keyword: IdentifierName<'a>,
         elements: Vec<'a, TSImportAttribute<'a>>,
     ) -> TSImportAttributes<'a> {
-        TSImportAttributes { span, attributes_keyword, elements }
+        TSImportAttributes { node_id: NodeId::DUMMY, span, attributes_keyword, elements }
     }
 
     /// Builds a [`TSImportAttributes`] and stores it in the memory arena.
@@ -11861,7 +12009,7 @@ impl<'a> AstBuilder<'a> {
         name: TSImportAttributeName<'a>,
         value: Expression<'a>,
     ) -> TSImportAttribute<'a> {
-        TSImportAttribute { span, name, value }
+        TSImportAttribute { node_id: NodeId::DUMMY, span, name, value }
     }
 
     /// Builds a [`TSImportAttribute`] and stores it in the memory arena.
@@ -11966,6 +12114,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSFunctionType {
+            node_id: NodeId::DUMMY,
             span,
             this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
@@ -12030,6 +12179,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSConstructorType {
+            node_id: NodeId::DUMMY,
             span,
             r#abstract,
             params: params.into_in(self.allocator),
@@ -12093,6 +12243,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
         TSMappedType {
+            node_id: NodeId::DUMMY,
             span,
             type_parameter: type_parameter.into_in(self.allocator),
             name_type,
@@ -12155,7 +12306,7 @@ impl<'a> AstBuilder<'a> {
         quasis: Vec<'a, TemplateElement<'a>>,
         types: Vec<'a, TSType<'a>>,
     ) -> TSTemplateLiteralType<'a> {
-        TSTemplateLiteralType { span, quasis, types }
+        TSTemplateLiteralType { node_id: NodeId::DUMMY, span, quasis, types }
     }
 
     /// Builds a [`TSTemplateLiteralType`] and stores it in the memory arena.
@@ -12191,7 +12342,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> TSAsExpression<'a> {
-        TSAsExpression { span, expression, type_annotation }
+        TSAsExpression { node_id: NodeId::DUMMY, span, expression, type_annotation }
     }
 
     /// Builds a [`TSAsExpression`] and stores it in the memory arena.
@@ -12227,7 +12378,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> TSSatisfiesExpression<'a> {
-        TSSatisfiesExpression { span, expression, type_annotation }
+        TSSatisfiesExpression { node_id: NodeId::DUMMY, span, expression, type_annotation }
     }
 
     /// Builds a [`TSSatisfiesExpression`] and stores it in the memory arena.
@@ -12263,7 +12414,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> TSTypeAssertion<'a> {
-        TSTypeAssertion { span, expression, type_annotation }
+        TSTypeAssertion { node_id: NodeId::DUMMY, span, expression, type_annotation }
     }
 
     /// Builds a [`TSTypeAssertion`] and stores it in the memory arena.
@@ -12301,7 +12452,13 @@ impl<'a> AstBuilder<'a> {
         module_reference: TSModuleReference<'a>,
         import_kind: ImportOrExportKind,
     ) -> TSImportEqualsDeclaration<'a> {
-        TSImportEqualsDeclaration { span, id, module_reference, import_kind }
+        TSImportEqualsDeclaration {
+            node_id: NodeId::DUMMY,
+            span,
+            id,
+            module_reference,
+            import_kind,
+        }
     }
 
     /// Builds a [`TSImportEqualsDeclaration`] and stores it in the memory arena.
@@ -12375,7 +12532,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSExternalModuleReference<'a> {
-        TSExternalModuleReference { span, expression }
+        TSExternalModuleReference { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`TSExternalModuleReference`] and stores it in the memory arena.
@@ -12407,7 +12564,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> TSNonNullExpression<'a> {
-        TSNonNullExpression { span, expression }
+        TSNonNullExpression { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`TSNonNullExpression`] and stores it in the memory arena.
@@ -12435,7 +12592,7 @@ impl<'a> AstBuilder<'a> {
     /// - expression
     #[inline]
     pub fn decorator(self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
-        Decorator { span, expression }
+        Decorator { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`Decorator`] and stores it in the memory arena.
@@ -12463,7 +12620,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> TSExportAssignment<'a> {
-        TSExportAssignment { span, expression }
+        TSExportAssignment { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`TSExportAssignment`] and stores it in the memory arena.
@@ -12495,7 +12652,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: IdentifierName<'a>,
     ) -> TSNamespaceExportDeclaration<'a> {
-        TSNamespaceExportDeclaration { span, id }
+        TSNamespaceExportDeclaration { node_id: NodeId::DUMMY, span, id }
     }
 
     /// Builds a [`TSNamespaceExportDeclaration`] and stores it in the memory arena.
@@ -12533,6 +12690,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
     {
         TSInstantiationExpression {
+            node_id: NodeId::DUMMY,
             span,
             expression,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -12578,7 +12736,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> JSDocNullableType<'a> {
-        JSDocNullableType { span, type_annotation, postfix }
+        JSDocNullableType { node_id: NodeId::DUMMY, span, type_annotation, postfix }
     }
 
     /// Builds a [`JSDocNullableType`] and stores it in the memory arena.
@@ -12614,7 +12772,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> JSDocNonNullableType<'a> {
-        JSDocNonNullableType { span, type_annotation, postfix }
+        JSDocNonNullableType { node_id: NodeId::DUMMY, span, type_annotation, postfix }
     }
 
     /// Builds a [`JSDocNonNullableType`] and stores it in the memory arena.
@@ -12643,7 +12801,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn js_doc_unknown_type(self, span: Span) -> JSDocUnknownType {
-        JSDocUnknownType { span }
+        JSDocUnknownType { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`JSDocUnknownType`] and stores it in the memory arena.
@@ -12679,6 +12837,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
     {
         JSXElement {
+            node_id: NodeId::DUMMY,
             span,
             opening_element: opening_element.into_in(self.allocator),
             closing_element: closing_element.into_in(self.allocator),
@@ -12736,6 +12895,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         JSXOpeningElement {
+            node_id: NodeId::DUMMY,
             span,
             self_closing,
             name,
@@ -12785,7 +12945,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: JSXElementName<'a>,
     ) -> JSXClosingElement<'a> {
-        JSXClosingElement { span, name }
+        JSXClosingElement { node_id: NodeId::DUMMY, span, name }
     }
 
     /// Builds a [`JSXClosingElement`] and stores it in the memory arena.
@@ -12821,7 +12981,7 @@ impl<'a> AstBuilder<'a> {
         closing_fragment: JSXClosingFragment,
         children: Vec<'a, JSXChild<'a>>,
     ) -> JSXFragment<'a> {
-        JSXFragment { span, opening_fragment, closing_fragment, children }
+        JSXFragment { node_id: NodeId::DUMMY, span, opening_fragment, closing_fragment, children }
     }
 
     /// Builds a [`JSXFragment`] and stores it in the memory arena.
@@ -12988,7 +13148,7 @@ impl<'a> AstBuilder<'a> {
         namespace: JSXIdentifier<'a>,
         property: JSXIdentifier<'a>,
     ) -> JSXNamespacedName<'a> {
-        JSXNamespacedName { span, namespace, property }
+        JSXNamespacedName { node_id: NodeId::DUMMY, span, namespace, property }
     }
 
     /// Builds a [`JSXNamespacedName`] and stores it in the memory arena.
@@ -13024,7 +13184,7 @@ impl<'a> AstBuilder<'a> {
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
     ) -> JSXMemberExpression<'a> {
-        JSXMemberExpression { span, object, property }
+        JSXMemberExpression { node_id: NodeId::DUMMY, span, object, property }
     }
 
     /// Builds a [`JSXMemberExpression`] and stores it in the memory arena.
@@ -13149,7 +13309,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXExpressionContainer<'a> {
-        JSXExpressionContainer { span, expression }
+        JSXExpressionContainer { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`JSXExpressionContainer`] and stores it in the memory arena.
@@ -13199,7 +13359,7 @@ impl<'a> AstBuilder<'a> {
     /// - span: The [`Span`] covering this node
     #[inline]
     pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
-        JSXEmptyExpression { span }
+        JSXEmptyExpression { node_id: NodeId::DUMMY, span }
     }
 
     /// Builds a [`JSXEmptyExpression`] and stores it in the memory arena.
@@ -13280,7 +13440,7 @@ impl<'a> AstBuilder<'a> {
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
     ) -> JSXAttribute<'a> {
-        JSXAttribute { span, name, value }
+        JSXAttribute { node_id: NodeId::DUMMY, span, name, value }
     }
 
     /// Builds a [`JSXAttribute`] and stores it in the memory arena.
@@ -13314,7 +13474,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: Expression<'a>,
     ) -> JSXSpreadAttribute<'a> {
-        JSXSpreadAttribute { span, argument }
+        JSXSpreadAttribute { node_id: NodeId::DUMMY, span, argument }
     }
 
     /// Builds a [`JSXSpreadAttribute`] and stores it in the memory arena.
@@ -13528,7 +13688,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        JSXIdentifier { span, name: name.into_in(self.allocator) }
+        JSXIdentifier { node_id: NodeId::DUMMY, span, name: name.into_in(self.allocator) }
     }
 
     /// Builds a [`JSXIdentifier`] and stores it in the memory arena.
@@ -13701,7 +13861,7 @@ impl<'a> AstBuilder<'a> {
     /// - expression: The expression being spread.
     #[inline]
     pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
-        JSXSpreadChild { span, expression }
+        JSXSpreadChild { node_id: NodeId::DUMMY, span, expression }
     }
 
     /// Builds a [`JSXSpreadChild`] and stores it in the memory arena.
@@ -13732,7 +13892,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        JSXText { span, value: value.into_in(self.allocator) }
+        JSXText { node_id: NodeId::DUMMY, span, value: value.into_in(self.allocator) }
     }
 
     /// Builds a [`JSXText`] and stores it in the memory arena.

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -21,6 +21,7 @@ impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
     type Cloned = BooleanLiteral;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         BooleanLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }
@@ -30,7 +31,10 @@ impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
 impl<'alloc> CloneIn<'alloc> for NullLiteral {
     type Cloned = NullLiteral;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        NullLiteral { span: CloneIn::clone_in(&self.span, allocator) }
+        NullLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -38,6 +42,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'old_alloc> 
     type Cloned = NumericLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NumericLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -50,6 +55,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'old_alloc> {
     type Cloned = BigIntLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
             base: CloneIn::clone_in(&self.base, allocator),
@@ -61,6 +67,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'old_alloc> {
     type Cloned = RegExpLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         RegExpLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             regex: CloneIn::clone_in(&self.regex, allocator),
@@ -100,6 +107,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StringLiteral<'old_alloc> {
     type Cloned = StringLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StringLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }
@@ -110,6 +118,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Program<'old_alloc> {
     type Cloned = Program<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Program {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             source_type: CloneIn::clone_in(&self.source_type, allocator),
             hashbang: CloneIn::clone_in(&self.hashbang, allocator),
@@ -238,6 +247,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierName<'old_alloc> 
     type Cloned = IdentifierName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierName {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -248,6 +258,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'old_al
     type Cloned = IdentifierReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierReference {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             reference_id: Default::default(),
@@ -259,6 +270,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'old_allo
     type Cloned = BindingIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingIdentifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             symbol_id: Default::default(),
@@ -270,6 +282,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'old_alloc>
     type Cloned = LabelIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabelIdentifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -279,7 +292,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'old_alloc>
 impl<'alloc> CloneIn<'alloc> for ThisExpression {
     type Cloned = ThisExpression;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        ThisExpression { span: CloneIn::clone_in(&self.span, allocator) }
+        ThisExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -287,6 +303,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'old_alloc>
     type Cloned = ArrayExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
@@ -433,7 +450,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'old
 impl<'alloc> CloneIn<'alloc> for Elision {
     type Cloned = Elision;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        Elision { span: CloneIn::clone_in(&self.span, allocator) }
+        Elision {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -441,6 +461,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'old_alloc
     type Cloned = ObjectExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
             trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
@@ -466,6 +487,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'old_alloc> 
     type Cloned = ObjectProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectProperty {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
@@ -613,6 +635,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'old_alloc>
     type Cloned = TemplateLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             quasis: CloneIn::clone_in(&self.quasis, allocator),
             expressions: CloneIn::clone_in(&self.expressions, allocator),
@@ -624,6 +647,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'o
     type Cloned = TaggedTemplateExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TaggedTemplateExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             tag: CloneIn::clone_in(&self.tag, allocator),
             quasi: CloneIn::clone_in(&self.quasi, allocator),
@@ -636,6 +660,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TemplateElement<'old_alloc>
     type Cloned = TemplateElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             tail: CloneIn::clone_in(&self.tail, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -674,6 +699,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'o
     type Cloned = ComputedMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ComputedMemberExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
@@ -686,6 +712,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'old
     type Cloned = StaticMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticMemberExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -698,6 +725,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'old
     type Cloned = PrivateFieldExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateFieldExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             field: CloneIn::clone_in(&self.field, allocator),
@@ -710,6 +738,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CallExpression<'old_alloc> 
     type Cloned = CallExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CallExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -723,6 +752,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NewExpression<'old_alloc> {
     type Cloned = NewExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NewExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
             arguments: CloneIn::clone_in(&self.arguments, allocator),
@@ -735,6 +765,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for MetaProperty<'old_alloc> {
     type Cloned = MetaProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MetaProperty {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             meta: CloneIn::clone_in(&self.meta, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -746,6 +777,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SpreadElement<'old_alloc> {
     type Cloned = SpreadElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SpreadElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -861,6 +893,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'old_alloc
     type Cloned = UpdateExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UpdateExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             prefix: CloneIn::clone_in(&self.prefix, allocator),
@@ -873,6 +906,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'old_alloc>
     type Cloned = UnaryExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UnaryExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
@@ -884,6 +918,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'old_alloc
     type Cloned = BinaryExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BinaryExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
@@ -896,6 +931,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'old_al
     type Cloned = PrivateInExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateInExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
@@ -908,6 +944,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'old_allo
     type Cloned = LogicalExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LogicalExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
@@ -920,6 +957,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'old_
     type Cloned = ConditionalExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ConditionalExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -932,6 +970,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'old_a
     type Cloned = AssignmentExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
@@ -1034,6 +1073,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'old_
     type Cloned = ArrayAssignmentTarget<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayAssignmentTarget {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1046,6 +1086,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'old
     type Cloned = ObjectAssignmentTarget<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectAssignmentTarget {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1057,6 +1098,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'old_a
     type Cloned = AssignmentTargetRest<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetRest {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             target: CloneIn::clone_in(&self.target, allocator),
         }
@@ -1125,6 +1167,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault
     type Cloned = AssignmentTargetWithDefault<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetWithDefault {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
@@ -1156,6 +1199,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc>
     type Cloned = AssignmentTargetPropertyIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
@@ -1167,6 +1211,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyPro
     type Cloned = AssignmentTargetPropertyProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
@@ -1178,6 +1223,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'old_all
     type Cloned = SequenceExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SequenceExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expressions: CloneIn::clone_in(&self.expressions, allocator),
         }
@@ -1187,7 +1233,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'old_all
 impl<'alloc> CloneIn<'alloc> for Super {
     type Cloned = Super;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        Super { span: CloneIn::clone_in(&self.span, allocator) }
+        Super {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -1195,6 +1244,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'old_alloc>
     type Cloned = AwaitExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AwaitExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -1205,6 +1255,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ChainExpression<'old_alloc>
     type Cloned = ChainExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ChainExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -1235,6 +1286,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'ol
     type Cloned = ParenthesizedExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ParenthesizedExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -1327,6 +1379,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Directive<'old_alloc> {
     type Cloned = Directive<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Directive {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             directive: CloneIn::clone_in(&self.directive, allocator),
@@ -1338,6 +1391,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Hashbang<'old_alloc> {
     type Cloned = Hashbang<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Hashbang {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }
@@ -1348,6 +1402,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BlockStatement<'old_alloc> 
     type Cloned = BlockStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BlockStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
@@ -1391,6 +1446,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'old_al
     type Cloned = VariableDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             declarations: CloneIn::clone_in(&self.declarations, allocator),
@@ -1416,6 +1472,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'old_all
     type Cloned = VariableDeclarator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclarator {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
@@ -1428,7 +1485,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'old_all
 impl<'alloc> CloneIn<'alloc> for EmptyStatement {
     type Cloned = EmptyStatement;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        EmptyStatement { span: CloneIn::clone_in(&self.span, allocator) }
+        EmptyStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -1436,6 +1496,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'old_al
     type Cloned = ExpressionStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExpressionStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -1446,6 +1507,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IfStatement<'old_alloc> {
     type Cloned = IfStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IfStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -1458,6 +1520,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'old_alloc
     type Cloned = DoWhileStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DoWhileStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
@@ -1469,6 +1532,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WhileStatement<'old_alloc> 
     type Cloned = WhileStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WhileStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -1480,6 +1544,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForStatement<'old_alloc> {
     type Cloned = ForStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
@@ -1625,6 +1690,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForInStatement<'old_alloc> 
     type Cloned = ForInStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForInStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -1682,6 +1748,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'old_alloc> 
     type Cloned = ForOfStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForOfStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             r#await: CloneIn::clone_in(&self.r#await, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
@@ -1696,6 +1763,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'old_allo
     type Cloned = ContinueStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ContinueStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
         }
@@ -1706,6 +1774,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BreakStatement<'old_alloc> 
     type Cloned = BreakStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BreakStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
         }
@@ -1716,6 +1785,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'old_alloc>
     type Cloned = ReturnStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ReturnStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -1726,6 +1796,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WithStatement<'old_alloc> {
     type Cloned = WithStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -1737,6 +1808,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'old_alloc>
     type Cloned = SwitchStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             discriminant: CloneIn::clone_in(&self.discriminant, allocator),
             cases: CloneIn::clone_in(&self.cases, allocator),
@@ -1749,6 +1821,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for SwitchCase<'old_alloc> {
     type Cloned = SwitchCase<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchCase {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -1760,6 +1833,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'old_alloc
     type Cloned = LabeledStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabeledStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -1771,6 +1845,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'old_alloc> 
     type Cloned = ThrowStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThrowStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -1781,6 +1856,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TryStatement<'old_alloc> {
     type Cloned = TryStatement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TryStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             block: CloneIn::clone_in(&self.block, allocator),
             handler: CloneIn::clone_in(&self.handler, allocator),
@@ -1793,6 +1869,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchClause<'old_alloc> {
     type Cloned = CatchClause<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchClause {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             param: CloneIn::clone_in(&self.param, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -1805,6 +1882,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchParameter<'old_alloc> 
     type Cloned = CatchParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchParameter {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             pattern: CloneIn::clone_in(&self.pattern, allocator),
         }
@@ -1814,7 +1892,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for CatchParameter<'old_alloc> 
 impl<'alloc> CloneIn<'alloc> for DebuggerStatement {
     type Cloned = DebuggerStatement;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        DebuggerStatement { span: CloneIn::clone_in(&self.span, allocator) }
+        DebuggerStatement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -1822,6 +1903,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingPattern<'old_alloc> 
     type Cloned = BindingPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingPattern {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
@@ -1853,6 +1935,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'old_allo
     type Cloned = AssignmentPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentPattern {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -1864,6 +1947,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'old_alloc> {
     type Cloned = ObjectPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectPattern {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1875,6 +1959,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingProperty<'old_alloc>
     type Cloned = BindingProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingProperty {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -1888,6 +1973,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'old_alloc> {
     type Cloned = ArrayPattern<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayPattern {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1899,6 +1985,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'old_all
     type Cloned = BindingRestElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingRestElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -1909,6 +1996,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Function<'old_alloc> {
     type Cloned = Function<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Function {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
@@ -1941,6 +2029,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FormalParameters<'old_alloc
     type Cloned = FormalParameters<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameters {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             items: CloneIn::clone_in(&self.items, allocator),
@@ -1953,6 +2042,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FormalParameter<'old_alloc>
     type Cloned = FormalParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameter {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             pattern: CloneIn::clone_in(&self.pattern, allocator),
@@ -1979,6 +2069,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for FunctionBody<'old_alloc> {
     type Cloned = FunctionBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FunctionBody {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             directives: CloneIn::clone_in(&self.directives, allocator),
             statements: CloneIn::clone_in(&self.statements, allocator),
@@ -1990,6 +2081,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'ol
     type Cloned = ArrowFunctionExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrowFunctionExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             r#async: CloneIn::clone_in(&self.r#async, allocator),
@@ -2006,6 +2098,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for YieldExpression<'old_alloc>
     type Cloned = YieldExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         YieldExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             delegate: CloneIn::clone_in(&self.delegate, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
@@ -2017,6 +2110,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Class<'old_alloc> {
     type Cloned = Class<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Class {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -2047,6 +2141,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ClassBody<'old_alloc> {
     type Cloned = ClassBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ClassBody {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
         }
@@ -2078,6 +2173,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'old_alloc
     type Cloned = MethodDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MethodDefinition {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -2107,6 +2203,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'old_all
     type Cloned = PropertyDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PropertyDefinition {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -2153,6 +2250,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'old_allo
     type Cloned = PrivateIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateIdentifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -2163,6 +2261,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StaticBlock<'old_alloc> {
     type Cloned = StaticBlock<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticBlock {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
@@ -2210,6 +2309,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'old_alloc
     type Cloned = AccessorProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AccessorProperty {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -2228,6 +2328,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportExpression<'old_alloc
     type Cloned = ImportExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
             arguments: CloneIn::clone_in(&self.arguments, allocator),
@@ -2239,6 +2340,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'old_allo
     type Cloned = ImportDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             specifiers: CloneIn::clone_in(&self.specifiers, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
@@ -2271,6 +2373,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'old_alloc>
     type Cloned = ImportSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportSpecifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             imported: CloneIn::clone_in(&self.imported, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
@@ -2283,6 +2386,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'old
     type Cloned = ImportDefaultSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDefaultSpecifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
         }
@@ -2293,6 +2397,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'o
     type Cloned = ImportNamespaceSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportNamespaceSpecifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
         }
@@ -2303,6 +2408,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for WithClause<'old_alloc> {
     type Cloned = WithClause<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithClause {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             attributes_keyword: CloneIn::clone_in(&self.attributes_keyword, allocator),
             with_entries: CloneIn::clone_in(&self.with_entries, allocator),
@@ -2314,6 +2420,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'old_alloc>
     type Cloned = ImportAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportAttribute {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -2339,6 +2446,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'old
     type Cloned = ExportNamedDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportNamedDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
             specifiers: CloneIn::clone_in(&self.specifiers, allocator),
@@ -2353,6 +2461,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'o
     type Cloned = ExportDefaultDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
@@ -2364,6 +2473,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'old_a
     type Cloned = ExportAllDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportAllDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
@@ -2377,6 +2487,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'old_alloc>
     type Cloned = ExportSpecifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportSpecifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
@@ -2565,6 +2676,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'old_alloc>
     type Cloned = TSThisParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisParameter {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             this_span: CloneIn::clone_in(&self.this_span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -2576,6 +2688,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'old_allo
     type Cloned = TSEnumDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             members: CloneIn::clone_in(&self.members, allocator),
@@ -2590,6 +2703,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'old_alloc> {
     type Cloned = TSEnumMember<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumMember {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             initializer: CloneIn::clone_in(&self.initializer, allocator),
@@ -2741,6 +2855,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'old_alloc
     type Cloned = TSTypeAnnotation<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAnnotation {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -2751,6 +2866,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'old_alloc> {
     type Cloned = TSLiteralType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSLiteralType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             literal: CloneIn::clone_in(&self.literal, allocator),
         }
@@ -2857,6 +2973,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'old_allo
     type Cloned = TSConditionalType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConditionalType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             check_type: CloneIn::clone_in(&self.check_type, allocator),
             extends_type: CloneIn::clone_in(&self.extends_type, allocator),
@@ -2871,6 +2988,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSUnionType<'old_alloc> {
     type Cloned = TSUnionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUnionType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
         }
@@ -2881,6 +2999,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'old_all
     type Cloned = TSIntersectionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntersectionType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
         }
@@ -2891,6 +3010,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'old_al
     type Cloned = TSParenthesizedType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSParenthesizedType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -2901,6 +3021,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'old_alloc> 
     type Cloned = TSTypeOperator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeOperator {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -2923,6 +3044,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSArrayType<'old_alloc> {
     type Cloned = TSArrayType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSArrayType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             element_type: CloneIn::clone_in(&self.element_type, allocator),
         }
@@ -2933,6 +3055,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'old_al
     type Cloned = TSIndexedAccessType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexedAccessType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object_type: CloneIn::clone_in(&self.object_type, allocator),
             index_type: CloneIn::clone_in(&self.index_type, allocator),
@@ -2944,6 +3067,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTupleType<'old_alloc> {
     type Cloned = TSTupleType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTupleType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             element_types: CloneIn::clone_in(&self.element_types, allocator),
         }
@@ -2954,6 +3078,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'old_all
     type Cloned = TSNamedTupleMember<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             element_type: CloneIn::clone_in(&self.element_type, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
@@ -2966,6 +3091,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'old_alloc> 
     type Cloned = TSOptionalType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSOptionalType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -2976,6 +3102,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSRestType<'old_alloc> {
     type Cloned = TSRestType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSRestType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -3099,98 +3226,140 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'old_alloc> 
 impl<'alloc> CloneIn<'alloc> for TSAnyKeyword {
     type Cloned = TSAnyKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSAnyKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSAnyKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSStringKeyword {
     type Cloned = TSStringKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSStringKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSStringKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSBooleanKeyword {
     type Cloned = TSBooleanKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSBooleanKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSBooleanKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNumberKeyword {
     type Cloned = TSNumberKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNumberKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSNumberKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNeverKeyword {
     type Cloned = TSNeverKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNeverKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSNeverKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSIntrinsicKeyword {
     type Cloned = TSIntrinsicKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSIntrinsicKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSIntrinsicKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSUnknownKeyword {
     type Cloned = TSUnknownKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSUnknownKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSUnknownKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSNullKeyword {
     type Cloned = TSNullKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSNullKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSNullKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSUndefinedKeyword {
     type Cloned = TSUndefinedKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSUndefinedKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSUndefinedKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSVoidKeyword {
     type Cloned = TSVoidKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSVoidKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSVoidKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSSymbolKeyword {
     type Cloned = TSSymbolKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSSymbolKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSSymbolKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSThisType {
     type Cloned = TSThisType;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSThisType { span: CloneIn::clone_in(&self.span, allocator) }
+        TSThisType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSObjectKeyword {
     type Cloned = TSObjectKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSObjectKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSObjectKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
 impl<'alloc> CloneIn<'alloc> for TSBigIntKeyword {
     type Cloned = TSBigIntKeyword;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        TSBigIntKeyword { span: CloneIn::clone_in(&self.span, allocator) }
+        TSBigIntKeyword {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -3198,6 +3367,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'old_alloc>
     type Cloned = TSTypeReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeReference {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_name: CloneIn::clone_in(&self.type_name, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3221,6 +3391,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'old_alloc>
     type Cloned = TSQualifiedName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSQualifiedName {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -3232,6 +3403,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiatio
     type Cloned = TSTypeParameterInstantiation<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterInstantiation {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
         }
@@ -3242,6 +3414,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'old_alloc>
     type Cloned = TSTypeParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameter {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             constraint: CloneIn::clone_in(&self.constraint, allocator),
@@ -3257,6 +3430,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<
     type Cloned = TSTypeParameterDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
         }
@@ -3267,6 +3441,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'old
     type Cloned = TSTypeAliasDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAliasDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3292,6 +3467,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'old_allo
     type Cloned = TSClassImplements<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSClassImplements {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3303,6 +3479,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'old
     type Cloned = TSInterfaceDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             extends: CloneIn::clone_in(&self.extends, allocator),
@@ -3318,6 +3495,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'old_alloc>
     type Cloned = TSInterfaceBody<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceBody {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
         }
@@ -3328,6 +3506,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'old_al
     type Cloned = TSPropertySignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSPropertySignature {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             computed: CloneIn::clone_in(&self.computed, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
@@ -3365,6 +3544,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'old_alloc
     type Cloned = TSIndexSignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignature {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             parameters: CloneIn::clone_in(&self.parameters, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3377,6 +3557,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<
     type Cloned = TSCallSignatureDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSCallSignatureDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
@@ -3401,6 +3582,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'old_allo
     type Cloned = TSMethodSignature<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMethodSignature {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             computed: CloneIn::clone_in(&self.computed, allocator),
@@ -3419,6 +3601,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclara
     type Cloned = TSConstructSignatureDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructSignatureDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
@@ -3432,6 +3615,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'old_a
     type Cloned = TSIndexSignatureName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignatureName {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3443,6 +3627,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'old_al
     type Cloned = TSInterfaceHeritage<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceHeritage {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3454,6 +3639,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'old_alloc>
     type Cloned = TSTypePredicate<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypePredicate {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             parameter_name: CloneIn::clone_in(&self.parameter_name, allocator),
             asserts: CloneIn::clone_in(&self.asserts, allocator),
@@ -3478,6 +3664,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'old_al
     type Cloned = TSModuleDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -3531,6 +3718,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'old_alloc> {
     type Cloned = TSModuleBlock<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleBlock {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             directives: CloneIn::clone_in(&self.directives, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -3542,6 +3730,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'old_alloc> {
     type Cloned = TSTypeLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeLiteral {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             members: CloneIn::clone_in(&self.members, allocator),
         }
@@ -3552,6 +3741,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInferType<'old_alloc> {
     type Cloned = TSInferType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInferType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
         }
@@ -3562,6 +3752,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'old_alloc> {
     type Cloned = TSTypeQuery<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeQuery {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expr_name: CloneIn::clone_in(&self.expr_name, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3590,6 +3781,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportType<'old_alloc> {
     type Cloned = TSImportType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             is_type_of: CloneIn::clone_in(&self.is_type_of, allocator),
             parameter: CloneIn::clone_in(&self.parameter, allocator),
@@ -3604,6 +3796,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttributes<'old_all
     type Cloned = TSImportAttributes<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportAttributes {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             attributes_keyword: CloneIn::clone_in(&self.attributes_keyword, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
@@ -3615,6 +3808,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttribute<'old_allo
     type Cloned = TSImportAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportAttribute {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -3640,6 +3834,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'old_alloc> 
     type Cloned = TSFunctionType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSFunctionType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
@@ -3653,6 +3848,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'old_allo
     type Cloned = TSConstructorType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructorType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
@@ -3666,6 +3862,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSMappedType<'old_alloc> {
     type Cloned = TSMappedType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
             name_type: CloneIn::clone_in(&self.name_type, allocator),
@@ -3693,6 +3890,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'old_
     type Cloned = TSTemplateLiteralType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTemplateLiteralType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             quasis: CloneIn::clone_in(&self.quasis, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
@@ -3704,6 +3902,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'old_alloc> 
     type Cloned = TSAsExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSAsExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3715,6 +3914,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'old_
     type Cloned = TSSatisfiesExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSatisfiesExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3726,6 +3926,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'old_alloc>
     type Cloned = TSTypeAssertion<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3737,6 +3938,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'
     type Cloned = TSImportEqualsDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportEqualsDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             module_reference: CloneIn::clone_in(&self.module_reference, allocator),
@@ -3766,6 +3968,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'
     type Cloned = TSExternalModuleReference<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExternalModuleReference {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -3776,6 +3979,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'old_al
     type Cloned = TSNonNullExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNonNullExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -3786,6 +3990,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Decorator<'old_alloc> {
     type Cloned = Decorator<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Decorator {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -3796,6 +4001,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'old_all
     type Cloned = TSExportAssignment<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExportAssignment {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -3806,6 +4012,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaratio
     type Cloned = TSNamespaceExportDeclaration<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamespaceExportDeclaration {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
         }
@@ -3816,6 +4023,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'
     type Cloned = TSInstantiationExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInstantiationExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -3837,6 +4045,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'old_allo
     type Cloned = JSDocNullableType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNullableType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in(&self.postfix, allocator),
@@ -3848,6 +4057,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'old_a
     type Cloned = JSDocNonNullableType<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNonNullableType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in(&self.postfix, allocator),
@@ -3858,7 +4068,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'old_a
 impl<'alloc> CloneIn<'alloc> for JSDocUnknownType {
     type Cloned = JSDocUnknownType;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSDocUnknownType { span: CloneIn::clone_in(&self.span, allocator) }
+        JSDocUnknownType {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -3866,6 +4079,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXElement<'old_alloc> {
     type Cloned = JSXElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             opening_element: CloneIn::clone_in(&self.opening_element, allocator),
             closing_element: CloneIn::clone_in(&self.closing_element, allocator),
@@ -3878,6 +4092,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'old_allo
     type Cloned = JSXOpeningElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             self_closing: CloneIn::clone_in(&self.self_closing, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
@@ -3891,6 +4106,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'old_allo
     type Cloned = JSXClosingElement<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingElement {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -3901,6 +4117,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXFragment<'old_alloc> {
     type Cloned = JSXFragment<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXFragment {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
             closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
@@ -3948,6 +4165,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'old_allo
     type Cloned = JSXNamespacedName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXNamespacedName {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             namespace: CloneIn::clone_in(&self.namespace, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -3959,6 +4177,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'old_al
     type Cloned = JSXMemberExpression<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXMemberExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -3987,6 +4206,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'old
     type Cloned = JSXExpressionContainer<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXExpressionContainer {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -4121,7 +4341,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXExpression<'old_alloc> {
 impl<'alloc> CloneIn<'alloc> for JSXEmptyExpression {
     type Cloned = JSXEmptyExpression;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXEmptyExpression { span: CloneIn::clone_in(&self.span, allocator) }
+        JSXEmptyExpression {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
+            span: CloneIn::clone_in(&self.span, allocator),
+        }
     }
 }
 
@@ -4141,6 +4364,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'old_alloc> {
     type Cloned = JSXAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXAttribute {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -4152,6 +4376,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'old_all
     type Cloned = JSXSpreadAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadAttribute {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -4190,6 +4415,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'old_alloc> {
     type Cloned = JSXIdentifier<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXIdentifier {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -4215,6 +4441,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'old_alloc> 
     type Cloned = JSXSpreadChild<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadChild {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -4225,6 +4452,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXText<'old_alloc> {
     type Cloned = JSXText<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXText {
+            node_id: CloneIn::clone_in(&self.node_id, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -19,19 +19,21 @@ use crate::ast::ts::*;
 
 impl ContentEq for BooleanLiteral {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl ContentEq for NullLiteral {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for NumericLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.raw, &other.raw)
             && ContentEq::content_eq(&self.base, &other.base)
     }
@@ -39,14 +41,16 @@ impl<'a> ContentEq for NumericLiteral<'a> {
 
 impl<'a> ContentEq for BigIntLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.raw, &other.raw)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.raw, &other.raw)
             && ContentEq::content_eq(&self.base, &other.base)
     }
 }
 
 impl<'a> ContentEq for RegExpLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.regex, &other.regex)
     }
 }
@@ -85,13 +89,15 @@ impl ContentEq for EmptyObject {
 
 impl<'a> ContentEq for StringLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for Program<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.source_type, &other.source_type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.source_type, &other.source_type)
             && ContentEq::content_eq(&self.hashbang, &other.hashbang)
             && ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -275,37 +281,42 @@ impl<'a> ContentEq for Expression<'a> {
 
 impl<'a> ContentEq for IdentifierName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for IdentifierReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for BindingIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for LabelIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl ContentEq for ThisExpression {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for ArrayExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
@@ -493,14 +504,15 @@ impl<'a> ContentEq for ArrayExpressionElement<'a> {
 }
 
 impl ContentEq for Elision {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for ObjectExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.properties, &other.properties)
     }
 }
 
@@ -521,7 +533,8 @@ impl<'a> ContentEq for ObjectPropertyKind<'a> {
 
 impl<'a> ContentEq for ObjectProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.init, &other.init)
@@ -722,14 +735,16 @@ impl ContentEq for PropertyKind {
 
 impl<'a> ContentEq for TemplateLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.quasis, &other.quasis)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.quasis, &other.quasis)
             && ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
 impl<'a> ContentEq for TaggedTemplateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.tag, &other.tag)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.tag, &other.tag)
             && ContentEq::content_eq(&self.quasi, &other.quasi)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -737,7 +752,8 @@ impl<'a> ContentEq for TaggedTemplateExpression<'a> {
 
 impl<'a> ContentEq for TemplateElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.tail, &other.tail)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.tail, &other.tail)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -770,7 +786,8 @@ impl<'a> ContentEq for MemberExpression<'a> {
 
 impl<'a> ContentEq for ComputedMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -778,7 +795,8 @@ impl<'a> ContentEq for ComputedMemberExpression<'a> {
 
 impl<'a> ContentEq for StaticMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.property, &other.property)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -786,7 +804,8 @@ impl<'a> ContentEq for StaticMemberExpression<'a> {
 
 impl<'a> ContentEq for PrivateFieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.field, &other.field)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -794,7 +813,8 @@ impl<'a> ContentEq for PrivateFieldExpression<'a> {
 
 impl<'a> ContentEq for CallExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.callee, &other.callee)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.callee, &other.callee)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.optional, &other.optional)
@@ -803,7 +823,8 @@ impl<'a> ContentEq for CallExpression<'a> {
 
 impl<'a> ContentEq for NewExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.callee, &other.callee)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.callee, &other.callee)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -811,14 +832,16 @@ impl<'a> ContentEq for NewExpression<'a> {
 
 impl<'a> ContentEq for MetaProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.meta, &other.meta)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.meta, &other.meta)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for SpreadElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
@@ -1003,7 +1026,8 @@ impl<'a> ContentEq for Argument<'a> {
 
 impl<'a> ContentEq for UpdateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.prefix, &other.prefix)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
@@ -1011,14 +1035,16 @@ impl<'a> ContentEq for UpdateExpression<'a> {
 
 impl<'a> ContentEq for UnaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for BinaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1026,7 +1052,8 @@ impl<'a> ContentEq for BinaryExpression<'a> {
 
 impl<'a> ContentEq for PrivateInExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1034,7 +1061,8 @@ impl<'a> ContentEq for PrivateInExpression<'a> {
 
 impl<'a> ContentEq for LogicalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1042,7 +1070,8 @@ impl<'a> ContentEq for LogicalExpression<'a> {
 
 impl<'a> ContentEq for ConditionalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
             && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
@@ -1050,7 +1079,8 @@ impl<'a> ContentEq for ConditionalExpression<'a> {
 
 impl<'a> ContentEq for AssignmentExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1167,21 +1197,24 @@ impl<'a> ContentEq for AssignmentTargetPattern<'a> {
 
 impl<'a> ContentEq for ArrayAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.elements, &other.elements)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for ObjectAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.properties, &other.properties)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetRest<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.target, &other.target)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.target, &other.target)
     }
 }
 
@@ -1244,7 +1277,8 @@ impl<'a> ContentEq for AssignmentTargetMaybeDefault<'a> {
 
 impl<'a> ContentEq for AssignmentTargetWithDefault<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.binding, &other.binding)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.binding, &other.binding)
             && ContentEq::content_eq(&self.init, &other.init)
     }
 }
@@ -1274,39 +1308,44 @@ impl<'a> ContentEq for AssignmentTargetProperty<'a> {
 
 impl<'a> ContentEq for AssignmentTargetPropertyIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.binding, &other.binding)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.binding, &other.binding)
             && ContentEq::content_eq(&self.init, &other.init)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetPropertyProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.binding, &other.binding)
     }
 }
 
 impl<'a> ContentEq for SequenceExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expressions, &other.expressions)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
 impl ContentEq for Super {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for AwaitExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for ChainExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -1335,7 +1374,8 @@ impl<'a> ContentEq for ChainElement<'a> {
 
 impl<'a> ContentEq for ParenthesizedExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -1478,20 +1518,23 @@ impl<'a> ContentEq for Statement<'a> {
 
 impl<'a> ContentEq for Directive<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.directive, &other.directive)
     }
 }
 
 impl<'a> ContentEq for Hashbang<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for BlockStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -1536,7 +1579,8 @@ impl<'a> ContentEq for Declaration<'a> {
 
 impl<'a> ContentEq for VariableDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.declarations, &other.declarations)
             && ContentEq::content_eq(&self.declare, &other.declare)
     }
@@ -1550,7 +1594,8 @@ impl ContentEq for VariableDeclarationKind {
 
 impl<'a> ContentEq for VariableDeclarator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.init, &other.init)
             && ContentEq::content_eq(&self.definite, &other.definite)
@@ -1558,20 +1603,22 @@ impl<'a> ContentEq for VariableDeclarator<'a> {
 }
 
 impl ContentEq for EmptyStatement {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for ExpressionStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for IfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
             && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
@@ -1579,21 +1626,24 @@ impl<'a> ContentEq for IfStatement<'a> {
 
 impl<'a> ContentEq for DoWhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.test, &other.test)
     }
 }
 
 impl<'a> ContentEq for WhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ForStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.init, &other.init)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.init, &other.init)
             && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.update, &other.update)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -1781,7 +1831,8 @@ impl<'a> ContentEq for ForStatementInit<'a> {
 
 impl<'a> ContentEq for ForInStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
             && ContentEq::content_eq(&self.body, &other.body)
     }
@@ -1844,7 +1895,8 @@ impl<'a> ContentEq for ForStatementLeft<'a> {
 
 impl<'a> ContentEq for ForOfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#await, &other.r#await)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#await, &other.r#await)
             && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -1853,59 +1905,68 @@ impl<'a> ContentEq for ForOfStatement<'a> {
 
 impl<'a> ContentEq for ContinueStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for BreakStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for ReturnStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for WithStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for SwitchStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.discriminant, &other.discriminant)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.discriminant, &other.discriminant)
             && ContentEq::content_eq(&self.cases, &other.cases)
     }
 }
 
 impl<'a> ContentEq for SwitchCase<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
     }
 }
 
 impl<'a> ContentEq for LabeledStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.label, &other.label)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ThrowStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for TryStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.block, &other.block)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.block, &other.block)
             && ContentEq::content_eq(&self.handler, &other.handler)
             && ContentEq::content_eq(&self.finalizer, &other.finalizer)
     }
@@ -1913,26 +1974,29 @@ impl<'a> ContentEq for TryStatement<'a> {
 
 impl<'a> ContentEq for CatchClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.param, &other.param)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.param, &other.param)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for CatchParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.pattern, &other.pattern)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.pattern, &other.pattern)
     }
 }
 
 impl ContentEq for DebuggerStatement {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for BindingPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -1963,21 +2027,24 @@ impl<'a> ContentEq for BindingPatternKind<'a> {
 
 impl<'a> ContentEq for AssignmentPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for ObjectPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.properties, &other.properties)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.shorthand, &other.shorthand)
             && ContentEq::content_eq(&self.computed, &other.computed)
@@ -1986,20 +2053,23 @@ impl<'a> ContentEq for BindingProperty<'a> {
 
 impl<'a> ContentEq for ArrayPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.elements, &other.elements)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingRestElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Function<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.generator, &other.generator)
             && ContentEq::content_eq(&self.r#async, &other.r#async)
@@ -2020,7 +2090,8 @@ impl ContentEq for FunctionType {
 
 impl<'a> ContentEq for FormalParameters<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.items, &other.items)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
@@ -2028,7 +2099,8 @@ impl<'a> ContentEq for FormalParameters<'a> {
 
 impl<'a> ContentEq for FormalParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.decorators, &other.decorators)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.pattern, &other.pattern)
             && ContentEq::content_eq(&self.accessibility, &other.accessibility)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
@@ -2044,14 +2116,16 @@ impl ContentEq for FormalParameterKind {
 
 impl<'a> ContentEq for FunctionBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.directives, &other.directives)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.statements, &other.statements)
     }
 }
 
 impl<'a> ContentEq for ArrowFunctionExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.r#async, &other.r#async)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.params, &other.params)
@@ -2062,14 +2136,16 @@ impl<'a> ContentEq for ArrowFunctionExpression<'a> {
 
 impl<'a> ContentEq for YieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.delegate, &other.delegate)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.delegate, &other.delegate)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Class<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -2090,7 +2166,8 @@ impl ContentEq for ClassType {
 
 impl<'a> ContentEq for ClassBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -2123,7 +2200,8 @@ impl<'a> ContentEq for ClassElement<'a> {
 
 impl<'a> ContentEq for MethodDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2144,7 +2222,8 @@ impl ContentEq for MethodDefinitionType {
 
 impl<'a> ContentEq for PropertyDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2174,13 +2253,15 @@ impl ContentEq for MethodDefinitionKind {
 
 impl<'a> ContentEq for PrivateIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for StaticBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -2225,7 +2306,8 @@ impl ContentEq for AccessorPropertyType {
 
 impl<'a> ContentEq for AccessorProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2239,14 +2321,16 @@ impl<'a> ContentEq for AccessorProperty<'a> {
 
 impl<'a> ContentEq for ImportExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.source, &other.source)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
     }
 }
 
 impl<'a> ContentEq for ImportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.specifiers, &other.specifiers)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.specifiers, &other.specifiers)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.with_clause, &other.with_clause)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
@@ -2274,7 +2358,8 @@ impl<'a> ContentEq for ImportDeclarationSpecifier<'a> {
 
 impl<'a> ContentEq for ImportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.imported, &other.imported)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.imported, &other.imported)
             && ContentEq::content_eq(&self.local, &other.local)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
@@ -2282,26 +2367,30 @@ impl<'a> ContentEq for ImportSpecifier<'a> {
 
 impl<'a> ContentEq for ImportDefaultSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for ImportNamespaceSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for WithClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
             && ContentEq::content_eq(&self.with_entries, &other.with_entries)
     }
 }
 
 impl<'a> ContentEq for ImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -2323,7 +2412,8 @@ impl<'a> ContentEq for ImportAttributeKey<'a> {
 
 impl<'a> ContentEq for ExportNamedDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.declaration, &other.declaration)
             && ContentEq::content_eq(&self.specifiers, &other.specifiers)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
@@ -2333,14 +2423,16 @@ impl<'a> ContentEq for ExportNamedDeclaration<'a> {
 
 impl<'a> ContentEq for ExportDefaultDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.declaration, &other.declaration)
             && ContentEq::content_eq(&self.exported, &other.exported)
     }
 }
 
 impl<'a> ContentEq for ExportAllDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.exported, &other.exported)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.exported, &other.exported)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.with_clause, &other.with_clause)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
@@ -2349,7 +2441,8 @@ impl<'a> ContentEq for ExportAllDeclaration<'a> {
 
 impl<'a> ContentEq for ExportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.local, &other.local)
             && ContentEq::content_eq(&self.exported, &other.exported)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
     }
@@ -2563,13 +2656,15 @@ impl<'a> ContentEq for ModuleExportName<'a> {
 
 impl<'a> ContentEq for TSThisParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSEnumDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.members, &other.members)
             && ContentEq::content_eq(&self.r#const, &other.r#const)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -2578,7 +2673,8 @@ impl<'a> ContentEq for TSEnumDeclaration<'a> {
 
 impl<'a> ContentEq for TSEnumMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.initializer, &other.initializer)
     }
 }
@@ -2776,13 +2872,15 @@ impl<'a> ContentEq for TSEnumMemberName<'a> {
 
 impl<'a> ContentEq for TSTypeAnnotation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.literal, &other.literal)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.literal, &other.literal)
     }
 }
 
@@ -2986,7 +3084,8 @@ impl<'a> ContentEq for TSType<'a> {
 
 impl<'a> ContentEq for TSConditionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.check_type, &other.check_type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.check_type, &other.check_type)
             && ContentEq::content_eq(&self.extends_type, &other.extends_type)
             && ContentEq::content_eq(&self.true_type, &other.true_type)
             && ContentEq::content_eq(&self.false_type, &other.false_type)
@@ -2995,25 +3094,29 @@ impl<'a> ContentEq for TSConditionalType<'a> {
 
 impl<'a> ContentEq for TSUnionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.types, &other.types)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSIntersectionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.types, &other.types)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSParenthesizedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeOperator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
@@ -3026,26 +3129,30 @@ impl ContentEq for TSTypeOperatorOperator {
 
 impl<'a> ContentEq for TSArrayType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.element_type, &other.element_type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.element_type, &other.element_type)
     }
 }
 
 impl<'a> ContentEq for TSIndexedAccessType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object_type, &other.object_type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object_type, &other.object_type)
             && ContentEq::content_eq(&self.index_type, &other.index_type)
     }
 }
 
 impl<'a> ContentEq for TSTupleType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.element_types, &other.element_types)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.element_types, &other.element_types)
     }
 }
 
 impl<'a> ContentEq for TSNamedTupleMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.element_type, &other.element_type)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.element_type, &other.element_type)
             && ContentEq::content_eq(&self.label, &other.label)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -3053,13 +3160,15 @@ impl<'a> ContentEq for TSNamedTupleMember<'a> {
 
 impl<'a> ContentEq for TSOptionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSRestType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
@@ -3231,92 +3340,93 @@ impl<'a> ContentEq for TSTupleElement<'a> {
 }
 
 impl ContentEq for TSAnyKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSStringKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSBooleanKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSNumberKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSNeverKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSIntrinsicKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSUnknownKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSNullKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSUndefinedKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSVoidKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSSymbolKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSThisType {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSObjectKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl ContentEq for TSBigIntKeyword {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for TSTypeReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_name, &other.type_name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_name, &other.type_name)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3338,20 +3448,23 @@ impl<'a> ContentEq for TSTypeName<'a> {
 
 impl<'a> ContentEq for TSQualifiedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameterInstantiation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.constraint, &other.constraint)
             && ContentEq::content_eq(&self.default, &other.default)
             && ContentEq::content_eq(&self.r#in, &other.r#in)
@@ -3362,13 +3475,15 @@ impl<'a> ContentEq for TSTypeParameter<'a> {
 
 impl<'a> ContentEq for TSTypeParameterDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeAliasDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -3383,14 +3498,16 @@ impl ContentEq for TSAccessibility {
 
 impl<'a> ContentEq for TSClassImplements<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.extends, &other.extends)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -3400,13 +3517,15 @@ impl<'a> ContentEq for TSInterfaceDeclaration<'a> {
 
 impl<'a> ContentEq for TSInterfaceBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSPropertySignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.computed, &other.computed)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.computed, &other.computed)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
             && ContentEq::content_eq(&self.key, &other.key)
@@ -3447,7 +3566,8 @@ impl<'a> ContentEq for TSSignature<'a> {
 
 impl<'a> ContentEq for TSIndexSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.parameters, &other.parameters)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.parameters, &other.parameters)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
     }
@@ -3455,7 +3575,8 @@ impl<'a> ContentEq for TSIndexSignature<'a> {
 
 impl<'a> ContentEq for TSCallSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3470,7 +3591,8 @@ impl ContentEq for TSMethodSignatureKind {
 
 impl<'a> ContentEq for TSMethodSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.computed, &other.computed)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.kind, &other.kind)
@@ -3483,7 +3605,8 @@ impl<'a> ContentEq for TSMethodSignature<'a> {
 
 impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -3491,21 +3614,24 @@ impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
 
 impl<'a> ContentEq for TSIndexSignatureName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceHeritage<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSTypePredicate<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.parameter_name, &other.parameter_name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.parameter_name, &other.parameter_name)
             && ContentEq::content_eq(&self.asserts, &other.asserts)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
@@ -3528,7 +3654,8 @@ impl<'a> ContentEq for TSTypePredicateName<'a> {
 
 impl<'a> ContentEq for TSModuleDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -3573,26 +3700,30 @@ impl<'a> ContentEq for TSModuleDeclarationBody<'a> {
 
 impl<'a> ContentEq for TSModuleBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.directives, &other.directives)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSTypeLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.members, &other.members)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.members, &other.members)
     }
 }
 
 impl<'a> ContentEq for TSInferType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
     }
 }
 
 impl<'a> ContentEq for TSTypeQuery<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expr_name, &other.expr_name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expr_name, &other.expr_name)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3618,7 +3749,8 @@ impl<'a> ContentEq for TSTypeQueryExprName<'a> {
 
 impl<'a> ContentEq for TSImportType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
             && ContentEq::content_eq(&self.parameter, &other.parameter)
             && ContentEq::content_eq(&self.qualifier, &other.qualifier)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
@@ -3628,14 +3760,16 @@ impl<'a> ContentEq for TSImportType<'a> {
 
 impl<'a> ContentEq for TSImportAttributes<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
             && ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
 impl<'a> ContentEq for TSImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -3657,7 +3791,8 @@ impl<'a> ContentEq for TSImportAttributeName<'a> {
 
 impl<'a> ContentEq for TSFunctionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3666,7 +3801,8 @@ impl<'a> ContentEq for TSFunctionType<'a> {
 
 impl<'a> ContentEq for TSConstructorType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3675,7 +3811,8 @@ impl<'a> ContentEq for TSConstructorType<'a> {
 
 impl<'a> ContentEq for TSMappedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
             && ContentEq::content_eq(&self.name_type, &other.name_type)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.optional, &other.optional)
@@ -3691,35 +3828,40 @@ impl ContentEq for TSMappedTypeModifierOperator {
 
 impl<'a> ContentEq for TSTemplateLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.quasis, &other.quasis)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.quasis, &other.quasis)
             && ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSAsExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSSatisfiesExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeAssertion<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSImportEqualsDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.module_reference, &other.module_reference)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
@@ -3746,37 +3888,43 @@ impl<'a> ContentEq for TSModuleReference<'a> {
 
 impl<'a> ContentEq for TSExternalModuleReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNonNullExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for Decorator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSExportAssignment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNamespaceExportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.id, &other.id)
     }
 }
 
 impl<'a> ContentEq for TSInstantiationExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3789,27 +3937,30 @@ impl ContentEq for ImportOrExportKind {
 
 impl<'a> ContentEq for JSDocNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
 impl<'a> ContentEq for JSDocNonNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
 impl ContentEq for JSDocUnknownType {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
 impl<'a> ContentEq for JSXElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.opening_element, &other.opening_element)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.opening_element, &other.opening_element)
             && ContentEq::content_eq(&self.closing_element, &other.closing_element)
             && ContentEq::content_eq(&self.children, &other.children)
     }
@@ -3817,7 +3968,8 @@ impl<'a> ContentEq for JSXElement<'a> {
 
 impl<'a> ContentEq for JSXOpeningElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.self_closing, &other.self_closing)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.self_closing, &other.self_closing)
             && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3826,13 +3978,15 @@ impl<'a> ContentEq for JSXOpeningElement<'a> {
 
 impl<'a> ContentEq for JSXClosingElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for JSXFragment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
             && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
             && ContentEq::content_eq(&self.children, &other.children)
     }
@@ -3879,14 +4033,16 @@ impl<'a> ContentEq for JSXElementName<'a> {
 
 impl<'a> ContentEq for JSXNamespacedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.namespace, &other.namespace)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.namespace, &other.namespace)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for JSXMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
@@ -3912,7 +4068,8 @@ impl<'a> ContentEq for JSXMemberExpressionObject<'a> {
 
 impl<'a> ContentEq for JSXExpressionContainer<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -4096,8 +4253,8 @@ impl<'a> ContentEq for JSXExpression<'a> {
 }
 
 impl ContentEq for JSXEmptyExpression {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.node_id, &other.node_id)
     }
 }
 
@@ -4118,14 +4275,16 @@ impl<'a> ContentEq for JSXAttributeItem<'a> {
 
 impl<'a> ContentEq for JSXAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for JSXSpreadAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
@@ -4169,7 +4328,8 @@ impl<'a> ContentEq for JSXAttributeValue<'a> {
 
 impl<'a> ContentEq for JSXIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
@@ -4202,12 +4362,14 @@ impl<'a> ContentEq for JSXChild<'a> {
 
 impl<'a> ContentEq for JSXSpreadChild<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for JSXText<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.node_id, &other.node_id)
+            && ContentEq::content_eq(&self.value, &other.value)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -19,21 +19,19 @@ use crate::ast::ts::*;
 
 impl ContentEq for BooleanLiteral {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl ContentEq for NullLiteral {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for NumericLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.raw, &other.raw)
             && ContentEq::content_eq(&self.base, &other.base)
     }
@@ -41,16 +39,14 @@ impl<'a> ContentEq for NumericLiteral<'a> {
 
 impl<'a> ContentEq for BigIntLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.raw, &other.raw)
+        ContentEq::content_eq(&self.raw, &other.raw)
             && ContentEq::content_eq(&self.base, &other.base)
     }
 }
 
 impl<'a> ContentEq for RegExpLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.regex, &other.regex)
     }
 }
@@ -89,15 +85,13 @@ impl ContentEq for EmptyObject {
 
 impl<'a> ContentEq for StringLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for Program<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.source_type, &other.source_type)
+        ContentEq::content_eq(&self.source_type, &other.source_type)
             && ContentEq::content_eq(&self.hashbang, &other.hashbang)
             && ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -281,42 +275,37 @@ impl<'a> ContentEq for Expression<'a> {
 
 impl<'a> ContentEq for IdentifierName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for IdentifierReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for BindingIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for LabelIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl ContentEq for ThisExpression {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for ArrayExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
@@ -504,15 +493,14 @@ impl<'a> ContentEq for ArrayExpressionElement<'a> {
 }
 
 impl ContentEq for Elision {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for ObjectExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.properties, &other.properties)
     }
 }
 
@@ -533,8 +521,7 @@ impl<'a> ContentEq for ObjectPropertyKind<'a> {
 
 impl<'a> ContentEq for ObjectProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.init, &other.init)
@@ -735,16 +722,14 @@ impl ContentEq for PropertyKind {
 
 impl<'a> ContentEq for TemplateLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.quasis, &other.quasis)
+        ContentEq::content_eq(&self.quasis, &other.quasis)
             && ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
 impl<'a> ContentEq for TaggedTemplateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.tag, &other.tag)
+        ContentEq::content_eq(&self.tag, &other.tag)
             && ContentEq::content_eq(&self.quasi, &other.quasi)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -752,8 +737,7 @@ impl<'a> ContentEq for TaggedTemplateExpression<'a> {
 
 impl<'a> ContentEq for TemplateElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.tail, &other.tail)
+        ContentEq::content_eq(&self.tail, &other.tail)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -786,8 +770,7 @@ impl<'a> ContentEq for MemberExpression<'a> {
 
 impl<'a> ContentEq for ComputedMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -795,8 +778,7 @@ impl<'a> ContentEq for ComputedMemberExpression<'a> {
 
 impl<'a> ContentEq for StaticMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.property, &other.property)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -804,8 +786,7 @@ impl<'a> ContentEq for StaticMemberExpression<'a> {
 
 impl<'a> ContentEq for PrivateFieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.field, &other.field)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -813,8 +794,7 @@ impl<'a> ContentEq for PrivateFieldExpression<'a> {
 
 impl<'a> ContentEq for CallExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.callee, &other.callee)
+        ContentEq::content_eq(&self.callee, &other.callee)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.optional, &other.optional)
@@ -823,8 +803,7 @@ impl<'a> ContentEq for CallExpression<'a> {
 
 impl<'a> ContentEq for NewExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.callee, &other.callee)
+        ContentEq::content_eq(&self.callee, &other.callee)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -832,16 +811,14 @@ impl<'a> ContentEq for NewExpression<'a> {
 
 impl<'a> ContentEq for MetaProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.meta, &other.meta)
+        ContentEq::content_eq(&self.meta, &other.meta)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for SpreadElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
@@ -1026,8 +1003,7 @@ impl<'a> ContentEq for Argument<'a> {
 
 impl<'a> ContentEq for UpdateExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.prefix, &other.prefix)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
@@ -1035,16 +1011,14 @@ impl<'a> ContentEq for UpdateExpression<'a> {
 
 impl<'a> ContentEq for UnaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for BinaryExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1052,8 +1026,7 @@ impl<'a> ContentEq for BinaryExpression<'a> {
 
 impl<'a> ContentEq for PrivateInExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1061,8 +1034,7 @@ impl<'a> ContentEq for PrivateInExpression<'a> {
 
 impl<'a> ContentEq for LogicalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1070,8 +1042,7 @@ impl<'a> ContentEq for LogicalExpression<'a> {
 
 impl<'a> ContentEq for ConditionalExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
             && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
@@ -1079,8 +1050,7 @@ impl<'a> ContentEq for ConditionalExpression<'a> {
 
 impl<'a> ContentEq for AssignmentExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
@@ -1197,24 +1167,21 @@ impl<'a> ContentEq for AssignmentTargetPattern<'a> {
 
 impl<'a> ContentEq for ArrayAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.elements, &other.elements)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for ObjectAssignmentTarget<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.properties, &other.properties)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetRest<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.target, &other.target)
+        ContentEq::content_eq(&self.target, &other.target)
     }
 }
 
@@ -1277,8 +1244,7 @@ impl<'a> ContentEq for AssignmentTargetMaybeDefault<'a> {
 
 impl<'a> ContentEq for AssignmentTargetWithDefault<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.binding, &other.binding)
+        ContentEq::content_eq(&self.binding, &other.binding)
             && ContentEq::content_eq(&self.init, &other.init)
     }
 }
@@ -1308,44 +1274,39 @@ impl<'a> ContentEq for AssignmentTargetProperty<'a> {
 
 impl<'a> ContentEq for AssignmentTargetPropertyIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.binding, &other.binding)
+        ContentEq::content_eq(&self.binding, &other.binding)
             && ContentEq::content_eq(&self.init, &other.init)
     }
 }
 
 impl<'a> ContentEq for AssignmentTargetPropertyProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.binding, &other.binding)
     }
 }
 
 impl<'a> ContentEq for SequenceExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expressions, &other.expressions)
+        ContentEq::content_eq(&self.expressions, &other.expressions)
     }
 }
 
 impl ContentEq for Super {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for AwaitExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for ChainExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -1374,8 +1335,7 @@ impl<'a> ContentEq for ChainElement<'a> {
 
 impl<'a> ContentEq for ParenthesizedExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -1518,23 +1478,20 @@ impl<'a> ContentEq for Statement<'a> {
 
 impl<'a> ContentEq for Directive<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.directive, &other.directive)
     }
 }
 
 impl<'a> ContentEq for Hashbang<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for BlockStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -1579,8 +1536,7 @@ impl<'a> ContentEq for Declaration<'a> {
 
 impl<'a> ContentEq for VariableDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.declarations, &other.declarations)
             && ContentEq::content_eq(&self.declare, &other.declare)
     }
@@ -1594,8 +1550,7 @@ impl ContentEq for VariableDeclarationKind {
 
 impl<'a> ContentEq for VariableDeclarator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.init, &other.init)
             && ContentEq::content_eq(&self.definite, &other.definite)
@@ -1603,22 +1558,20 @@ impl<'a> ContentEq for VariableDeclarator<'a> {
 }
 
 impl ContentEq for EmptyStatement {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for ExpressionStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for IfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
             && ContentEq::content_eq(&self.alternate, &other.alternate)
     }
@@ -1626,24 +1579,21 @@ impl<'a> ContentEq for IfStatement<'a> {
 
 impl<'a> ContentEq for DoWhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.test, &other.test)
     }
 }
 
 impl<'a> ContentEq for WhileStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ForStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.init, &other.init)
+        ContentEq::content_eq(&self.init, &other.init)
             && ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.update, &other.update)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -1831,8 +1781,7 @@ impl<'a> ContentEq for ForStatementInit<'a> {
 
 impl<'a> ContentEq for ForInStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
             && ContentEq::content_eq(&self.body, &other.body)
     }
@@ -1895,8 +1844,7 @@ impl<'a> ContentEq for ForStatementLeft<'a> {
 
 impl<'a> ContentEq for ForOfStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#await, &other.r#await)
+        ContentEq::content_eq(&self.r#await, &other.r#await)
             && ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -1905,68 +1853,59 @@ impl<'a> ContentEq for ForOfStatement<'a> {
 
 impl<'a> ContentEq for ContinueStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for BreakStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.label, &other.label)
     }
 }
 
 impl<'a> ContentEq for ReturnStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for WithStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for SwitchStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.discriminant, &other.discriminant)
+        ContentEq::content_eq(&self.discriminant, &other.discriminant)
             && ContentEq::content_eq(&self.cases, &other.cases)
     }
 }
 
 impl<'a> ContentEq for SwitchCase<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.test, &other.test)
+        ContentEq::content_eq(&self.test, &other.test)
             && ContentEq::content_eq(&self.consequent, &other.consequent)
     }
 }
 
 impl<'a> ContentEq for LabeledStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.label, &other.label)
+        ContentEq::content_eq(&self.label, &other.label)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for ThrowStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for TryStatement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.block, &other.block)
+        ContentEq::content_eq(&self.block, &other.block)
             && ContentEq::content_eq(&self.handler, &other.handler)
             && ContentEq::content_eq(&self.finalizer, &other.finalizer)
     }
@@ -1974,29 +1913,26 @@ impl<'a> ContentEq for TryStatement<'a> {
 
 impl<'a> ContentEq for CatchClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.param, &other.param)
+        ContentEq::content_eq(&self.param, &other.param)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for CatchParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.pattern, &other.pattern)
+        ContentEq::content_eq(&self.pattern, &other.pattern)
     }
 }
 
 impl ContentEq for DebuggerStatement {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for BindingPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -2027,24 +1963,21 @@ impl<'a> ContentEq for BindingPatternKind<'a> {
 
 impl<'a> ContentEq for AssignmentPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for ObjectPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.properties, &other.properties)
+        ContentEq::content_eq(&self.properties, &other.properties)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.shorthand, &other.shorthand)
             && ContentEq::content_eq(&self.computed, &other.computed)
@@ -2053,23 +1986,20 @@ impl<'a> ContentEq for BindingProperty<'a> {
 
 impl<'a> ContentEq for ArrayPattern<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.elements, &other.elements)
+        ContentEq::content_eq(&self.elements, &other.elements)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
 }
 
 impl<'a> ContentEq for BindingRestElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Function<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.generator, &other.generator)
             && ContentEq::content_eq(&self.r#async, &other.r#async)
@@ -2090,8 +2020,7 @@ impl ContentEq for FunctionType {
 
 impl<'a> ContentEq for FormalParameters<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.items, &other.items)
             && ContentEq::content_eq(&self.rest, &other.rest)
     }
@@ -2099,8 +2028,7 @@ impl<'a> ContentEq for FormalParameters<'a> {
 
 impl<'a> ContentEq for FormalParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.decorators, &other.decorators)
+        ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.pattern, &other.pattern)
             && ContentEq::content_eq(&self.accessibility, &other.accessibility)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
@@ -2116,16 +2044,14 @@ impl ContentEq for FormalParameterKind {
 
 impl<'a> ContentEq for FunctionBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.directives, &other.directives)
+        ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.statements, &other.statements)
     }
 }
 
 impl<'a> ContentEq for ArrowFunctionExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.r#async, &other.r#async)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.params, &other.params)
@@ -2136,16 +2062,14 @@ impl<'a> ContentEq for ArrowFunctionExpression<'a> {
 
 impl<'a> ContentEq for YieldExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.delegate, &other.delegate)
+        ContentEq::content_eq(&self.delegate, &other.delegate)
             && ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
 impl<'a> ContentEq for Class<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -2166,8 +2090,7 @@ impl ContentEq for ClassType {
 
 impl<'a> ContentEq for ClassBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -2200,8 +2123,7 @@ impl<'a> ContentEq for ClassElement<'a> {
 
 impl<'a> ContentEq for MethodDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2222,8 +2144,7 @@ impl ContentEq for MethodDefinitionType {
 
 impl<'a> ContentEq for PropertyDefinition<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2253,15 +2174,13 @@ impl ContentEq for MethodDefinitionKind {
 
 impl<'a> ContentEq for PrivateIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for StaticBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
@@ -2306,8 +2225,7 @@ impl ContentEq for AccessorPropertyType {
 
 impl<'a> ContentEq for AccessorProperty<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#type, &other.r#type)
+        ContentEq::content_eq(&self.r#type, &other.r#type)
             && ContentEq::content_eq(&self.decorators, &other.decorators)
             && ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
@@ -2321,16 +2239,14 @@ impl<'a> ContentEq for AccessorProperty<'a> {
 
 impl<'a> ContentEq for ImportExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.source, &other.source)
+        ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
     }
 }
 
 impl<'a> ContentEq for ImportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.specifiers, &other.specifiers)
+        ContentEq::content_eq(&self.specifiers, &other.specifiers)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.with_clause, &other.with_clause)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
@@ -2358,8 +2274,7 @@ impl<'a> ContentEq for ImportDeclarationSpecifier<'a> {
 
 impl<'a> ContentEq for ImportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.imported, &other.imported)
+        ContentEq::content_eq(&self.imported, &other.imported)
             && ContentEq::content_eq(&self.local, &other.local)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
@@ -2367,30 +2282,26 @@ impl<'a> ContentEq for ImportSpecifier<'a> {
 
 impl<'a> ContentEq for ImportDefaultSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for ImportNamespaceSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.local, &other.local)
     }
 }
 
 impl<'a> ContentEq for WithClause<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
             && ContentEq::content_eq(&self.with_entries, &other.with_entries)
     }
 }
 
 impl<'a> ContentEq for ImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -2412,8 +2323,7 @@ impl<'a> ContentEq for ImportAttributeKey<'a> {
 
 impl<'a> ContentEq for ExportNamedDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
             && ContentEq::content_eq(&self.specifiers, &other.specifiers)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
@@ -2423,16 +2333,14 @@ impl<'a> ContentEq for ExportNamedDeclaration<'a> {
 
 impl<'a> ContentEq for ExportDefaultDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.declaration, &other.declaration)
+        ContentEq::content_eq(&self.declaration, &other.declaration)
             && ContentEq::content_eq(&self.exported, &other.exported)
     }
 }
 
 impl<'a> ContentEq for ExportAllDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.exported, &other.exported)
+        ContentEq::content_eq(&self.exported, &other.exported)
             && ContentEq::content_eq(&self.source, &other.source)
             && ContentEq::content_eq(&self.with_clause, &other.with_clause)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
@@ -2441,8 +2349,7 @@ impl<'a> ContentEq for ExportAllDeclaration<'a> {
 
 impl<'a> ContentEq for ExportSpecifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.local, &other.local)
+        ContentEq::content_eq(&self.local, &other.local)
             && ContentEq::content_eq(&self.exported, &other.exported)
             && ContentEq::content_eq(&self.export_kind, &other.export_kind)
     }
@@ -2656,15 +2563,13 @@ impl<'a> ContentEq for ModuleExportName<'a> {
 
 impl<'a> ContentEq for TSThisParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSEnumDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.members, &other.members)
             && ContentEq::content_eq(&self.r#const, &other.r#const)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -2673,8 +2578,7 @@ impl<'a> ContentEq for TSEnumDeclaration<'a> {
 
 impl<'a> ContentEq for TSEnumMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.initializer, &other.initializer)
     }
 }
@@ -2872,15 +2776,13 @@ impl<'a> ContentEq for TSEnumMemberName<'a> {
 
 impl<'a> ContentEq for TSTypeAnnotation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.literal, &other.literal)
+        ContentEq::content_eq(&self.literal, &other.literal)
     }
 }
 
@@ -3084,8 +2986,7 @@ impl<'a> ContentEq for TSType<'a> {
 
 impl<'a> ContentEq for TSConditionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.check_type, &other.check_type)
+        ContentEq::content_eq(&self.check_type, &other.check_type)
             && ContentEq::content_eq(&self.extends_type, &other.extends_type)
             && ContentEq::content_eq(&self.true_type, &other.true_type)
             && ContentEq::content_eq(&self.false_type, &other.false_type)
@@ -3094,29 +2995,25 @@ impl<'a> ContentEq for TSConditionalType<'a> {
 
 impl<'a> ContentEq for TSUnionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.types, &other.types)
+        ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSIntersectionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.types, &other.types)
+        ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSParenthesizedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeOperator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.operator, &other.operator)
+        ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
@@ -3129,30 +3026,26 @@ impl ContentEq for TSTypeOperatorOperator {
 
 impl<'a> ContentEq for TSArrayType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.element_type, &other.element_type)
+        ContentEq::content_eq(&self.element_type, &other.element_type)
     }
 }
 
 impl<'a> ContentEq for TSIndexedAccessType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object_type, &other.object_type)
+        ContentEq::content_eq(&self.object_type, &other.object_type)
             && ContentEq::content_eq(&self.index_type, &other.index_type)
     }
 }
 
 impl<'a> ContentEq for TSTupleType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.element_types, &other.element_types)
+        ContentEq::content_eq(&self.element_types, &other.element_types)
     }
 }
 
 impl<'a> ContentEq for TSNamedTupleMember<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.element_type, &other.element_type)
+        ContentEq::content_eq(&self.element_type, &other.element_type)
             && ContentEq::content_eq(&self.label, &other.label)
             && ContentEq::content_eq(&self.optional, &other.optional)
     }
@@ -3160,15 +3053,13 @@ impl<'a> ContentEq for TSNamedTupleMember<'a> {
 
 impl<'a> ContentEq for TSOptionalType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSRestType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
@@ -3340,93 +3231,92 @@ impl<'a> ContentEq for TSTupleElement<'a> {
 }
 
 impl ContentEq for TSAnyKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSStringKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSBooleanKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSNumberKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSNeverKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSIntrinsicKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSUnknownKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSNullKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSUndefinedKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSVoidKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSSymbolKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSThisType {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSObjectKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl ContentEq for TSBigIntKeyword {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for TSTypeReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_name, &other.type_name)
+        ContentEq::content_eq(&self.type_name, &other.type_name)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3448,23 +3338,20 @@ impl<'a> ContentEq for TSTypeName<'a> {
 
 impl<'a> ContentEq for TSQualifiedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.left, &other.left)
+        ContentEq::content_eq(&self.left, &other.left)
             && ContentEq::content_eq(&self.right, &other.right)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameterInstantiation<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.constraint, &other.constraint)
             && ContentEq::content_eq(&self.default, &other.default)
             && ContentEq::content_eq(&self.r#in, &other.r#in)
@@ -3475,15 +3362,13 @@ impl<'a> ContentEq for TSTypeParameter<'a> {
 
 impl<'a> ContentEq for TSTypeParameterDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.params, &other.params)
     }
 }
 
 impl<'a> ContentEq for TSTypeAliasDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -3498,16 +3383,14 @@ impl ContentEq for TSAccessibility {
 
 impl<'a> ContentEq for TSClassImplements<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.extends, &other.extends)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.body, &other.body)
@@ -3517,15 +3400,13 @@ impl<'a> ContentEq for TSInterfaceDeclaration<'a> {
 
 impl<'a> ContentEq for TSInterfaceBody<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.body, &other.body)
+        ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSPropertySignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.computed, &other.computed)
+        ContentEq::content_eq(&self.computed, &other.computed)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
             && ContentEq::content_eq(&self.key, &other.key)
@@ -3566,8 +3447,7 @@ impl<'a> ContentEq for TSSignature<'a> {
 
 impl<'a> ContentEq for TSIndexSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.parameters, &other.parameters)
+        ContentEq::content_eq(&self.parameters, &other.parameters)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
     }
@@ -3575,8 +3455,7 @@ impl<'a> ContentEq for TSIndexSignature<'a> {
 
 impl<'a> ContentEq for TSCallSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3591,8 +3470,7 @@ impl ContentEq for TSMethodSignatureKind {
 
 impl<'a> ContentEq for TSMethodSignature<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.key, &other.key)
+        ContentEq::content_eq(&self.key, &other.key)
             && ContentEq::content_eq(&self.computed, &other.computed)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.kind, &other.kind)
@@ -3605,8 +3483,7 @@ impl<'a> ContentEq for TSMethodSignature<'a> {
 
 impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
@@ -3614,24 +3491,21 @@ impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
 
 impl<'a> ContentEq for TSIndexSignatureName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSInterfaceHeritage<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSTypePredicate<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.parameter_name, &other.parameter_name)
+        ContentEq::content_eq(&self.parameter_name, &other.parameter_name)
             && ContentEq::content_eq(&self.asserts, &other.asserts)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
@@ -3654,8 +3528,7 @@ impl<'a> ContentEq for TSTypePredicateName<'a> {
 
 impl<'a> ContentEq for TSModuleDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.declare, &other.declare)
@@ -3700,30 +3573,26 @@ impl<'a> ContentEq for TSModuleDeclarationBody<'a> {
 
 impl<'a> ContentEq for TSModuleBlock<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.directives, &other.directives)
+        ContentEq::content_eq(&self.directives, &other.directives)
             && ContentEq::content_eq(&self.body, &other.body)
     }
 }
 
 impl<'a> ContentEq for TSTypeLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.members, &other.members)
+        ContentEq::content_eq(&self.members, &other.members)
     }
 }
 
 impl<'a> ContentEq for TSInferType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
     }
 }
 
 impl<'a> ContentEq for TSTypeQuery<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expr_name, &other.expr_name)
+        ContentEq::content_eq(&self.expr_name, &other.expr_name)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3749,8 +3618,7 @@ impl<'a> ContentEq for TSTypeQueryExprName<'a> {
 
 impl<'a> ContentEq for TSImportType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
+        ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
             && ContentEq::content_eq(&self.parameter, &other.parameter)
             && ContentEq::content_eq(&self.qualifier, &other.qualifier)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
@@ -3760,16 +3628,14 @@ impl<'a> ContentEq for TSImportType<'a> {
 
 impl<'a> ContentEq for TSImportAttributes<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
+        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
             && ContentEq::content_eq(&self.elements, &other.elements)
     }
 }
 
 impl<'a> ContentEq for TSImportAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
@@ -3791,8 +3657,7 @@ impl<'a> ContentEq for TSImportAttributeName<'a> {
 
 impl<'a> ContentEq for TSFunctionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3801,8 +3666,7 @@ impl<'a> ContentEq for TSFunctionType<'a> {
 
 impl<'a> ContentEq for TSConstructorType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
+        ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3811,8 +3675,7 @@ impl<'a> ContentEq for TSConstructorType<'a> {
 
 impl<'a> ContentEq for TSMappedType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
+        ContentEq::content_eq(&self.type_parameter, &other.type_parameter)
             && ContentEq::content_eq(&self.name_type, &other.name_type)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.optional, &other.optional)
@@ -3828,40 +3691,35 @@ impl ContentEq for TSMappedTypeModifierOperator {
 
 impl<'a> ContentEq for TSTemplateLiteralType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.quasis, &other.quasis)
+        ContentEq::content_eq(&self.quasis, &other.quasis)
             && ContentEq::content_eq(&self.types, &other.types)
     }
 }
 
 impl<'a> ContentEq for TSAsExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSSatisfiesExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSTypeAssertion<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
     }
 }
 
 impl<'a> ContentEq for TSImportEqualsDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.module_reference, &other.module_reference)
             && ContentEq::content_eq(&self.import_kind, &other.import_kind)
     }
@@ -3888,43 +3746,37 @@ impl<'a> ContentEq for TSModuleReference<'a> {
 
 impl<'a> ContentEq for TSExternalModuleReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNonNullExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for Decorator<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSExportAssignment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for TSNamespaceExportDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.id, &other.id)
+        ContentEq::content_eq(&self.id, &other.id)
     }
 }
 
 impl<'a> ContentEq for TSInstantiationExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
@@ -3937,30 +3789,27 @@ impl ContentEq for ImportOrExportKind {
 
 impl<'a> ContentEq for JSDocNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
 impl<'a> ContentEq for JSDocNonNullableType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
+        ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.postfix, &other.postfix)
     }
 }
 
 impl ContentEq for JSDocUnknownType {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
 impl<'a> ContentEq for JSXElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.opening_element, &other.opening_element)
+        ContentEq::content_eq(&self.opening_element, &other.opening_element)
             && ContentEq::content_eq(&self.closing_element, &other.closing_element)
             && ContentEq::content_eq(&self.children, &other.children)
     }
@@ -3968,8 +3817,7 @@ impl<'a> ContentEq for JSXElement<'a> {
 
 impl<'a> ContentEq for JSXOpeningElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.self_closing, &other.self_closing)
+        ContentEq::content_eq(&self.self_closing, &other.self_closing)
             && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
@@ -3978,15 +3826,13 @@ impl<'a> ContentEq for JSXOpeningElement<'a> {
 
 impl<'a> ContentEq for JSXClosingElement<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
 impl<'a> ContentEq for JSXFragment<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
+        ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
             && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
             && ContentEq::content_eq(&self.children, &other.children)
     }
@@ -4033,16 +3879,14 @@ impl<'a> ContentEq for JSXElementName<'a> {
 
 impl<'a> ContentEq for JSXNamespacedName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.namespace, &other.namespace)
+        ContentEq::content_eq(&self.namespace, &other.namespace)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
 
 impl<'a> ContentEq for JSXMemberExpression<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.object, &other.object)
+        ContentEq::content_eq(&self.object, &other.object)
             && ContentEq::content_eq(&self.property, &other.property)
     }
 }
@@ -4068,8 +3912,7 @@ impl<'a> ContentEq for JSXMemberExpressionObject<'a> {
 
 impl<'a> ContentEq for JSXExpressionContainer<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
@@ -4253,8 +4096,8 @@ impl<'a> ContentEq for JSXExpression<'a> {
 }
 
 impl ContentEq for JSXEmptyExpression {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
+    fn content_eq(&self, _: &Self) -> bool {
+        true
     }
 }
 
@@ -4275,16 +4118,14 @@ impl<'a> ContentEq for JSXAttributeItem<'a> {
 
 impl<'a> ContentEq for JSXAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.value, &other.value)
     }
 }
 
 impl<'a> ContentEq for JSXSpreadAttribute<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.argument, &other.argument)
+        ContentEq::content_eq(&self.argument, &other.argument)
     }
 }
 
@@ -4328,8 +4169,7 @@ impl<'a> ContentEq for JSXAttributeValue<'a> {
 
 impl<'a> ContentEq for JSXIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
     }
 }
 
@@ -4362,14 +4202,12 @@ impl<'a> ContentEq for JSXChild<'a> {
 
 impl<'a> ContentEq for JSXSpreadChild<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.expression, &other.expression)
+        ContentEq::content_eq(&self.expression, &other.expression)
     }
 }
 
 impl<'a> ContentEq for JSXText<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.node_id, &other.node_id)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -21,12 +21,14 @@ use crate::ast::ts::*;
 
 impl ContentHash for BooleanLiteral {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BigIntLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.raw, state);
         ContentHash::content_hash(&self.base, state);
     }
@@ -34,6 +36,7 @@ impl<'a> ContentHash for BigIntLiteral<'a> {
 
 impl<'a> ContentHash for RegExpLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
         ContentHash::content_hash(&self.regex, state);
     }
@@ -63,12 +66,14 @@ impl ContentHash for EmptyObject {
 
 impl<'a> ContentHash for StringLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for Program<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.source_type, state);
         ContentHash::content_hash(&self.hashbang, state);
         ContentHash::content_hash(&self.directives, state);
@@ -128,34 +133,41 @@ impl<'a> ContentHash for Expression<'a> {
 
 impl<'a> ContentHash for IdentifierName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for IdentifierReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for BindingIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for LabelIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl ContentHash for ThisExpression {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for ArrayExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
     }
 }
@@ -213,11 +225,14 @@ impl<'a> ContentHash for ArrayExpressionElement<'a> {
 }
 
 impl ContentHash for Elision {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for ObjectExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
     }
 }
@@ -234,6 +249,7 @@ impl<'a> ContentHash for ObjectPropertyKind<'a> {
 
 impl<'a> ContentHash for ObjectProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
@@ -304,6 +320,7 @@ impl ContentHash for PropertyKind {
 
 impl<'a> ContentHash for TemplateLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.quasis, state);
         ContentHash::content_hash(&self.expressions, state);
     }
@@ -311,6 +328,7 @@ impl<'a> ContentHash for TemplateLiteral<'a> {
 
 impl<'a> ContentHash for TaggedTemplateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.tag, state);
         ContentHash::content_hash(&self.quasi, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -319,6 +337,7 @@ impl<'a> ContentHash for TaggedTemplateExpression<'a> {
 
 impl<'a> ContentHash for TemplateElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.tail, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -344,6 +363,7 @@ impl<'a> ContentHash for MemberExpression<'a> {
 
 impl<'a> ContentHash for ComputedMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.optional, state);
@@ -352,6 +372,7 @@ impl<'a> ContentHash for ComputedMemberExpression<'a> {
 
 impl<'a> ContentHash for StaticMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.property, state);
         ContentHash::content_hash(&self.optional, state);
@@ -360,6 +381,7 @@ impl<'a> ContentHash for StaticMemberExpression<'a> {
 
 impl<'a> ContentHash for PrivateFieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.field, state);
         ContentHash::content_hash(&self.optional, state);
@@ -368,6 +390,7 @@ impl<'a> ContentHash for PrivateFieldExpression<'a> {
 
 impl<'a> ContentHash for CallExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.callee, state);
         ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.arguments, state);
@@ -377,6 +400,7 @@ impl<'a> ContentHash for CallExpression<'a> {
 
 impl<'a> ContentHash for NewExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.callee, state);
         ContentHash::content_hash(&self.arguments, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -385,6 +409,7 @@ impl<'a> ContentHash for NewExpression<'a> {
 
 impl<'a> ContentHash for MetaProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.meta, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -392,6 +417,7 @@ impl<'a> ContentHash for MetaProperty<'a> {
 
 impl<'a> ContentHash for SpreadElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
@@ -449,6 +475,7 @@ impl<'a> ContentHash for Argument<'a> {
 
 impl<'a> ContentHash for UpdateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.prefix, state);
         ContentHash::content_hash(&self.argument, state);
@@ -457,6 +484,7 @@ impl<'a> ContentHash for UpdateExpression<'a> {
 
 impl<'a> ContentHash for UnaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.argument, state);
     }
@@ -464,6 +492,7 @@ impl<'a> ContentHash for UnaryExpression<'a> {
 
 impl<'a> ContentHash for BinaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -472,6 +501,7 @@ impl<'a> ContentHash for BinaryExpression<'a> {
 
 impl<'a> ContentHash for PrivateInExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -480,6 +510,7 @@ impl<'a> ContentHash for PrivateInExpression<'a> {
 
 impl<'a> ContentHash for LogicalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -488,6 +519,7 @@ impl<'a> ContentHash for LogicalExpression<'a> {
 
 impl<'a> ContentHash for ConditionalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
         ContentHash::content_hash(&self.alternate, state);
@@ -496,6 +528,7 @@ impl<'a> ContentHash for ConditionalExpression<'a> {
 
 impl<'a> ContentHash for AssignmentExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
@@ -550,6 +583,7 @@ impl<'a> ContentHash for AssignmentTargetPattern<'a> {
 
 impl<'a> ContentHash for ArrayAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -557,6 +591,7 @@ impl<'a> ContentHash for ArrayAssignmentTarget<'a> {
 
 impl<'a> ContentHash for ObjectAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -564,6 +599,7 @@ impl<'a> ContentHash for ObjectAssignmentTarget<'a> {
 
 impl<'a> ContentHash for AssignmentTargetRest<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.target, state);
     }
 }
@@ -590,6 +626,7 @@ impl<'a> ContentHash for AssignmentTargetMaybeDefault<'a> {
 
 impl<'a> ContentHash for AssignmentTargetWithDefault<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.binding, state);
         ContentHash::content_hash(&self.init, state);
     }
@@ -607,6 +644,7 @@ impl<'a> ContentHash for AssignmentTargetProperty<'a> {
 
 impl<'a> ContentHash for AssignmentTargetPropertyIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.binding, state);
         ContentHash::content_hash(&self.init, state);
     }
@@ -614,6 +652,7 @@ impl<'a> ContentHash for AssignmentTargetPropertyIdentifier<'a> {
 
 impl<'a> ContentHash for AssignmentTargetPropertyProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.binding, state);
     }
@@ -621,22 +660,27 @@ impl<'a> ContentHash for AssignmentTargetPropertyProperty<'a> {
 
 impl<'a> ContentHash for SequenceExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expressions, state);
     }
 }
 
 impl ContentHash for Super {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for AwaitExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for ChainExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -655,6 +699,7 @@ impl<'a> ContentHash for ChainElement<'a> {
 
 impl<'a> ContentHash for ParenthesizedExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -701,6 +746,7 @@ impl<'a> ContentHash for Statement<'a> {
 
 impl<'a> ContentHash for Directive<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.directive, state);
     }
@@ -708,12 +754,14 @@ impl<'a> ContentHash for Directive<'a> {
 
 impl<'a> ContentHash for Hashbang<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BlockStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -736,6 +784,7 @@ impl<'a> ContentHash for Declaration<'a> {
 
 impl<'a> ContentHash for VariableDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.declarations, state);
         ContentHash::content_hash(&self.declare, state);
@@ -750,6 +799,7 @@ impl ContentHash for VariableDeclarationKind {
 
 impl<'a> ContentHash for VariableDeclarator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.init, state);
@@ -758,17 +808,21 @@ impl<'a> ContentHash for VariableDeclarator<'a> {
 }
 
 impl ContentHash for EmptyStatement {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for ExpressionStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for IfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
         ContentHash::content_hash(&self.alternate, state);
@@ -777,6 +831,7 @@ impl<'a> ContentHash for IfStatement<'a> {
 
 impl<'a> ContentHash for DoWhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
         ContentHash::content_hash(&self.test, state);
     }
@@ -784,6 +839,7 @@ impl<'a> ContentHash for DoWhileStatement<'a> {
 
 impl<'a> ContentHash for WhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -791,6 +847,7 @@ impl<'a> ContentHash for WhileStatement<'a> {
 
 impl<'a> ContentHash for ForStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.init, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.update, state);
@@ -851,6 +908,7 @@ impl<'a> ContentHash for ForStatementInit<'a> {
 
 impl<'a> ContentHash for ForInStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
         ContentHash::content_hash(&self.body, state);
@@ -879,6 +937,7 @@ impl<'a> ContentHash for ForStatementLeft<'a> {
 
 impl<'a> ContentHash for ForOfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#await, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
@@ -888,24 +947,28 @@ impl<'a> ContentHash for ForOfStatement<'a> {
 
 impl<'a> ContentHash for ContinueStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for BreakStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for ReturnStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for WithStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -913,6 +976,7 @@ impl<'a> ContentHash for WithStatement<'a> {
 
 impl<'a> ContentHash for SwitchStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.discriminant, state);
         ContentHash::content_hash(&self.cases, state);
     }
@@ -920,6 +984,7 @@ impl<'a> ContentHash for SwitchStatement<'a> {
 
 impl<'a> ContentHash for SwitchCase<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
     }
@@ -927,6 +992,7 @@ impl<'a> ContentHash for SwitchCase<'a> {
 
 impl<'a> ContentHash for LabeledStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -934,12 +1000,14 @@ impl<'a> ContentHash for LabeledStatement<'a> {
 
 impl<'a> ContentHash for ThrowStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for TryStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.block, state);
         ContentHash::content_hash(&self.handler, state);
         ContentHash::content_hash(&self.finalizer, state);
@@ -948,6 +1016,7 @@ impl<'a> ContentHash for TryStatement<'a> {
 
 impl<'a> ContentHash for CatchClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.param, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -955,16 +1024,20 @@ impl<'a> ContentHash for CatchClause<'a> {
 
 impl<'a> ContentHash for CatchParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.pattern, state);
     }
 }
 
 impl ContentHash for DebuggerStatement {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for BindingPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.optional, state);
@@ -985,6 +1058,7 @@ impl<'a> ContentHash for BindingPatternKind<'a> {
 
 impl<'a> ContentHash for AssignmentPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
     }
@@ -992,6 +1066,7 @@ impl<'a> ContentHash for AssignmentPattern<'a> {
 
 impl<'a> ContentHash for ObjectPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -999,6 +1074,7 @@ impl<'a> ContentHash for ObjectPattern<'a> {
 
 impl<'a> ContentHash for BindingProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
         ContentHash::content_hash(&self.shorthand, state);
@@ -1008,6 +1084,7 @@ impl<'a> ContentHash for BindingProperty<'a> {
 
 impl<'a> ContentHash for ArrayPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -1015,12 +1092,14 @@ impl<'a> ContentHash for ArrayPattern<'a> {
 
 impl<'a> ContentHash for BindingRestElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for Function<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.generator, state);
@@ -1042,6 +1121,7 @@ impl ContentHash for FunctionType {
 
 impl<'a> ContentHash for FormalParameters<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.items, state);
         ContentHash::content_hash(&self.rest, state);
@@ -1050,6 +1130,7 @@ impl<'a> ContentHash for FormalParameters<'a> {
 
 impl<'a> ContentHash for FormalParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.pattern, state);
         ContentHash::content_hash(&self.accessibility, state);
@@ -1066,6 +1147,7 @@ impl ContentHash for FormalParameterKind {
 
 impl<'a> ContentHash for FunctionBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.directives, state);
         ContentHash::content_hash(&self.statements, state);
     }
@@ -1073,6 +1155,7 @@ impl<'a> ContentHash for FunctionBody<'a> {
 
 impl<'a> ContentHash for ArrowFunctionExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.r#async, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -1084,6 +1167,7 @@ impl<'a> ContentHash for ArrowFunctionExpression<'a> {
 
 impl<'a> ContentHash for YieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.delegate, state);
         ContentHash::content_hash(&self.argument, state);
     }
@@ -1091,6 +1175,7 @@ impl<'a> ContentHash for YieldExpression<'a> {
 
 impl<'a> ContentHash for Class<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.id, state);
@@ -1112,6 +1197,7 @@ impl ContentHash for ClassType {
 
 impl<'a> ContentHash for ClassBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -1131,6 +1217,7 @@ impl<'a> ContentHash for ClassElement<'a> {
 
 impl<'a> ContentHash for MethodDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1152,6 +1239,7 @@ impl ContentHash for MethodDefinitionType {
 
 impl<'a> ContentHash for PropertyDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1182,12 +1270,14 @@ impl ContentHash for MethodDefinitionKind {
 
 impl<'a> ContentHash for PrivateIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for StaticBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -1214,6 +1304,7 @@ impl ContentHash for AccessorPropertyType {
 
 impl<'a> ContentHash for AccessorProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1228,6 +1319,7 @@ impl<'a> ContentHash for AccessorProperty<'a> {
 
 impl<'a> ContentHash for ImportExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.arguments, state);
     }
@@ -1235,6 +1327,7 @@ impl<'a> ContentHash for ImportExpression<'a> {
 
 impl<'a> ContentHash for ImportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.specifiers, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.with_clause, state);
@@ -1255,6 +1348,7 @@ impl<'a> ContentHash for ImportDeclarationSpecifier<'a> {
 
 impl<'a> ContentHash for ImportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.imported, state);
         ContentHash::content_hash(&self.local, state);
         ContentHash::content_hash(&self.import_kind, state);
@@ -1263,18 +1357,21 @@ impl<'a> ContentHash for ImportSpecifier<'a> {
 
 impl<'a> ContentHash for ImportDefaultSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for ImportNamespaceSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for WithClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.attributes_keyword, state);
         ContentHash::content_hash(&self.with_entries, state);
     }
@@ -1282,6 +1379,7 @@ impl<'a> ContentHash for WithClause<'a> {
 
 impl<'a> ContentHash for ImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -1299,6 +1397,7 @@ impl<'a> ContentHash for ImportAttributeKey<'a> {
 
 impl<'a> ContentHash for ExportNamedDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.declaration, state);
         ContentHash::content_hash(&self.specifiers, state);
         ContentHash::content_hash(&self.source, state);
@@ -1309,6 +1408,7 @@ impl<'a> ContentHash for ExportNamedDeclaration<'a> {
 
 impl<'a> ContentHash for ExportDefaultDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.declaration, state);
         ContentHash::content_hash(&self.exported, state);
     }
@@ -1316,6 +1416,7 @@ impl<'a> ContentHash for ExportDefaultDeclaration<'a> {
 
 impl<'a> ContentHash for ExportAllDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.exported, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.with_clause, state);
@@ -1325,6 +1426,7 @@ impl<'a> ContentHash for ExportAllDeclaration<'a> {
 
 impl<'a> ContentHash for ExportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
         ContentHash::content_hash(&self.exported, state);
         ContentHash::content_hash(&self.export_kind, state);
@@ -1397,12 +1499,14 @@ impl<'a> ContentHash for ModuleExportName<'a> {
 
 impl<'a> ContentHash for TSThisParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSEnumDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.members, state);
         ContentHash::content_hash(&self.r#const, state);
@@ -1412,6 +1516,7 @@ impl<'a> ContentHash for TSEnumDeclaration<'a> {
 
 impl<'a> ContentHash for TSEnumMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.initializer, state);
     }
@@ -1473,12 +1578,14 @@ impl<'a> ContentHash for TSEnumMemberName<'a> {
 
 impl<'a> ContentHash for TSTypeAnnotation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.literal, state);
     }
 }
@@ -1547,6 +1654,7 @@ impl<'a> ContentHash for TSType<'a> {
 
 impl<'a> ContentHash for TSConditionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.check_type, state);
         ContentHash::content_hash(&self.extends_type, state);
         ContentHash::content_hash(&self.true_type, state);
@@ -1556,24 +1664,28 @@ impl<'a> ContentHash for TSConditionalType<'a> {
 
 impl<'a> ContentHash for TSUnionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSIntersectionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSParenthesizedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeOperator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -1587,12 +1699,14 @@ impl ContentHash for TSTypeOperatorOperator {
 
 impl<'a> ContentHash for TSArrayType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_type, state);
     }
 }
 
 impl<'a> ContentHash for TSIndexedAccessType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object_type, state);
         ContentHash::content_hash(&self.index_type, state);
     }
@@ -1600,12 +1714,14 @@ impl<'a> ContentHash for TSIndexedAccessType<'a> {
 
 impl<'a> ContentHash for TSTupleType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_types, state);
     }
 }
 
 impl<'a> ContentHash for TSNamedTupleMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_type, state);
         ContentHash::content_hash(&self.label, state);
         ContentHash::content_hash(&self.optional, state);
@@ -1614,12 +1730,14 @@ impl<'a> ContentHash for TSNamedTupleMember<'a> {
 
 impl<'a> ContentHash for TSOptionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSRestType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
@@ -1673,63 +1791,92 @@ impl<'a> ContentHash for TSTupleElement<'a> {
 }
 
 impl ContentHash for TSAnyKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSStringKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSBooleanKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSNumberKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSNeverKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSIntrinsicKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSUnknownKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSNullKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSUndefinedKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSVoidKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSSymbolKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSThisType {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSObjectKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl ContentHash for TSBigIntKeyword {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for TSTypeReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_name, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1747,6 +1894,7 @@ impl<'a> ContentHash for TSTypeName<'a> {
 
 impl<'a> ContentHash for TSQualifiedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
     }
@@ -1754,12 +1902,14 @@ impl<'a> ContentHash for TSQualifiedName<'a> {
 
 impl<'a> ContentHash for TSTypeParameterInstantiation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.constraint, state);
         ContentHash::content_hash(&self.default, state);
@@ -1771,12 +1921,14 @@ impl<'a> ContentHash for TSTypeParameter<'a> {
 
 impl<'a> ContentHash for TSTypeParameterDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeAliasDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -1792,6 +1944,7 @@ impl ContentHash for TSAccessibility {
 
 impl<'a> ContentHash for TSClassImplements<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1799,6 +1952,7 @@ impl<'a> ContentHash for TSClassImplements<'a> {
 
 impl<'a> ContentHash for TSInterfaceDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.extends, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -1809,12 +1963,14 @@ impl<'a> ContentHash for TSInterfaceDeclaration<'a> {
 
 impl<'a> ContentHash for TSInterfaceBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for TSPropertySignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.computed, state);
         ContentHash::content_hash(&self.optional, state);
         ContentHash::content_hash(&self.readonly, state);
@@ -1838,6 +1994,7 @@ impl<'a> ContentHash for TSSignature<'a> {
 
 impl<'a> ContentHash for TSIndexSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.parameters, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.readonly, state);
@@ -1846,6 +2003,7 @@ impl<'a> ContentHash for TSIndexSignature<'a> {
 
 impl<'a> ContentHash for TSCallSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -1861,6 +2019,7 @@ impl ContentHash for TSMethodSignatureKind {
 
 impl<'a> ContentHash for TSMethodSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.computed, state);
         ContentHash::content_hash(&self.optional, state);
@@ -1874,6 +2033,7 @@ impl<'a> ContentHash for TSMethodSignature<'a> {
 
 impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -1882,6 +2042,7 @@ impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
 
 impl<'a> ContentHash for TSIndexSignatureName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -1889,6 +2050,7 @@ impl<'a> ContentHash for TSIndexSignatureName<'a> {
 
 impl<'a> ContentHash for TSInterfaceHeritage<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1896,6 +2058,7 @@ impl<'a> ContentHash for TSInterfaceHeritage<'a> {
 
 impl<'a> ContentHash for TSTypePredicate<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.parameter_name, state);
         ContentHash::content_hash(&self.asserts, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -1914,6 +2077,7 @@ impl<'a> ContentHash for TSTypePredicateName<'a> {
 
 impl<'a> ContentHash for TSModuleDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.body, state);
         ContentHash::content_hash(&self.kind, state);
@@ -1949,6 +2113,7 @@ impl<'a> ContentHash for TSModuleDeclarationBody<'a> {
 
 impl<'a> ContentHash for TSModuleBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.directives, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -1956,18 +2121,21 @@ impl<'a> ContentHash for TSModuleBlock<'a> {
 
 impl<'a> ContentHash for TSTypeLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.members, state);
     }
 }
 
 impl<'a> ContentHash for TSInferType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_parameter, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeQuery<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expr_name, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1986,6 +2154,7 @@ impl<'a> ContentHash for TSTypeQueryExprName<'a> {
 
 impl<'a> ContentHash for TSImportType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.is_type_of, state);
         ContentHash::content_hash(&self.parameter, state);
         ContentHash::content_hash(&self.qualifier, state);
@@ -1996,6 +2165,7 @@ impl<'a> ContentHash for TSImportType<'a> {
 
 impl<'a> ContentHash for TSImportAttributes<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.attributes_keyword, state);
         ContentHash::content_hash(&self.elements, state);
     }
@@ -2003,6 +2173,7 @@ impl<'a> ContentHash for TSImportAttributes<'a> {
 
 impl<'a> ContentHash for TSImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -2020,6 +2191,7 @@ impl<'a> ContentHash for TSImportAttributeName<'a> {
 
 impl<'a> ContentHash for TSFunctionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -2029,6 +2201,7 @@ impl<'a> ContentHash for TSFunctionType<'a> {
 
 impl<'a> ContentHash for TSConstructorType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#abstract, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -2038,6 +2211,7 @@ impl<'a> ContentHash for TSConstructorType<'a> {
 
 impl<'a> ContentHash for TSMappedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_parameter, state);
         ContentHash::content_hash(&self.name_type, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -2054,6 +2228,7 @@ impl ContentHash for TSMappedTypeModifierOperator {
 
 impl<'a> ContentHash for TSTemplateLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.quasis, state);
         ContentHash::content_hash(&self.types, state);
     }
@@ -2061,6 +2236,7 @@ impl<'a> ContentHash for TSTemplateLiteralType<'a> {
 
 impl<'a> ContentHash for TSAsExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2068,6 +2244,7 @@ impl<'a> ContentHash for TSAsExpression<'a> {
 
 impl<'a> ContentHash for TSSatisfiesExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2075,6 +2252,7 @@ impl<'a> ContentHash for TSSatisfiesExpression<'a> {
 
 impl<'a> ContentHash for TSTypeAssertion<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2082,6 +2260,7 @@ impl<'a> ContentHash for TSTypeAssertion<'a> {
 
 impl<'a> ContentHash for TSImportEqualsDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.module_reference, state);
         ContentHash::content_hash(&self.import_kind, state);
@@ -2101,36 +2280,42 @@ impl<'a> ContentHash for TSModuleReference<'a> {
 
 impl<'a> ContentHash for TSExternalModuleReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNonNullExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for Decorator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSExportAssignment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNamespaceExportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
     }
 }
 
 impl<'a> ContentHash for TSInstantiationExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -2144,6 +2329,7 @@ impl ContentHash for ImportOrExportKind {
 
 impl<'a> ContentHash for JSDocNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.postfix, state);
     }
@@ -2151,17 +2337,21 @@ impl<'a> ContentHash for JSDocNullableType<'a> {
 
 impl<'a> ContentHash for JSDocNonNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.postfix, state);
     }
 }
 
 impl ContentHash for JSDocUnknownType {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for JSXElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.opening_element, state);
         ContentHash::content_hash(&self.closing_element, state);
         ContentHash::content_hash(&self.children, state);
@@ -2170,6 +2360,7 @@ impl<'a> ContentHash for JSXElement<'a> {
 
 impl<'a> ContentHash for JSXOpeningElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.self_closing, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.attributes, state);
@@ -2179,12 +2370,14 @@ impl<'a> ContentHash for JSXOpeningElement<'a> {
 
 impl<'a> ContentHash for JSXClosingElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for JSXFragment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.opening_fragment, state);
         ContentHash::content_hash(&self.closing_fragment, state);
         ContentHash::content_hash(&self.children, state);
@@ -2214,6 +2407,7 @@ impl<'a> ContentHash for JSXElementName<'a> {
 
 impl<'a> ContentHash for JSXNamespacedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.namespace, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -2221,6 +2415,7 @@ impl<'a> ContentHash for JSXNamespacedName<'a> {
 
 impl<'a> ContentHash for JSXMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -2239,6 +2434,7 @@ impl<'a> ContentHash for JSXMemberExpressionObject<'a> {
 
 impl<'a> ContentHash for JSXExpressionContainer<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -2295,7 +2491,9 @@ impl<'a> ContentHash for JSXExpression<'a> {
 }
 
 impl ContentHash for JSXEmptyExpression {
-    fn content_hash<H: Hasher>(&self, _: &mut H) {}
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
+    }
 }
 
 impl<'a> ContentHash for JSXAttributeItem<'a> {
@@ -2310,6 +2508,7 @@ impl<'a> ContentHash for JSXAttributeItem<'a> {
 
 impl<'a> ContentHash for JSXAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -2317,6 +2516,7 @@ impl<'a> ContentHash for JSXAttribute<'a> {
 
 impl<'a> ContentHash for JSXSpreadAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
@@ -2345,6 +2545,7 @@ impl<'a> ContentHash for JSXAttributeValue<'a> {
 
 impl<'a> ContentHash for JSXIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
@@ -2364,12 +2565,14 @@ impl<'a> ContentHash for JSXChild<'a> {
 
 impl<'a> ContentHash for JSXSpreadChild<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for JSXText<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -21,14 +21,12 @@ use crate::ast::ts::*;
 
 impl ContentHash for BooleanLiteral {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BigIntLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.raw, state);
         ContentHash::content_hash(&self.base, state);
     }
@@ -36,7 +34,6 @@ impl<'a> ContentHash for BigIntLiteral<'a> {
 
 impl<'a> ContentHash for RegExpLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
         ContentHash::content_hash(&self.regex, state);
     }
@@ -66,14 +63,12 @@ impl ContentHash for EmptyObject {
 
 impl<'a> ContentHash for StringLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for Program<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.source_type, state);
         ContentHash::content_hash(&self.hashbang, state);
         ContentHash::content_hash(&self.directives, state);
@@ -133,41 +128,34 @@ impl<'a> ContentHash for Expression<'a> {
 
 impl<'a> ContentHash for IdentifierName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for IdentifierReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for BindingIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for LabelIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl ContentHash for ThisExpression {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for ArrayExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
     }
 }
@@ -225,14 +213,11 @@ impl<'a> ContentHash for ArrayExpressionElement<'a> {
 }
 
 impl ContentHash for Elision {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for ObjectExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
     }
 }
@@ -249,7 +234,6 @@ impl<'a> ContentHash for ObjectPropertyKind<'a> {
 
 impl<'a> ContentHash for ObjectProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
@@ -320,7 +304,6 @@ impl ContentHash for PropertyKind {
 
 impl<'a> ContentHash for TemplateLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.quasis, state);
         ContentHash::content_hash(&self.expressions, state);
     }
@@ -328,7 +311,6 @@ impl<'a> ContentHash for TemplateLiteral<'a> {
 
 impl<'a> ContentHash for TaggedTemplateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.tag, state);
         ContentHash::content_hash(&self.quasi, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -337,7 +319,6 @@ impl<'a> ContentHash for TaggedTemplateExpression<'a> {
 
 impl<'a> ContentHash for TemplateElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.tail, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -363,7 +344,6 @@ impl<'a> ContentHash for MemberExpression<'a> {
 
 impl<'a> ContentHash for ComputedMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.optional, state);
@@ -372,7 +352,6 @@ impl<'a> ContentHash for ComputedMemberExpression<'a> {
 
 impl<'a> ContentHash for StaticMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.property, state);
         ContentHash::content_hash(&self.optional, state);
@@ -381,7 +360,6 @@ impl<'a> ContentHash for StaticMemberExpression<'a> {
 
 impl<'a> ContentHash for PrivateFieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.field, state);
         ContentHash::content_hash(&self.optional, state);
@@ -390,7 +368,6 @@ impl<'a> ContentHash for PrivateFieldExpression<'a> {
 
 impl<'a> ContentHash for CallExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.callee, state);
         ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.arguments, state);
@@ -400,7 +377,6 @@ impl<'a> ContentHash for CallExpression<'a> {
 
 impl<'a> ContentHash for NewExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.callee, state);
         ContentHash::content_hash(&self.arguments, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -409,7 +385,6 @@ impl<'a> ContentHash for NewExpression<'a> {
 
 impl<'a> ContentHash for MetaProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.meta, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -417,7 +392,6 @@ impl<'a> ContentHash for MetaProperty<'a> {
 
 impl<'a> ContentHash for SpreadElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
@@ -475,7 +449,6 @@ impl<'a> ContentHash for Argument<'a> {
 
 impl<'a> ContentHash for UpdateExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.prefix, state);
         ContentHash::content_hash(&self.argument, state);
@@ -484,7 +457,6 @@ impl<'a> ContentHash for UpdateExpression<'a> {
 
 impl<'a> ContentHash for UnaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.argument, state);
     }
@@ -492,7 +464,6 @@ impl<'a> ContentHash for UnaryExpression<'a> {
 
 impl<'a> ContentHash for BinaryExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -501,7 +472,6 @@ impl<'a> ContentHash for BinaryExpression<'a> {
 
 impl<'a> ContentHash for PrivateInExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -510,7 +480,6 @@ impl<'a> ContentHash for PrivateInExpression<'a> {
 
 impl<'a> ContentHash for LogicalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.right, state);
@@ -519,7 +488,6 @@ impl<'a> ContentHash for LogicalExpression<'a> {
 
 impl<'a> ContentHash for ConditionalExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
         ContentHash::content_hash(&self.alternate, state);
@@ -528,7 +496,6 @@ impl<'a> ContentHash for ConditionalExpression<'a> {
 
 impl<'a> ContentHash for AssignmentExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
@@ -583,7 +550,6 @@ impl<'a> ContentHash for AssignmentTargetPattern<'a> {
 
 impl<'a> ContentHash for ArrayAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -591,7 +557,6 @@ impl<'a> ContentHash for ArrayAssignmentTarget<'a> {
 
 impl<'a> ContentHash for ObjectAssignmentTarget<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -599,7 +564,6 @@ impl<'a> ContentHash for ObjectAssignmentTarget<'a> {
 
 impl<'a> ContentHash for AssignmentTargetRest<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.target, state);
     }
 }
@@ -626,7 +590,6 @@ impl<'a> ContentHash for AssignmentTargetMaybeDefault<'a> {
 
 impl<'a> ContentHash for AssignmentTargetWithDefault<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.binding, state);
         ContentHash::content_hash(&self.init, state);
     }
@@ -644,7 +607,6 @@ impl<'a> ContentHash for AssignmentTargetProperty<'a> {
 
 impl<'a> ContentHash for AssignmentTargetPropertyIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.binding, state);
         ContentHash::content_hash(&self.init, state);
     }
@@ -652,7 +614,6 @@ impl<'a> ContentHash for AssignmentTargetPropertyIdentifier<'a> {
 
 impl<'a> ContentHash for AssignmentTargetPropertyProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.binding, state);
     }
@@ -660,27 +621,22 @@ impl<'a> ContentHash for AssignmentTargetPropertyProperty<'a> {
 
 impl<'a> ContentHash for SequenceExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expressions, state);
     }
 }
 
 impl ContentHash for Super {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for AwaitExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for ChainExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -699,7 +655,6 @@ impl<'a> ContentHash for ChainElement<'a> {
 
 impl<'a> ContentHash for ParenthesizedExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -746,7 +701,6 @@ impl<'a> ContentHash for Statement<'a> {
 
 impl<'a> ContentHash for Directive<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.directive, state);
     }
@@ -754,14 +708,12 @@ impl<'a> ContentHash for Directive<'a> {
 
 impl<'a> ContentHash for Hashbang<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }
 
 impl<'a> ContentHash for BlockStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -784,7 +736,6 @@ impl<'a> ContentHash for Declaration<'a> {
 
 impl<'a> ContentHash for VariableDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.declarations, state);
         ContentHash::content_hash(&self.declare, state);
@@ -799,7 +750,6 @@ impl ContentHash for VariableDeclarationKind {
 
 impl<'a> ContentHash for VariableDeclarator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.init, state);
@@ -808,21 +758,17 @@ impl<'a> ContentHash for VariableDeclarator<'a> {
 }
 
 impl ContentHash for EmptyStatement {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for ExpressionStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for IfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
         ContentHash::content_hash(&self.alternate, state);
@@ -831,7 +777,6 @@ impl<'a> ContentHash for IfStatement<'a> {
 
 impl<'a> ContentHash for DoWhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
         ContentHash::content_hash(&self.test, state);
     }
@@ -839,7 +784,6 @@ impl<'a> ContentHash for DoWhileStatement<'a> {
 
 impl<'a> ContentHash for WhileStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -847,7 +791,6 @@ impl<'a> ContentHash for WhileStatement<'a> {
 
 impl<'a> ContentHash for ForStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.init, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.update, state);
@@ -908,7 +851,6 @@ impl<'a> ContentHash for ForStatementInit<'a> {
 
 impl<'a> ContentHash for ForInStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
         ContentHash::content_hash(&self.body, state);
@@ -937,7 +879,6 @@ impl<'a> ContentHash for ForStatementLeft<'a> {
 
 impl<'a> ContentHash for ForOfStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#await, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
@@ -947,28 +888,24 @@ impl<'a> ContentHash for ForOfStatement<'a> {
 
 impl<'a> ContentHash for ContinueStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for BreakStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
     }
 }
 
 impl<'a> ContentHash for ReturnStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for WithStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -976,7 +913,6 @@ impl<'a> ContentHash for WithStatement<'a> {
 
 impl<'a> ContentHash for SwitchStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.discriminant, state);
         ContentHash::content_hash(&self.cases, state);
     }
@@ -984,7 +920,6 @@ impl<'a> ContentHash for SwitchStatement<'a> {
 
 impl<'a> ContentHash for SwitchCase<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.test, state);
         ContentHash::content_hash(&self.consequent, state);
     }
@@ -992,7 +927,6 @@ impl<'a> ContentHash for SwitchCase<'a> {
 
 impl<'a> ContentHash for LabeledStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.label, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -1000,14 +934,12 @@ impl<'a> ContentHash for LabeledStatement<'a> {
 
 impl<'a> ContentHash for ThrowStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for TryStatement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.block, state);
         ContentHash::content_hash(&self.handler, state);
         ContentHash::content_hash(&self.finalizer, state);
@@ -1016,7 +948,6 @@ impl<'a> ContentHash for TryStatement<'a> {
 
 impl<'a> ContentHash for CatchClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.param, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -1024,20 +955,16 @@ impl<'a> ContentHash for CatchClause<'a> {
 
 impl<'a> ContentHash for CatchParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.pattern, state);
     }
 }
 
 impl ContentHash for DebuggerStatement {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for BindingPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.optional, state);
@@ -1058,7 +985,6 @@ impl<'a> ContentHash for BindingPatternKind<'a> {
 
 impl<'a> ContentHash for AssignmentPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
     }
@@ -1066,7 +992,6 @@ impl<'a> ContentHash for AssignmentPattern<'a> {
 
 impl<'a> ContentHash for ObjectPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.properties, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -1074,7 +999,6 @@ impl<'a> ContentHash for ObjectPattern<'a> {
 
 impl<'a> ContentHash for BindingProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
         ContentHash::content_hash(&self.shorthand, state);
@@ -1084,7 +1008,6 @@ impl<'a> ContentHash for BindingProperty<'a> {
 
 impl<'a> ContentHash for ArrayPattern<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.elements, state);
         ContentHash::content_hash(&self.rest, state);
     }
@@ -1092,14 +1015,12 @@ impl<'a> ContentHash for ArrayPattern<'a> {
 
 impl<'a> ContentHash for BindingRestElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
 
 impl<'a> ContentHash for Function<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.generator, state);
@@ -1121,7 +1042,6 @@ impl ContentHash for FunctionType {
 
 impl<'a> ContentHash for FormalParameters<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.items, state);
         ContentHash::content_hash(&self.rest, state);
@@ -1130,7 +1050,6 @@ impl<'a> ContentHash for FormalParameters<'a> {
 
 impl<'a> ContentHash for FormalParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.pattern, state);
         ContentHash::content_hash(&self.accessibility, state);
@@ -1147,7 +1066,6 @@ impl ContentHash for FormalParameterKind {
 
 impl<'a> ContentHash for FunctionBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.directives, state);
         ContentHash::content_hash(&self.statements, state);
     }
@@ -1155,7 +1073,6 @@ impl<'a> ContentHash for FunctionBody<'a> {
 
 impl<'a> ContentHash for ArrowFunctionExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.r#async, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -1167,7 +1084,6 @@ impl<'a> ContentHash for ArrowFunctionExpression<'a> {
 
 impl<'a> ContentHash for YieldExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.delegate, state);
         ContentHash::content_hash(&self.argument, state);
     }
@@ -1175,7 +1091,6 @@ impl<'a> ContentHash for YieldExpression<'a> {
 
 impl<'a> ContentHash for Class<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.id, state);
@@ -1197,7 +1112,6 @@ impl ContentHash for ClassType {
 
 impl<'a> ContentHash for ClassBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -1217,7 +1131,6 @@ impl<'a> ContentHash for ClassElement<'a> {
 
 impl<'a> ContentHash for MethodDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1239,7 +1152,6 @@ impl ContentHash for MethodDefinitionType {
 
 impl<'a> ContentHash for PropertyDefinition<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1270,14 +1182,12 @@ impl ContentHash for MethodDefinitionKind {
 
 impl<'a> ContentHash for PrivateIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for StaticBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
@@ -1304,7 +1214,6 @@ impl ContentHash for AccessorPropertyType {
 
 impl<'a> ContentHash for AccessorProperty<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#type, state);
         ContentHash::content_hash(&self.decorators, state);
         ContentHash::content_hash(&self.key, state);
@@ -1319,7 +1228,6 @@ impl<'a> ContentHash for AccessorProperty<'a> {
 
 impl<'a> ContentHash for ImportExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.arguments, state);
     }
@@ -1327,7 +1235,6 @@ impl<'a> ContentHash for ImportExpression<'a> {
 
 impl<'a> ContentHash for ImportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.specifiers, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.with_clause, state);
@@ -1348,7 +1255,6 @@ impl<'a> ContentHash for ImportDeclarationSpecifier<'a> {
 
 impl<'a> ContentHash for ImportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.imported, state);
         ContentHash::content_hash(&self.local, state);
         ContentHash::content_hash(&self.import_kind, state);
@@ -1357,21 +1263,18 @@ impl<'a> ContentHash for ImportSpecifier<'a> {
 
 impl<'a> ContentHash for ImportDefaultSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for ImportNamespaceSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
     }
 }
 
 impl<'a> ContentHash for WithClause<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.attributes_keyword, state);
         ContentHash::content_hash(&self.with_entries, state);
     }
@@ -1379,7 +1282,6 @@ impl<'a> ContentHash for WithClause<'a> {
 
 impl<'a> ContentHash for ImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -1397,7 +1299,6 @@ impl<'a> ContentHash for ImportAttributeKey<'a> {
 
 impl<'a> ContentHash for ExportNamedDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.declaration, state);
         ContentHash::content_hash(&self.specifiers, state);
         ContentHash::content_hash(&self.source, state);
@@ -1408,7 +1309,6 @@ impl<'a> ContentHash for ExportNamedDeclaration<'a> {
 
 impl<'a> ContentHash for ExportDefaultDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.declaration, state);
         ContentHash::content_hash(&self.exported, state);
     }
@@ -1416,7 +1316,6 @@ impl<'a> ContentHash for ExportDefaultDeclaration<'a> {
 
 impl<'a> ContentHash for ExportAllDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.exported, state);
         ContentHash::content_hash(&self.source, state);
         ContentHash::content_hash(&self.with_clause, state);
@@ -1426,7 +1325,6 @@ impl<'a> ContentHash for ExportAllDeclaration<'a> {
 
 impl<'a> ContentHash for ExportSpecifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.local, state);
         ContentHash::content_hash(&self.exported, state);
         ContentHash::content_hash(&self.export_kind, state);
@@ -1499,14 +1397,12 @@ impl<'a> ContentHash for ModuleExportName<'a> {
 
 impl<'a> ContentHash for TSThisParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSEnumDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.members, state);
         ContentHash::content_hash(&self.r#const, state);
@@ -1516,7 +1412,6 @@ impl<'a> ContentHash for TSEnumDeclaration<'a> {
 
 impl<'a> ContentHash for TSEnumMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.initializer, state);
     }
@@ -1578,14 +1473,12 @@ impl<'a> ContentHash for TSEnumMemberName<'a> {
 
 impl<'a> ContentHash for TSTypeAnnotation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.literal, state);
     }
 }
@@ -1654,7 +1547,6 @@ impl<'a> ContentHash for TSType<'a> {
 
 impl<'a> ContentHash for TSConditionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.check_type, state);
         ContentHash::content_hash(&self.extends_type, state);
         ContentHash::content_hash(&self.true_type, state);
@@ -1664,28 +1556,24 @@ impl<'a> ContentHash for TSConditionalType<'a> {
 
 impl<'a> ContentHash for TSUnionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSIntersectionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.types, state);
     }
 }
 
 impl<'a> ContentHash for TSParenthesizedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeOperator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.operator, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -1699,14 +1587,12 @@ impl ContentHash for TSTypeOperatorOperator {
 
 impl<'a> ContentHash for TSArrayType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_type, state);
     }
 }
 
 impl<'a> ContentHash for TSIndexedAccessType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object_type, state);
         ContentHash::content_hash(&self.index_type, state);
     }
@@ -1714,14 +1600,12 @@ impl<'a> ContentHash for TSIndexedAccessType<'a> {
 
 impl<'a> ContentHash for TSTupleType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_types, state);
     }
 }
 
 impl<'a> ContentHash for TSNamedTupleMember<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.element_type, state);
         ContentHash::content_hash(&self.label, state);
         ContentHash::content_hash(&self.optional, state);
@@ -1730,14 +1614,12 @@ impl<'a> ContentHash for TSNamedTupleMember<'a> {
 
 impl<'a> ContentHash for TSOptionalType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
 
 impl<'a> ContentHash for TSRestType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
 }
@@ -1791,92 +1673,63 @@ impl<'a> ContentHash for TSTupleElement<'a> {
 }
 
 impl ContentHash for TSAnyKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSStringKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSBooleanKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSNumberKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSNeverKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSIntrinsicKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSUnknownKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSNullKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSUndefinedKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSVoidKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSSymbolKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSThisType {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSObjectKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl ContentHash for TSBigIntKeyword {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for TSTypeReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_name, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1894,7 +1747,6 @@ impl<'a> ContentHash for TSTypeName<'a> {
 
 impl<'a> ContentHash for TSQualifiedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.left, state);
         ContentHash::content_hash(&self.right, state);
     }
@@ -1902,14 +1754,12 @@ impl<'a> ContentHash for TSQualifiedName<'a> {
 
 impl<'a> ContentHash for TSTypeParameterInstantiation<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeParameter<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.constraint, state);
         ContentHash::content_hash(&self.default, state);
@@ -1921,14 +1771,12 @@ impl<'a> ContentHash for TSTypeParameter<'a> {
 
 impl<'a> ContentHash for TSTypeParameterDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeAliasDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -1944,7 +1792,6 @@ impl ContentHash for TSAccessibility {
 
 impl<'a> ContentHash for TSClassImplements<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -1952,7 +1799,6 @@ impl<'a> ContentHash for TSClassImplements<'a> {
 
 impl<'a> ContentHash for TSInterfaceDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.extends, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -1963,14 +1809,12 @@ impl<'a> ContentHash for TSInterfaceDeclaration<'a> {
 
 impl<'a> ContentHash for TSInterfaceBody<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.body, state);
     }
 }
 
 impl<'a> ContentHash for TSPropertySignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.computed, state);
         ContentHash::content_hash(&self.optional, state);
         ContentHash::content_hash(&self.readonly, state);
@@ -1994,7 +1838,6 @@ impl<'a> ContentHash for TSSignature<'a> {
 
 impl<'a> ContentHash for TSIndexSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.parameters, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.readonly, state);
@@ -2003,7 +1846,6 @@ impl<'a> ContentHash for TSIndexSignature<'a> {
 
 impl<'a> ContentHash for TSCallSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -2019,7 +1861,6 @@ impl ContentHash for TSMethodSignatureKind {
 
 impl<'a> ContentHash for TSMethodSignature<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.key, state);
         ContentHash::content_hash(&self.computed, state);
         ContentHash::content_hash(&self.optional, state);
@@ -2033,7 +1874,6 @@ impl<'a> ContentHash for TSMethodSignature<'a> {
 
 impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
         ContentHash::content_hash(&self.type_parameters, state);
@@ -2042,7 +1882,6 @@ impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
 
 impl<'a> ContentHash for TSIndexSignatureName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2050,7 +1889,6 @@ impl<'a> ContentHash for TSIndexSignatureName<'a> {
 
 impl<'a> ContentHash for TSInterfaceHeritage<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -2058,7 +1896,6 @@ impl<'a> ContentHash for TSInterfaceHeritage<'a> {
 
 impl<'a> ContentHash for TSTypePredicate<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.parameter_name, state);
         ContentHash::content_hash(&self.asserts, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -2077,7 +1914,6 @@ impl<'a> ContentHash for TSTypePredicateName<'a> {
 
 impl<'a> ContentHash for TSModuleDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.body, state);
         ContentHash::content_hash(&self.kind, state);
@@ -2113,7 +1949,6 @@ impl<'a> ContentHash for TSModuleDeclarationBody<'a> {
 
 impl<'a> ContentHash for TSModuleBlock<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.directives, state);
         ContentHash::content_hash(&self.body, state);
     }
@@ -2121,21 +1956,18 @@ impl<'a> ContentHash for TSModuleBlock<'a> {
 
 impl<'a> ContentHash for TSTypeLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.members, state);
     }
 }
 
 impl<'a> ContentHash for TSInferType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_parameter, state);
     }
 }
 
 impl<'a> ContentHash for TSTypeQuery<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expr_name, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -2154,7 +1986,6 @@ impl<'a> ContentHash for TSTypeQueryExprName<'a> {
 
 impl<'a> ContentHash for TSImportType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.is_type_of, state);
         ContentHash::content_hash(&self.parameter, state);
         ContentHash::content_hash(&self.qualifier, state);
@@ -2165,7 +1996,6 @@ impl<'a> ContentHash for TSImportType<'a> {
 
 impl<'a> ContentHash for TSImportAttributes<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.attributes_keyword, state);
         ContentHash::content_hash(&self.elements, state);
     }
@@ -2173,7 +2003,6 @@ impl<'a> ContentHash for TSImportAttributes<'a> {
 
 impl<'a> ContentHash for TSImportAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -2191,7 +2020,6 @@ impl<'a> ContentHash for TSImportAttributeName<'a> {
 
 impl<'a> ContentHash for TSFunctionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -2201,7 +2029,6 @@ impl<'a> ContentHash for TSFunctionType<'a> {
 
 impl<'a> ContentHash for TSConstructorType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.r#abstract, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
@@ -2211,7 +2038,6 @@ impl<'a> ContentHash for TSConstructorType<'a> {
 
 impl<'a> ContentHash for TSMappedType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_parameter, state);
         ContentHash::content_hash(&self.name_type, state);
         ContentHash::content_hash(&self.type_annotation, state);
@@ -2228,7 +2054,6 @@ impl ContentHash for TSMappedTypeModifierOperator {
 
 impl<'a> ContentHash for TSTemplateLiteralType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.quasis, state);
         ContentHash::content_hash(&self.types, state);
     }
@@ -2236,7 +2061,6 @@ impl<'a> ContentHash for TSTemplateLiteralType<'a> {
 
 impl<'a> ContentHash for TSAsExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2244,7 +2068,6 @@ impl<'a> ContentHash for TSAsExpression<'a> {
 
 impl<'a> ContentHash for TSSatisfiesExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2252,7 +2075,6 @@ impl<'a> ContentHash for TSSatisfiesExpression<'a> {
 
 impl<'a> ContentHash for TSTypeAssertion<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_annotation, state);
     }
@@ -2260,7 +2082,6 @@ impl<'a> ContentHash for TSTypeAssertion<'a> {
 
 impl<'a> ContentHash for TSImportEqualsDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
         ContentHash::content_hash(&self.module_reference, state);
         ContentHash::content_hash(&self.import_kind, state);
@@ -2280,42 +2101,36 @@ impl<'a> ContentHash for TSModuleReference<'a> {
 
 impl<'a> ContentHash for TSExternalModuleReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNonNullExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for Decorator<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSExportAssignment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for TSNamespaceExportDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.id, state);
     }
 }
 
 impl<'a> ContentHash for TSInstantiationExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
         ContentHash::content_hash(&self.type_parameters, state);
     }
@@ -2329,7 +2144,6 @@ impl ContentHash for ImportOrExportKind {
 
 impl<'a> ContentHash for JSDocNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.postfix, state);
     }
@@ -2337,21 +2151,17 @@ impl<'a> ContentHash for JSDocNullableType<'a> {
 
 impl<'a> ContentHash for JSDocNonNullableType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.postfix, state);
     }
 }
 
 impl ContentHash for JSDocUnknownType {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for JSXElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.opening_element, state);
         ContentHash::content_hash(&self.closing_element, state);
         ContentHash::content_hash(&self.children, state);
@@ -2360,7 +2170,6 @@ impl<'a> ContentHash for JSXElement<'a> {
 
 impl<'a> ContentHash for JSXOpeningElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.self_closing, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.attributes, state);
@@ -2370,14 +2179,12 @@ impl<'a> ContentHash for JSXOpeningElement<'a> {
 
 impl<'a> ContentHash for JSXClosingElement<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
 
 impl<'a> ContentHash for JSXFragment<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.opening_fragment, state);
         ContentHash::content_hash(&self.closing_fragment, state);
         ContentHash::content_hash(&self.children, state);
@@ -2407,7 +2214,6 @@ impl<'a> ContentHash for JSXElementName<'a> {
 
 impl<'a> ContentHash for JSXNamespacedName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.namespace, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -2415,7 +2221,6 @@ impl<'a> ContentHash for JSXNamespacedName<'a> {
 
 impl<'a> ContentHash for JSXMemberExpression<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.object, state);
         ContentHash::content_hash(&self.property, state);
     }
@@ -2434,7 +2239,6 @@ impl<'a> ContentHash for JSXMemberExpressionObject<'a> {
 
 impl<'a> ContentHash for JSXExpressionContainer<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
@@ -2491,9 +2295,7 @@ impl<'a> ContentHash for JSXExpression<'a> {
 }
 
 impl ContentHash for JSXEmptyExpression {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
-    }
+    fn content_hash<H: Hasher>(&self, _: &mut H) {}
 }
 
 impl<'a> ContentHash for JSXAttributeItem<'a> {
@@ -2508,7 +2310,6 @@ impl<'a> ContentHash for JSXAttributeItem<'a> {
 
 impl<'a> ContentHash for JSXAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
         ContentHash::content_hash(&self.value, state);
     }
@@ -2516,7 +2317,6 @@ impl<'a> ContentHash for JSXAttribute<'a> {
 
 impl<'a> ContentHash for JSXSpreadAttribute<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.argument, state);
     }
 }
@@ -2545,7 +2345,6 @@ impl<'a> ContentHash for JSXAttributeValue<'a> {
 
 impl<'a> ContentHash for JSXIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.name, state);
     }
 }
@@ -2565,14 +2364,12 @@ impl<'a> ContentHash for JSXChild<'a> {
 
 impl<'a> ContentHash for JSXSpreadChild<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.expression, state);
     }
 }
 
 impl<'a> ContentHash for JSXText<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.node_id, state);
         ContentHash::content_hash(&self.value, state);
     }
 }

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::parse_quote;
 
 /// returns `#[repr(C, u8)]` if `enum_` has any non-unit variant,
 /// Otherwise it would return `#[repr(u8)]`.
@@ -149,12 +150,28 @@ fn assert_generated_derives(attrs: &[syn::Attribute]) -> TokenStream2 {
 /// 2. `tsify`
 #[proc_macro_attribute]
 #[allow(clippy::missing_panics_doc)]
-pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as syn::Item);
+pub fn ast(args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut input = syn::parse_macro_input!(input as syn::Item);
 
-    let (head, tail) = match &input {
+    let (head, tail) = match &mut input {
         syn::Item::Enum(enum_) => (enum_repr(enum_), assert_generated_derives(&enum_.attrs)),
         syn::Item::Struct(struct_) => {
+            {
+                // HACK: temperorary messure to speed up the initial implementation.
+                let args = TokenStream2::from(args);
+                if args.into_iter().next().is_some_and(
+                    |tk| matches!(tk, proc_macro2::TokenTree::Ident(id) if id == "visit" ),
+                ) {
+                    match &mut struct_.fields {
+                        syn::Fields::Named(fields) => {
+                            fields
+                                .named
+                                .insert(0, parse_quote!(pub node_id: ::oxc_syntax::node::NodeId));
+                        }
+                        _ => {}
+                    }
+                }
+            }
             (quote!(#[repr(C)]), assert_generated_derives(&struct_.attrs))
         }
 

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -156,19 +156,16 @@ pub fn ast(args: TokenStream, input: TokenStream) -> TokenStream {
     let (head, tail) = match &mut input {
         syn::Item::Enum(enum_) => (enum_repr(enum_), assert_generated_derives(&enum_.attrs)),
         syn::Item::Struct(struct_) => {
+            // HACK: temperorary measure to speed up the initial implementation of `node_id`.
             {
-                // HACK: temperorary messure to speed up the initial implementation.
                 let args = TokenStream2::from(args);
                 if args.into_iter().next().is_some_and(
                     |tk| matches!(tk, proc_macro2::TokenTree::Ident(id) if id == "visit" ),
                 ) {
-                    match &mut struct_.fields {
-                        syn::Fields::Named(fields) => {
-                            fields
-                                .named
-                                .insert(0, parse_quote!(pub node_id: ::oxc_syntax::node::NodeId));
-                        }
-                        _ => {}
+                    if let syn::Fields::Named(fields) = &mut struct_.fields {
+                        fields
+                            .named
+                            .insert(0, parse_quote!(pub node_id: ::oxc_syntax::node::NodeId));
                     }
                 }
             }

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -546,7 +546,7 @@ impl<'a> IsolatedDeclarations<'a> {
         kind: BindingPatternKind<'a>,
         type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     ) -> Box<'a, FormalParameters<'a>> {
-        let pattern = BindingPattern { kind, type_annotation, optional: false };
+        let pattern = self.ast.binding_pattern(kind, type_annotation, false);
         let parameter =
             self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, None, false, false);
         let items = self.ast.vec1(parameter);

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,6 +1,7 @@
 use oxc_allocator::Box;
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
+use oxc_ast::NONE;
 use oxc_span::{Atom, GetSpan, SPAN};
 
 use crate::{diagnostics::default_export_inferred, IsolatedDeclarations};
@@ -12,14 +13,14 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<ExportNamedDeclaration<'a>> {
         let decl = self.transform_declaration(decl.declaration.as_ref()?, false)?;
 
-        Some(ExportNamedDeclaration {
-            span: decl.span(),
-            declaration: Some(decl),
-            specifiers: self.ast.vec(),
-            source: None,
-            export_kind: ImportOrExportKind::Value,
-            with_clause: None,
-        })
+        Some(self.ast.export_named_declaration(
+            decl.span(),
+            Some(decl),
+            self.ast.vec(),
+            None,
+            ImportOrExportKind::Value,
+            NONE,
+        ))
     }
 
     pub fn create_unique_name(&mut self, name: &str) -> Atom<'a> {
@@ -69,12 +70,12 @@ impl<'a> IsolatedDeclarations<'a> {
                         self.ast.vec1(self.ast.variable_declarator(SPAN, kind, id, None, true));
 
                     Some((
-                        Some(VariableDeclaration {
-                            span: SPAN,
+                        Some(self.ast.variable_declaration(
+                            SPAN,
                             kind,
                             declarations,
-                            declare: self.is_declare(),
-                        }),
+                            self.is_declare(),
+                        )),
                         ExportDefaultDeclarationKind::from(
                             self.ast.expression_identifier_reference(SPAN, &name),
                         ),
@@ -86,7 +87,7 @@ impl<'a> IsolatedDeclarations<'a> {
         declaration.map(|(var_decl, declaration)| {
             let exported =
                 ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
-            (var_decl, ExportDefaultDeclaration { span: decl.span, declaration, exported })
+            (var_decl, self.ast.export_default_declaration(decl.span, declaration, exported))
         })
     }
 

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -1,9 +1,13 @@
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
+use oxc_allocator::CloneIn;
+use oxc_ast_macros::ast;
 use oxc_index::Idx;
+use oxc_span::{cmp::ContentEq, hash::ContentHash};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
+#[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct NodeId(NonMaxU32);
 
@@ -43,6 +47,25 @@ impl Idx for NodeId {
 
     fn index(self) -> usize {
         self.0.get() as usize
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for NodeId {
+    type Cloned = Self;
+    fn clone_in(&self, _: &'alloc oxc_allocator::Allocator) -> Self::Cloned {
+        *self
+    }
+}
+
+impl ContentEq for NodeId {
+    fn content_eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl ContentHash for NodeId {
+    fn content_hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(self, state);
     }
 }
 

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -3,7 +3,6 @@ use nonmax::NonMaxU32;
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;
 use oxc_index::Idx;
-use oxc_span::{cmp::ContentEq, hash::ContentHash};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
@@ -54,18 +53,6 @@ impl<'alloc> CloneIn<'alloc> for NodeId {
     type Cloned = Self;
     fn clone_in(&self, _: &'alloc oxc_allocator::Allocator) -> Self::Cloned {
         *self
-    }
-}
-
-impl ContentEq for NodeId {
-    fn content_eq(&self, other: &Self) -> bool {
-        self == other
-    }
-}
-
-impl ContentHash for NodeId {
-    fn content_hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::hash::Hash::hash(self, state);
     }
 }
 

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -63,6 +63,7 @@ use std::cell::Cell;
 
 use oxc_allocator::Vec;
 use oxc_ast::{ast::*, NONE};
+use oxc_semantic::NodeId;
 use oxc_span::SPAN;
 use oxc_syntax::{scope::ScopeFlags, symbol::SymbolFlags};
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -291,6 +292,7 @@ impl<'a> ArrowFunctions<'a> {
         }
 
         let new_function = Function {
+            node_id: NodeId::DUMMY,
             r#type: FunctionType::FunctionExpression,
             span: arrow_function_expr.span,
             id: None,

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -34,7 +34,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::{ast::*, NONE};
-use oxc_semantic::{ReferenceFlags, SymbolFlags};
+use oxc_semantic::{NodeId, ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -315,6 +315,7 @@ impl<'a> ExponentiationOperator<'a> {
         {
             // var _name;
             let binding_identifier = BindingIdentifier {
+                node_id: NodeId::DUMMY,
                 span: SPAN,
                 name: symbol_name.clone(),
                 symbol_id: Cell::new(Some(symbol_id)),

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -35,7 +35,7 @@
 use std::cell::Cell;
 
 use oxc_ast::{ast::*, NONE};
-use oxc_semantic::SymbolFlags;
+use oxc_semantic::{NodeId, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
 
@@ -66,8 +66,12 @@ impl<'a> Traverse<'a> for OptionalCatchBinding<'a> {
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );
         let name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
-        let binding_identifier =
-            BindingIdentifier { span: SPAN, symbol_id: Cell::new(Some(symbol_id)), name };
+        let binding_identifier = BindingIdentifier {
+            node_id: NodeId::DUMMY,
+            span: SPAN,
+            symbol_id: Cell::new(Some(symbol_id)),
+            name,
+        };
         let binding_pattern_kind =
             ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
         let binding_pattern = ctx.ast.binding_pattern(binding_pattern_kind, NONE, false);

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -32,7 +32,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::{ast::*, NONE};
-use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
+use oxc_semantic::{NodeId, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
@@ -187,6 +187,7 @@ impl<'a> NullishCoalescingOperator<'a> {
 
         // var _name;
         let binding_identifier = BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span: SPAN,
             name: symbol_name.clone(),
             symbol_id: Cell::new(Some(symbol_id)),

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -57,7 +57,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::{ast::*, NONE};
-use oxc_semantic::{ReferenceFlags, SymbolFlags};
+use oxc_semantic::{NodeId, ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -361,6 +361,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
 
         // var _name;
         let binding_identifier = BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span: SPAN,
             name: symbol_name.clone(),
             symbol_id: Cell::new(Some(symbol_id)),

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 
 use oxc_ast::ast::{BindingIdentifier, IdentifierReference};
+use oxc_semantic::NodeId;
 use oxc_span::{Atom, Span, SPAN};
 use oxc_syntax::{
     reference::ReferenceFlags,
@@ -79,6 +80,7 @@ impl<'a> BoundIdentifier<'a> {
     /// Create `BindingIdentifier` for this binding
     pub fn create_binding_identifier(&self) -> BindingIdentifier<'a> {
         BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span: SPAN,
             name: self.name.clone(),
             symbol_id: Cell::new(Some(self.symbol_id)),

--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell};
 use indexmap::IndexMap;
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::{ast::*, AstBuilder, NONE};
-use oxc_semantic::ReferenceFlags;
+use oxc_semantic::{NodeId, ReferenceFlags};
 use oxc_span::{Atom, SPAN};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::TraverseCtx;
@@ -90,19 +90,17 @@ impl<'a> ModuleImports<'a> {
     ) -> Statement<'a> {
         let specifiers = self.ast.vec_from_iter(names.into_iter().map(|name| {
             let local = name.local.unwrap_or_else(|| name.imported.clone());
-            ImportDeclarationSpecifier::ImportSpecifier(self.ast.alloc(ImportSpecifier {
-                span: SPAN,
-                imported: ModuleExportName::IdentifierName(IdentifierName::new(
-                    SPAN,
-                    name.imported,
-                )),
-                local: BindingIdentifier {
+            self.ast.import_declaration_specifier_import_specifier(
+                SPAN,
+                self.ast.module_export_name_identifier_name(SPAN, name.imported),
+                BindingIdentifier {
+                    node_id: NodeId::DUMMY,
                     span: SPAN,
                     name: local,
                     symbol_id: Cell::new(Some(name.symbol_id)),
                 },
-                import_kind: ImportOrExportKind::Value,
-            }))
+                ImportOrExportKind::Value,
+            )
         }));
         let import_stmt = self.ast.module_declaration_import_declaration(
             SPAN,
@@ -133,6 +131,7 @@ impl<'a> ModuleImports<'a> {
         let name = names.into_iter().next().unwrap();
         let id = {
             let ident = BindingIdentifier {
+                node_id: NodeId::DUMMY,
                 span: SPAN,
                 name: name.imported,
                 symbol_id: Cell::new(Some(name.symbol_id)),

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -3,7 +3,7 @@ use std::{cell::Cell, iter::once};
 use base64::prelude::{Engine, BASE64_STANDARD};
 use oxc_allocator::CloneIn;
 use oxc_ast::{ast::*, match_expression, AstBuilder, NONE};
-use oxc_semantic::{Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
+use oxc_semantic::{NodeId, Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{Atom, GetSpan, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
@@ -151,6 +151,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
         for (symbol_id, persistent_id) in self.registrations.drain(..) {
             let name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
             let binding_identifier = BindingIdentifier {
+                node_id: NodeId::DUMMY,
                 name: name.clone(),
                 symbol_id: Cell::new(Some(symbol_id)),
                 span: SPAN,
@@ -691,6 +692,7 @@ impl<'a> ReactRefresh<'a> {
         let symbol_name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
 
         let binding_identifier = BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span: SPAN,
             name: symbol_name.clone(),
             symbol_id: Cell::new(Some(symbol_id)),

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -5,7 +5,7 @@ use std::{cell::Cell, rc::Rc};
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::SymbolFlags;
+use oxc_semantic::{NodeId, SymbolFlags};
 use oxc_span::{Atom, GetSpan, Span, SPAN};
 use oxc_syntax::{
     operator::AssignmentOperator,
@@ -554,8 +554,12 @@ impl<'a> TypeScriptAnnotations<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let scope_id = ctx.insert_scope_below_statement(&stmt, ScopeFlags::empty());
-        let block =
-            BlockStatement { span, body: ctx.ast.vec1(stmt), scope_id: Cell::new(Some(scope_id)) };
+        let block = BlockStatement {
+            node_id: NodeId::DUMMY,
+            span,
+            body: ctx.ast.vec1(stmt),
+            scope_id: Cell::new(Some(scope_id)),
+        };
         Statement::BlockStatement(ctx.ast.alloc(block))
     }
 
@@ -576,6 +580,7 @@ impl<'a> TypeScriptAnnotations<'a> {
         if stmt.is_typescript_syntax() {
             let scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
             let block = BlockStatement {
+                node_id: NodeId::DUMMY,
                 span: stmt.span(),
                 body: ctx.ast.vec(),
                 scope_id: Cell::new(Some(scope_id)),

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -89,6 +89,7 @@ impl<'a> TypeScriptEnum<'a> {
         );
         ctx.scopes_mut().add_binding(func_scope_id, enum_name.to_compact_str(), param_symbol_id);
         let ident = BindingIdentifier {
+            node_id: NodeId::DUMMY,
             span: decl.id.span,
             name: decl.id.name.clone(),
             symbol_id: Cell::new(Some(param_symbol_id)),
@@ -112,6 +113,7 @@ impl<'a> TypeScriptEnum<'a> {
         let statements = self.transform_ts_enum_members(&mut decl.members, &ident, ctx);
         let body = ast.alloc_function_body(decl.span, ast.vec(), statements);
         let callee = Expression::FunctionExpression(ctx.alloc(Function {
+            node_id: NodeId::DUMMY,
             r#type: FunctionType::FunctionExpression,
             span: SPAN,
             id: None,

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -296,7 +296,12 @@ impl TraverseScoping {
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_bound_reference(symbol_id, flags);
-        IdentifierReference { span, name, reference_id: Cell::new(Some(reference_id)) }
+        IdentifierReference {
+            node_id: NodeId::DUMMY,
+            span,
+            name,
+            reference_id: Cell::new(Some(reference_id)),
+        }
     }
 
     /// Create an unbound reference
@@ -319,7 +324,12 @@ impl TraverseScoping {
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_unbound_reference(name.to_compact_str(), flags);
-        IdentifierReference { span, name, reference_id: Cell::new(Some(reference_id)) }
+        IdentifierReference {
+            node_id: NodeId::DUMMY,
+            span,
+            name,
+            reference_id: Cell::new(Some(reference_id)),
+        }
     }
 
     /// Create a reference optionally bound to a `SymbolId`.

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -13,14 +13,8 @@ define_derive! {
     pub struct DeriveContentEq;
 }
 
-const IGNORE_FIELDS: [(/* field name */ &str, /* field type */ &str); 6] = [
-    ("span", "Span"),
-    ("trailing_comma", "Span"),
-    ("this_span", "Span"),
-    ("scope_id", "ScopeId"),
-    ("symbol_id", "SymbolId"),
-    ("reference_id", "ReferenceId"),
-];
+const IGNORE_FIELD_TYPES: [/* field type */ &str; 5] =
+    ["Span", "NodeId", "ScopeId", "SymbolId", "ReferenceId"];
 
 impl Derive for DeriveContentEq {
     fn trait_name() -> &'static str {
@@ -86,10 +80,7 @@ fn derive_struct(def: &StructDef) -> (&str, TokenStream) {
             .fields
             .iter()
             .filter(|field| {
-                let Some(name) = field.name.as_ref() else { return false };
-                !IGNORE_FIELDS
-                    .iter()
-                    .any(|it| name == it.0 && field.typ.name().inner_name() == it.1)
+                !IGNORE_FIELD_TYPES.iter().any(|it| field.typ.name().inner_name() == *it)
             })
             .map(|field| {
                 let ident = field.ident();

--- a/tasks/ast_tools/src/derives/content_hash.rs
+++ b/tasks/ast_tools/src/derives/content_hash.rs
@@ -13,8 +13,9 @@ define_derive! {
     pub struct DeriveContentHash;
 }
 
-const IGNORE_FIELD_TYPES: [/* type name */ &str; 4] = [
+const IGNORE_FIELD_TYPES: [/* type name */ &str; 5] = [
     "Span",
+    "NodeId",
     "ScopeId",
     "SymbolId",
     "ReferenceId",

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -42,6 +42,7 @@ impl Generator for AssertLayouts {
                 ///@@line_break
                 #[allow(clippy::wildcard_imports)]
                 use oxc_regular_expression::ast::*;
+                use oxc_syntax::node::NodeId;
 
                 ///@@line_break
                 #[cfg(target_pointer_width = "64")]

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -248,7 +248,7 @@ fn generate_struct_builder_fn(ty: &StructDef, ctx: &LateCtx) -> TokenStream {
     fn default_field(param: &Param) -> TokenStream {
         debug_assert!(param.is_default);
         let ident = &param.ident;
-        // HACK: remove this condition when `node_id`s are added manually
+        // HACK: remove this condition after making types `non_exhaustive`!
         if param.ident == "node_id" {
             quote!(#ident: NodeId::DUMMY)
         } else {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -23,7 +23,7 @@ use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, Generator, GeneratorOutput,
     VisitGenerator, VisitMutGenerator,
 };
-use passes::{CalcLayout, Linker};
+use passes::{CalcLayout, FakeNodeId, Linker};
 use util::{write_all_to, NormalizeError};
 
 static SOURCE_PATHS: &[&str] = &[
@@ -31,6 +31,7 @@ static SOURCE_PATHS: &[&str] = &[
     "crates/oxc_ast/src/ast/js.rs",
     "crates/oxc_ast/src/ast/ts.rs",
     "crates/oxc_ast/src/ast/jsx.rs",
+    "crates/oxc_syntax/src/node.rs",
     "crates/oxc_syntax/src/number.rs",
     "crates/oxc_syntax/src/operator.rs",
     "crates/oxc_span/src/span/types.rs",
@@ -68,6 +69,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .iter()
         .fold(AstCodegen::default(), AstCodegen::add_file)
         .pass(Linker)
+        .pass(FakeNodeId)
         .pass(CalcLayout)
         .derive(DeriveCloneIn)
         .derive(DeriveGetSpan)

--- a/tasks/ast_tools/src/passes/calc_layout.rs
+++ b/tasks/ast_tools/src/passes/calc_layout.rs
@@ -365,5 +365,8 @@ lazy_static! {
         ReferenceFlags: { _ => Layout::known(1, 1, 0), },
         // Unsupported: this is a `bitflags` generated type, we don't expand macros
         RegExpFlags: { _ => Layout::known(1, 1, 0), },
+        // External type
+        // NOTE: It's a wrapper around `NonZeroU32`
+        NonMaxU32: { _ => Layout::of::<std::num::NonZeroU32>(), },
     };
 }

--- a/tasks/ast_tools/src/passes/fake_node_id.rs
+++ b/tasks/ast_tools/src/passes/fake_node_id.rs
@@ -1,0 +1,21 @@
+use super::{define_pass, AstType, Pass};
+use crate::codegen::EarlyCtx;
+use syn::{parse_quote, Fields};
+
+define_pass! {
+    pub struct FakeNodeId;
+}
+
+impl Pass for FakeNodeId {
+    fn each(&mut self, ty: &mut AstType, _: &EarlyCtx) -> crate::Result<bool> {
+        match ty {
+            AstType::Struct(struct_) if struct_.meta.visitable => {
+                if let Fields::Named(fields) = &mut struct_.item.fields {
+                    fields.named.insert(0, parse_quote!(pub node_id: NodeId));
+                }
+            }
+            _ => {}
+        }
+        Ok(true)
+    }
+}

--- a/tasks/ast_tools/src/passes/mod.rs
+++ b/tasks/ast_tools/src/passes/mod.rs
@@ -3,8 +3,10 @@ use std::collections::VecDeque;
 use crate::{codegen::EarlyCtx, rust_ast::AstType, Result};
 
 mod calc_layout;
+mod fake_node_id;
 mod linker;
 pub use calc_layout::CalcLayout;
+pub use fake_node_id::FakeNodeId;
 pub use linker::Linker;
 
 pub trait Pass {


### PR DESCRIPTION
Part of #5689 

A few places are creating these nodes without `AstBuilder`; For now I've assigned them directly but should be taken care of as part of making types `non_exhaustive`.