### PR TITLE
fix(linter): replace bitwise AND (&) with logical AND (&&) in explici…

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -164,7 +164,7 @@ impl Rule for ExplicitFunctionReturnType {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(func) => {
-                if !func.is_declaration() & !func.is_expression() {
+                if !func.is_declaration() && !func.is_expression() {
                     return;
                 }
 


### PR DESCRIPTION
…t_function_return_type rule

This PR fixes an issue where the Bitwise AND (&) operator was mistakenly used in a conditional statement, instead of the Logical AND (&&) operator.