### PR TITLE
feat(prettier): support typescript enums

### DIFF
--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -966,7 +966,55 @@ impl<'a> Format<'a> for TSInterfaceDeclaration<'a> {
 
 impl<'a> Format<'a> for TSEnumDeclaration<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
-        line!()
+        let mut parts = p.vec();
+        if self.declare {
+            parts.push(ss!("declare "));
+        }
+        if self.r#const {
+            parts.push(ss!("const "));
+        }
+        parts.push(ss!("enum "));
+        parts.push(self.id.format(p));
+        parts.push(ss!(" {"));
+        if self.members.len() > 0 {
+            let mut indent_parts = p.vec();
+            for member in &self.members {
+                indent_parts.extend(hardline!());
+                indent_parts.push(member.format(p));
+            }
+            parts.push(Doc::Indent(indent_parts));
+            parts.extend(hardline!());
+        }
+        parts.push(ss!("}"));
+        
+        Doc::Array(parts)
+    }
+}
+
+impl<'a> Format<'a> for TSEnumMember<'a> {
+    fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
+        let mut parts = p.vec();
+        parts.push(self.id.format(p));
+
+        if let Some(initializer) = &self.initializer {
+            parts.push(ss!(" = "));
+            parts.push(initializer.format(p));
+        }
+
+        parts.push(ss!(","));
+        
+        Doc::Array(parts)
+    }
+}
+
+impl<'a> Format<'a> for TSEnumMemberName<'a> {
+    fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
+        match self {
+            TSEnumMemberName::StaticIdentifier(identifier) => identifier.format(p),
+            TSEnumMemberName::StaticStringLiteral(string_literal) => string_literal.format(p),
+            TSEnumMemberName::StaticTemplateLiteral(template_literal) => template_literal.format(p),
+            name => array!(p, ss!("["), name.as_expression().unwrap().format(p), ss!("]"))
+        }
     }
 }
 

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -986,7 +986,7 @@ impl<'a> Format<'a> for TSEnumDeclaration<'a> {
             parts.extend(hardline!());
         }
         parts.push(ss!("}"));
-        
+
         Doc::Array(parts)
     }
 }
@@ -1002,7 +1002,7 @@ impl<'a> Format<'a> for TSEnumMember<'a> {
         }
 
         parts.push(ss!(","));
-        
+
         Doc::Array(parts)
     }
 }
@@ -1013,7 +1013,7 @@ impl<'a> Format<'a> for TSEnumMemberName<'a> {
             TSEnumMemberName::StaticIdentifier(identifier) => identifier.format(p),
             TSEnumMemberName::StaticStringLiteral(string_literal) => string_literal.format(p),
             TSEnumMemberName::StaticTemplateLiteral(template_literal) => template_literal.format(p),
-            name => array!(p, ss!("["), name.as_expression().unwrap().format(p), ss!("]"))
+            name => array!(p, ss!("["), name.as_expression().unwrap().format(p), ss!("]")),
         }
     }
 }

--- a/tasks/prettier_conformance/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 50/526 (9.51%)
+ts compatibility: 55/526 (10.46%)
 
 # Failed
 
@@ -239,12 +239,6 @@ ts compatibility: 50/526 (9.51%)
 * conformance/types/any/anyAsConstructor.ts
 * conformance/types/any/anyAsGenericFunctionCall.ts
 
-### conformance/types/constKeyword
-* conformance/types/constKeyword/constKeyword.ts
-
-### conformance/types/enumDeclaration
-* conformance/types/enumDeclaration/enumDeclaration.ts
-
 ### conformance/types/firstTypeNode
 * conformance/types/firstTypeNode/firstTypeNode.ts
 
@@ -393,7 +387,6 @@ ts compatibility: 50/526 (9.51%)
 ### declare
 * declare/declare-get-set-field.ts
 * declare/declare_class_fields.ts
-* declare/declare_enum.ts
 * declare/declare_function.ts
 * declare/declare_interface.ts
 * declare/declare_module.ts
@@ -441,9 +434,7 @@ ts compatibility: 50/526 (9.51%)
 * end-of-line/multiline.ts
 
 ### enum
-* enum/computed-members.ts
 * enum/enum.ts
-* enum/multiline.ts
 
 ### error-recovery
 * error-recovery/generic.ts


### PR DESCRIPTION
The last failed test is only because of the comments. the oxc prettier output is:

```
enum Direction {
  Up = 1,
  Down,
  Left,
  Right,
}

enum FileAccess {
  None,
  Read = // constant members
  1 << 1,
  Write = 1 << 2,
  ReadWrite = Read | Write,
  G = // computed member
  "123".length,
}

enum Empty {}

const enum Enum {
  A = 1,
  B = A * 2,
}
```
Expected output: https://github.com/prettier/prettier/blob/aa3853b7765645b3f3d8a76e41cf6d70b93c01fd/tests/format/typescript/enum/__snapshots__/format.test.js.snap#L91-L99

Hope you can tell more why this happens :) 