### PR TITLE
refactor(ast): import `syn` types in `ast` macro

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use syn::{parse_macro_input, Item};
 
 mod ast;
 
@@ -69,7 +70,7 @@ mod ast;
 /// 2. `tsify`
 #[proc_macro_attribute]
 pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as syn::Item);
+    let input = parse_macro_input!(input as Item);
     let expanded = ast::ast(&input);
     TokenStream::from(expanded)
 }


### PR DESCRIPTION
Pure refactor. Import `syn` types with a use statement. This allows shortening the rest of the code, which, in my opinion, makes it easier to read.