### PR TITLE
[RFC] feat(linter): support persisted rule state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1646,7 @@ dependencies = [
  "markdown",
  "memchr",
  "mime_guess",
+ "nohash-hasher",
  "once_cell",
  "oxc_allocator",
  "oxc_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ memoffset = "0.9.1"
 miette = { version = "7.2.0", features = ["fancy-no-syscall"] }
 mimalloc = "0.1.43"
 mime_guess = "2.0.5"
+nohash-hasher = "0.2.0"
 nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -45,6 +45,7 @@ language-tags = { workspace = true }
 lazy_static = { workspace = true }
 memchr = { workspace = true }
 mime_guess = { workspace = true }
+nohash-hasher = { workspace = true }
 once_cell = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }

--- a/crates/oxc_linter/src/context/rule_state.rs
+++ b/crates/oxc_linter/src/context/rule_state.rs
@@ -1,0 +1,40 @@
+use std::{
+    any::Any,
+    cell::{RefCell, RefMut},
+};
+
+use nohash_hasher::IntMap;
+
+use crate::{rules::RuleEnum, RuleMeta};
+
+#[must_use]
+pub struct RuleState {
+    inner: IntMap</* RuleId */ usize, Box<RefCell<dyn Any>>>,
+}
+
+impl RuleState {
+    pub fn new<I, R>(rules: I) -> Self
+    where
+        R: AsRef<RuleEnum>,
+        I: IntoIterator<Item = R>,
+    {
+        let inner = rules
+            .into_iter()
+            .map(|rule| {
+                let rule = rule.as_ref();
+                (rule.id(), rule.new_state())
+            })
+            .collect();
+        Self { inner }
+    }
+
+    pub fn get_raw_mut(&self, rule_id: usize) -> RefMut<'_, dyn Any> {
+        self.inner[&rule_id].borrow_mut()
+    }
+
+    pub fn get_mut<R: RuleMeta + 'static>(&self, rule_id: usize) -> RefMut<'_, R::State> {
+        RefMut::map(self.get_raw_mut(rule_id), |state| {
+            state.downcast_mut().expect("downcast failed")
+        })
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -115,8 +115,9 @@ impl Linter {
     }
 
     pub fn run<'a>(&self, path: &Path, semantic: Rc<Semantic<'a>>) -> Vec<Message<'a>> {
-        let ctx_host =
-            Rc::new(ContextHost::new(path, semantic, self.options).with_config(&self.config));
+        let ctx_host = Rc::new(
+            ContextHost::new(path, semantic, self.options, &self.rules).with_config(&self.config),
+        );
 
         let rules = self
             .rules

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -55,6 +55,13 @@ pub trait RuleMeta {
     /// What kind of auto-fixing can this rule do?
     const FIX: RuleFixMeta = RuleFixMeta::None;
 
+    /// Data stored between each call to [run](`Rule::run`),
+    /// [run_on_symbol](`Rule::run_on_symbol`), and
+    /// [run_once](`Rule::run_once`). State is reset between files.
+    ///
+    /// By default, this is the unit type (aka `()`).
+    type State: Default + 'static;
+
     fn documentation() -> Option<&'static str> {
         None
     }
@@ -257,6 +264,12 @@ impl Deref for RuleWithSeverity {
     type Target = RuleEnum;
 
     fn deref(&self) -> &Self::Target {
+        &self.rule
+    }
+}
+
+impl AsRef<RuleEnum> for RuleWithSeverity {
+    fn as_ref(&self) -> &RuleEnum {
         &self.rule
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
     /// ```
     JsxBooleanValue,
     style,
-    fix,
+    fix
 );
 
 impl Rule for JsxBooleanValue {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
     /// ```
     PreferStructuredClone,
     style,
-    pending,
+    pending
 );
 
 impl Rule for PreferStructuredClone {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -321,8 +321,13 @@ mod test {
         let semantic_ret = Rc::new(semantic_ret);
 
         let build_ctx = |path: &'static str| {
-            Rc::new(ContextHost::new(path, Rc::clone(&semantic_ret), LintOptions::default()))
-                .spawn_for_test()
+            Rc::new(ContextHost::new(
+                path,
+                Rc::clone(&semantic_ret),
+                LintOptions::default(),
+                &vec![],
+            ))
+            .spawn_for_test()
         };
 
         let ctx = build_ctx("foo.js");

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -139,6 +139,12 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                     #(Self::#struct_names(rule) => rule.should_run(ctx)),*
                 }
             }
+
+            pub(crate) fn new_state(&self) -> Box<std::cell::RefCell<dyn std::any::Any>> {
+                match self {
+                    #(Self::#struct_names(_) => Box::new(std::cell::RefCell::new(<#struct_names as RuleMeta>::State::default()))),*
+                }
+            }
         }
 
         impl std::hash::Hash for RuleEnum {


### PR DESCRIPTION
Provides a way for rules to maintain state across invocations of `run`, `run_on_symbol`, and `run_once` without forcing those functions to take `&mut self`.

### Note
I really do not like this approach. It's way too loose w.r.t Rust's type checker, and solutions requiring `Any` are red flags to me. I'd much prefer rules to create state ad-hoc inside of `run_once` and then iterate over nodes themselves.

I also didn't test this code at all. For now, this PR is meant to be a conversation starter.