### PR TITLE
refactor(parser): remove dead code warning when running tests

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -138,7 +138,7 @@ impl<'a> Lexer<'a> {
         source_text: &'a str,
         source_type: SourceType,
     ) -> Self {
-        let unique = UniquePromise::new_for_tests();
+        let unique = UniquePromise::new_for_benchmarks();
         Self::new(allocator, source_text, source_type, unique)
     }
 

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -176,7 +176,7 @@ mod parser_parse {
     ///
     /// `UniquePromise` is a zero-sized type and has no runtime cost. It's purely for the type-checker.
     ///
-    /// `UniquePromise::new_for_tests` is a backdoor for unit tests and benchmarks, so they can create a
+    /// `UniquePromise::new_for_benchmarks` is a backdoor for benchmarks, so they can create a
     /// `ParserImpl` or `Lexer`, and manipulate it directly, for testing/benchmarking purposes.
     pub(crate) struct UniquePromise {
         _dummy: (),
@@ -191,8 +191,8 @@ mod parser_parse {
         /// Backdoor for tests/benchmarks to create a `UniquePromise` (see above).
         /// This function must NOT be exposed outside of tests and benchmarks,
         /// as it allows circumventing safety invariants of the parser.
-        #[cfg(any(test, feature = "benchmarking"))]
-        pub fn new_for_tests() -> Self {
+        #[cfg(feature = "benchmarking")]
+        pub fn new_for_benchmarks() -> Self {
             Self { _dummy: () }
         }
     }


### PR DESCRIPTION
`UniquePromise::new_for_tests` is not used in tests, so produces a dead code warning when running tests. Prevent that.

Also, rename it to `new_for_benchmarks`, since that's where it's used.