### PR TITLE
perf(linter): make all rules share a diagnostics vec

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -1,7 +1,7 @@
 #![allow(rustdoc::private_intra_doc_links)] // useful for intellisense
 mod host;
 
-use std::{cell::RefCell, path::Path, rc::Rc};
+use std::{path::Path, rc::Rc};
 
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
@@ -18,18 +18,13 @@ use crate::{
     AllowWarnDeny, FrameworkFlags, OxlintEnv, OxlintGlobals, OxlintSettings,
 };
 
-pub use host::ContextHost;
+pub(crate) use host::ContextHost;
 
 #[derive(Clone)]
 #[must_use]
 pub struct LintContext<'a> {
     /// Shared context independent of the rule being linted.
     parent: Rc<ContextHost<'a>>,
-
-    /// Diagnostics reported by the linter.
-    ///
-    /// Contains diagnostics for all rules across all files.
-    diagnostics: RefCell<Vec<Message<'a>>>,
 
     // states
     current_plugin_name: &'static str,
@@ -158,10 +153,6 @@ impl<'a> LintContext<'a> {
 
     /* Diagnostics */
 
-    pub fn into_message(self) -> Vec<Message<'a>> {
-        self.diagnostics.into_inner()
-    }
-
     fn add_diagnostic(&self, mut message: Message<'a>) {
         if self.parent.disable_directives.contains(self.current_rule_name, message.span()) {
             return;
@@ -179,7 +170,7 @@ impl<'a> LintContext<'a> {
             message.error = message.error.with_severity(self.severity);
         }
 
-        self.diagnostics.borrow_mut().push(message);
+        self.parent.push_diagnostic(message);
     }
 
     /// Report a lint rule violation.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -142,7 +142,7 @@ impl Linter {
             }
         }
 
-        rules.into_iter().flat_map(|(_, ctx)| ctx.into_message()).collect::<Vec<_>>()
+        ctx_host.take_diagnostics()
     }
 
     /// # Panics


### PR DESCRIPTION
## What This PR Does

Each time a lint rule is run on a file, it will now store diagnostics in a
shared vec instead of having its own list. This is done by moving `diagnostics`
from `LintContext` to `ContextHost`.

The motivating line of code can be found in `Linter::run` in
`oxc_linter/src/lib.rs#145`

```rust
rules.into_iter().flat_map(|(_, ctx)| ctx.into_message()).collect::<Vec<_>>()
```

Each `LintContext` allocates a new vec, and pushes diagnostics into it. After
all run-related methods have been run, a new vec is created and those
diagnostics are copied into it. This is `O(n+1)` allocations and `O(n)` copies,
not to mention that allocations for the original vecs cannot be re-used since
those vecs aren't dropped until after the new one is created.