### PR TITLE
fix(linter): improve diagnostic messages for various lint rules

### DIFF
--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -10,9 +10,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_exports_assign(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow the assignment to `exports`.")
+    OxcDiagnostic::warn("Unexpected assignment to 'exports'.")
         .with_label(span)
-        .with_help("Unexpected assignment to 'exports' variable. Use 'module.exports' instead.")
+        .with_help("Use 'module.exports' instead.")
 }
 
 fn is_exports(node: &AssignmentTarget, ctx: &LintContext) -> bool {
@@ -40,12 +40,18 @@ pub struct NoExportsAssign;
 
 declare_oxc_lint!(
     /// ### What it does
-    ///
-    /// This rule is aimed at disallowing `exports = {}`, but allows `module.exports = exports = {}` to avoid conflict with `n/exports-style` rule's `allowBatchAssign` option.
+    /// Disallows assignment to `exports`.
     ///
     /// ### Why is this bad?
     ///
-    /// Directly using `exports = {}` can lead to confusion and potential bugs because it reassigns the `exports` object, which may break module exports. It is more predictable and clearer to use `module.exports` directly or in conjunction with `exports`.
+    /// Directly using `exports = {}` can lead to confusion and potential bugs
+    /// because it reassigns the `exports` object, which may break module
+    /// exports. It is more predictable and clearer to use `module.exports`
+    /// directly or in conjunction with `exports`.
+    ///
+    /// This rule is aimed at disallowing `exports = {}`, but allows
+    /// `module.exports = exports = {}` to avoid conflict with `n/exports-style`
+    /// rule's `allowBatchAssign` option.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -6,7 +6,10 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
 
 fn static_promise_diagnostic(static_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{static_name}`"))
+    OxcDiagnostic::warn(format!("Do not use `new` on `Promise.{static_name}`"))
+        .with_help(format!(
+            "`Promise.{static_name}` is not a constructor. Call it as a function instead."
+        ))
         .with_label(span)
 }
 
@@ -16,15 +19,23 @@ pub struct NoNewStatics;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow calling new on a Promise static method.
+    /// Disallows calling new on static `Promise` methods.
     ///
     /// ### Why is this bad?
     ///
-    /// Calling a Promise static method with new is invalid, resulting in a TypeError at runtime.
+    /// Calling a static `Promise` method with `new` is invalid and will result
+    /// in a `TypeError` at runtime.
     ///
     /// ### Example
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// new Promise.resolve(value);
+    /// const x = new Promise.resolve(value);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const x = Promise.resolve(value);
     /// ```
     NoNewStatics,
     correctness,

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -13,9 +13,7 @@ use crate::{
 };
 
 fn jsx_no_undef_diagnostic(ident_name: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow undeclared variables in JSX")
-        .with_help(format!("'{ident_name}' is not defined."))
-        .with_label(span1)
+    OxcDiagnostic::warn(format!("'{ident_name}' is not defined.")).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -19,11 +19,9 @@ use crate::{
 
 fn void_dom_elements_no_children_diagnostic(tag: &str, span: Span) -> OxcDiagnostic {
     // TODO: use imperative phrasing
-    OxcDiagnostic::warn(
-        "Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.",
-    )
-    .with_help(format!("Void DOM element <{tag:?} /> cannot receive children."))
-    .with_label(span)
+    OxcDiagnostic::warn(format!("Void DOM element <{tag:?} /> cannot receive children."))
+        .with_help("Remove this element's children or use a non-void element.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -31,6 +29,9 @@ pub struct VoidDomElementsNoChildren;
 
 declare_oxc_lint!(
     /// ### What it does
+    /// Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+    ///
+    /// ### Why is this bad?
     /// There are some HTML elements that are only self-closing (e.g. img, br, hr). These are collectively known as void DOM elements.
     /// This rule checks that children are not passed to void DOM elements.
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -28,9 +28,7 @@ declare_oxc_lint!(
 );
 
 fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
-        .with_help("Disallow using the `delete` operator on computed key expressions")
-        .with_label(span)
+    OxcDiagnostic::warn("Do not delete dynamically computed property keys.").with_label(span)
 }
 
 impl Rule for NoDynamicDelete {

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_empty_export_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow empty exports that don't change anything in a module file")
-        .with_help("Empty export does nothing and can be removed.")
+    OxcDiagnostic::warn("Empty exports do nothing in module files")
+        .with_help("Remove this empty export.")
         .with_label(span)
 }
 
@@ -19,19 +19,35 @@ declare_oxc_lint!(
     ///
     /// Disallow empty exports that don't change anything in a module file.
     ///
+    /// ## Why is this bad?
+    /// An empty `export {}` statement is sometimes useful in TypeScript code to
+    /// turn a file that would otherwise be a script file into a module file.
+    /// Per the [TypeScript Handbook Modules page](https://www.typescriptlang.org/docs/handbook/modules/introduction.html):
+    ///
+    /// In TypeScript, just as in ECMAScript 2015, any file containing a
+    /// top-level import or export is considered a module. Conversely, a file
+    /// without any top-level import or export declarations is treated as a
+    /// script whose contents are available in the global scope (and therefore
+    /// to modules as well).
+    ///
+    /// However, an `export {}` statement does nothing if there are any other
+    /// top-level import or export statements in a file.
+    ///
+    /// This rule reports an `export {}` that doesn't do anything in a file
+    /// already using ES modules.
+    ///
     /// ### Example
     ///
-    /// ### Bad
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// export const value = 'Hello, world!';
     /// export {};
     /// ```
     ///
-    /// ### Good
+    /// Examples of **correct** code for this rule:
     /// ```ts
     /// export const value = 'Hello, world!';
     /// ```
-    ///
     NoUselessEmptyExport,
     correctness,
     fix

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -11,8 +11,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_anonymous_default_export_diagnostic(span: Span, kind: ErrorNodeKind) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow anonymous functions and classes as the default export")
-        .with_help(format!("The {kind} should be named."))
+    OxcDiagnostic::warn(format!("This {kind} default export is missing a name"))
+        // TODO: suggest a name. https://github.com/sindresorhus/eslint-plugin-unicorn/blob/d3e4b805da31c6ed7275e2e2e770b6b0fbcf11c2/rules/no-anonymous-default-export.js#L41
         .with_label(span)
 }
 
@@ -24,7 +24,9 @@ declare_oxc_lint!(
     /// Disallow anonymous functions and classes as the default export
     ///
     /// ### Why is this bad?
-    /// Naming default exports improves codebase searchability by ensuring consistent identifier use for a module's default export, both where it's declared and where it's imported.
+    /// Naming default exports improves codebase searchability by ensuring
+    /// consistent identifier use for a module's default export, both where it's
+    /// declared and where it's imported.
     ///
     /// ### Example
     ///

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -6,8 +6,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_await_expression_member_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow member access from await expression")
-        .with_help("When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.")
+    OxcDiagnostic::warn("Do not access a member directly from an await expression.")
+        .with_help("Assign the result of the await expression to a variable, then access the member from that variable.")
         .with_label(span)
 }
 
@@ -17,12 +17,12 @@ pub struct NoAwaitExpressionMember;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule disallows member access from await expression
+    /// Disallows member access from `await` expressions.
     ///
     /// ### Why is this bad?
     ///
-    /// When accessing a member from an await expression,
-    /// the await expression has to be parenthesized, which is not readable.
+    /// When accessing a member from an `await` expression,
+    /// the `await` expression has to be parenthesized, which is not readable.
     ///
     /// ### Example
     /// ```javascript
@@ -35,7 +35,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAwaitExpressionMember,
-    style
+    style,
+    pending
 );
 
 impl Rule for NoAwaitExpressionMember {

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_static_only_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow classes that only have static members.")
-        .with_help("A class with only static members could just be an object instead.")
+    OxcDiagnostic::warn("Use an object instead of a class with only static members.")
         .with_label(span)
 }
 
@@ -22,7 +21,6 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// A class with only static members could just be an object instead.
-    ///
     ///
     /// ### Example
     ///
@@ -41,8 +39,21 @@ declare_oxc_lint!(
     ///     constructor() {}
     /// }
     /// ```
+    /// ```javascript
+    /// const X = {
+    ///     foo: false,
+    ///     bar() {}
+    /// };
+    /// ```
+    /// ```javascript
+    /// class X {
+    ///     static #foo = false; // private field
+    ///     static bar() {}
+    /// }
+    /// ```
     NoStaticOnlyClass,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoStaticOnlyClass {

--- a/crates/oxc_linter/src/snapshots/jsx_no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_no_undef.snap
@@ -1,58 +1,50 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<App />);
    ·                          ───
    ╰────
-  help: 'App' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'Appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Appp.Foo />);
    ·                          ────
    ╰────
-  help: 'Appp' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.Foo />);
    ·                          ────
    ╰────
-  help: 'appp' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.foo.Bar />);
    ·                          ────
    ╰────
-  help: 'appp' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'Foo' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Foo />);
    ·                          ───
    ╰────
-  help: 'Foo' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'Unknown' is not defined.
    ╭─[jsx_no_undef.tsx:1:35]
  1 │ var React; Unknown; React.render(<Unknown />)
    ·                                   ───────
    ╰────
-  help: 'Unknown' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:49]
  1 │ var React; { const App = null; }; React.render(<App />);
    ·                                                 ───
    ╰────
-  help: 'App' is not defined.
 
-  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+  ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:42]
  1 │ var React; enum A { App }; React.render(<App />);
    ·                                          ───
    ╰────
-  help: 'App' is not defined.

--- a/crates/oxc_linter/src/snapshots/jsx_props_no_spread_multi.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_props_no_spread_multi.snap
@@ -1,47 +1,47 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same identifier multiple times.
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Prop 'props' is spread multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};
  3 │           <App {...props} {...props} />
    ·                ────────── ──────────
  4 │         
    ╰────
-  help: Prop 'props' is spread multiple times.
+  help: Remove all but one spread.
 
-  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same member expression multiple times.
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): 'props.foo' is spread multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};
  3 │           <App {...props.foo} {...props.foo} />
    ·                ────────────── ──────────────
  4 │         
    ╰────
-  help: Remove the first spread.
+  help: Remove all but one spread.
 
-  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same member expression multiple times.
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): '(props.foo).baz' is spread multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};
  3 │           <App {...(props.foo).baz} {...(props.foo.baz)} />
    ·                ──────────────────── ────────────────────
  4 │         
    ╰────
-  help: Remove the first spread.
+  help: Remove all but one spread.
 
-  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same identifier multiple times.
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Prop 'props' is spread multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};
  3 │           <div {...props} a="a" {...props} />
    ·                ──────────       ──────────
  4 │         
    ╰────
-  help: Prop 'props' is spread multiple times.
+  help: Remove all but one spread.
 
-  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same identifier multiple times.
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Prop 'props' is spread multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};
  3 │           <div {...props} {...props} {...props} />
    ·                ────────── ────────── ──────────
  4 │         
    ╰────
-  help: Prop 'props' is spread multiple times.
+  help: Remove all but one spread.

--- a/crates/oxc_linter/src/snapshots/no_anonymous_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/no_anonymous_default_export.snap
@@ -1,58 +1,50 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default class {}
    · ───────────────────────
    ╰────
-  help: The class should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default function () {}
    · ─────────────────────────────
    ╰────
-  help: The function should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default () => {};
    · ────────────────────────
    ╰────
-  help: The function should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ module.exports = class {}
    · ─────────────────────────
    ╰────
-  help: The class should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ module.exports = function () {}
    · ───────────────────────────────
    ╰────
-  help: The function should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ module.exports = () => {}
    · ─────────────────────────
    ╰────
-  help: The function should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:17]
  1 │ export default (async function * () {})
    ·                 ──────────────────────
    ╰────
-  help: The function should be named.
 
-  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export
+  ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:17]
  1 │ export default (class extends class {} {})
    ·                 ─────────────────────────
    ╰────
-  help: The class should be named.

--- a/crates/oxc_linter/src/snapshots/no_await_expression_member.snap
+++ b/crates/oxc_linter/src/snapshots/no_await_expression_member.snap
@@ -1,177 +1,177 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:1]
  1 │ (await promise)[0]
    · ──────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:1]
  1 │ (await promise).property
    · ────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:13]
  1 │ const foo = (await promise).bar()
    ·             ───────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:13]
  1 │ const foo = (await promise).bar?.()
    ·             ───────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:13]
  1 │ const foo = (await promise)?.bar()
    ·             ────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:22]
  1 │ const firstElement = (await getArray())[0]
    ·                      ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:23]
  1 │ const secondElement = (await getArray())[1]
    ·                       ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:22]
  1 │ const thirdElement = (await getArray())[2]
    ·                      ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:30]
  1 │ const optionalFirstElement = (await getArray())?.[0]
    ·                              ───────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:34]
  1 │ const {propertyOfFirstElement} = (await getArray())[0]
    ·                                  ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:38]
  1 │ const [firstElementOfFirstElement] = (await getArray())[0]
    ·                                      ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:25]
  1 │ let foo, firstElement = (await getArray())[0]
    ·                         ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:20]
  1 │ var firstElement = (await getArray())[0], bar
    ·                    ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:18]
  1 │ const property = (await getObject()).property
    ·                  ────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:17]
  1 │ const renamed = (await getObject()).property
    ·                 ────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:18]
  1 │ const property = (await getObject())[property]
    ·                  ─────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:18]
  1 │ const property = (await getObject())?.property
    ·                  ─────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:30]
  1 │ const {propertyOfProperty} = (await getObject()).property
    ·                              ────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:30]
  1 │ const {propertyOfProperty} = (await getObject()).propertyOfProperty
    ·                              ──────────────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:34]
  1 │ const [firstElementOfProperty] = (await getObject()).property
    ·                                  ────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:34]
  1 │ const [firstElementOfProperty] = (await getObject()).firstElementOfProperty
    ·                                  ──────────────────────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:16]
  1 │ firstElement = (await getArray())[0]
    ·                ─────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:12]
  1 │ property = (await getArray()).property
    ·            ───────────────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:19]
  1 │ const foo: Type = (await promise)[0]
    ·                   ──────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.
 
-  ⚠ eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression
+  ⚠ eslint-plugin-unicorn(no-await-expression-member): Do not access a member directly from an await expression.
    ╭─[no_await_expression_member.tsx:1:23]
  1 │ const foo: Type | A = (await promise).foo
    ·                       ───────────────────
    ╰────
-  help: When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.
+  help: Assign the result of the await expression to a variable, then access the member from that variable.

--- a/crates/oxc_linter/src/snapshots/no_dynamic_delete.snap
+++ b/crates/oxc_linter/src/snapshots/no_dynamic_delete.snap
@@ -8,7 +8,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -17,7 +16,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -26,7 +24,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -35,7 +32,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -44,7 +40,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -53,7 +48,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────
  5 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -62,7 +56,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  5 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -71,7 +64,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────
  5 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -80,7 +72,6 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -89,4 +80,3 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────
  4 │                   
    ╰────
-  help: Disallow using the `delete` operator on computed key expressions

--- a/crates/oxc_linter/src/snapshots/no_exports_assign.snap
+++ b/crates/oxc_linter/src/snapshots/no_exports_assign.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-node(no-exports-assign): Disallow the assignment to `exports`.
+  ⚠ eslint-plugin-node(no-exports-assign): Unexpected assignment to 'exports'.
    ╭─[no_exports_assign.tsx:1:1]
  1 │ exports = {}
    · ───────
    ╰────
-  help: Unexpected assignment to 'exports' variable. Use 'module.exports' instead.
+  help: Use 'module.exports' instead.

--- a/crates/oxc_linter/src/snapshots/no_new_statics.snap
+++ b/crates/oxc_linter/src/snapshots/no_new_statics.snap
@@ -1,53 +1,53 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.resolve`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.resolve`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.resolve()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.resolve` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.reject`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.reject`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.reject()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.reject` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.all`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.all`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.all()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.all` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.allSettled`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.allSettled`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.allSettled()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.allSettled` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.any`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.any`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.any()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.any` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.race`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.race`
    ╭─[no_new_statics.tsx:1:1]
  1 │ new Promise.race()
    · ───
    ╰────
-  help: Delete this code.
+  help: `Promise.race` is not a constructor. Call it as a function instead.
 
-  ⚠ eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.resolve`
+  ⚠ eslint-plugin-promise(no-new-statics): Do not use `new` on `Promise.resolve`
    ╭─[no_new_statics.tsx:3:13]
  2 │               var a = getA()
  3 │               return new Promise.resolve(a)
    ·                      ───
  4 │             }
    ╰────
-  help: Delete this code.
+  help: `Promise.resolve` is not a constructor. Call it as a function instead.

--- a/crates/oxc_linter/src/snapshots/no_static_only_class.snap
+++ b/crates/oxc_linter/src/snapshots/no_static_only_class.snap
@@ -1,72 +1,62 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static a() {}; }
    · ──────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static a() {} }
    · ─────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:11]
  1 │ const A = class A { static a() {}; }
    ·           ──────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:11]
  1 │ const A = class { static a() {}; }
    ·           ────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static constructor() {}; }
    · ────────────────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:16]
  1 │ export default class A { static a() {}; }
    ·                ──────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:16]
  1 │ export default class { static a() {}; }
    ·                ────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:8]
  1 │ export class A { static a() {}; }
    ·        ──────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A {static [this.a] = 1}
    · ─────────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.
 
-  ⚠ eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.
+  ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a class with only static members.
    ╭─[no_static_only_class.tsx:1:1]
  1 │ class A { static a() {} }
    · ─────────────────────────
    ╰────
-  help: A class with only static members could just be an object instead.

--- a/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
@@ -1,56 +1,56 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:3:13]
  2 │             export const _ = {};
  3 │             export {};
    ·             ──────────
  4 │         
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.
 
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:3:13]
  2 │             export * from '_';
  3 │             export {};
    ·             ──────────
  4 │         
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.
 
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:2:13]
  1 │ 
  2 │             export {};
    ·             ──────────
  3 │             export * from '_';
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.
 
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:4:13]
  3 │             export default _;
  4 │             export {};
    ·             ──────────
  5 │         
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.
 
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:2:13]
  1 │ 
  2 │             export {};
    ·             ──────────
  3 │             const _ = {};
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.
 
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+  ⚠ typescript-eslint(no-useless-empty-export): Empty exports do nothing in module files
    ╭─[no_useless_empty_export.tsx:4:13]
  3 │             export { _ };
  4 │             export {};
    ·             ──────────
  5 │         
    ╰────
-  help: Empty export does nothing and can be removed.
+  help: Remove this empty export.

--- a/crates/oxc_linter/src/snapshots/void_dom_elements_no_children.snap
+++ b/crates/oxc_linter/src/snapshots/void_dom_elements_no_children.snap
@@ -1,78 +1,78 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:2]
  1 │ <br>Foo</br>;
    ·  ──
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:2]
  1 │ <br children='Foo' />;
    ·  ──
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"img" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:2]
  1 │ <img {...props} children='Foo' />;
    ·  ───
    ╰────
-  help: Void DOM element <"img" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:2]
  1 │ <br dangerouslySetInnerHTML={{ __html: 'Foo' }} />;
    ·  ──
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:21]
  1 │ React.createElement('br', {}, 'Foo');
    ·                     ────
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:21]
  1 │ React.createElement('br', { children: 'Foo' });
    ·                     ────
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"br" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:1:21]
  1 │ React.createElement('br', { dangerouslySetInnerHTML: { __html: 'Foo' } });
    ·                     ────
    ╰────
-  help: Void DOM element <"br" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"img" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:3:31]
  2 │                 import React, {createElement} from 'react';
  3 │                 createElement('img', {}, 'Foo');
    ·                               ─────
  4 │             
    ╰────
-  help: Void DOM element <"img" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"img" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:3:31]
  2 │                 import React, {createElement} from 'react';
  3 │                 createElement('img', { children: 'Foo' });
    ·                               ─────
  4 │             
    ╰────
-  help: Void DOM element <"img" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.
 
-  ⚠ eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.
+  ⚠ eslint-plugin-react(void-dom-elements-no-children): Void DOM element <"img" /> cannot receive children.
    ╭─[void_dom_elements_no_children.tsx:3:31]
  2 │                 import React, {createElement} from 'react';
  3 │                 createElement('img', { dangerouslySetInnerHTML: { __html: 'Foo' } });
    ·                               ─────
  4 │             
    ╰────
-  help: Void DOM element <"img" /> cannot receive children.
+  help: Remove this element's children or use a non-void element.


### PR DESCRIPTION
This is the first of a few PRs to remove "Disallow <x>" from all diagnostic
messages. More to come.