### PR TITLE
fix(linter): remove all* remaining "Disallow <foo>" messages

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow `Array` constructors")
-        .with_help("Use array literal instead")
+    OxcDiagnostic::warn("Do not use `new` to create arrays")
+        .with_help("Use an array literal instead")
         .with_label(span)
 }
 
@@ -16,19 +16,33 @@ pub struct NoArrayConstructor;
 
 declare_oxc_lint!(
     /// ### What it does
-    /// Disallow array constructor
+    /// Disallows creating arrays with the `Array` constructor.
     ///
     /// ### Why is this bad?
     ///
-    /// Use of the Array constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the Array global may be redefined.
-    /// The exception is when the Array constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument.
+    /// Use of the `Array` constructor to construct a new array is generally
+    /// discouraged in favor of array literal notation because of the
+    /// single-argument pitfall and because the `Array` global may be redefined.
+    /// The exception is when the `Array` constructor is used to intentionally
+    /// create sparse arrays of a specified size by giving the constructor a
+    /// single numeric argument.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// let arr = new Array();
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// let arr = [];
+    /// let arr2 = Array.from(iterable);
+    /// let arr3 = new Array(9);
+    /// ```
     NoArrayConstructor,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoArrayConstructor {

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_caller_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow the use of arguments.caller or arguments.callee")
-        .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
+fn no_caller_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not use `arguments.{method_name}`"))
+        .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.")
         .with_label(span)
 }
 
@@ -79,7 +79,7 @@ impl Rule for NoCaller {
             if (expr.property.name == "callee" || expr.property.name == "caller")
                 && expr.object.is_specific_id("arguments")
             {
-                ctx.diagnostic(no_caller_diagnostic(expr.property.span));
+                ctx.diagnostic(no_caller_diagnostic(expr.property.span, &expr.property.name));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -6,9 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_diagnostic(stmt_kind: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow empty block statements")
-        .with_help(format!("Add comment inside empty {stmt_kind} statement"))
-        .with_label(span.label(format!("Empty {stmt_kind} statement")))
+    OxcDiagnostic::warn("Unexpected empty block statements")
+        .with_help(format!("Remove this {stmt_kind} or add a comment inside it"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -1,13 +1,26 @@
-use oxc_ast::AstKind;
+use std::borrow::Cow;
+
+use oxc_ast::{
+    ast::{IdentifierName, IdentifierReference, MethodDefinitionKind},
+    AstKind,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_function_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow empty functions")
-        .with_help("Unexpected empty function block")
+fn no_empty_function_diagnostic<S: AsRef<str>>(
+    span: Span,
+    fn_kind: &str,
+    fn_name: Option<S>,
+) -> OxcDiagnostic {
+    let message = match fn_name {
+        Some(name) => Cow::Owned(format!("Unexpected empty {fn_kind} `{}`", name.as_ref())),
+        None => Cow::Borrowed("Unexpected empty function"),
+    };
+    OxcDiagnostic::warn(message)
+        .with_help(format!("Consider removing this {fn_kind} or adding logic to it."))
         .with_label(span)
 }
 
@@ -23,13 +36,25 @@ declare_oxc_lint!(
     /// intentional or not. So writing a clear comment for empty functions is a good practice.
     ///
     /// ### Example
-    /// ```javascript
     ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
     /// function foo() {
     /// }
     ///
     /// const bar = () => {};
+    /// ```
     ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// function foo() {
+    ///     // do nothing
+    /// }
+    ///
+    /// function foo() {
+    ///     return;
+    /// }
+    /// const add = (a, b) => a + b
     /// ```
     NoEmptyFunction,
     restriction,
@@ -37,12 +62,64 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyFunction {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::FunctionBody(fb) = node.kind() {
-            if fb.is_empty() && !ctx.semantic().trivias().has_comments_between(fb.span) {
-                ctx.diagnostic(no_empty_function_diagnostic(fb.span));
-            }
+        let AstKind::FunctionBody(fb) = node.kind() else {
+            return;
+        };
+        if fb.is_empty() && !ctx.semantic().trivias().has_comments_between(fb.span) {
+            let (kind, fn_name) = get_function_name_and_kind(node, ctx);
+            ctx.diagnostic(no_empty_function_diagnostic(fb.span, kind, fn_name));
         }
     }
+}
+
+fn get_function_name_and_kind<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> (&'static str, Option<Cow<'a, str>>) {
+    for parent in ctx.nodes().iter_parents(node.id()).skip(1).map(AstNode::kind) {
+        match parent {
+            AstKind::Function(f) => {
+                if let Some(name) = f.name() {
+                    let kind = if f.generator { "generator function" } else { "function" };
+                    return (kind, Some(name.into()));
+                }
+                continue;
+            }
+            AstKind::ArrowFunctionExpression(_) => {
+                continue;
+            }
+            AstKind::IdentifierName(IdentifierName { name, .. })
+            | AstKind::IdentifierReference(IdentifierReference { name, .. }) => {
+                return ("function", Some(Cow::Borrowed(name.as_str())));
+            }
+            AstKind::PropertyDefinition(prop) => {
+                return ("function", prop.key.name());
+            }
+            AstKind::MethodDefinition(method) => {
+                let kind = match method.kind {
+                    MethodDefinitionKind::Method => {
+                        if method.r#static {
+                            "static method"
+                        } else {
+                            "method"
+                        }
+                    }
+                    MethodDefinitionKind::Get => "getter",
+                    MethodDefinitionKind::Set => "setter",
+                    MethodDefinitionKind::Constructor => "constructor",
+                };
+                return (kind, method.key.name());
+            }
+            AstKind::VariableDeclarator(decl) => {
+                return ("function", decl.id.get_identifier().map(Into::into));
+            }
+            _ => return ("function", None),
+        }
+    }
+    #[cfg(debug_assertions)]
+    unreachable!();
+    #[cfg(not(debug_assertions))]
+    ("function", None)
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_pattern_diagnostic(pattern_type: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow empty destructuring patterns.")
+    OxcDiagnostic::warn(format!("Empty {pattern_type} binding pattern"))
         .with_help("Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.")
-        .with_label(
-            span.label(format!("Empty {pattern_type} binding pattern")),
-        )
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_static_block_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow empty static blocks")
-        .with_help("Unexpected empty static block.")
+    OxcDiagnostic::warn("Unexpected empty static blocks")
+        .with_help("Remove this empty block or add content to it.")
         .with_label(span)
 }
 
@@ -47,7 +47,8 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoEmptyStaticBlock,
-    correctness
+    correctness,
+    pending // TODO: add a safe suggestion
 );
 
 impl Rule for NoEmptyStaticBlock {

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_iterator_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Reserved name '__iterator__'")
-        .with_help("Disallow the use of the `__iterator__` property.")
+        .with_help("Consider using [Symbol.iterator] instead")
         .with_label(span)
 }
 
@@ -53,7 +53,8 @@ declare_oxc_lint!(
     /// };
     /// ```
     NoIterator,
-    restriction
+    restriction,
+    pending // TODO: suggestion
 );
 
 impl Rule for NoIterator {

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -6,10 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_wrappers_diagnostic(builtin_name: &str, new_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow new operators with the String, Number, and Boolean objects")
-        .with_help(format!(
-            "do not use {builtin_name} as a constructor, consider removing the new operator."
-        ))
+    OxcDiagnostic::warn(format!("Do not use `{builtin_name}` as a constructor"))
+        .with_help("Remove the `new` operator.")
         .with_label(new_span)
 }
 
@@ -48,7 +46,8 @@ declare_oxc_lint!(
     /// var booleanObject = Boolean(value);
     /// ```
     NoNewWrappers,
-    pedantic
+    pedantic,
+    pending
 );
 
 impl Rule for NoNewWrappers {

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -13,8 +13,8 @@ const GLOBAL_THIS: &str = "globalThis";
 const NON_CALLABLE_GLOBALS: [&str; 5] = ["Atomics", "Intl", "JSON", "Math", "Reflect"];
 
 fn no_obj_calls_diagnostic(obj_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow calling some global objects as functions")
-        .with_help(format!("{obj_name} is not a function."))
+    OxcDiagnostic::warn(format!("`{obj_name}` is not a function and cannot be called"))
+        .with_help("This call will throw a TypeError at runtime.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_proto_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The '__proto__' property is deprecated")
-        .with_help("Disallow the use of the `__proto__` property.")
+        .with_help("use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.")
         .with_label(span)
 }
 
@@ -16,10 +16,12 @@ pub struct NoProto;
 
 declare_oxc_lint!(
     /// ### What it does
-    /// Disallow the use of the __proto__ property
+    /// Disallow the use of the `__proto__` property
     ///
     /// ### Why is this bad?
-    /// __proto__ property has been deprecated as of ECMAScript 3.1 and shouldn’t be used in the code. Use Object.getPrototypeOf and Object.setPrototypeOf instead.
+    /// The `__proto__` property has been deprecated as of ECMAScript 3.1 and
+    /// shouldn’t be used in new code. Use `Object.getPrototypeOf` and
+    /// `Object.setPrototypeOf` instead.
     ///
     /// ### Example
     /// ```javascript
@@ -34,7 +36,8 @@ declare_oxc_lint!(
     /// obj["__proto__"] = b;
     /// ```
     NoProto,
-    restriction
+    restriction,
+    pending
 );
 
 impl Rule for NoProto {

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -7,8 +7,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_script_url_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Script URL is a form of eval")
-        .with_help("Disallow `javascript:` urls")
+    OxcDiagnostic::warn("Unexpeced `javascript:` url")
+        .with_help("Execute the code directly instead.")
         .with_label(span)
 }
 
@@ -20,9 +20,14 @@ declare_oxc_lint!(
     /// Disallow javascript: urls
     ///
     /// ### Why is this bad?
-    /// Using javascript: URLs is considered by some as a form of eval. Code passed in javascript: URLs has to be parsed and evaluated by the browser in the same way that eval is processed.
+    /// Using `javascript:` URLs is considered by some as a form of `eval`. Code
+    /// passed in `javascript:` URLs must be parsed and evaluated by the browser
+    /// in the same way that `eval` is processed. This can lead to security and
+    /// performance issues.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule
     /// ```javascript
     /// /*eslint no-script-url: "error"*/
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -7,7 +7,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_self_compare_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow comparisons where both sides are exactly the same")
+    OxcDiagnostic::warn("Both sides of this comparison are exactly the same")
         .with_help("If you are testing for NaN, you can use Number.isNaN function.")
         .with_labels([span, span1])
 }
@@ -26,6 +26,8 @@ declare_oxc_lint!(
     /// It is confusing to the reader and may potentially introduce a runtime error.
     ///
     /// ### Example
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var x = 10;
     /// if (x === x) {

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_template_curly_in_string_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected template string expression")
-        .with_help("Disallow template literal placeholder syntax in regular strings")
+    OxcDiagnostic::warn("Template placeholders will not interpolate in regular strings")
+        .with_help("Did you mean to use a template string literal?")
         .with_label(span)
 }
 
@@ -19,9 +19,17 @@ declare_oxc_lint!(
     /// Disallow template literal placeholder syntax in regular strings
     ///
     /// ### Why is this bad?
-    /// ECMAScript 6 allows programmers to create strings containing variable or expressions using template literals, instead of string concatenation, by writing expressions like ${variable} between two backtick quotes (`). It can be easy to use the wrong quotes when wanting to use template literals, by writing "${variable}", and end up with the literal value "${variable}" instead of a string containing the value of the injected expressions.
+    /// ECMAScript 6 allows programmers to create strings containing variable or
+    /// expressions using template literals, instead of string concatenation, by
+    /// writing expressions like `${variable}` between two backtick quotes. It
+    /// can be easy to use the wrong quotes when wanting to use template
+    /// literals, by writing `"${variable}"`, and end up with the literal value
+    /// `"${variable}"` instead of a string containing the value of the injected
+    /// expressions.
     ///
     /// ### Example
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// /*eslint no-template-curly-in-string: "error"*/
     /// "Hello ${name}!";
@@ -29,7 +37,8 @@ declare_oxc_lint!(
     /// "Time: ${12 * 60 * 60 * 1000}";
     /// ```
     NoTemplateCurlyInString,
-    style
+    style,
+    pending // TODO: conditional_fix
 );
 
 impl Rule for NoTemplateCurlyInString {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -7,9 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow the use of undeclared variables.")
-        .with_help(format!("'{name}' is not defined."))
-        .with_label(span)
+    OxcDiagnostic::warn(format!("'{name}' is not defined.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,9 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow the use of `undefined` as an identifier")
-        .with_help("Unexpected use of undefined.")
-        .with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -6,9 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unused_labels_diagnostic(label_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow unused labels")
-        .with_help(format!("'{label_name}:' is defined but never used."))
-        .with_label(span)
+    OxcDiagnostic::warn(format!("'{label_name}:' is defined but never used.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -10,9 +10,9 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
-        "Disallow renaming import, export, and destructured assignments to the same name",
+        "Do not rename import, export, or destructured assignments to the same name",
     )
-    .with_help("Either remove the renaming or rename the variable.")
+    .with_help("Use the variable's original name or rename it to a different name")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -7,8 +7,8 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_void_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow `void` operators")
-        .with_help("Expected 'undefined' and instead saw 'void'.")
+    OxcDiagnostic::warn("Unexpected `void` operator")
+        .with_help("Use `undefined` instead")
         .with_label(span)
 }
 
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// ```
     NoVoid,
     restriction,
+    pending // TODO: suggestion
 );
 
 impl Rule for NoVoid {

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -10,9 +10,7 @@ use crate::{
 };
 
 fn no_conditional_in_test(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow conditional logic in tests")
-        .with_help("Avoid having conditionals in tests.")
-        .with_label(span)
+    OxcDiagnostic::warn("Avoid having conditionals in tests.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -8,10 +8,9 @@ use phf::{phf_map, Map};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn deprecated_function(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow use of deprecated functions")
-        .with_help(format!("{x0:?} has been deprecated in favor of {x1:?}"))
-        .with_label(span2)
+fn deprecated_function(deprecated: &str, new: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{deprecated:?} has been deprecated in favor of {new:?}"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 fn no_duplicate_hooks_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow duplicate setup and teardown hooks.")
-        .with_help(format!("Duplicate {x0:?} in describe block."))
+    OxcDiagnostic::warn(format!("Duplicate {x0:?} in describe block."))
+        .with_help("Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 fn unexpected_hook_diagonsitc(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow setup and teardown hooks.").with_label(span)
+    OxcDiagnostic::warn("Do not use setup or teardown hooks").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -34,16 +34,20 @@ impl std::ops::Deref for NoHooks {
 
 declare_oxc_lint!(
     /// ### What it does
-    /// Jest provides global functions for setup and teardown tasks, which are called before/after each test case
-    /// and each test suite. The use of these hooks promotes shared state between tests.
+    ///
+    /// Disallows Jest setup and teardown hooks, such as `beforeAll`.
     ///
     /// ### Why is this bad?
     ///
+    /// Jest provides global functions for setup and teardown tasks, which are
+    /// called before/after each test case and each test suite. The use of these
+    /// hooks promotes shared state between tests.
+    ///
     /// This rule reports for the following function calls:
-    /// * beforeAll
-    /// * beforeEach
-    /// * afterAll
-    /// * afterEach
+    /// * `beforeAll`
+    /// * `beforeEach`
+    /// * `afterAll`
+    /// * `afterEach`
     ///
     /// ### Example
     ///

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
+// TODO: re-word diagnostic messages
 fn no_snapshot(x0: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow large snapshots.")
         .with_help(format!("`{x0:?}`s should begin with lowercase"))

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -13,16 +13,12 @@ use crate::{
     },
 };
 
-fn restricted_jest_method(method_name: &str, x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Disallow specific `{method_name}.` methods"))
-        .with_help(format!("Use of `{x0:?}` is disallowed"))
-        .with_label(span1)
+fn restricted_jest_method(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use of `{x0}` is not allowed")).with_label(span1)
 }
 
-fn restricted_jest_method_with_message(method_name: &str, x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Disallow specific `{method_name}.` methods"))
-        .with_help(format!("{x0:?}"))
-        .with_label(span1)
+fn restricted_jest_method_with_message(x0: &str, span1: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(x0.to_string()).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -125,21 +121,15 @@ impl NoRestrictedJestMethods {
         };
 
         if self.contains(property_name) {
-            let method_name =
-                mem_expr.object().get_identifier_reference().map_or("jest", |id| id.name.as_str());
             self.get_message(property_name).map_or_else(
                 || {
-                    ctx.diagnostic(restricted_jest_method(method_name, property_name, span));
+                    ctx.diagnostic(restricted_jest_method(property_name, span));
                 },
                 |message| {
                     if message.trim() == "" {
-                        ctx.diagnostic(restricted_jest_method(method_name, property_name, span));
+                        ctx.diagnostic(restricted_jest_method(property_name, span));
                     } else {
-                        ctx.diagnostic(restricted_jest_method_with_message(
-                            method_name,
-                            &message,
-                            span,
-                        ));
+                        ctx.diagnostic(restricted_jest_method_with_message(&message, span));
                     }
                 },
             );

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 
+// TODO: re-word diagnostic messages
 fn restricted_chain(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow specific matchers & modifiers")
         .with_help(format!("Use of `{x0:?}` is disallowed`"))

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -14,7 +14,7 @@ use crate::{
 
 fn add_type_parameter_to_module_mock_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
-        "Disallow using `jest.mock()` factories without an explicit type parameter.",
+        "`jest.mock()` factories should not be used without an explicit type parameter.",
     )
     .with_help(format!("Add a type parameter to the mock factory such as `typeof import({x0:?})`"))
     .with_label(span1)

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_process_exit_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow `process.exit()`.")
-        .with_help("Only use `process.exit()` in CLI apps. Throw an error instead.")
+    OxcDiagnostic::warn("Don't use `process.exit()`")
+        .with_help("Throw an error instead.")
         .with_label(span)
 }
 
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// ```
     NoProcessExit,
     restriction,
+    pending // TODO: suggestion
 );
 
 impl Rule for NoProcessExit {

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -6,8 +6,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unnecessary_await_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow awaiting non-promise values")
-        .with_help("consider to remove the `await`")
+    OxcDiagnostic::warn("Unexpected `await` on a non-Promise value")
+        .with_help("Consider removing the `await`")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -7,8 +7,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unreadable_array_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow unreadable array destructuring")
-        .with_help("Array destructuring may not contain consecutive ignored values.")
+    OxcDiagnostic::warn("Array destructuring may not contain consecutive ignored values.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::LogicalOperator;
 use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_fallback_in_spread_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow useless fallback when spreading in object literals")
+    OxcDiagnostic::warn("Empty fallbacks in spreads are unnecessary")
         .with_help("Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_import_node_test(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("disallow importing `node:test`".to_string())
-        .with_help("Import from `vitest` instead of `node:test`")
+    OxcDiagnostic::warn("Do not import from `node:test`")
+        .with_help("Import from `vitest` instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/no_array_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/no_array_constructor.snap
@@ -1,51 +1,51 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array()
    · ───────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array
    · ─────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array();
    · ───────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(x, y)
    · ───────────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(0, 1, 2)
    · ──────────────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(x, y)
    · ───────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead
 
-  ⚠ eslint(no-array-constructor): Disallow `Array` constructors
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(0, 1, 2)
    · ──────────────
    ╰────
-  help: Use array literal instead
+  help: Use an array literal instead

--- a/crates/oxc_linter/src/snapshots/no_caller.snap
+++ b/crates/oxc_linter/src/snapshots/no_caller.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-caller): Disallow the use of arguments.caller or arguments.callee
+  ⚠ eslint(no-caller): Do not use `arguments.callee`
    ╭─[no_caller.tsx:1:19]
  1 │ var x = arguments.callee
    ·                   ──────
    ╰────
-  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
+  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.
 
-  ⚠ eslint(no-caller): Disallow the use of arguments.caller or arguments.callee
+  ⚠ eslint(no-caller): Do not use `arguments.caller`
    ╭─[no_caller.tsx:1:19]
  1 │ var x = arguments.caller
    ·                   ──────
    ╰────
-  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
+  help: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them.

--- a/crates/oxc_linter/src/snapshots/no_conditional_in_test.snap
+++ b/crates/oxc_linter/src/snapshots/no_conditional_in_test.snap
@@ -1,61 +1,55 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:21]
  2 │                     it('foo', () => {
  3 │                       expect(bar ? foo : baz).toBe(boo);
    ·                              ───────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       const foo = function (bar) {
  4 │                         return foo ? bar : null;
    ·                                ────────────────
  5 │                       };
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
    ·                                   ───────────────
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:33]
  3 │                       const foo = bar ? foo : baz;
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
    ·                                          ────────────────────────────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:4:16]
   3 │                           const values = something.map(thing => {
   4 │ ╭─▶                         switch (thing.isFoo) {
@@ -66,9 +60,8 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                         }
  10 │                           });
     ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                         it('foo', () => {
  3 │ ╭─▶                       switch (true) {
@@ -76,144 +69,128 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                       }
  6 │                         })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.only('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xit('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     fit('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.skip('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.only('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', () => {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', function () {
  3 │                       switch('bar') {}
    ·                       ────────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:5:16]
  4 │             
  5 │                         switch('bar') {}
    ·                         ────────────────
  6 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         switch('bar') {}
    ·                         ────────────────
  5 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:16]
  6 │                       it('baz', () => {
  7 │                         switch('qux') {}
    ·                         ────────────────
  8 │                         switch('quux') {}
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:16]
  7 │                         switch('qux') {}
  8 │                         switch('quux') {}
    ·                         ─────────────────
  9 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       switch ('bar') {}
    ·                       ─────────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:20]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             switch (thing.isFoo) {
@@ -224,9 +201,8 @@ source: crates/oxc_linter/src/tester.rs
  11 │ ╰─▶                             }
  12 │                               });
     ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:14:18]
  13 │                 
  14 │ ╭─▶                           switch('invalid') {
@@ -235,9 +211,8 @@ source: crates/oxc_linter/src/tester.rs
  17 │ ╰─▶                           }
  18 │                             });
     ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                           const foo = function(bar) {
  4 │ ╭─▶                         if (bar) {
@@ -247,9 +222,8 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                         }
  9 │                           };
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                           function foo(bar) {
  4 │ ╭─▶                         if (bar) {
@@ -259,180 +233,160 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                         }
  9 │                           };
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', function () {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.only('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xit('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     fit('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.skip('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.only('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', () => {
  3 │                       if ('bar') {}
    ·                       ─────────────
  4 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
    ·                         ─────────────
  5 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
    ·                         ─────────────
  5 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:16]
  6 │                       it('baz', () => {
  7 │                         if ('qux') {}
    ·                         ─────────────
  8 │                         if ('quux') {}
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:16]
  7 │                         if ('qux') {}
  8 │                         if ('quux') {}
    ·                         ──────────────
  9 │                       })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
    ·                       ─────────────
  5 │                     })
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:20]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             if (thing.isFoo) {
@@ -442,9 +396,8 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                             }
  11 │                               });
     ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:13:18]
  12 │                 
  13 │ ╭─▶                           if ('invalid') {
@@ -452,9 +405,8 @@ source: crates/oxc_linter/src/tester.rs
  15 │ ╰─▶                           }
  16 │                             });
     ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                         test("shows error", () => {
  3 │ ╭─▶                       if (1 === 2) {
@@ -462,9 +414,8 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                       }
  6 │                         });
    ╰────
-  help: Avoid having conditionals in tests.
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Disallow conditional logic in tests
+  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:10:14]
   9 │                           setTimeout(() => console.log("noop"));
  10 │ ╭─▶                       if (1 === 2) {
@@ -472,4 +423,3 @@ source: crates/oxc_linter/src/tester.rs
  12 │ ╰─▶                       }
  13 │                         });
     ╰────
-  help: Avoid having conditionals in tests.

--- a/crates/oxc_linter/src/snapshots/no_deprecated_functions.snap
+++ b/crates/oxc_linter/src/snapshots/no_deprecated_functions.snap
@@ -1,51 +1,51 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "jest.resetModuleRegistry" has been deprecated in favor of "jest.resetModules"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ jest.resetModuleRegistry
    · ────────────────────────
    ╰────
-  help: "jest.resetModuleRegistry" has been deprecated in favor of "jest.resetModules"
+  help: Replace `jest.resetModuleRegistry` with `jest.resetModules`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "jest.resetModuleRegistry" has been deprecated in favor of "jest.resetModules"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ jest.resetModuleRegistry
    · ────────────────────────
    ╰────
-  help: "jest.resetModuleRegistry" has been deprecated in favor of "jest.resetModules"
+  help: Replace `jest.resetModuleRegistry` with `jest.resetModules`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "jest.addMatchers" has been deprecated in favor of "expect.extend"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ jest.addMatchers
    · ────────────────
    ╰────
-  help: "jest.addMatchers" has been deprecated in favor of "expect.extend"
+  help: Replace `jest.addMatchers` with `expect.extend`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "require.requireMock" has been deprecated in favor of "jest.requireMock"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ require.requireMock
    · ───────────────────
    ╰────
-  help: "require.requireMock" has been deprecated in favor of "jest.requireMock"
+  help: Replace `require.requireMock` with `jest.requireMock`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "require.requireActual" has been deprecated in favor of "jest.requireMock"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ require.requireActual
    · ─────────────────────
    ╰────
-  help: "require.requireActual" has been deprecated in favor of "jest.requireMock"
+  help: Replace `require.requireActual` with `jest.requireMock`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "jest.runTimersToTime" has been deprecated in favor of "jest.advanceTimersByTime"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ jest.runTimersToTime
    · ────────────────────
    ╰────
-  help: "jest.runTimersToTime" has been deprecated in favor of "jest.advanceTimersByTime"
+  help: Replace `jest.runTimersToTime` with `jest.advanceTimersByTime`.
 
-  ⚠ eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions
+  ⚠ eslint-plugin-jest(no-deprecated-functions): "jest.genMockFromModule" has been deprecated in favor of "jest.createMockFromModule"
    ╭─[no_deprecated_functions.tsx:1:1]
  1 │ jest.genMockFromModule
    · ──────────────────────
    ╰────
-  help: "jest.genMockFromModule" has been deprecated in favor of "jest.createMockFromModule"
+  help: Replace `jest.genMockFromModule` with `jest.createMockFromModule`.

--- a/crates/oxc_linter/src/snapshots/no_duplicate_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/no_duplicate_hooks.snap
@@ -1,164 +1,164 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     beforeEach(() => {});
  4 │                     beforeEach(() => {});
    ·                     ────────────────────
  5 │                     test("bar", () => {
    ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeAll" in describe block.
    ╭─[no_duplicate_hooks.tsx:5:21]
  4 │                     beforeAll(() => {}),
  5 │                     beforeAll(() => {}),
    ·                     ───────────────────
  6 │                     test("bar", () => {
    ╰────
-  help: Duplicate "beforeAll" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     afterEach(() => {}),
  4 │                     afterEach(() => {}),
    ·                     ───────────────────
  5 │                     test("bar", () => {
    ╰────
-  help: Duplicate "afterEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:6:21]
  5 │                     afterEach(() => {}),
  6 │                     afterEach(() => {}),
    ·                     ───────────────────
  7 │                     test("bar", () => {
    ╰────
-  help: Duplicate "afterEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:6:21]
  5 │                     afterEach(() => {}),
  6 │                     somethingElse(() => {}),
    ·                     ───────────────────────
  7 │                     test("bar", () => {
    ╰────
-  help: Duplicate "afterEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterAll" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     afterAll(() => {}),
  4 │                     afterAll(() => {}),
    ·                     ──────────────────
  5 │                     test("bar", () => {
    ╰────
-  help: Duplicate "afterAll" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterAll" in describe block.
    ╭─[no_duplicate_hooks.tsx:3:17]
  2 │                 afterAll(() => {}),
  3 │                 afterAll(() => {}),
    ·                 ──────────────────
  4 │                 test("bar", () => {
    ╰────
-  help: Duplicate "afterAll" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     beforeEach(() => {}),
  4 │                     beforeEach(() => {}),
    ·                     ────────────────────
  5 │                     beforeEach(() => {}),
    ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:5:21]
  4 │                     beforeEach(() => {}),
  5 │                     beforeEach(() => {}),
    ·                     ────────────────────
  6 │                     test("bar", () => {
    ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "afterAll" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     afterAll(() => {}),
  4 │                     afterAll(() => {}),
    ·                     ──────────────────
  5 │                     beforeAll(() => {}),
    ╰────
-  help: Duplicate "afterAll" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeAll" in describe block.
    ╭─[no_duplicate_hooks.tsx:6:21]
  5 │                     beforeAll(() => {}),
  6 │                     beforeAll(() => {}),
    ·                     ───────────────────
  7 │                     test("bar", () => {
    ╰────
-  help: Duplicate "beforeAll" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
     ╭─[no_duplicate_hooks.tsx:11:21]
  10 │                     beforeEach(() => {}),
  11 │                     beforeEach(() => {}),
     ·                     ────────────────────
  12 │                     beforeAll(() => {}),
     ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
     ╭─[no_duplicate_hooks.tsx:9:25]
   8 │                         beforeEach(() => {})
   9 │                         beforeEach(() => {})
     ·                         ────────────────────
  10 │                         test("inner bar", () => {
     ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     beforeEach(() => {});
  4 │                     beforeEach(() => {});
    ·                     ────────────────────
  5 │ 
    ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
     ╭─[no_duplicate_hooks.tsx:11:25]
  10 │                         beforeEach(() => {});
  11 │                         beforeEach(() => {});
     ·                         ────────────────────
  12 │ 
     ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
     ╭─[no_duplicate_hooks.tsx:12:29]
  11 │                             beforeEach(() => {});
  12 │                             beforeEach(() => {});
     ·                             ────────────────────
  13 │ 
     ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
    ╭─[no_duplicate_hooks.tsx:4:21]
  3 │                     beforeEach(() => {});
  4 │                     beforeEach(() => {});
    ·                     ────────────────────
  5 │ 
    ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
-  ⚠ eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-duplicate-hooks): Duplicate "beforeEach" in describe block.
     ╭─[no_duplicate_hooks.tsx:11:25]
  10 │                         beforeEach(() => {});
  11 │                         beforeEach(() => {});
     ·                         ────────────────────
  12 │ 
     ╰────
-  help: Duplicate "beforeEach" in describe block.
+  help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.

--- a/crates/oxc_linter/src/snapshots/no_empty.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty.snap
@@ -1,114 +1,100 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:5]
  1 │ try {} catch (ex) {throw ex}
-   ·     ─┬
-   ·      ╰── Empty block statement
+   ·     ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:45]
  1 │ try { foo() } catch (ex) {throw ex} finally {}
-   ·                                             ─┬
-   ·                                              ╰── Empty block statement
+   ·                                             ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:26]
  1 │ try { foo() } catch (ex) {}
-   ·                          ─┬
-   ·                           ╰── Empty block statement
+   ·                          ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:10]
  1 │ if (foo) {}
-   ·          ─┬
-   ·           ╰── Empty block statement
+   ·          ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:13]
  1 │ while (foo) {}
-   ·             ─┬
-   ·              ╰── Empty block statement
+   ·             ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:13]
  1 │ for (;foo;) {}
-   ·             ─┬
-   ·              ╰── Empty block statement
+   ·             ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:1]
  1 │ switch(foo) {}
-   · ───────┬──────
-   ·        ╰── Empty switch statement
+   · ──────────────
    ╰────
-  help: Add comment inside empty switch statement
+  help: Remove this switch or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:1]
  1 │ switch (foo) { /* empty */ }
-   · ──────────────┬─────────────
-   ·               ╰── Empty switch statement
+   · ────────────────────────────
    ╰────
-  help: Add comment inside empty switch statement
+  help: Remove this switch or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:5]
  1 │ try {} catch (ex) {}
-   ·     ─┬
-   ·      ╰── Empty block statement
+   ·     ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:38]
  1 │ try { foo(); } catch (ex) {} finally {}
-   ·                                      ─┬
-   ·                                       ╰── Empty block statement
+   ·                                      ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:5]
  1 │ try {} catch (ex) {} finally {}
-   ·     ─┬
-   ·      ╰── Empty block statement
+   ·     ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:30]
  1 │ try {} catch (ex) {} finally {}
-   ·                              ─┬
-   ·                               ╰── Empty block statement
+   ·                              ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:27]
  1 │ try { foo(); } catch (ex) {} finally {}
-   ·                           ─┬
-   ·                            ╰── Empty block statement
+   ·                           ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it
 
-  ⚠ eslint(no-empty): Disallow empty block statements
+  ⚠ eslint(no-empty): Unexpected empty block statements
    ╭─[no_empty.tsx:1:38]
  1 │ try { foo(); } catch (ex) {} finally {}
-   ·                                      ─┬
-   ·                                       ╰── Empty block statement
+   ·                                      ──
    ╰────
-  help: Add comment inside empty block statement
+  help: Remove this block or add a comment inside it

--- a/crates/oxc_linter/src/snapshots/no_empty_function.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_function.snap
@@ -1,131 +1,131 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty function `foo`
    ╭─[no_empty_function.tsx:1:16]
  1 │ function foo() {}
    ·                ──
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty function `bar`
    ╭─[no_empty_function.tsx:1:19]
  1 │ const bar = () => {};
    ·                   ──
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty generator function `baz`
    ╭─[no_empty_function.tsx:1:17]
  1 │ function* baz() {}
    ·                 ──
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this generator function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty function
    ╭─[no_empty_function.tsx:3:29]
  2 │             const obj = {
  3 │ ╭─▶             foo: function() {
  4 │ ╰─▶             },
  5 │                 bar: function*() {
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty function
    ╭─[no_empty_function.tsx:5:30]
  4 │                 },
  5 │ ╭─▶             bar: function*() {
  6 │ ╰─▶             },
  7 │                 foobar() {
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty function
    ╭─[no_empty_function.tsx:7:22]
  6 │                 },
  7 │ ╭─▶             foobar() {
  8 │ ╰─▶             }
  9 │             };
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this function or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty constructor `constructor`
    ╭─[no_empty_function.tsx:3:27]
  2 │             class A {
  3 │ ╭─▶             constructor() {
  4 │ ╰─▶             }
  5 │                 foo() {
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this constructor or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty method `foo`
    ╭─[no_empty_function.tsx:5:19]
  4 │                 }
  5 │ ╭─▶             foo() {
  6 │ ╰─▶             }
  7 │                 *foo1() {
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this method or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty method `foo1`
    ╭─[no_empty_function.tsx:7:21]
  6 │                 }
  7 │ ╭─▶             *foo1() {
  8 │ ╰─▶             }
  9 │                 get fooz() {
    ╰────
-  help: Unexpected empty function block
+  help: Consider removing this method or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty getter `fooz`
     ╭─[no_empty_function.tsx:9:24]
   8 │                 }
   9 │ ╭─▶             get fooz() {
  10 │ ╰─▶             }
  11 │                 set fooz(value) {
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this getter or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty setter `fooz`
     ╭─[no_empty_function.tsx:11:29]
  10 │                 }
  11 │ ╭─▶             set fooz(value) {
  12 │ ╰─▶             }
  13 │                 static bar() {
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this setter or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty static method `bar`
     ╭─[no_empty_function.tsx:13:26]
  12 │                 }
  13 │ ╭─▶             static bar() {
  14 │ ╰─▶             }
  15 │                 static *barr() {
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this static method or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty static method `barr`
     ╭─[no_empty_function.tsx:15:28]
  14 │                 }
  15 │ ╭─▶             static *barr() {
  16 │ ╰─▶             }
  17 │                 static get baz() {
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this static method or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty getter `baz`
     ╭─[no_empty_function.tsx:17:30]
  16 │                 }
  17 │ ╭─▶             static get baz() {
  18 │ ╰─▶             }
  19 │                 static set baz(value) {
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this getter or adding logic to it.
 
-  ⚠ eslint(no-empty-function): Disallow empty functions
+  ⚠ eslint(no-empty-function): Unexpected empty setter `baz`
     ╭─[no_empty_function.tsx:19:35]
  18 │                 }
  19 │ ╭─▶             static set baz(value) {
  20 │ ╰─▶             }
  21 │             }
     ╰────
-  help: Unexpected empty function block
+  help: Consider removing this setter or adding logic to it.

--- a/crates/oxc_linter/src/snapshots/no_empty_pattern.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_pattern.snap
@@ -1,74 +1,65 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty object binding pattern
    ╭─[no_empty_pattern.tsx:1:5]
  1 │ var {} = foo
-   ·     ─┬
-   ·      ╰── Empty object binding pattern
+   ·     ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty array binding pattern
    ╭─[no_empty_pattern.tsx:1:5]
  1 │ var [] = foo
-   ·     ─┬
-   ·      ╰── Empty array binding pattern
+   ·     ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty object binding pattern
    ╭─[no_empty_pattern.tsx:1:9]
  1 │ var {a: {}} = foo
-   ·         ─┬
-   ·          ╰── Empty object binding pattern
+   ·         ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty object binding pattern
    ╭─[no_empty_pattern.tsx:1:12]
  1 │ var {a, b: {}} = foo
-   ·            ─┬
-   ·             ╰── Empty object binding pattern
+   ·            ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty array binding pattern
    ╭─[no_empty_pattern.tsx:1:9]
  1 │ var {a: []} = foo
-   ·         ─┬
-   ·          ╰── Empty array binding pattern
+   ·         ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty object binding pattern
    ╭─[no_empty_pattern.tsx:1:14]
  1 │ function foo({}) {}
-   ·              ─┬
-   ·               ╰── Empty object binding pattern
+   ·              ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty array binding pattern
    ╭─[no_empty_pattern.tsx:1:14]
  1 │ function foo([]) {}
-   ·              ─┬
-   ·               ╰── Empty array binding pattern
+   ·              ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty object binding pattern
    ╭─[no_empty_pattern.tsx:1:18]
  1 │ function foo({a: {}}) {}
-   ·                  ─┬
-   ·                   ╰── Empty object binding pattern
+   ·                  ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.
 
-  ⚠ eslint(no-empty-pattern): Disallow empty destructuring patterns.
+  ⚠ eslint(no-empty-pattern): Empty array binding pattern
    ╭─[no_empty_pattern.tsx:1:18]
  1 │ function foo({a: []}) {}
-   ·                  ─┬
-   ·                   ╰── Empty array binding pattern
+   ·                  ──
    ╰────
   help: Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.

--- a/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
@@ -1,31 +1,31 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+  ⚠ eslint(no-empty-static-block): Unexpected empty static blocks
    ╭─[no_empty_static_block.tsx:1:13]
  1 │ class Foo { static {} }
    ·             ─────────
    ╰────
-  help: Unexpected empty static block.
+  help: Remove this empty block or add content to it.
 
-  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+  ⚠ eslint(no-empty-static-block): Unexpected empty static blocks
    ╭─[no_empty_static_block.tsx:1:13]
  1 │ class Foo { static { } }
    ·             ──────────
    ╰────
-  help: Unexpected empty static block.
+  help: Remove this empty block or add content to it.
 
-  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+  ⚠ eslint(no-empty-static-block): Unexpected empty static blocks
    ╭─[no_empty_static_block.tsx:1:13]
  1 │ ╭─▶ class Foo { static {
  2 │ │   
  3 │ ╰─▶              } }
    ╰────
-  help: Unexpected empty static block.
+  help: Remove this empty block or add content to it.
 
-  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+  ⚠ eslint(no-empty-static-block): Unexpected empty static blocks
    ╭─[no_empty_static_block.tsx:1:31]
  1 │ class Foo { static { bar(); } static {} }
    ·                               ─────────
    ╰────
-  help: Unexpected empty static block.
+  help: Remove this empty block or add content to it.

--- a/crates/oxc_linter/src/snapshots/no_eq_null.snap
+++ b/crates/oxc_linter/src/snapshots/no_eq_null.snap
@@ -1,23 +1,23 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-eq-null): Use '===' to compare with null
+  ⚠ eslint(no-eq-null): Do not use `null` comparisons without type-checking operators.
    ╭─[no_eq_null.tsx:1:5]
  1 │ if (x == null) { }
    ·     ─────────
    ╰────
-  help: Disallow `null` comparisons without type-checking operators.
+  help: Use '===' to compare with null
 
-  ⚠ eslint(no-eq-null): Use '===' to compare with null
+  ⚠ eslint(no-eq-null): Do not use `null` comparisons without type-checking operators.
    ╭─[no_eq_null.tsx:1:5]
  1 │ if (x != null) { }
    ·     ─────────
    ╰────
-  help: Disallow `null` comparisons without type-checking operators.
+  help: Use '!==' to compare with null
 
-  ⚠ eslint(no-eq-null): Use '===' to compare with null
+  ⚠ eslint(no-eq-null): Do not use `null` comparisons without type-checking operators.
    ╭─[no_eq_null.tsx:1:14]
  1 │ do {} while (null == x)
    ·              ─────────
    ╰────
-  help: Disallow `null` comparisons without type-checking operators.
+  help: Use '===' to compare with null

--- a/crates/oxc_linter/src/snapshots/no_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/no_hooks.snap
@@ -1,37 +1,37 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeAll(() => {})
    · ─────────
    ╰────
 
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {})
    · ──────────
    ╰────
 
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:1:1]
  1 │ afterAll(() => {})
    · ────────
    ╰────
 
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:1:1]
  1 │ afterEach(() => {})
    · ─────────
    ╰────
 
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {}); afterEach(() => { jest.resetModules() });
    · ──────────
    ╰────
 
-  ⚠ eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.
+  ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks
    ╭─[no_hooks.tsx:5:17]
  4 │                 afterEach(() => {});
  5 │                 beforeEach(() => { jest.resetModules() });

--- a/crates/oxc_linter/src/snapshots/no_import_node_test.snap
+++ b/crates/oxc_linter/src/snapshots/no_import_node_test.snap
@@ -1,17 +1,16 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-vitest(no-import-node-test): disallow importing `node:test`
+  ⚠ eslint-plugin-vitest(no-import-node-test): Do not import from `node:test`
    ╭─[no_import_node_test.tsx:1:22]
  1 │ import { test } from "node:test"
    ·                      ───────────
    ╰────
-  help: Import from `vitest` instead of `node:test`
+  help: Import from `vitest` instead.
 
-  ⚠ eslint-plugin-vitest(no-import-node-test): disallow importing `node:test`
+  ⚠ eslint-plugin-vitest(no-import-node-test): Do not import from `node:test`
    ╭─[no_import_node_test.tsx:1:22]
  1 │ import * as foo from 'node:test'
    ·                      ───────────
    ╰────
-  help: Import from `vitest` instead of `node:test`
+  help: Import from `vitest` instead.

--- a/crates/oxc_linter/src/snapshots/no_iterator.snap
+++ b/crates/oxc_linter/src/snapshots/no_iterator.snap
@@ -6,32 +6,32 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var a = test.__iterator__;
    ·         ─────────────────
    ╰────
-  help: Disallow the use of the `__iterator__` property.
+  help: Consider using [Symbol.iterator] instead
 
   ⚠ eslint(no-iterator): Reserved name '__iterator__'
    ╭─[no_iterator.tsx:1:1]
  1 │ Foo.prototype.__iterator__ = function() {};
    · ──────────────────────────
    ╰────
-  help: Disallow the use of the `__iterator__` property.
+  help: Consider using [Symbol.iterator] instead
 
   ⚠ eslint(no-iterator): Reserved name '__iterator__'
    ╭─[no_iterator.tsx:1:9]
  1 │ var a = test['__iterator__'];
    ·         ────────────────────
    ╰────
-  help: Disallow the use of the `__iterator__` property.
+  help: Consider using [Symbol.iterator] instead
 
   ⚠ eslint(no-iterator): Reserved name '__iterator__'
    ╭─[no_iterator.tsx:1:9]
  1 │ var a = test[`__iterator__`];
    ·         ────────────────────
    ╰────
-  help: Disallow the use of the `__iterator__` property.
+  help: Consider using [Symbol.iterator] instead
 
   ⚠ eslint(no-iterator): Reserved name '__iterator__'
    ╭─[no_iterator.tsx:1:1]
  1 │ test[`__iterator__`] = function () {};
    · ────────────────────
    ╰────
-  help: Disallow the use of the `__iterator__` property.
+  help: Consider using [Symbol.iterator] instead

--- a/crates/oxc_linter/src/snapshots/no_new_wrappers.snap
+++ b/crates/oxc_linter/src/snapshots/no_new_wrappers.snap
@@ -1,41 +1,41 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects
+  ⚠ eslint(no-new-wrappers): Do not use `String` as a constructor
    ╭─[no_new_wrappers.tsx:1:9]
  1 │ var a = new String('hello');
    ·         ───────────────────
    ╰────
-  help: do not use String as a constructor, consider removing the new operator.
+  help: Remove the `new` operator.
 
-  ⚠ eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects
+  ⚠ eslint(no-new-wrappers): Do not use `Number` as a constructor
    ╭─[no_new_wrappers.tsx:1:9]
  1 │ var a = new Number(10);
    ·         ──────────────
    ╰────
-  help: do not use Number as a constructor, consider removing the new operator.
+  help: Remove the `new` operator.
 
-  ⚠ eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects
+  ⚠ eslint(no-new-wrappers): Do not use `Boolean` as a constructor
    ╭─[no_new_wrappers.tsx:1:9]
  1 │ var a = new Boolean(false);
    ·         ──────────────────
    ╰────
-  help: do not use Boolean as a constructor, consider removing the new operator.
+  help: Remove the `new` operator.
 
-  ⚠ eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects
+  ⚠ eslint(no-new-wrappers): Do not use `String` as a constructor
    ╭─[no_new_wrappers.tsx:2:23]
  1 │ 
  2 │             const a = new String('bar');
    ·                       ─────────────────
  3 │             {
    ╰────
-  help: do not use String as a constructor, consider removing the new operator.
+  help: Remove the `new` operator.
 
-  ⚠ eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects
+  ⚠ eslint(no-new-wrappers): Do not use `String` as a constructor
    ╭─[no_new_wrappers.tsx:5:27]
  4 │                 const String = CustomString;
  5 │                 const b = new String('foo');
    ·                           ─────────────────
  6 │             }
    ╰────
-  help: do not use String as a constructor, consider removing the new operator.
+  help: Remove the `new` operator.

--- a/crates/oxc_linter/src/snapshots/no_obj_calls.snap
+++ b/crates/oxc_linter/src/snapshots/no_obj_calls.snap
@@ -1,135 +1,135 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `JSON` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:14]
  1 │ let newObj = new JSON();
    ·              ──────────
    ╰────
-  help: JSON is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `JSON` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = JSON();
    ·           ──────
    ╰────
-  help: JSON is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `JSON` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = globalThis.JSON()
    ·           ─────────────────
    ╰────
-  help: JSON is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `JSON` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:1]
  1 │ new JSON
    · ────────
    ╰────
-  help: JSON is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `JSON` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:18]
  1 │ const foo = x => new JSON()
    ·                  ──────────
    ╰────
-  help: JSON is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Math` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:14]
  1 │ let newObj = new Math();
    ·              ──────────
    ╰────
-  help: Math is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Math` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = Math();
    ·           ──────
    ╰────
-  help: Math is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Math` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = new Math().foo;
    ·           ──────────
    ╰────
-  help: Math is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Math` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = new globalThis.Math()
    ·           ─────────────────────
    ╰────
-  help: Math is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Atomics` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:14]
  1 │ let newObj = new Atomics();
    ·              ─────────────
    ╰────
-  help: Atomics is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Atomics` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = Atomics();
    ·           ─────────
    ╰────
-  help: Atomics is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Intl` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:14]
  1 │ let newObj = new Intl();
    ·              ──────────
    ╰────
-  help: Intl is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Intl` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = Intl();
    ·           ──────
    ╰────
-  help: Intl is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Reflect` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:14]
  1 │ let newObj = new Reflect();
    ·              ─────────────
    ╰────
-  help: Reflect is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Reflect` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:11]
  1 │ let obj = Reflect();
    ·           ─────────
    ╰────
-  help: Reflect is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `Atomics` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:27]
  1 │ function d() { JSON.parse(Atomics()) }
    ·                           ─────────
    ╰────
-  help: Atomics is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `j` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:15]
  1 │ let j = JSON; j();
    ·               ───
    ╰────
-  help: j is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `b` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:37]
  1 │ let a = JSON; let b = a; let c = b; b();
    ·                                     ───
    ╰────
-  help: b is not a function.
+  help: This call will throw a TypeError at runtime.
 
-  ⚠ eslint(no-obj-calls): Disallow calling some global objects as functions
+  ⚠ eslint(no-obj-calls): `m` is not a function and cannot be called
    ╭─[no_obj_calls.tsx:1:26]
  1 │ let m = globalThis.Math; new m();
    ·                          ───────
    ╰────
-  help: m is not a function.
+  help: This call will throw a TypeError at runtime.

--- a/crates/oxc_linter/src/snapshots/no_process_exit.snap
+++ b/crates/oxc_linter/src/snapshots/no_process_exit.snap
@@ -1,150 +1,150 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:1]
  1 │ process.exit();
    · ──────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:1]
  1 │ process.exit(1);
    · ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:3]
  1 │ x(process.exit(1));
    ·   ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:37]
  1 │ process.on("SIGINT", function() {});process.exit();
    ·                                     ──────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:40]
  1 │ process.once("SIGINT", function() {}); process.exit(0)
    ·                                        ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:3:13]
  2 │             const mod = require('not_worker_threads');
  3 │             process.exit(1);
    ·             ───────────────
  4 │         
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:3:13]
  2 │             import mod from 'not_worker_threads';
  3 │             process.exit(1);
    ·             ───────────────
  4 │         
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:3:13]
  2 │             const mod = new require('worker_threads');
  3 │             process.exit(1);
    ·             ───────────────
  4 │         
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:3:13]
  2 │             const mod = require(worker_threads);
  3 │             process.exit(1);
    ·             ───────────────
  4 │         
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:39]
  1 │ new process.on("SIGINT", function() { process.exit(1); })
    ·                                       ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:41]
  1 │ new process.once("SIGINT", function() { process.exit(1); })
    ·                                         ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:27]
  1 │ on("SIGINT", function() { process.exit(1); })
    ·                           ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:29]
  1 │ once("SIGINT", function() { process.exit(1); })
    ·                             ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:36]
  1 │ process[on]("SIGINT", function() { process.exit(1); })
    ·                                    ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:38]
  1 │ process[once]("SIGINT", function() { process.exit(1); })
    ·                                      ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:36]
  1 │ process.foo("SIGINT", function() { process.exit(1); })
    ·                                    ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:31]
  1 │ foo.on("SIGINT", function() { process.exit(1); })
    ·                               ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:33]
  1 │ foo.once("SIGINT", function() { process.exit(1); })
    ·                                 ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:39]
  1 │ lib.process.on("SIGINT", function() { process.exit(1); })
    ·                                       ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.
 
-  ⚠ eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.
+  ⚠ eslint-plugin-unicorn(no-process-exit): Don't use `process.exit()`
    ╭─[no_process_exit.tsx:1:41]
  1 │ lib.process.once("SIGINT", function() { process.exit(1); })
    ·                                         ───────────────
    ╰────
-  help: Only use `process.exit()` in CLI apps. Throw an error instead.
+  help: Throw an error instead.

--- a/crates/oxc_linter/src/snapshots/no_proto.snap
+++ b/crates/oxc_linter/src/snapshots/no_proto.snap
@@ -6,25 +6,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var a = test.__proto__;
    ·         ──────────────
    ╰────
-  help: Disallow the use of the `__proto__` property.
+  help: use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.
 
   ⚠ eslint(no-proto): The '__proto__' property is deprecated
    ╭─[no_proto.tsx:1:9]
  1 │ var a = test['__proto__'];
    ·         ─────────────────
    ╰────
-  help: Disallow the use of the `__proto__` property.
+  help: use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.
 
   ⚠ eslint(no-proto): The '__proto__' property is deprecated
    ╭─[no_proto.tsx:1:9]
  1 │ var a = test[`__proto__`];
    ·         ─────────────────
    ╰────
-  help: Disallow the use of the `__proto__` property.
+  help: use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.
 
   ⚠ eslint(no-proto): The '__proto__' property is deprecated
    ╭─[no_proto.tsx:1:1]
  1 │ test[`__proto__`] = function () {};
    · ─────────────────
    ╰────
-  help: Disallow the use of the `__proto__` property.
+  help: use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.

--- a/crates/oxc_linter/src/snapshots/no_restricted_jest_methods.snap
+++ b/crates/oxc_linter/src/snapshots/no_restricted_jest_methods.snap
@@ -1,69 +1,60 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `jest.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.fn()
    ·      ──
    ╰────
-  help: Use of `"fn"` is disallowed
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `jest.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["fn"]()
    ·      ────
    ╰────
-  help: Use of `"fn"` is disallowed
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `jest.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.mock()
    ·      ────
    ╰────
-  help: "Do not use mocks"
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `jest.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["mock"]()
    ·      ──────
    ╰────
-  help: "Do not use mocks"
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `jest.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:22]
  2 │                 import { jest } from '@jest/globals';
  3 │                 jest.advanceTimersByTime();
    ·                      ───────────────────
  4 │             
    ╰────
-  help: Use of `"advanceTimersByTime"` is disallowed
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `vi.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.fn()
    ·    ──
    ╰────
-  help: Use of `"fn"` is disallowed
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `vi.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.mock()
    ·    ────
    ╰────
-  help: "Do not use mocks"
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `vi.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:12]
  2 │                  import { vi } from 'vitest';
  3 │                  vi.advanceTimersByTime();
    ·                     ───────────────────
  4 │                 
    ╰────
-  help: Use of `"advanceTimersByTime"` is disallowed
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Disallow specific `vi.` methods
+  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi["fn"]()
    ·    ────
    ╰────
-  help: Use of `"fn"` is disallowed

--- a/crates/oxc_linter/src/snapshots/no_script_url.snap
+++ b/crates/oxc_linter/src/snapshots/no_script_url.snap
@@ -1,30 +1,30 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-script-url): Script URL is a form of eval
+  ⚠ eslint(no-script-url): Unexpeced `javascript:` url
    ╭─[no_script_url.tsx:1:9]
  1 │ var a = 'javascript:void(0);';
    ·         ─────────────────────
    ╰────
-  help: Disallow `javascript:` urls
+  help: Execute the code directly instead.
 
-  ⚠ eslint(no-script-url): Script URL is a form of eval
+  ⚠ eslint(no-script-url): Unexpeced `javascript:` url
    ╭─[no_script_url.tsx:1:9]
  1 │ var a = 'javascript:';
    ·         ─────────────
    ╰────
-  help: Disallow `javascript:` urls
+  help: Execute the code directly instead.
 
-  ⚠ eslint(no-script-url): Script URL is a form of eval
+  ⚠ eslint(no-script-url): Unexpeced `javascript:` url
    ╭─[no_script_url.tsx:1:9]
  1 │ var a = `javascript:`;
    ·         ─────────────
    ╰────
-  help: Disallow `javascript:` urls
+  help: Execute the code directly instead.
 
-  ⚠ eslint(no-script-url): Script URL is a form of eval
+  ⚠ eslint(no-script-url): Unexpeced `javascript:` url
    ╭─[no_script_url.tsx:1:9]
  1 │ var a = `JavaScript:`;
    ·         ─────────────
    ╰────
-  help: Disallow `javascript:` urls
+  help: Execute the code directly instead.

--- a/crates/oxc_linter/src/snapshots/no_self_compare.snap
+++ b/crates/oxc_linter/src/snapshots/no_self_compare.snap
@@ -1,105 +1,105 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if (x === x) { }
    ·     ─     ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if (x !== x) { }
    ·     ─     ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if (x > x) { }
    ·     ─   ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:5]
  1 │ if ('x' > 'x') { }
    ·     ───   ───
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:14]
  1 │ do {} while (x === x)
    ·              ─     ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x === x
    · ─     ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x !== x
    · ─     ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x == x
    · ─    ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x != x
    · ─    ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x > x
    · ─   ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x < x
    · ─   ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x >= x
    · ─    ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ x <= x
    · ─    ─
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
  1 │ foo.bar().baz.qux >= foo.bar ().baz .qux
    · ─────────────────    ───────────────────
    ╰────
   help: If you are testing for NaN, you can use Number.isNaN function.
 
-  ⚠ eslint(no-self-compare): Disallow comparisons where both sides are exactly the same
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:27]
  1 │ class C { #field; foo() { this.#field === this.#field; } }
    ·                           ───────────     ───────────

--- a/crates/oxc_linter/src/snapshots/no_template_curly_in_string.snap
+++ b/crates/oxc_linter/src/snapshots/no_template_curly_in_string.snap
@@ -1,51 +1,51 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ 'Hello, ${name}'
    ·         ───────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ "Hello, ${name}"
    ·         ───────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:2]
  1 │ '${greeting}, ${name}'
    ·  ───────────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ 'Hello, ${index + 1}'
    ·         ────────────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ 'Hello, ${name + " foo"}'
    ·         ────────────────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ 'Hello, ${name || "foo"}'
    ·         ────────────────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?
 
-  ⚠ eslint(no-template-curly-in-string): Unexpected template string expression
+  ⚠ eslint(no-template-curly-in-string): Template placeholders will not interpolate in regular strings
    ╭─[no_template_curly_in_string.tsx:1:9]
  1 │ 'Hello, ${{foo: "bar"}.foo}'
    ·         ───────────────────
    ╰────
-  help: Disallow template literal placeholder syntax in regular strings
+  help: Did you mean to use a template string literal?

--- a/crates/oxc_linter/src/snapshots/no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/no_undef.snap
@@ -1,184 +1,158 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ a = 1;
    · ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:9]
  1 │ var a = b;
    ·         ─
    ╰────
-  help: 'b' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:16]
  1 │ function f() { b; }
    ·                ─
    ╰────
-  help: 'b' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'window' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ window;
    · ──────
    ╰────
-  help: 'window' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'require' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ require("a");
    · ───────
    ╰────
-  help: 'require' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:36]
  1 │ var React; React.render(<img attr={a} />);
    ·                                    ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:41]
  1 │ var React, App; React.render(<App attr={a} />);
    ·                                         ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:2]
  1 │ [a] = [0];
    ·  ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:3]
  1 │ ({a} = {});
    ·   ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:6]
  1 │ ({b: a} = {});
    ·      ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'obj' is not defined.
    ╭─[no_undef.tsx:1:2]
  1 │ [obj.a, obj.b] = [0, 1];
    ·  ───
    ╰────
-  help: 'obj' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'obj' is not defined.
    ╭─[no_undef.tsx:1:9]
  1 │ [obj.a, obj.b] = [0, 1];
    ·         ───
    ╰────
-  help: 'obj' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:28]
  1 │ const c = 0; const a = {...b, c};
    ·                            ─
    ╰────
-  help: 'b' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:20]
  1 │ class C { static { a; } }
    ·                    ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:31]
  1 │ class C { static { { let a; } a; } }
    ·                               ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:40]
  1 │ class C { static { { function a() {} } a; } }
    ·                                        ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:47]
  1 │ class C { static { function foo() { var a; }  a; } }
    ·                                               ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:38]
  1 │ class C { static { var a; } static { a; } }
    ·                                      ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:38]
  1 │ class C { static { let a; } static { a; } }
    ·                                      ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:46]
  1 │ class C { static { function a(){} } static { a; } }
    ·                                              ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:37]
  1 │ class C { static { var a; } foo() { a; } }
    ·                                     ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:37]
  1 │ class C { static { let a; } foo() { a; } }
    ·                                     ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:30]
  1 │ class C { static { var a; } [a]; }
    ·                              ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:30]
  1 │ class C { static { let a; } [a]; }
    ·                              ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:39]
  1 │ class C { static { function a() {} } [a]; }
    ·                                       ─
    ╰────
-  help: 'a' is not defined.
 
-  ⚠ eslint(no-undef): Disallow the use of undeclared variables.
+  ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:31]
  1 │ class C { static { var a; } } a;
    ·                               ─
    ╰────
-  help: 'a' is not defined.

--- a/crates/oxc_linter/src/snapshots/no_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/no_undefined.snap
@@ -1,247 +1,212 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined
    · ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined.a
    · ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ a[undefined]
    ·   ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined[0]
    · ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ f(undefined)
    ·   ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ function f(undefined) {}
    ·            ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ function f() { var undefined; }
    ·                    ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ function f() { undefined = true; }
    ·                ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined;
    ·     ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ try {} catch(undefined) {}
    ·              ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ function undefined() {}
    ·          ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (function undefined(){}())
    ·           ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ var foo = function undefined() {}
    ·                    ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ foo = function undefined() {}
    ·                ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined = true
    · ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true
    ·     ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:4]
  1 │ ({ undefined })
    ·    ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ ({ [undefined]: foo })
    ·     ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined })
    ·         ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined } = foo)
    ·         ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:7]
  1 │ var { undefined } = foo
    ·       ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ var { bar: undefined } = foo
    ·            ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:24]
  1 │ ({ undefined: function undefined() {} })
    ·                        ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:18]
  1 │ ({ foo: function undefined() {} })
    ·                  ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ class Foo { [undefined]() {} }
    ·              ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (class { [undefined]() {} })
    ·           ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true; undefined = false;
    ·     ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:23]
  1 │ var undefined = true; undefined = false;
    ·                       ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ import undefined from 'foo'
    ·        ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:13]
  1 │ import * as undefined from 'foo'
    ·             ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ import { undefined } from 'foo'
    ·          ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:15]
  1 │ import { a as undefined } from 'foo'
    ·               ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ let a = [b, ...undefined]
    ·                ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ [a, ...undefined] = b
    ·        ─────────
    ╰────
-  help: Unexpected use of undefined.
 
-  ⚠ eslint(no-undefined): Disallow the use of `undefined` as an identifier
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:6]
  1 │ [a = undefined] = b
    ·      ─────────
    ╰────
-  help: Unexpected use of undefined.

--- a/crates/oxc_linter/src/snapshots/no_unnecessary_await.snap
+++ b/crates/oxc_linter/src/snapshots/no_unnecessary_await.snap
@@ -1,247 +1,247 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await []
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await [Promise.resolve()]
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (() => {})
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (() => Promise.resolve())
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (a === b)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (a instanceof Promise)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (a > b)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await class {}
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await class extends Promise {}
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await function() {}
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await function name() {}
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await function() { return Promise.resolve() }
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (<></>)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (<a></a>)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await 0
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await 1
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await ""
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await "string"
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await true
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await false
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await null
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await 0n
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await 1n
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await `${Promise.resolve()}`
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await !Promise.resolve()
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await void Promise.resolve()
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await +Promise.resolve()
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await ~1
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await ++foo
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await foo--
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await (Promise.resolve(), 1)
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:24]
  1 │ async function foo() {+await +1}
    ·                        ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:24]
  1 │ async function foo() {-await-1}
    ·                        ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:24]
  1 │ async function foo() {+await -1}
    ·                        ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`
 
-  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values
+  ⚠ eslint-plugin-unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.tsx:1:1]
  1 │ await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);
    · ─────
    ╰────
-  help: consider to remove the `await`
+  help: Consider removing the `await`

--- a/crates/oxc_linter/src/snapshots/no_unreadable_array_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/no_unreadable_array_destructuring.snap
@@ -1,205 +1,176 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,, foo] = parts;
    ·       ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo,,, bar] = parts;
    ·       ────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo,,,] = parts;
    ·       ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo, bar,, baz ,,, qux] = parts;
    ·       ────────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:1]
  1 │ [,, foo] = bar;
    · ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:10]
  1 │ ({parts: [,, foo]} = bar);
    ·          ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([,, bar]) {}
    ·              ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar,,, baz]) {}
    ·              ────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar,,,]) {}
    ·              ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar, baz,, qux ,,, quux]) {}
    ·              ─────────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = parts;
    ·       ───────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,,] = parts;
    ·       ─────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = new Array;
    ·       ───────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = (0, foo);
    ·       ───────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement] = new Array;
    ·     ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ var [,,thirdElement] = (((0, foo)));
    ·     ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,[,,thirdElementInThirdElement]] = foo
    ·     ──────────────────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:8]
  1 │ let [,,[,,thirdElementInThirdElement]] = foo
    ·        ──────────────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,{propertyOfThirdElement}] = foo
    ·     ────────────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement] = foo, anotherVariable = bar;
    ·     ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement = {}] = foo;
    ·     ─────────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:12]
  1 │ for (const [, , id] of shuffle(list)) {}
    ·            ────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ let[,,thirdElement] = foo;
    ·    ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ let[,,...thirdElement] = foo;
    ·    ───────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:6]
  1 │ const[,,thirdElement] = foo;
    ·      ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:6]
  1 │ const[,,...thirdElement] = foo;
    ·      ───────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ var[,,thirdElement] = foo;
    ·    ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ var[,,...thirdElement] = foo;
    ·    ───────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.
 
-  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring
+  ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:10]
  1 │ let[]=[],[,,thirdElement] = foo;
    ·          ────────────────
    ╰────
-  help: Array destructuring may not contain consecutive ignored values.

--- a/crates/oxc_linter/src/snapshots/no_untyped_mock_factory.snap
+++ b/crates/oxc_linter/src/snapshots/no_untyped_mock_factory.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:2:22]
  1 │ 
  2 │                 jest.mock('../moduleName', () => {
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a type parameter to the mock factory such as `typeof import("../moduleName")`
 
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:2:22]
  1 │ 
  2 │                 jest.mock("./module", () => ({
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a type parameter to the mock factory such as `typeof import("./module")`
 
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:2:22]
  1 │ 
  2 │                 jest.mock('random-num', () => {
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a type parameter to the mock factory such as `typeof import("random-num")`
 
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:2:22]
  1 │ 
  2 │                 jest.doMock('random-num', () => {
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a type parameter to the mock factory such as `typeof import("random-num")`
 
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:2:22]
  1 │ 
  2 │                 jest['mock']('random-num', () => {
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add a type parameter to the mock factory such as `typeof import("random-num")`
 
-  ⚠ eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.
+  ⚠ eslint-plugin-jest(no-untyped-mock-factory): `jest.mock()` factories should not be used without an explicit type parameter.
    ╭─[no_untyped_mock_factory.tsx:3:22]
  2 │                 const moduleToMock = 'random-num';
  3 │                 jest.mock(moduleToMock, () => {

--- a/crates/oxc_linter/src/snapshots/no_unused_labels.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_labels.snap
@@ -1,65 +1,65 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: var foo = 0;` with `var foo = 0;`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: { foo(); bar(); }
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: { foo(); bar(); }` with `{ foo(); bar(); }`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: if (a) { foo(); bar(); }
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: if (a) { foo(); bar(); }` with `if (a) { foo(); bar(); }`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }` with `for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }` with `for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'B:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:35]
  1 │ A: for (var i = 0; i < 10; ++i) { B: break A; }
    ·                                   ─
    ╰────
-  help: 'B:' is defined but never used.
+  help: Replace `B: break A;` with `break A;`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: { var A = 0; console.log(A); }
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: { var A = 0; console.log(A); }` with `{ var A = 0; console.log(A); }`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A: /* comment */ foo
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A: /* comment */ foo` with `foo`.
 
-  ⚠ eslint(no-unused-labels): Disallow unused labels
+  ⚠ eslint(no-unused-labels): 'A:' is defined but never used.
    ╭─[no_unused_labels.tsx:1:1]
  1 │ A /* comment */: foo
    · ─
    ╰────
-  help: 'A:' is defined but never used.
+  help: Replace `A /* comment */: foo` with `foo`.

--- a/crates/oxc_linter/src/snapshots/no_useless_fallback_in_spread.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_fallback_in_spread.snap
@@ -1,175 +1,175 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(foo || {})}
    ·                 ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(foo ?? {})}
    ·                 ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(foo ?? (( {} )))}
    ·                 ────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...((( foo )) ?? (( {} )))}
    ·                 ──────────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(( (( foo )) ?? (( {} )) ))}
    ·                 ──────────────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:14]
  1 │ async ()=> ({...((await foo) || {})})
    ·              ──────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(0 || {})}
    ·                 ────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...((-0) || {})}
    ·                 ───────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(.0 || {})}
    ·                 ─────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(0n || {})}
    ·                 ─────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(false || {})}
    ·                 ────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(null || {})}
    ·                 ───────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(undefined || {})}
    ·                 ────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...((a && b) || {})}
    ·                 ───────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(NaN || {})}
    ·                 ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...("" || {})}
    ·                 ─────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...([] || {})}
    ·                 ─────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...({} || {})}
    ·                 ─────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(foo || {}),}
    ·                 ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...((foo ?? {}) || {})}
    ·                 ──────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...((foo && {}) || {})}
    ·                 ──────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(foo && {} || {})}
    ·                 ────────────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:22]
  1 │ const object = {...({...(foo || {})})}
    ·                      ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:19]
  1 │ function foo(a = {...(bar || {})}){}
    ·                   ──────────────
    ╰────
   help: Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.
 
-  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals
+  ⚠ eslint-plugin-unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
    ╭─[no_useless_fallback_in_spread.tsx:1:17]
  1 │ const object = {...(document.all || {})}
    ·                 ───────────────────────

--- a/crates/oxc_linter/src/snapshots/no_useless_rename.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_rename.snap
@@ -1,888 +1,888 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo} = obj;
    ·      ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (foo)} = obj);
    ·   ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {\u0061: a} = obj;
    ·      ─────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {a: \u0061} = obj;
    ·      ─────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {\u0061: \u0061} = obj;
    ·      ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ let {a, foo: foo} = obj;
    ·         ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo, bar: baz} = obj;
    ·      ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ let {foo: bar, baz: baz} = obj;
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo, bar: bar} = obj;
    ·      ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ let {foo: foo, bar: bar} = obj;
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:12]
  1 │ let {foo: {bar: bar}} = obj;
    ·            ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:23]
  1 │ let {foo: {bar: bar}, baz: baz} = obj;
    ·                       ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:12]
  1 │ let {foo: {bar: bar}, baz: baz} = obj;
    ·            ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {'foo': foo} = obj;
    ·      ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {'foo': foo, 'bar': baz} = obj;
    ·      ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let {'foo': bar, 'baz': baz} = obj;
    ·                  ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {'foo': foo, 'bar': bar} = obj;
    ·      ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let {'foo': foo, 'bar': bar} = obj;
    ·                  ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:14]
  1 │ let {'foo': {'bar': bar}} = obj;
    ·              ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:27]
  1 │ let {'foo': {'bar': bar}, 'baz': baz} = obj;
    ·                           ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:14]
  1 │ let {'foo': {'bar': bar}, 'baz': baz} = obj;
    ·              ──────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo = 1, 'bar': bar = 1, baz: baz} = obj;
    ·      ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:20]
  1 │ let {foo: foo = 1, 'bar': bar = 1, baz: baz} = obj;
    ·                    ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:36]
  1 │ let {foo: foo = 1, 'bar': bar = 1, baz: baz} = obj;
    ·                                    ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:12]
  1 │ let {foo: {bar: bar = 1, 'baz': baz = 1}} = obj;
    ·            ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:26]
  1 │ let {foo: {bar: bar = 1, 'baz': baz = 1}} = obj;
    ·                          ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:12]
  1 │ let {foo: {bar: bar = {}} = {}} = obj;
    ·            ─────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (foo) = a} = obj);
    ·   ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo = (a)} = obj;
    ·      ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:6]
  1 │ let {foo: foo = (a, b)} = obj;
    ·      ─────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ function func({foo: foo}) {}
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ function func({foo: foo, bar: baz}) {}
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:26]
  1 │ function func({foo: bar, baz: baz}) {}
    ·                          ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ function func({foo: foo, bar: bar}) {}
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:26]
  1 │ function func({foo: foo, bar: bar}) {}
    ·                          ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ function func({foo: foo = 1, 'bar': bar = 1, baz: baz}) {}
    ·                ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:30]
  1 │ function func({foo: foo = 1, 'bar': bar = 1, baz: baz}) {}
    ·                              ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:46]
  1 │ function func({foo: foo = 1, 'bar': bar = 1, baz: baz}) {}
    ·                                              ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:22]
  1 │ function func({foo: {bar: bar = 1, 'baz': baz = 1}}) {}
    ·                      ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:36]
  1 │ function func({foo: {bar: bar = 1, 'baz': baz = 1}}) {}
    ·                                    ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:22]
  1 │ function func({foo: {bar: bar = {}} = {}}) {}
    ·                      ─────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo}) => {}
    ·   ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo, bar: baz}) => {}
    ·   ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:13]
  1 │ ({foo: bar, baz: baz}) => {}
    ·             ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo, bar: bar}) => {}
    ·   ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:13]
  1 │ ({foo: foo, bar: bar}) => {}
    ·             ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo = 1, 'bar': bar = 1, baz: baz}) => {}
    ·   ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:17]
  1 │ ({foo: foo = 1, 'bar': bar = 1, baz: baz}) => {}
    ·                 ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:33]
  1 │ ({foo: foo = 1, 'bar': bar = 1, baz: baz}) => {}
    ·                                 ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ ({foo: {bar: bar = 1, 'baz': baz = 1}}) => {}
    ·         ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:23]
  1 │ ({foo: {bar: bar = 1, 'baz': baz = 1}}) => {}
    ·                       ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ ({foo: {bar: bar = {}} = {}}) => {}
    ·         ─────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:8]
  1 │ const {foo: foo, ...stuff} = myObject;
    ·        ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:8]
  1 │ const {foo: foo, bar: baz, ...stuff} = myObject;
    ·        ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:8]
  1 │ const {foo: foo, bar: bar, ...stuff} = myObject;
    ·        ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ const {foo: foo, bar: bar, ...stuff} = myObject;
    ·                  ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ import {foo as foo} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ import {'foo' as foo} from 'foo';
    ·                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:19]
  1 │ import {\u0061 as a} from 'foo';
    ·                   ─
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:14]
  1 │ import {a as \u0061} from 'foo';
    ·              ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:19]
  1 │ import {\u0061 as \u0061} from 'foo';
    ·                   ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ import {foo as foo, bar as baz} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:28]
  1 │ import {foo as bar, baz as baz} from 'foo';
    ·                            ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ import {foo as foo, bar as bar} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:28]
  1 │ import {foo as foo, bar as bar} from 'foo';
    ·                            ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:22]
  1 │ var foo = 0; export {foo as foo};
    ·                      ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:22]
  1 │ var foo = 0; export {foo as 'foo'};
    ·                      ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {foo as 'foo'} from 'bar';
    ·         ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {'foo' as foo} from 'bar';
    ·         ─────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {'foo' as 'foo'} from 'bar';
    ·         ─────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {' 👍 ' as ' 👍 '} from 'bar';
    ·         ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {'' as ''} from 'bar';
    ·         ──
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:20]
  1 │ var a = 0; export {a as \u0061};
    ·                    ─
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:25]
  1 │ var \u0061 = 0; export {\u0061 as a};
    ·                         ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:25]
  1 │ var \u0061 = 0; export {\u0061 as \u0061};
    ·                         ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:35]
  1 │ var foo = 0; var bar = 0; export {foo as foo, bar as baz};
    ·                                   ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:47]
  1 │ var foo = 0; var baz = 0; export {foo as bar, baz as baz};
    ·                                               ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:34]
  1 │ var foo = 0; var bar = 0;export {foo as foo, bar as bar};
    ·                                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:46]
  1 │ var foo = 0; var bar = 0;export {foo as foo, bar as bar};
    ·                                              ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {foo as foo} from 'foo';
    ·         ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {a as \u0061} from 'foo';
    ·         ─
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {\u0061 as a} from 'foo';
    ·         ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {\u0061 as \u0061} from 'foo';
    ·         ──────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {foo as foo, bar as baz} from 'foo';
    ·         ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:47]
  1 │ var foo = 0; var bar = 0; export {foo as bar, baz as baz} from 'foo';
    ·                                               ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:9]
  1 │ export {foo as foo, bar as bar} from 'foo';
    ·         ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:21]
  1 │ export {foo as foo, bar as bar} from 'foo';
    ·                     ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ ({/* comment */foo: foo} = {});
    ·                ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ ({/* comment */foo: foo = 1} = {});
    ·                ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:21]
  1 │ ({foo, /* comment */bar: bar} = {});
    ·                     ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo/**/ : foo} = {});
    ·   ─────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo/**/ : foo = 1} = {});
    ·   ─────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo /**/: foo} = {});
    ·   ─────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo /**/: foo = 1} = {});
    ·   ─────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ╭─▶ ({foo://
  2 │ ╰─▶             foo} = {});
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: /**/foo} = {});
    ·   ────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (/**/foo)} = {});
    ·   ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (foo/**/)} = {});
    ·   ──────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ╭─▶ ({foo: (foo //
  2 │ ╰─▶             )} = {});
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: /**/foo = 1} = {});
    ·   ────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (/**/foo) = 1} = {});
    ·   ──────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: (foo/**/) = 1} = {});
    ·   ──────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo/* comment */} = {});
    ·   ────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo//comment
    ·   ────────
  2 │             ,bar} = {});
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo/* comment */ = 1} = {});
    ·   ─────────────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ╭─▶ ({foo: foo // comment
  2 │ ╰─▶              = 1} = {});
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo = /* comment */ 1} = {});
    ·   ──────────────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ╭─▶ ({foo: foo = // comment
  2 │ ╰─▶              1} = {});
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:3]
  1 │ ({foo: foo = (1/* comment */)} = {});
    ·   ───────────────────────────
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:29]
  1 │ import {/* comment */foo as foo} from 'foo';
    ·                             ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:33]
  1 │ import {foo,/* comment */bar as bar} from 'foo';
    ·                                 ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:20]
  1 │ import {foo/**/ as foo} from 'foo';
    ·                    ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:20]
  1 │ import {foo /**/as foo} from 'foo';
    ·                    ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:2:7]
  1 │ import {foo //
  2 │             as foo} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:19]
  1 │ import {foo as/**/foo} from 'foo';
    ·                   ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ import {foo as foo/* comment */} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:16]
  1 │ import {foo as foo/* comment */,bar} from 'foo';
    ·                ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:31]
  1 │ let foo; export {/* comment */foo as foo};
    ·                               ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:40]
  1 │ let foo, bar; export {foo,/* comment */bar as bar};
    ·                                        ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let foo; export {foo/**/as foo};
    ·                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let foo; export {foo as/**/ foo};
    ·                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let foo; export {foo as /**/foo};
    ·                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let foo; export {foo as//comment
    ·                  ───
  2 │              foo};
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:18]
  1 │ let foo; export {foo as foo/* comment*/};
    ·                  ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:23]
  1 │ let foo, bar; export {foo as foo/* comment*/,bar};
    ·                       ───
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name
 
-  ⚠ eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name
+  ⚠ eslint(no-useless-rename): Do not rename import, export, or destructured assignments to the same name
    ╭─[no_useless_rename.tsx:1:23]
  1 │ let foo, bar; export {foo as foo//comment
    ·                       ───
  2 │             ,bar};
    ╰────
-  help: Either remove the renaming or rename the variable.
+  help: Use the variable's original name or rename it to a different name

--- a/crates/oxc_linter/src/snapshots/no_void.snap
+++ b/crates/oxc_linter/src/snapshots/no_void.snap
@@ -1,44 +1,44 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:1]
  1 │ void 0
    · ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead
 
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:1]
  1 │ void 0
    · ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead
 
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:1]
  1 │ void 0
    · ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead
 
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:1]
  1 │ void(0)
    · ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead
 
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:11]
  1 │ var foo = void 0
    ·           ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead
 
-  ⚠ eslint(no-void): Disallow `void` operators
+  ⚠ eslint(no-void): Unexpected `void` operator
    ╭─[no_void.tsx:1:11]
  1 │ var foo = void 0
    ·           ────
    ╰────
-  help: Expected 'undefined' and instead saw 'void'.
+  help: Use `undefined` instead


### PR DESCRIPTION
Cleans diagnostic messages and help texts for (almost) all remaining rules.
There were two rules I couldn' find good replacements for.

I also made some logical improvements to a few rules, and added `pending` fixers
to others.