### PR TITLE
fix(parser): hashbang comment should not keep the end newline char

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -52,6 +52,7 @@ impl<'a> Gen for Hashbang<'a> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_str("#!");
         p.print_str(self.value.as_str());
+        p.print_hard_newline();
     }
 }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -282,6 +282,11 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
+    fn print_hard_newline(&mut self) {
+        self.print_char(b'\n');
+    }
+
+    #[inline]
     fn print_semicolon(&mut self) {
         self.print_char(b';');
     }

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -176,10 +176,11 @@ impl<'a> Lexer<'a> {
 
     /// Section 12.5 Hashbang Comments
     pub(super) fn read_hashbang_comment(&mut self) -> Kind {
-        while let Some(c) = self.next_char().as_ref() {
+        while let Some(c) = self.peek_char().as_ref() {
             if is_line_terminator(*c) {
                 break;
             }
+            self.consume_char();
         }
         self.token.is_on_new_line = true;
         Kind::HashbangComment

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -178,7 +178,7 @@ token
             kind: CommentKind::Block,
             position: CommentPosition::Leading,
             attached_to: 36,
-            preceded_by_newline: false, // hashbang comment always end in newline
+            preceded_by_newline: true,
             followed_by_newline: true,
         }];
         assert_eq!(comments, expected);

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -524,6 +524,15 @@ mod test {
     }
 
     #[test]
+    fn hashbang() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        let source = "#!/usr/bin/node\n;";
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        assert_eq!(ret.program.hashbang.unwrap().value.as_str(), "/usr/bin/node");
+    }
+
+    #[test]
     fn unambiguous() {
         let allocator = Allocator::default();
         let source_type = SourceType::unambiguous();


### PR DESCRIPTION
Previously it included a newline in the value

```
  "hashbang": {
    "type": "Hashbang",
    "start": 0,
    "end": 16,
    "value": "/usr/bin/node\n"
  },
```

This change will also make the lexer emit a `\n` token, which will make comment position detection correct.