### PR TITLE
perf(transformer): arrow function transform: calculate whether `this` is in arrow function lazily

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -51,26 +51,6 @@ impl<'a> Traverse<'a> for ES2015<'a> {
         }
     }
 
-    fn enter_arrow_function_expression(
-        &mut self,
-        arrow: &mut ArrowFunctionExpression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        if self.options.arrow_function.is_some() {
-            self.arrow_functions.enter_arrow_function_expression(arrow, ctx);
-        }
-    }
-
-    fn exit_arrow_function_expression(
-        &mut self,
-        arrow: &mut ArrowFunctionExpression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        if self.options.arrow_function.is_some() {
-            self.arrow_functions.exit_arrow_function_expression(arrow, ctx);
-        }
-    }
-
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.arrow_function.is_some() {
             self.arrow_functions.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -142,7 +142,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.enter_arrow_function_expression(arrow, ctx);
-        self.x3_es2015.enter_arrow_function_expression(arrow, ctx);
     }
 
     fn enter_binding_pattern(&mut self, pat: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -306,8 +305,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         arrow: &mut ArrowFunctionExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x3_es2015.exit_arrow_function_expression(arrow, ctx);
-
         // Some plugins may add new statements to the ArrowFunctionExpression's body,
         // which can cause issues with the `() => x;` case, as it only allows a single statement.
         // To address this, we wrap the last statement in a return statement and set the expression to false.


### PR DESCRIPTION
I initially added `inside_arrow_function_stack` as we haven't got `TraverseCtx` in `Transformer`. Now we can use `ctx.current_scope_flags().is_arrow()` directly instead