### PR TITLE
perf(linter): Check file path after checking node kind for `nextjs/no-head-element`

### DIFF
--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -30,19 +30,20 @@ declare_oxc_lint!(
 
 impl Rule for NoHeadElement {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let Some(full_file_path) = ctx.file_path().to_str() else {
-            return;
-        };
-        if is_in_app_dir(full_file_path) {
-            return;
-        }
         if let AstKind::JSXOpeningElement(elem) = node.kind() {
             let JSXElementName::Identifier(id) = &elem.name else {
                 return;
             };
-            if id.name == "head" {
-                ctx.diagnostic(no_head_element_diagnostic(elem.span));
+            if id.name != "head" {
+                return;
             }
+            let Some(full_file_path) = ctx.file_path().to_str() else {
+                return;
+            };
+            if is_in_app_dir(full_file_path) {
+                return;
+            }
+            ctx.diagnostic(no_head_element_diagnostic(elem.span));
         }
     }
 }


### PR DESCRIPTION
We should check the node AST kind before looking at the file path. Doing otherwise is slow because we have to do some string comparisons for every AST node.