### PR TITLE
perf(linter): Perform fewer allocation in `jest/no-deprecated-functions`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -121,10 +121,10 @@ impl Rule for NoDeprecatedFunctions {
 
         let node_name = chain.as_str();
 
-        if let Some((base_version, replacement)) = DEPRECATED_FUNCTIONS_MAP.get(&node_name) {
+        if let Some((base_version, replacement)) = DEPRECATED_FUNCTIONS_MAP.get(node_name) {
             if self.jest.version >= *base_version {
                 ctx.diagnostic_with_fix(
-                    deprecated_function(&node_name, replacement, mem_expr.span()),
+                    deprecated_function(node_name, replacement, mem_expr.span()),
                     |fixer| fixer.replace(mem_expr.span(), *replacement),
                 );
             }

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -109,7 +109,7 @@ impl Rule for NoDeprecatedFunctions {
             return;
         };
 
-        let mut chain = String::new();
+        let mut chain = String::with_capacity(64);
         if let Expression::Identifier(ident) = mem_expr.object() {
             chain.push_str(ident.name.as_str());
         }


### PR DESCRIPTION
hypothesis: flamegraphs show that this rule is copying and allocating quite a bit of the time. I wanted to try and see if using a single String would be more efficient.