### PR TITLE
docs(semantic): document `AstNode` and `AstNodes`

### DIFF
--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -4,6 +4,7 @@ use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
+/// AST Node ID
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct NodeId(NonMaxU32);
 
@@ -78,16 +79,19 @@ bitflags! {
 }
 
 impl NodeFlags {
+    /// Returns `true` if this node has a JSDoc comment attached to it.
     #[inline]
     pub fn has_jsdoc(&self) -> bool {
         self.contains(Self::JSDoc)
     }
 
+    /// Returns `true` if this node is inside a class.
     #[inline]
     pub fn has_class(&self) -> bool {
         self.contains(Self::Class)
     }
 
+    /// Returns `true` if this function has a yield statement.
     #[inline]
     pub fn has_yield(&self) -> bool {
         self.contains(Self::HasYield)


### PR DESCRIPTION
Part of #5870 