### PR TITLE
fix(isolated_declarations): Don't require private method arguments to have type annotations

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -376,6 +376,8 @@ impl<'a> IsolatedDeclarations<'a> {
                         continue;
                     }
 
+                    let errors_length = self.errors.borrow().len();
+
                     let inferred_accessor_types = self.collect_inferred_accessor_types(decl);
                     let function = &method.value;
                     let params = if method.kind.is_set() {
@@ -404,6 +406,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     }
 
                     if method.accessibility.is_some_and(TSAccessibility::is_private) {
+                        self.errors.borrow_mut().truncate(errors_length);
                         elements.push(self.transform_private_modifier_method(method));
                         continue;
                     }

--- a/crates/oxc_isolated_declarations/tests/fixtures/function-parameters.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/function-parameters.ts
@@ -14,6 +14,10 @@ const x = 42;
 const y = '';
 export function fooGood3({a = x, b: [{c = y}]}: object): void {}
 
+export class Foo {
+  private good(a): void {}
+}
+
 // Incorrect
 export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
 export function fnDeclBad2<T>(p: T = [], r2: T): void { }
@@ -25,4 +29,8 @@ export function fooBad([a, b] = [1, 2]): number {
 
 export const fooBad2 = ({a, b} = { a: 1, b: 2 }): number => {
   return 2;
+}
+
+export class Bar {
+  public bad(a): void {}
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
@@ -9,65 +9,80 @@ export declare function fnDeclGood2(p?: T, rParam?: number): void;
 export declare function fooGood([a, b]?: any[]): number;
 export declare const fooGood2: ({ a, b }?: object) => number;
 export declare function fooGood3({ a, b: [{ c }] }: object): void;
+export declare class Foo {
+	private good;
+}
 export declare function fnDeclBad<T>(p: T, rParam: T, r2: T): void;
 export declare function fnDeclBad2<T>(p: T, r2: T): void;
 export declare function fnDeclBad3<T>(p: T, rParam?: T, r2: T): void;
 export declare function fooBad(): number;
 export declare const fooBad2: () => number;
+export declare class Bar {
+	bad(a): void;
+}
 
 
 ==================== Errors ====================
 
   x TS9025: Declaration emit for this parameter requires implicitly adding
   | undefined to it's type. This is not supported with --isolatedDeclarations.
-    ,-[18:30]
- 17 | // Incorrect
- 18 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
+    ,-[22:30]
+ 21 | // Incorrect
+ 22 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
     :                              ^^^^^^^^^
- 19 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
+ 23 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
     `----
 
   x TS9025: Declaration emit for this parameter requires implicitly adding
   | undefined to it's type. This is not supported with --isolatedDeclarations.
-    ,-[18:41]
- 17 | // Incorrect
- 18 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
+    ,-[22:41]
+ 21 | // Incorrect
+ 22 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
     :                                         ^^^^^^^^^^^^^^
- 19 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
+ 23 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
     `----
 
   x TS9025: Declaration emit for this parameter requires implicitly adding
   | undefined to it's type. This is not supported with --isolatedDeclarations.
-    ,-[19:31]
- 18 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
- 19 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
+    ,-[23:31]
+ 22 | export function fnDeclBad<T>(p: T = [], rParam: T = "", r2: T): void { }
+ 23 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
     :                               ^^^^^^^^^
- 20 | export function fnDeclBad3<T>(p: T = [], rParam?: T, r2: T): void { }
+ 24 | export function fnDeclBad3<T>(p: T = [], rParam?: T, r2: T): void { }
     `----
 
   x TS9025: Declaration emit for this parameter requires implicitly adding
   | undefined to it's type. This is not supported with --isolatedDeclarations.
-    ,-[20:31]
- 19 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
- 20 | export function fnDeclBad3<T>(p: T = [], rParam?: T, r2: T): void { }
+    ,-[24:31]
+ 23 | export function fnDeclBad2<T>(p: T = [], r2: T): void { }
+ 24 | export function fnDeclBad3<T>(p: T = [], rParam?: T, r2: T): void { }
     :                               ^^^^^^^^^
- 21 | 
-    `----
-
-  x TS9011: Parameter must have an explicit type annotation with
-  | --isolatedDeclarations.
-    ,-[22:24]
- 21 | 
- 22 | export function fooBad([a, b] = [1, 2]): number {
-    :                        ^^^^^^^^^^^^^^^
- 23 |   return 2;
-    `----
-
-  x TS9011: Parameter must have an explicit type annotation with
-  | --isolatedDeclarations.
-    ,-[26:25]
  25 | 
- 26 | export const fooBad2 = ({a, b} = { a: 1, b: 2 }): number => {
-    :                         ^^^^^^^^^^^^^^^^^^^^^^^
+    `----
+
+  x TS9011: Parameter must have an explicit type annotation with
+  | --isolatedDeclarations.
+    ,-[26:24]
+ 25 | 
+ 26 | export function fooBad([a, b] = [1, 2]): number {
+    :                        ^^^^^^^^^^^^^^^
  27 |   return 2;
+    `----
+
+  x TS9011: Parameter must have an explicit type annotation with
+  | --isolatedDeclarations.
+    ,-[30:25]
+ 29 | 
+ 30 | export const fooBad2 = ({a, b} = { a: 1, b: 2 }): number => {
+    :                         ^^^^^^^^^^^^^^^^^^^^^^^
+ 31 |   return 2;
+    `----
+
+  x TS9011: Parameter must have an explicit type annotation with
+  | --isolatedDeclarations.
+    ,-[35:14]
+ 34 | export class Bar {
+ 35 |   public bad(a): void {}
+    :              ^
+ 36 | }
     `----


### PR DESCRIPTION
In https://github.com/oxc-project/oxc/pull/4934 I introduced a regression which caused the following code to begin having an isolated declarations error where it shouldn't:
```ts
export class Foo {
  private foo(a): void {}
}
```
[TS playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/KYDwDg9gTgLgBAYwDYEMDOa4DEITgbwCg44B6UuAARjQFpQxgEZ6oppi4woBLANxQxgcAGa4AFCgCUALjh8IPACYEAvoVVA)