### PR TITLE
refactor(semantic): Remove redundunt is_leading check for JSDoc

### DIFF
--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -15,10 +15,7 @@ pub struct JSDocBuilder<'a> {
 impl<'a> JSDocBuilder<'a> {
     pub fn new(source_text: &'a str, trivias: &Trivias) -> Self {
         let mut not_attached_docs: FxHashMap<u32, Vec<_>> = FxHashMap::default();
-        for comment in trivias
-            .comments()
-            .filter(|comment| comment.is_leading() && comment.is_jsdoc(source_text))
-        {
+        for comment in trivias.comments().filter(|comment| comment.is_jsdoc(source_text)) {
             not_attached_docs
                 .entry(comment.attached_to)
                 .or_default()


### PR DESCRIPTION
Late review for #5876 👀 

`is_leading()` was already covered by `is_jsdoc()`.

https://github.com/oxc-project/oxc/blob/9115dd947afdb525cdb9c40cb851177f132b39a4/crates/oxc_ast/src/trivia.rs#L108-L110