### PR TITLE
refactor(semantic): rename lifetime on `impl IntoIterator for &AstNodes`

### DIFF
--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -266,9 +266,9 @@ impl<'a> AstNodes<'a> {
     }
 }
 
-impl<'ast, 'a> IntoIterator for &'ast AstNodes<'a> {
-    type Item = &'ast AstNode<'a>;
-    type IntoIter = std::slice::Iter<'ast, AstNode<'a>>;
+impl<'a, 'n> IntoIterator for &'n AstNodes<'a> {
+    type Item = &'n AstNode<'a>;
+    type IntoIter = std::slice::Iter<'n, AstNode<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.nodes.iter()


### PR DESCRIPTION
Follow on after #5873.

Rename lifetime. I generally consider `'a` in AST types as short for `'ast`, so using `'ast` to mean something else is confusing. Rename lifetime to `'n` (short for `'nodes`).