### PR TITLE
fix(ast): serialize `JSXMemberExpressionObject` to estree

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -238,7 +238,7 @@ pub struct JSXMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
+#[cfg_attr(feature = "serialize", derive(Tsify))]
 #[serde(untagged)]
 pub enum JSXMemberExpressionObject<'a> {
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -9,8 +9,8 @@ use crate::ast::{
     ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
     AssignmentTargetRest, BindingPattern, BindingPatternKind, BindingProperty, BindingRestElement,
     Directive, Elision, FormalParameter, FormalParameterKind, FormalParameters, JSXElementName,
-    JSXIdentifier, ObjectAssignmentTarget, ObjectPattern, Program, RegExpFlags, Statement,
-    StringLiteral, TSModuleBlock, TSTypeAnnotation,
+    JSXIdentifier, JSXMemberExpressionObject, ObjectAssignmentTarget, ObjectPattern, Program,
+    RegExpFlags, Statement, StringLiteral, TSModuleBlock, TSTypeAnnotation,
 };
 
 pub struct EcmaFormatter;
@@ -258,6 +258,20 @@ impl<'a> Serialize for JSXElementName<'a> {
                 JSXIdentifier { span: ident.span, name: ident.name.clone() }.serialize(serializer)
             }
             Self::NamespacedName(name) => name.serialize(serializer),
+            Self::MemberExpression(expr) => expr.serialize(serializer),
+            Self::ThisExpression(expr) => {
+                JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer)
+            }
+        }
+    }
+}
+
+impl<'a> Serialize for JSXMemberExpressionObject<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::IdentifierReference(ident) => {
+                JSXIdentifier { span: ident.span, name: ident.name.clone() }.serialize(serializer)
+            }
             Self::MemberExpression(expr) => expr.serialize(serializer),
             Self::ThisExpression(expr) => {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer)


### PR DESCRIPTION
Follow-on after #5882, part of #5354.

Make JSON AST ESTree-compatible for:

* `<Foo.bar />`
* `<this.foo />`
