### PR TITLE
fix(ast): correct TS types for JSX

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -168,7 +168,6 @@ pub struct JSXClosingFragment {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash)]
-#[cfg_attr(feature = "serialize", derive(Tsify))]
 #[serde(untagged)]
 pub enum JSXElementName<'a> {
     /// `<div />`
@@ -238,7 +237,6 @@ pub struct JSXMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash)]
-#[cfg_attr(feature = "serialize", derive(Tsify))]
 #[serde(untagged)]
 pub enum JSXMemberExpressionObject<'a> {
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -6,6 +6,13 @@ use oxc_span::{Atom, Span};
 
 use crate::ast::*;
 
+#[cfg(feature = "serialize")]
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
+export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
+"#;
+
 // 1.2 JSX Elements
 
 impl<'a> JSXIdentifier<'a> {


### PR DESCRIPTION
Part of #5354. #5882 and #5883 corrected the JSON AST for JSX types to make it ESTree-compatible. Bring the TS types into line with those changes.