### PR TITLE
perf(linter): use `aho-corasick` instead of `regex` for string matching in `jsx-a11y/img-redundant-alt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ dependencies = [
 name = "oxc_linter"
 version = "0.9.6"
 dependencies = [
+ "aho-corasick",
  "bitflags 2.6.0",
  "convert_case",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ napi = "3.0.0-alpha.8"
 napi-build = "2.1.3"
 napi-derive = "3.0.0-alpha.7"
 
+aho-corasick = "1.1.3"
 allocator-api2 = "0.2.18"
 assert-unchecked = "0.1.2"
 base64 = "0.22.1"

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -34,6 +34,7 @@ oxc_semantic = { workspace = true }
 oxc_span = { workspace = true, features = ["schemars", "serialize"] }
 oxc_syntax = { workspace = true }
 
+aho-corasick = { workspace = true }
 bitflags = { workspace = true }
 convert_case = { workspace = true }
 cow-utils = { workspace = true }


### PR DESCRIPTION
hypothesis: profiling shows that Regex creation takes a decent amount of time. the `regex` crate uses `aho-corasick` internally for string matching, which is all we need in some cases. in theory, we could save time by using the lib directly and not needing the full regex syntax.