### PR TITLE
fix(transformer): JSX source: add `var _jsxFileName` statement

### DIFF
--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -59,6 +59,12 @@ impl<'a> ReactJsxSource<'a> {
 }
 
 impl<'a> Traverse<'a> for ReactJsxSource<'a> {
+    fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        if let Some(stmt) = self.get_var_file_name_statement() {
+            program.body.insert(0, stmt);
+        }
+    }
+
     fn enter_jsx_opening_element(
         &mut self,
         elem: &mut JSXOpeningElement<'a>,

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -84,6 +84,8 @@ impl<'a> Traverse<'a> for React<'a> {
         }
         if self.jsx_plugin {
             self.jsx.exit_program(program, ctx);
+        } else if self.jsx_source_plugin {
+            self.jsx.jsx_source.exit_program(program, ctx);
         }
     }
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,12 +1,13 @@
 commit: 3bcfee23
 
-Passed: 46/56
+Passed: 47/57
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
+* babel-plugin-transform-react-jsx-source
 * regexp
 
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/input.jsx
@@ -1,0 +1,1 @@
+var x = <sometag />;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/output.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/output.jsx
@@ -1,0 +1,6 @@
+var _jsxFileName = "<CWD>/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/basic-sample/input.jsx";
+var x = <sometag __source={{
+  fileName: _jsxFileName,
+  lineNumber: 1,
+  columnNumber: 9
+}} />;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-jsx", "transform-react-jsx-source"]
+}


### PR DESCRIPTION
Fix JSX source transform when run alone without main JSX transform.

The added test case is same as one of Babel's exec test cases, but the exec test fails due to `transformAsync` not being present.