### PR TITLE
fix(transformer): fix references in logical assignment operator transform

### DIFF
--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -118,9 +118,10 @@ impl<'a> Traverse<'a> for LogicalAssignmentOperators<'a> {
         // TODO: refactor this block, add tests, cover private identifier
         match &mut assignment_expr.left {
             AssignmentTarget::AssignmentTargetIdentifier(ident) => {
-                left_expr = ctx.ast.expression_from_identifier_reference(
-                    ctx.clone_identifier_reference(ident, ReferenceFlags::Read),
-                );
+                let reference = ctx.symbols_mut().get_reference_mut(ident.reference_id().unwrap());
+                *reference.flags_mut() = ReferenceFlags::Read;
+                left_expr = ctx.ast.expression_from_identifier_reference(ident.clone());
+
                 assign_target = AssignmentTarget::from(
                     ctx.ast.simple_assignment_target_from_identifier_reference(
                         ctx.clone_identifier_reference(ident, ReferenceFlags::Write),

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1442,31 +1442,25 @@ x Output mismatch
 
 # babel-plugin-transform-logical-assignment-operators (0/6)
 * logical-assignment/anonymous-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
+after transform: ReferenceId(3): ReferenceFlags(Write)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
+after transform: ReferenceId(4): ReferenceFlags(Write)
 rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
+after transform: ReferenceId(5): ReferenceFlags(Write)
 rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/arrow-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
+after transform: ReferenceId(3): ReferenceFlags(Write)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
+after transform: ReferenceId(4): ReferenceFlags(Write)
 rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
+after transform: ReferenceId(5): ReferenceFlags(Write)
 rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/general-semantics/input.js
@@ -1568,17 +1562,14 @@ after transform: ReferenceId(134): ReferenceFlags(Write)
 rebuilt        : ReferenceId(128): ReferenceFlags(Read)
 
 * logical-assignment/named-functions-transform/input.js
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
+after transform: ReferenceId(3): ReferenceFlags(Write)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
+after transform: ReferenceId(4): ReferenceFlags(Write)
 rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
+after transform: ReferenceId(5): ReferenceFlags(Write)
 rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 
 * logical-assignment/null-coalescing/input.js
@@ -1586,28 +1577,25 @@ x Output mismatch
 
 * logical-assignment/null-coalescing-without-other/input.js
 Symbol reference IDs mismatch:
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(11)]
+after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7), ReferenceId(10)]
 rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(8)]
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6)]
 Reference flags mismatch:
-after transform: ReferenceId(4): ReferenceFlags(Write)
+after transform: ReferenceId(3): ReferenceFlags(Write)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(6): ReferenceFlags(Write)
+after transform: ReferenceId(5): ReferenceFlags(Write)
 rebuilt        : ReferenceId(2): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(5): ReferenceFlags(Write)
+after transform: ReferenceId(4): ReferenceFlags(Write)
 rebuilt        : ReferenceId(4): ReferenceFlags(Read)
 Reference flags mismatch:
-after transform: ReferenceId(8): ReferenceFlags(Write)
+after transform: ReferenceId(7): ReferenceFlags(Write)
 rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(10): ReferenceFlags(Write)
+after transform: ReferenceId(9): ReferenceFlags(Write)
 rebuilt        : ReferenceId(7): ReferenceFlags(Read | Write)
 Reference flags mismatch:
-after transform: ReferenceId(9): ReferenceFlags(Write)
+after transform: ReferenceId(8): ReferenceFlags(Write)
 rebuilt        : ReferenceId(9): ReferenceFlags(Read)
 
 


### PR DESCRIPTION
Re-use existing reference, rather than creating a new one.