### PR TITLE
refactor(ast): remove `.iter()` where not needed

### DIFF
--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -1381,7 +1381,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_directive(el);
         }
     }
@@ -1403,7 +1403,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Statement<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_statement(el);
         }
     }
@@ -1591,7 +1591,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TemplateElement<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_template_element(el);
         }
     }
@@ -1603,7 +1603,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Expression<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_expression(el);
         }
     }
@@ -1654,7 +1654,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, ArrayExpressionElement<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_array_expression_element(el);
         }
     }
@@ -1743,7 +1743,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSTypeParameter<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_type_parameter(el);
         }
     }
@@ -1948,7 +1948,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, FormalParameter<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_formal_parameter(el);
         }
     }
@@ -1964,7 +1964,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_decorator(el);
         }
     }
@@ -2015,7 +2015,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, BindingProperty<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_binding_property(el);
         }
     }
@@ -2162,7 +2162,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSImportAttribute<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_import_attribute(el);
         }
     }
@@ -2198,7 +2198,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSType<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_type(el);
         }
     }
@@ -2342,7 +2342,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSTupleElement<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_tuple_element(el);
         }
     }
@@ -2357,7 +2357,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_ts_signatures<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSSignature<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_signature(el);
         }
     }
@@ -2389,7 +2389,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSIndexSignatureName<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_index_signature_name(el);
         }
     }
@@ -2831,7 +2831,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, AssignmentTargetProperty<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_assignment_target_property(el);
         }
     }
@@ -2904,7 +2904,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Argument<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_argument(el);
         }
     }
@@ -2975,7 +2975,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSClassImplements<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_class_implements(el);
         }
     }
@@ -3001,7 +3001,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_class_elements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, ClassElement<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_class_element(el);
         }
     }
@@ -3165,7 +3165,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, ObjectPropertyKind<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_object_property_kind(el);
         }
     }
@@ -3357,7 +3357,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, JSXAttributeItem<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_jsx_attribute_item(el);
         }
     }
@@ -3436,7 +3436,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, JSXChild<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_jsx_child(el);
         }
     }
@@ -3540,7 +3540,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, VariableDeclarator<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_variable_declarator(el);
         }
     }
@@ -3645,7 +3645,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, SwitchCase<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_switch_case(el);
         }
     }
@@ -3792,7 +3792,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, TSInterfaceHeritage<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_interface_heritage(el);
         }
     }
@@ -3830,7 +3830,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_ts_enum_members<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSEnumMember<'a>>) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_ts_enum_member(el);
         }
     }
@@ -3992,7 +3992,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_import_declaration_specifier(el);
         }
     }
@@ -4065,7 +4065,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, ImportAttribute<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_import_attribute(el);
         }
     }
@@ -4162,7 +4162,7 @@ pub mod walk {
         visitor: &mut V,
         it: &Vec<'a, ExportSpecifier<'a>>,
     ) {
-        for el in it.iter() {
+        for el in it {
             visitor.visit_export_specifier(el);
         }
     }

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -263,9 +263,10 @@ impl<'a> VisitBuilder<'a> {
         let (walk_body, may_inline) = if collection {
             let singular_visit = self.get_visitor(def, false, None);
             let iter = self.get_iter();
+            let iter = if self.is_mut { quote!(it.#iter()) } else { quote!(it) };
             (
                 quote! {
-                    for el in it.#iter() {
+                    for el in #iter {
                         visitor.#singular_visit(el);
                     }
                 },


### PR DESCRIPTION
this is just an experiment, I noticed while profiling these code paths came up a number of times:
<img width="1077" alt="Screenshot 2024-09-19 at 8 32 51 PM" src="https://github.com/user-attachments/assets/d0f4d703-c456-4344-8f57-81f0b3f491a0">
