### PR TITLE
feat(span)!: expose `SourceType` fields; change builder pattern to setters

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1402,6 +1402,9 @@ const _: () = {
 
     assert!(size_of::<SourceType>() == 3usize);
     assert!(align_of::<SourceType>() == 1usize);
+    assert!(offset_of!(SourceType, language) == 0usize);
+    assert!(offset_of!(SourceType, module_kind) == 1usize);
+    assert!(offset_of!(SourceType, variant) == 2usize);
 
     assert!(size_of::<Language>() == 1usize);
     assert!(align_of::<Language>() == 1usize);
@@ -2957,6 +2960,9 @@ const _: () = {
 
     assert!(size_of::<SourceType>() == 3usize);
     assert!(align_of::<SourceType>() == 1usize);
+    assert!(offset_of!(SourceType, language) == 0usize);
+    assert!(offset_of!(SourceType, module_kind) == 1usize);
+    assert!(offset_of!(SourceType, variant) == 2usize);
 
     assert!(size_of::<Language>() == 1usize);
     assert!(align_of::<Language>() == 1usize);

--- a/crates/oxc_linter/src/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/partial_loader/svelte.rs
@@ -41,7 +41,10 @@ impl<'a> SveltePartialLoader<'a> {
         let js_end = pointer + offset;
 
         let source_text = &self.source_text[js_start..js_end];
-        let source_type = SourceType::mjs().with_typescript(is_ts);
+        let mut source_type = SourceType::mjs();
+        if is_ts {
+            source_type = source_type.set_ts();
+        }
         Some(JavaScriptSource::new(source_text, source_type, js_start))
     }
 }

--- a/crates/oxc_linter/src/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/partial_loader/vue.rs
@@ -56,7 +56,13 @@ impl<'a> VuePartialLoader<'a> {
         *pointer += offset + SCRIPT_END.len();
 
         let source_text = &self.source_text[js_start..js_end];
-        let source_type = SourceType::mjs().with_typescript(is_ts).with_jsx(is_jsx);
+        let mut source_type = SourceType::mjs();
+        if is_ts {
+            source_type = source_type.set_ts();
+        }
+        if is_jsx {
+            source_type = source_type.set_jsx();
+        }
         Some(JavaScriptSource::new(source_text, source_type, js_start))
     }
 }

--- a/crates/oxc_module_lexer/tests/typescript.rs
+++ b/crates/oxc_module_lexer/tests/typescript.rs
@@ -6,7 +6,7 @@ use oxc_span::SourceType;
 
 fn parse(source: &str) -> ModuleLexer {
     let allocator = Allocator::default();
-    let source_type = SourceType::mjs().with_typescript_definition(true);
+    let source_type = SourceType::d_ts();
     let ret = Parser::new(&allocator, source, source_type).parse();
     assert!(ret.errors.is_empty(), "{source} should not produce errors.\n{:?}", ret.errors);
     let module_lexer = oxc_module_lexer::ModuleLexer::new().build(&ret.program);

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -452,7 +452,7 @@ impl<'a> ParserImpl<'a> {
 
     fn default_context(source_type: SourceType, options: ParseOptions) -> Context {
         let mut ctx = Context::default().and_ambient(source_type.is_typescript_definition());
-        if source_type.module_kind() == ModuleKind::Module {
+        if source_type.module_kind == ModuleKind::Module {
             // for [top-level-await](https://tc39.es/proposal-top-level-await/)
             ctx = ctx.and_await(true);
         }
@@ -515,13 +515,13 @@ impl<'a> ParserImpl<'a> {
 
     fn set_source_type_to_module_if_unambiguous(&mut self) {
         if self.source_type.is_unambiguous() {
-            self.source_type = self.source_type.with_module(true);
+            self.source_type = self.source_type.set_module();
         }
     }
 
     fn set_source_type_to_script_if_unambiguous(&mut self) {
         if self.source_type.is_unambiguous() {
-            self.source_type = self.source_type.with_script(true);
+            self.source_type = self.source_type.set_script();
         }
     }
 }
@@ -602,7 +602,7 @@ mod test {
     #[test]
     fn comments() {
         let allocator = Allocator::default();
-        let source_type = SourceType::default().with_typescript(true);
+        let source_type = SourceType::ts();
         let sources = [
             ("// line comment", CommentKind::Line),
             ("/* line comment */", CommentKind::Block),

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -404,7 +404,7 @@ pub fn check_module_declaration<'a>(
     };
     let start = decl.span().start;
     let span = Span::new(start, start + 6);
-    match ctx.source_type.module_kind() {
+    match ctx.source_type.module_kind {
         ModuleKind::Unambiguous => {
             #[cfg(debug_assertions)]
             panic!("Technically unreachable, omit to avoid panic.");

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -361,7 +361,7 @@ mod test {
             "bar: string;",
         )];
 
-        let source_type = SourceType::default().with_typescript(true);
+        let source_type = SourceType::ts();
         for (source_text, target) in source_texts {
             test_jsdoc_found(source_text, target, Some(source_type));
         }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -299,7 +299,7 @@ mod tests {
     fn type_alias_gets_reference() {
         let source = "type A = 1; type B = A";
         let allocator = Allocator::default();
-        let source_type: SourceType = SourceType::default().with_typescript(true);
+        let source_type: SourceType = SourceType::ts();
         let semantic = get_semantic(&allocator, source, source_type);
         assert!(semantic.symbols().references.len() == 1);
     }

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -63,7 +63,7 @@ fn test_top_level_strict() {
     }
     "#,
     )
-    .with_module(false)
+    .set_module()
     .has_root_symbol("foo")
     .is_in_scope(ScopeFlags::Top | ScopeFlags::StrictMode)
     .test();
@@ -76,7 +76,7 @@ fn test_top_level_strict() {
     }
     ",
     )
-    .with_module(false)
+    .set_script()
     .has_root_symbol("foo")
     .is_in_scope(ScopeFlags::Top)
     .is_not_in_scope(ScopeFlags::StrictMode)
@@ -94,7 +94,7 @@ fn test_function_level_strict() {
     }
     "#,
     )
-    .with_module(false);
+    .set_script();
 
     tester.has_some_symbol("x")
         .is_in_scope(ScopeFlags::StrictMode | ScopeFlags::Function)

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -45,7 +45,7 @@ impl<'a> SemanticTester<'a> {
     ///
     /// Use [`SemanticTester::ts`] for TypeScript test cases without JSX.
     pub fn tsx(source_text: &'static str) -> Self {
-        Self::ts(source_text).with_jsx(true)
+        Self::ts(source_text).set_jsx()
     }
 
     /// Create a new tester for a JavaScript test case.
@@ -71,22 +71,27 @@ impl<'a> SemanticTester<'a> {
     }
 
     /// Set the [`SourceType`] to TypeScript (or JavaScript, using `false`)
-    pub fn with_typescript(mut self, yes: bool) -> Self {
-        self.source_type = SourceType::default().with_typescript(yes);
+    pub fn set_typescript(mut self) -> Self {
+        self.source_type = self.source_type.set_ts();
         self
     }
 
     /// Mark the [`SourceType`] as JSX
     ///
     /// If the source is currently TypeScript, it will become TSX.
-    pub fn with_jsx(mut self, yes: bool) -> Self {
-        self.source_type = self.source_type.with_jsx(yes);
+    pub fn set_jsx(mut self) -> Self {
+        self.source_type = self.source_type.set_jsx();
         self
     }
 
     /// Mark the [`SourceType`] as an ESM module.
-    pub fn with_module(mut self, yes: bool) -> Self {
-        self.source_type = self.source_type.with_module(yes);
+    pub fn set_module(mut self) -> Self {
+        self.source_type = self.source_type.set_module();
+        self
+    }
+
+    pub fn set_script(mut self) -> Self {
+        self.source_type = self.source_type.set_script();
         self
     }
 

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -20,13 +20,13 @@ pub use error::UnknownExtension;
 #[serde(rename_all = "camelCase")]
 pub struct SourceType {
     /// JavaScript or TypeScript, default JavaScript
-    pub(super) language: Language,
+    pub language: Language,
 
     /// Script or Module, default Module
-    pub(super) module_kind: ModuleKind,
+    pub module_kind: ModuleKind,
 
     /// Support JSX for JavaScript and TypeScript? default without JSX
-    pub(super) variant: LanguageVariant,
+    pub variant: LanguageVariant,
 }
 
 /// JavaScript or TypeScript
@@ -160,7 +160,7 @@ impl SourceType {
     ///
     /// [`JavaScript`]: Language::JavaScript
     pub const fn jsx() -> Self {
-        Self::mjs().with_jsx(true)
+        Self::mjs().set_jsx()
     }
 
     /// Creates a [`SourceType`] representing a [`TypeScript`] file.
@@ -206,7 +206,7 @@ impl SourceType {
     /// [`TypeScript`]: Language::TypeScript
     /// [`JSX`]: LanguageVariant::Jsx
     pub const fn tsx() -> Self {
-        Self::ts().with_jsx(true)
+        Self::ts().set_jsx()
     }
 
     /// Creates a [`SourceType`] representing a [`TypeScript definition`] file.
@@ -241,10 +241,6 @@ impl SourceType {
         self.module_kind == ModuleKind::Unambiguous
     }
 
-    pub fn module_kind(self) -> ModuleKind {
-        self.module_kind
-    }
-
     pub fn is_javascript(self) -> bool {
         self.language == Language::JavaScript
     }
@@ -269,68 +265,50 @@ impl SourceType {
     }
 
     #[must_use]
-    pub const fn with_script(mut self, yes: bool) -> Self {
-        if yes {
-            self.module_kind = ModuleKind::Script;
-        }
+    pub const fn set_script(mut self) -> Self {
+        self.module_kind = ModuleKind::Script;
         self
     }
 
     #[must_use]
-    pub const fn with_module(mut self, yes: bool) -> Self {
-        if yes {
-            self.module_kind = ModuleKind::Module;
-        } else {
-            self.module_kind = ModuleKind::Script;
-        }
+    pub const fn set_module(mut self) -> Self {
+        self.module_kind = ModuleKind::Module;
         self
     }
 
     #[must_use]
-    pub const fn with_unambiguous(mut self, yes: bool) -> Self {
-        if yes {
-            self.module_kind = ModuleKind::Unambiguous;
-        }
+    pub const fn set_unambiguous(mut self) -> Self {
+        self.module_kind = ModuleKind::Unambiguous;
         self
     }
 
     #[must_use]
-    pub const fn with_javascript(mut self, yes: bool) -> Self {
-        if yes {
-            self.language = Language::JavaScript;
-        }
+    pub const fn set_js(mut self) -> Self {
+        self.language = Language::JavaScript;
         self
     }
 
     #[must_use]
-    pub const fn with_typescript(mut self, yes: bool) -> Self {
-        if yes {
-            self.language = Language::TypeScript;
-        }
+    pub const fn set_ts(mut self) -> Self {
+        self.language = Language::TypeScript;
         self
     }
 
     #[must_use]
-    pub const fn with_typescript_definition(mut self, yes: bool) -> Self {
-        if yes {
-            self.language = Language::TypeScriptDefinition;
-        }
+    pub const fn set_dts(mut self) -> Self {
+        self.language = Language::TypeScriptDefinition;
         self
     }
 
     #[must_use]
-    pub const fn with_jsx(mut self, yes: bool) -> Self {
-        if yes {
-            self.variant = LanguageVariant::Jsx;
-        }
+    pub const fn set_jsx(mut self) -> Self {
+        self.variant = LanguageVariant::Jsx;
         self
     }
 
     #[must_use]
-    pub const fn with_standard(mut self, yes: bool) -> Self {
-        if yes {
-            self.variant = LanguageVariant::Standard;
-        }
+    pub const fn unset_jsx(mut self) -> Self {
+        self.variant = LanguageVariant::Standard;
         self
     }
 
@@ -524,7 +502,7 @@ mod tests {
         }
 
         assert_eq!(SourceType::jsx(), js);
-        assert_eq!(SourceType::jsx().with_module(true), jsx);
+        assert_eq!(SourceType::jsx().set_module(), jsx);
 
         assert!(js.is_module());
         assert!(mjs.is_module());

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -71,7 +71,7 @@ impl<'a> React<'a> {
 impl<'a> Traverse<'a> for React<'a> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.jsx_plugin {
-            program.source_type = program.source_type.with_standard(true);
+            program.source_type = program.source_type.unset_jsx();
         }
         if self.refresh_plugin {
             self.refresh.enter_program(program, ctx);

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -77,7 +77,7 @@ impl<'a> Traverse<'a> for TypeScript<'a> {
             program.hashbang = None;
             program.body.clear();
         } else {
-            program.source_type = program.source_type.with_javascript(true);
+            program.source_type = program.source_type.set_js();
             self.namespace.enter_program(program, ctx);
         }
     }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -173,8 +173,8 @@ impl Oxc {
         );
         let source_type = SourceType::from_path(&path).unwrap_or_default();
         let source_type = match parser_options.source_type.as_deref() {
-            Some("script") => source_type.with_script(true),
-            Some("module") => source_type.with_module(true),
+            Some("script") => source_type.set_script(),
+            Some("module") => source_type.set_module(),
             _ => source_type,
         };
 

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -59,8 +59,8 @@ fn parse<'a>(
         .and_then(|name| SourceType::from_path(name).ok())
         .unwrap_or_default();
     let source_type = match options.source_type.as_deref() {
-        Some("script") => source_type.with_script(true),
-        Some("module") => source_type.with_module(true),
+        Some("script") => source_type.set_script(),
+        Some("module") => source_type.set_module(),
         _ => source_type,
     };
     Parser::new(allocator, source_text, source_type)

--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -35,7 +35,7 @@ pub fn isolated_declaration(
     source_text: String,
     options: Option<IsolatedDeclarationsOptions>,
 ) -> IsolatedDeclarationsResult {
-    let source_type = SourceType::from_path(&filename).unwrap_or_default().with_typescript(true);
+    let source_type = SourceType::from_path(&filename).unwrap_or_default().set_script();
     let allocator = Allocator::default();
     let options = options.unwrap_or_default();
     let ctx = TransformContext::new(

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -66,13 +66,15 @@ pub fn transform(
         let mut source_type = SourceType::from_path(&filename).unwrap_or_default();
         // Force `script` or `module`
         match options.as_ref().and_then(|options| options.source_type.as_deref()) {
-            Some("script") => source_type = source_type.with_script(true),
-            Some("module") => source_type = source_type.with_module(true),
+            Some("script") => source_type = source_type.set_script(),
+            Some("module") => source_type = source_type.set_module(),
             _ => {}
         }
         // Force `jsx`
         if let Some(jsx) = options.as_ref().and_then(|options| options.jsx.as_ref()) {
-            source_type = source_type.with_jsx(*jsx);
+            if *jsx {
+                source_type = source_type.set_jsx();
+            }
         }
         source_type
     };

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -129,16 +129,20 @@ impl Case for BabelCase {
     fn new(path: PathBuf, code: String) -> Self {
         let dir = workspace_root().join(&path);
         let options = BabelOptions::from_test_path(dir.parent().unwrap());
-        let mut source_type = SourceType::from_path(&path)
-            .unwrap()
-            .with_script(true)
-            .with_jsx(options.is_jsx())
-            .with_typescript(options.is_typescript())
-            .with_typescript_definition(options.is_typescript_definition());
+        let mut source_type = SourceType::from_path(&path).unwrap().set_script();
+        if options.is_jsx() {
+            source_type = source_type.set_jsx();
+        }
+        if options.is_typescript() {
+            source_type = source_type.set_ts();
+        }
+        if options.is_typescript_definition() {
+            source_type = source_type.set_dts();
+        }
         if options.is_unambiguous() {
-            source_type = source_type.with_unambiguous(true);
+            source_type = source_type.set_unambiguous();
         } else if options.is_module() {
-            source_type = source_type.with_module(true);
+            source_type = source_type.set_module();
         }
         let should_fail = Self::determine_should_fail(&path, &options);
         Self { path, code, source_type, options, should_fail, result: TestResult::ToBeRun }

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -136,7 +136,7 @@ impl Case for CodegenRuntimeTest262Case {
                 let source_text = self.base.code();
                 let is_module = self.base.meta().flags.contains(&TestFlag::Module);
                 let is_only_strict = self.base.meta().flags.contains(&TestFlag::OnlyStrict);
-                let source_type = SourceType::default().with_module(is_module);
+                let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
                 let allocator = Allocator::default();
                 let ret = Parser::new(&allocator, source_text, source_type).parse();
                 let mut text = CodeGenerator::new().build(&ret.program).source_text;

--- a/tasks/coverage/src/test262/mod.rs
+++ b/tasks/coverage/src/test262/mod.rs
@@ -126,13 +126,13 @@ impl Case for Test262Case {
     // https://github.com/tc39/test262/blob/main/INTERPRETING.md#strict-mode
     fn run(&mut self) {
         let flags = &self.meta.flags;
-        let source_type = SourceType::default().with_script(true);
+        let source_type = SourceType::cjs();
 
         self.result = if flags.contains(&TestFlag::OnlyStrict) {
             self.always_strict = true;
             self.execute(source_type)
         } else if flags.contains(&TestFlag::Module) {
-            self.execute(source_type.with_module(true))
+            self.execute(source_type.set_module())
         } else if flags.contains(&TestFlag::NoStrict) || flags.contains(&TestFlag::Raw) {
             self.execute(source_type)
         } else {

--- a/tasks/coverage/src/tools/codegen.rs
+++ b/tasks/coverage/src/tools/codegen.rs
@@ -59,7 +59,7 @@ impl Case for CodegenTest262Case {
     fn run(&mut self) {
         let source_text = self.base.code();
         let is_module = self.base.meta().flags.contains(&TestFlag::Module);
-        let source_type = SourceType::default().with_module(is_module);
+        let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
         let result = get_result(source_text, source_type);
         self.base.set_result(result);
     }

--- a/tasks/coverage/src/tools/minifier.rs
+++ b/tasks/coverage/src/tools/minifier.rs
@@ -46,7 +46,7 @@ impl Case for MinifierTest262Case {
     fn run(&mut self) {
         let source_text = self.base.code();
         let is_module = self.base.meta().flags.contains(&TestFlag::Module);
-        let source_type = SourceType::default().with_module(is_module);
+        let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
         let result = get_result(source_text, source_type);
         self.base.set_result(result);
     }

--- a/tasks/coverage/src/tools/prettier.rs
+++ b/tasks/coverage/src/tools/prettier.rs
@@ -65,7 +65,7 @@ impl Case for PrettierTest262Case {
     fn run(&mut self) {
         let source_text = self.base.code();
         let is_module = self.base.meta().flags.contains(&TestFlag::Module);
-        let source_type = SourceType::default().with_module(is_module);
+        let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
         let result = get_result(source_text, source_type);
         self.base.set_result(result);
     }

--- a/tasks/coverage/src/tools/semantic.rs
+++ b/tasks/coverage/src/tools/semantic.rs
@@ -82,7 +82,7 @@ impl Case for SemanticTest262Case {
     fn run(&mut self) {
         let source_text = self.base.code();
         let is_module = self.base.meta().flags.contains(&TestFlag::Module);
-        let source_type = SourceType::default().with_module(is_module);
+        let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
         let result = get_result(source_text, source_type, self.path(), None);
         self.base.set_result(result);
     }
@@ -151,7 +151,7 @@ impl Case for SemanticTypeScriptCase {
         let mut source_type = source_type;
         // handle @jsx: react, `react` of behavior is match babel following options
         if self.base.settings.jsx.last().is_some_and(|jsx| jsx == "react") {
-            source_type = source_type.with_module(true);
+            source_type = source_type.set_module();
             options.react.runtime = ReactJsxRuntime::Classic;
         }
         get_result(self.base.code(), source_type, self.path(), Some(options))

--- a/tasks/coverage/src/tools/transformer.rs
+++ b/tasks/coverage/src/tools/transformer.rs
@@ -36,7 +36,10 @@ fn get_result(
     };
     // Second pass with only JavaScript syntax
     let transformed2 = {
-        driver.run(&transformed1, SourceType::default().with_module(source_type.is_module()));
+        driver.run(
+            &transformed1,
+            if source_type.is_module() { SourceType::mjs() } else { SourceType::cjs() },
+        );
         driver.printed.clone()
     };
     if transformed1 == transformed2 {
@@ -88,7 +91,7 @@ impl Case for TransformerTest262Case {
     fn run(&mut self) {
         let source_text = self.base.code();
         let is_module = self.base.meta().flags.contains(&TestFlag::Module);
-        let source_type = SourceType::default().with_module(is_module);
+        let source_type = if is_module { SourceType::mjs() } else { SourceType::cjs() };
         let result = get_result(source_text, source_type, self.path(), None);
         self.base.set_result(result);
     }
@@ -157,7 +160,7 @@ impl Case for TransformerTypeScriptCase {
         let mut source_type = source_type;
         // handle @jsx: react, `react` of behavior is match babel following options
         if self.base.settings.jsx.last().is_some_and(|jsx| jsx == "react") {
-            source_type = source_type.with_module(true);
+            source_type = source_type.set_module();
             options.react.runtime = ReactJsxRuntime::Classic;
         }
         get_result(self.base.code(), source_type, self.path(), Some(options))

--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -145,7 +145,7 @@ impl TestCaseContent {
             .filter_map(|mut unit| {
                 let mut source_type = Self::get_source_type(Path::new(&unit.name), &settings)?;
                 if is_module {
-                    source_type = source_type.with_module(true);
+                    source_type = source_type.set_module();
                 }
                 unit.source_type = source_type;
                 Some(unit)
@@ -157,10 +157,10 @@ impl TestCaseContent {
     }
 
     fn get_source_type(path: &Path, options: &CompilerSettings) -> Option<SourceType> {
-        let source_type = SourceType::from_path(path)
-            .ok()?
-            .with_jsx(!options.jsx.is_empty())
-            .with_unambiguous(true);
+        let mut source_type = SourceType::from_path(path).ok()?.set_unambiguous();
+        if !options.jsx.is_empty() {
+            source_type = source_type.set_jsx();
+        }
         Some(source_type)
     }
 

--- a/tasks/website/src/linter/rules/test.rs
+++ b/tasks/website/src/linter/rules/test.rs
@@ -107,7 +107,7 @@ fn source_type_from_code_element(code: ElementRef) -> Option<SourceType> {
 
     match *lang {
         "javascript" | "js" => Some(SourceType::default()),
-        "typescript" | "ts" => Some(SourceType::default().with_typescript(true)),
+        "typescript" | "ts" => Some(SourceType::default().set_ts()),
         "tsx" => Some(SourceType::tsx()),
         // FIXME: lots of jsx examples are usefully succinct but not valid JSX.
         // "jsx" => Some(SourceType::default().with_jsx(true).with_always_strict(true)),

--- a/wasm/parser/src/lib.rs
+++ b/wasm/parser/src/lib.rs
@@ -63,8 +63,8 @@ pub fn parse_sync(
         .unwrap_or_default();
 
     let source_type = match options.source_type.as_deref() {
-        Some("script") => source_type.with_script(true),
-        Some("module") => source_type.with_module(true),
+        Some("script") => source_type.set_script(),
+        Some("module") => source_type.set_module(),
         _ => source_type,
     };
 


### PR DESCRIPTION
Hated the `with_xxx(&self, yes: bool)` thing, its behavior was too confusing.