### PR TITLE
refactor(isolated-declarations): pre-filter statements that do not need to be transformed

### DIFF
--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -140,10 +140,14 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
     }
 
     fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
-        for specifier in &decl.specifiers {
-            if let Some(name) = specifier.local.identifier_name() {
-                self.add_type_reference(name.clone());
-                self.add_value_reference(name);
+        if let Some(declaration) = &decl.declaration {
+            walk_declaration(self, declaration);
+        } else {
+            for specifier in &decl.specifiers {
+                if let Some(name) = specifier.local.identifier_name() {
+                    self.add_type_reference(name.clone());
+                    self.add_value_reference(name);
+                }
             }
         }
     }

--- a/crates/oxc_isolated_declarations/tests/snapshots/expando-function.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/expando-function.snap
@@ -24,16 +24,6 @@ export default qux;
   x TS9023: Assigning properties to functions without declaring them is not
   | supported with --isolatedDeclarations. Add an explicit declaration for the
   | properties assigned to this function.
-    ,-[10:3]
-  9 |   export const goo = (): void => {}
- 10 |   goo.length = 10
-    :   ^^^^^^^^^^
- 11 | }
-    `----
-
-  x TS9023: Assigning properties to functions without declaring them is not
-  | supported with --isolatedDeclarations. Add an explicit declaration for the
-  | properties assigned to this function.
    ,-[2:1]
  1 | export function foo(): void {}
  2 | foo.apply = () => {}
@@ -59,4 +49,14 @@ export default qux;
  19 | foo.bar = 42;
     : ^^^^^^^
  20 | foo.baz = 100;
+    `----
+
+  x TS9023: Assigning properties to functions without declaring them is not
+  | supported with --isolatedDeclarations. Add an explicit declaration for the
+  | properties assigned to this function.
+    ,-[10:3]
+  9 |   export const goo = (): void => {}
+ 10 |   goo.length = 10
+    :   ^^^^^^^^^^
+ 11 | }
     `----


### PR DESCRIPTION
We only transform `Declaration` and `ModuleDeclaration` in `IsolatedDeclaration`. We pre-filter statements that need to transform and then use `clone_in` which will avoid producing overhead for clone `Statements`.

