### PR TITLE
chore(oxc): add `.idea` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 
 /editors/vscode/out/
 /editors/vscode/*.vsix
+.idea/
 
 npm/cli-*
 


### PR DESCRIPTION
Given that RustRover now has a community license, I think people might be interested in using for open-source contributions, so I think it can be a good idea to add `.idea/` directory to .gitignore