### PR TITLE
perf(transformer): nullish coalescing operator transform use `SparseStack`

### DIFF
--- a/crates/oxc_transformer/src/es2020/mod.rs
+++ b/crates/oxc_transformer/src/es2020/mod.rs
@@ -31,6 +31,13 @@ impl<'a> ES2020<'a> {
 }
 
 impl<'a> Traverse<'a> for ES2020<'a> {
+    #[inline] // Inline because it's no-op in release mode
+    fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.options.nullish_coalescing_operator {
+            self.nullish_coalescing_operator.exit_program(program, ctx);
+        }
+    }
+
     fn enter_statements(
         &mut self,
         statements: &mut Vec<'a, Statement<'a>>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -132,6 +132,7 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x1_react.exit_program(program, ctx);
         self.x0_typescript.exit_program(program, ctx);
+        self.x2_es2020.exit_program(program, ctx);
         self.x3_es2015.exit_program(program, ctx);
     }
 


### PR DESCRIPTION
Use `SparseStack` (introduced in #5940) to store the stack of blocks which may need a `var _temp;` statement added to them. This reduces the memory required for the stack, on assumption that most blocks won't need a `var` statement.