### PR TITLE
feat(isolated-declarations): handle `export` in the `namespace` correctly

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1073,11 +1073,20 @@ pub enum TSModuleDeclarationBody<'a> {
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>) = 1,
 }
 
-impl TSModuleDeclarationBody<'_> {
+impl<'a> TSModuleDeclarationBody<'a> {
     pub fn is_empty(&self) -> bool {
         match self {
             TSModuleDeclarationBody::TSModuleDeclaration(declaration) => declaration.body.is_none(),
             TSModuleDeclarationBody::TSModuleBlock(block) => block.body.len() == 0,
+        }
+    }
+
+    pub fn as_module_block_mut(&mut self) -> Option<&mut TSModuleBlock<'a>> {
+        match self {
+            TSModuleDeclarationBody::TSModuleBlock(block) => Some(block.as_mut()),
+            TSModuleDeclarationBody::TSModuleDeclaration(decl) => {
+                decl.body.as_mut().and_then(|body| body.as_module_block_mut())
+            }
         }
     }
 }

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,4 +1,5 @@
 use oxc_allocator::Box;
+use oxc_allocator::Vec;
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
 use oxc_span::{Atom, GetSpan, SPAN};
@@ -123,5 +124,26 @@ impl<'a> IsolatedDeclarations<'a> {
                 decl.import_kind,
             ))
         }
+    }
+
+    /// Strip export keyword from ExportNamedDeclaration
+    ///
+    /// ```ts
+    /// export const a = 1;
+    /// export function b() {}
+    /// ```
+    /// to
+    /// ```ts
+    /// const a = 1;
+    /// function b() {}
+    /// ```
+    pub fn strip_export_keyword(&self, stmts: &mut Vec<'a, Statement<'a>>) {
+        stmts.iter_mut().for_each(|stmt| {
+            if let Statement::ExportNamedDeclaration(decl) = stmt {
+                if let Some(declaration) = &mut decl.declaration {
+                    *stmt = Statement::from(self.ast.move_declaration(declaration));
+                }
+            }
+        });
     }
 }

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -45,7 +45,7 @@ impl<'a> ScopeTree<'a> {
         Self { levels }
     }
 
-    pub fn is_ts_module_block_flag(&self) -> bool {
+    pub fn is_ts_module_block(&self) -> bool {
         let scope = self.levels.last().unwrap();
         scope.flags.contains(ScopeFlags::TsModuleBlock)
     }

--- a/crates/oxc_isolated_declarations/tests/fixtures/module-declaration-with-export.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/module-declaration-with-export.ts
@@ -1,0 +1,36 @@
+export namespace OnlyOneExport {
+  export const a = 0;
+}
+
+
+export namespace TwoExports {
+  export const c = 0;
+  export const a:  typeof c = 0;
+}
+
+
+export namespace OneExportReferencedANonExported {
+  const c = 0;
+  export const a: typeof c = c;
+}
+
+declare module "OnlyOneExport" {
+  export const a = 0;
+}
+
+
+declare module "TwoExports" {
+  export const c = 0;
+  export const a:  typeof c;
+}
+
+
+declare module "OneExportReferencedANonExported" {
+  const c = 0;
+  export const a: typeof c;
+}
+
+declare global {
+  const c = 0;
+  export const a: typeof c;
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/expando-function.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/expando-function.snap
@@ -8,14 +8,14 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/expando-function.ts
 export declare function foo(): void;
 export declare const bar: () => void;
 export declare namespace NS {
-	export const goo: () => void;
+	const goo: () => void;
 }
 export declare namespace foo {
-	export let baz: number;
+	let baz: number;
 }
 declare function qux(): void;
 declare namespace qux {
-	export let woo: number;
+	let woo: number;
 }
 export default qux;
 

--- a/crates/oxc_isolated_declarations/tests/snapshots/module-declaration-with-export.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/module-declaration-with-export.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/module-declaration-with-export.ts
+---
+```
+==================== .D.TS ====================
+
+export declare namespace OnlyOneExport {
+	const a = 0;
+}
+export declare namespace TwoExports {
+	const c = 0;
+	const a: typeof c;
+}
+export declare namespace OneExportReferencedANonExported {
+	const c = 0;
+	export const a: typeof c;
+	export {};
+}
+declare module "OnlyOneExport" {
+	const a = 0;
+}
+declare module "TwoExports" {
+	const c = 0;
+	const a: typeof c;
+}
+declare module "OneExportReferencedANonExported" {
+	const c = 0;
+	const a: typeof c;
+}
+declare global {
+	const c = 0;
+	export const a: typeof c;
+}

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -2,9 +2,8 @@ commit: a709f989
 
 transpile Summary:
 AST Parsed     : 20/20 (100.00%)
-Positive Passed: 17/20 (85.00%)
+Positive Passed: 18/20 (90.00%)
 Mismatch: tasks/coverage/typescript/tests/cases/transpile/declarationBasicSyntax.ts
-Mismatch: tasks/coverage/typescript/tests/cases/transpile/declarationEmitPartialNodeReuse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/transpile/declarationRestParameters.ts
 
 #### "typescript/tests/cases/transpile/declarationComputedPropertyNames.ts" ####
@@ -68,7 +67,7 @@ export const D = {
 
 //// [declarationComputedPropertyNames.d.ts] ////
 export declare namespace presentNs {
-	export const a: unknown;
+	const a: unknown;
 }
 declare const aliasing: unknown;
 export type A = {


### PR DESCRIPTION
Previous I didn't follow the behavior of `TypeScript` to handle `export` in `namespace` as I thought no one used this 