### PR TITLE
perf(transformer): `SparseStack` always keep minimum 1 entry

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -105,11 +105,8 @@ pub struct ArrowFunctions<'a> {
 
 impl<'a> ArrowFunctions<'a> {
     pub fn new(options: ArrowFunctionsOptions, ctx: Ctx<'a>) -> Self {
-        // Init stack with empty entry for `Program` (instead of pushing entry in `enter_program`)
-        let mut this_var_stack = SparseStack::new();
-        this_var_stack.push(None);
-
-        Self { ctx, _options: options, this_var_stack }
+        // `SparseStack` is created with 1 empty entry, for `Program`
+        Self { ctx, _options: options, this_var_stack: SparseStack::new() }
     }
 }
 

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -65,7 +65,7 @@ impl<'a> ExponentiationOperator<'a> {
 impl<'a> Traverse<'a> for ExponentiationOperator<'a> {
     #[inline] // Inline because it's no-op in release mode
     fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        debug_assert!(self.var_declarations.is_empty());
+        debug_assert!(self.var_declarations.len() == 1);
     }
 
     fn enter_statements(

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -51,7 +51,7 @@ impl<'a> NullishCoalescingOperator<'a> {
 impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
     #[inline] // Inline because it's no-op in release mode
     fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        debug_assert!(self.var_declarations.is_empty());
+        debug_assert!(self.var_declarations.len() == 1);
     }
 
     fn enter_statements(

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -76,7 +76,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
 impl<'a> Traverse<'a> for LogicalAssignmentOperators<'a> {
     #[inline] // Inline because it's no-op in release mode
     fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        debug_assert!(self.var_declarations.is_empty());
+        debug_assert!(self.var_declarations.len() == 1);
     }
 
     fn enter_statements(


### PR DESCRIPTION
Optimize `SparseStack` (which was introduced in #5940). Initialize it with a single entry, and ensure the stack is never emptied. This makes `take`, `get_or_init` and `get_mut_or_init` methods infallible, since there is always an entry on the stack to read.