### PR TITLE
test(semantic): add comprehensive regression test suite

### DIFF
--- a/crates/oxc_semantic/tests/conformance/mod.rs
+++ b/crates/oxc_semantic/tests/conformance/mod.rs
@@ -1,0 +1,165 @@
+//! Conformance tests.
+//!
+//! Since these cases are a contract-as-code, they _must be well documented_. When adding a new
+//! test, please describe what behavior it guarantees in as plain language as possible.
+
+use crate::TestContext;
+use std::{borrow::Cow, sync::Arc};
+
+use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource, OxcDiagnostic};
+use oxc_semantic::{AstNode, Semantic, SymbolId};
+
+mod test_identifier_reference;
+mod test_symbol_declaration;
+
+pub fn conformance_suite() -> SemanticConformance {
+    SemanticConformance::default()
+        .with_test(test_symbol_declaration::SymbolDeclarationTest)
+        .with_test(test_identifier_reference::IdentifierReferenceTest)
+}
+
+pub trait ConformanceTest {
+    fn name(&self) -> &'static str;
+
+    #[must_use]
+    #[allow(dead_code, unused_variables)]
+    fn run_once(&self, semantic: &Semantic<'_>) -> TestResult {
+        TestResult::Pass
+    }
+
+    #[must_use]
+    #[allow(unused_variables)]
+    fn run_on_node<'a>(&self, node: &AstNode<'a>, semantic: &Semantic<'a>) -> TestResult {
+        TestResult::Pass
+    }
+
+    #[must_use]
+    #[allow(unused_variables)]
+    fn run_on_symbol(&self, symbol_id: SymbolId, semantic: &Semantic<'_>) -> TestResult {
+        TestResult::Pass
+    }
+}
+
+pub struct SemanticConformance {
+    tests: Vec<Box<dyn ConformanceTest>>,
+    reporter: GraphicalReportHandler,
+}
+
+impl Default for SemanticConformance {
+    fn default() -> Self {
+        Self {
+            tests: Vec::new(),
+            reporter: GraphicalReportHandler::default()
+                .with_theme(GraphicalTheme::unicode_nocolor()),
+        }
+    }
+}
+
+impl SemanticConformance {
+    /// Add a test case to the conformance suite.
+    pub fn with_test<Test: ConformanceTest + 'static>(mut self, test: Test) -> Self {
+        self.tests.push(Box::new(test));
+        self
+    }
+
+    pub fn run_on_source(&self, ctx: &TestContext<'_>) -> String {
+        let named_source = Arc::new(NamedSource::new(
+            ctx.path.to_string_lossy(),
+            ctx.semantic.source_text().to_string(),
+        ));
+
+        let results = self
+            .run(&ctx.semantic)
+            .into_iter()
+            .map(|diagnostic| diagnostic.with_source_code(Arc::clone(&named_source)))
+            .collect::<Vec<_>>();
+
+        if results.is_empty() {
+            return String::new();
+        }
+
+        let mut output = String::new();
+        for result in results {
+            self.reporter.render_report(&mut output, result.as_ref()).unwrap();
+        }
+
+        output
+    }
+
+    fn run(&self, semantic: &Semantic) -> Vec<OxcDiagnostic> {
+        let mut diagnostics = Vec::new();
+        for test in &self.tests {
+            // Run file-level tests
+            self.record_results(&mut diagnostics, test.as_ref(), test.run_once(semantic));
+
+            // Run AST node tests
+            for node in semantic.nodes() {
+                self.record_results(
+                    &mut diagnostics,
+                    test.as_ref(),
+                    test.run_on_node(node, semantic),
+                );
+            }
+
+            // Run symbol tests
+            for symbol_id in semantic.symbols().symbol_ids() {
+                self.record_results(
+                    &mut diagnostics,
+                    test.as_ref(),
+                    test.run_on_symbol(symbol_id, semantic),
+                );
+            }
+        }
+
+        diagnostics
+    }
+
+    #[allow(clippy::unused_self)]
+    fn record_results(
+        &self,
+        diagnostics: &mut Vec<OxcDiagnostic>,
+        test: &dyn ConformanceTest,
+        result: TestResult,
+    ) {
+        if let TestResult::Fail(reasons) = result {
+            diagnostics.extend(
+                reasons.into_iter().map(|reason| reason.with_error_code_scope(test.name())),
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TestResult {
+    Pass,
+    Fail(/* reasons */ Vec<OxcDiagnostic>),
+}
+impl From<String> for TestResult {
+    fn from(reason: String) -> Self {
+        TestResult::Fail(vec![OxcDiagnostic::error(Cow::Owned(reason))])
+    }
+}
+impl From<Option<String>> for TestResult {
+    fn from(result: Option<String>) -> Self {
+        match result {
+            Some(reason) => TestResult::Fail(vec![OxcDiagnostic::error(Cow::Owned(reason))]),
+            None => TestResult::Pass,
+        }
+    }
+}
+
+impl From<OxcDiagnostic> for TestResult {
+    fn from(diagnostic: OxcDiagnostic) -> Self {
+        TestResult::Fail(vec![diagnostic])
+    }
+}
+impl From<Vec<OxcDiagnostic>> for TestResult {
+    fn from(diagnostics: Vec<OxcDiagnostic>) -> Self {
+        TestResult::Fail(diagnostics)
+    }
+}
+impl FromIterator<OxcDiagnostic> for TestResult {
+    fn from_iter<I: IntoIterator<Item = OxcDiagnostic>>(iter: I) -> Self {
+        TestResult::Fail(iter.into_iter().collect())
+    }
+}

--- a/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
+++ b/crates/oxc_semantic/tests/conformance/test_identifier_reference.rs
@@ -1,0 +1,77 @@
+use oxc_ast::{ast::IdentifierReference, AstKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::{NodeId, Reference};
+use oxc_span::GetSpan;
+use oxc_syntax::reference::ReferenceId;
+
+use super::{ConformanceTest, TestResult};
+use crate::Semantic;
+
+/// Tests reflexivity between [`IdentifierReference`] AST nodes and their corresponding
+/// [`Reference`]s.
+///
+/// Performs the following checks:
+/// 1. All [`IdentifierReference`]s have been populated with a [`ReferenceId`], even if the
+///    referenced symbol could not be resolved.
+///
+/// 2. When an [`IdentifierReference`] is used to find a [`Reference`] in the symbol table, the AST
+///    node id associated with that [`Reference`] should be the [`IdentifierReference`]'s AST node
+///    id.
+#[derive(Debug, Clone, Default)]
+pub struct IdentifierReferenceTest;
+
+/// [`IdentifierReference::reference_id`] returned [`None`].
+fn missing_reference_id(reference: &IdentifierReference) -> TestResult {
+    OxcDiagnostic::error("After semantic analysis, all IdentifierReferences should have a reference_id, even if a symbol could not be resolved.")
+        .with_label(reference.span().label("This reference's reference_id is None"))
+        .into()
+}
+
+/// The [`NodeId`] of the [`IdentifierReference`] did not match the [`NodeId`] of the
+/// [`Reference`].
+fn node_id_mismatch(
+    identifier_reference_id: NodeId,
+    identifier_reference: &IdentifierReference,
+    reference_id: ReferenceId,
+    reference: &Reference,
+) -> TestResult {
+    OxcDiagnostic::error(
+        "NodeId mismatch between an IdentifierReference and its corresponding Reference",
+    )
+    .with_label(
+        identifier_reference
+            .span
+            .label(format!("This IdentifierReference's NodeId is {identifier_reference_id:?}")),
+    )
+    .with_help(format!(
+        "The Reference with id {reference_id:?} has a NodeId of {:?}",
+        reference.node_id()
+    ))
+    .into()
+}
+
+impl ConformanceTest for IdentifierReferenceTest {
+    fn name(&self) -> &'static str {
+        "identifier-reference"
+    }
+
+    fn run_on_node<'a>(
+        &self,
+        node: &oxc_semantic::AstNode<'a>,
+        semantic: &Semantic<'a>,
+    ) -> TestResult {
+        let AstKind::IdentifierReference(id) = node.kind() else {
+            return TestResult::Pass;
+        };
+        let Some(reference_id) = id.reference_id() else {
+            return missing_reference_id(id);
+        };
+
+        let reference = semantic.symbols().get_reference(reference_id);
+        if reference.node_id() != node.id() {
+            return node_id_mismatch(node.id(), id, reference_id, reference);
+        }
+
+        TestResult::Pass
+    }
+}

--- a/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
+++ b/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
@@ -1,0 +1,130 @@
+use oxc_ast::ast::BindingPattern;
+use oxc_ast::{ast::BindingIdentifier, AstKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::symbol::SymbolId;
+
+use super::{ConformanceTest, TestResult};
+use crate::Semantic;
+
+/// Verifies that symbol binding relationships between the SymbolTable and AST nodes are reflexive.
+///
+/// What does this mean?
+/// 1. [`SymbolTable`] stores the AST node id of the node declaring a symbol.
+/// 2. That symbol should _always_ be a declaration-like node containing either a
+///    [`BindingIdentifier`] or a [`BindingPattern`].
+/// 3. The binding pattern or identifier in that node should be populated (e.g. not [`None`]) and
+///    contain the symbol id.
+///
+/// [`SymbolTable`]: oxc_semantic::SymbolTable
+#[derive(Debug, Clone, Default)]
+pub struct SymbolDeclarationTest;
+
+/// The binding pattern or identifier contained in the declaration node is [`None`].
+///
+/// See: [`BindingIdentifier::symbol_id`]
+fn bound_to_statement_with_no_binding_identifier(
+    symbol_id: SymbolId,
+    span: Span,
+    statement_kind: &str,
+) -> TestResult {
+    OxcDiagnostic::error(format!(
+        "Symbol {symbol_id:?} got bound to a {statement_kind} with no BindingIdentifier"
+    ))
+    .with_label(span.label("Symbol was declared here"))
+    .into()
+}
+
+/// [`BindingIdentifier::symbol_id`] contained [`Some`] value, but it was not the [`SymbolId`] used
+/// to find it in the [`SymbolTable`].
+fn symbol_declaration_not_in_ast_node(
+    expected_id: SymbolId,
+    binding: &BindingIdentifier,
+) -> TestResult {
+    let bound_id = binding.symbol_id.get();
+    OxcDiagnostic::error(format!(
+        "Expected binding to be bound to {expected_id:?} but it was bound to {bound_id:?}"
+    ))
+    .with_label(binding.span())
+    .into()
+}
+
+/// Found a non-destructuring [`BindingPattern`] that did not contain a [`BindingIdentifier`].
+fn malformed_binding_pattern(expected_id: SymbolId, pattern: &BindingPattern) -> TestResult {
+    OxcDiagnostic::error(format!("BindingPattern for {expected_id:?} is not a destructuring pattern but get_binding_identifier() still returned None"))
+        .with_label(pattern.span().label("BindingPattern is here"))
+        .into()
+}
+
+fn invalid_declaration_node(kind: AstKind) -> TestResult {
+    OxcDiagnostic::error(format!("Invalid declaration node kind: {}", kind.debug_name()))
+        .with_label(kind.span())
+        .into()
+}
+
+impl ConformanceTest for SymbolDeclarationTest {
+    fn name(&self) -> &'static str {
+        "symbol-declaration"
+    }
+
+    fn run_on_symbol(
+        &self,
+        symbol_id: oxc_semantic::SymbolId,
+        semantic: &Semantic<'_>,
+    ) -> TestResult {
+        let declaration_id = semantic.symbols().get_declaration(symbol_id);
+        let declaration = semantic.nodes().get_node(declaration_id);
+        let span = semantic.symbols().get_span(symbol_id);
+
+        match declaration.kind() {
+            AstKind::VariableDeclarator(decl) => check_binding_pattern(symbol_id, &decl.id),
+            AstKind::CatchParameter(caught) => check_binding_pattern(symbol_id, &caught.pattern),
+            AstKind::Function(func) => match func.id.as_ref() {
+                Some(id) => check_binding(symbol_id, id),
+                None => bound_to_statement_with_no_binding_identifier(symbol_id, span, "Function"),
+            },
+            AstKind::Class(class) => match class.id.as_ref() {
+                Some(id) => check_binding(symbol_id, id),
+                None => bound_to_statement_with_no_binding_identifier(symbol_id, span, "Class"),
+            },
+            AstKind::BindingRestElement(rest) => check_binding_pattern(symbol_id, &rest.argument),
+            AstKind::FormalParameter(param) => check_binding_pattern(symbol_id, &param.pattern),
+            AstKind::ImportSpecifier(import) => check_binding(symbol_id, &import.local),
+            AstKind::ImportNamespaceSpecifier(import) => check_binding(symbol_id, &import.local),
+            AstKind::ImportDefaultSpecifier(import) => check_binding(symbol_id, &import.local),
+            // =========================== TYPESCRIPT ===========================
+            AstKind::TSImportEqualsDeclaration(import) => check_binding(symbol_id, &import.id),
+            AstKind::TSTypeParameter(decl) => check_binding(symbol_id, &decl.name),
+            // NOTE: namespaces do not store the symbol id they create. We may want to add this in
+            // the future.
+            AstKind::TSModuleDeclaration(_decl) => TestResult::Pass,
+            AstKind::TSTypeAliasDeclaration(decl) => check_binding(symbol_id, &decl.id),
+            AstKind::TSInterfaceDeclaration(decl) => check_binding(symbol_id, &decl.id),
+            AstKind::TSEnumDeclaration(decl) => check_binding(symbol_id, &decl.id),
+            // NOTE: enum members do not store the symbol id they create. We may want to add this
+            // in the future.
+            AstKind::TSEnumMember(_member) => TestResult::Pass,
+            invalid_kind => invalid_declaration_node(invalid_kind),
+        }
+    }
+}
+
+fn check_binding_pattern(expected_id: SymbolId, binding: &BindingPattern) -> TestResult {
+    if binding.kind.is_destructuring_pattern() {
+        return TestResult::Pass;
+    }
+
+    let Some(id) = binding.kind.get_binding_identifier() else {
+        return malformed_binding_pattern(expected_id, binding);
+    };
+
+    check_binding(expected_id, id)
+}
+
+fn check_binding(expected_id: SymbolId, binding: &BindingIdentifier) -> TestResult {
+    if binding.symbol_id.get() == Some(expected_id) {
+        TestResult::Pass
+    } else {
+        symbol_declaration_not_in_ast_node(expected_id, binding)
+    }
+}

--- a/crates/oxc_semantic/tests/fixtures/oxc/assignment/nested-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/assignment/nested-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/oxc/assignment/nested-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -38,3 +42,9 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/assignment/nested-assignment.
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.jsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -40,3 +44,9 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/element-name.jsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.jsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -32,3 +36,9 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/jsx/member-expression.jsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/property-with-type-import.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -81,3 +85,9 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/type-declarations/signatures/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -60,3 +64,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -57,3 +61,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -50,3 +54,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -55,3 +59,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -72,3 +76,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -105,3 +109,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -133,3 +137,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/private-identifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/private-identifier.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/private-identifier.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-block.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-block.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-block.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -81,3 +85,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -105,3 +109,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -133,3 +137,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -103,3 +107,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -54,3 +58,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -61,3 +65,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -61,3 +65,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.ts
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-so
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-so
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-type1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-type1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-ty
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inl
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -57,3 +61,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -104,3 +108,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -57,3 +61,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -111,3 +115,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -57,3 +61,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -111,3 +115,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implic
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -47,3 +51,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -33,3 +37,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -47,3 +51,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -47,3 +51,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -47,3 +51,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespac
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -85,3 +89,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -105,3 +109,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-s
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -33,3 +37,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-intrinsic-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-intrinsic-name.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-intrinsic-name.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-i
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma-fragment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma-fragment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma-fragment.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -33,3 +37,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-ch
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -11,3 +15,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.ts
     "symbols": []
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-typ
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -97,3 +101,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.tsx
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.tsx
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxide
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -50,3 +54,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expressi
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -34,3 +38,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -19,3 +23,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/externa
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.t
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-re
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/globa
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -35,3 +39,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/impor
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -55,3 +59,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [],
@@ -26,3 +30,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -94,3 +98,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -79,3 +83,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -65,3 +69,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -65,3 +69,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -65,3 +69,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -61,3 +65,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -54,3 +58,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -54,3 +58,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -41,3 +45,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-qualifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-qualifier.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-qualifier.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -69,3 +73,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -62,3 +66,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -86,3 +90,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -69,3 +73,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -81,3 +85,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -70,3 +74,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -63,3 +67,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -54,3 +58,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -62,3 +66,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -76,3 +80,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -64,3 +68,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -62,3 +66,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -62,3 +66,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -56,3 +60,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -69,3 +73,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -71,3 +75,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -77,3 +81,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -42,3 +46,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -49,3 +53,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -55,3 +59,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -92,3 +96,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -55,3 +59,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type1.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type1.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -48,3 +52,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/typeof-import-type-with-qualifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/typeof-import-type-with-qualifier.snap
@@ -2,6 +2,10 @@
 source: crates/oxc_semantic/tests/main.rs
 input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/typeof-import-type-with-qualifier.ts
 ---
+================================================================================
+SCOPES
+================================================================================
+
 [
   {
     "children": [
@@ -27,3 +31,9 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     ]
   }
 ]
+
+================================================================================
+CONFORMANCE
+================================================================================
+
+All tests passed.

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -1,10 +1,19 @@
+mod conformance;
+
 use std::{fs, path::Path};
 
+use conformance::SemanticConformance;
 use oxc_allocator::Allocator;
 use oxc_index::Idx;
 use oxc_parser::Parser;
 use oxc_semantic::{ScopeId, Semantic, SemanticBuilder};
 use oxc_span::SourceType;
+
+/// A test case representing an input source file.
+struct TestContext<'a> {
+    pub path: &'a Path,
+    pub semantic: Semantic<'a>,
+}
 
 fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>) -> String {
     let scope_tree = semantic.scopes();
@@ -95,16 +104,55 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
     result
 }
 
-fn analyze(path: &Path, source_text: &str) -> String {
+fn run_scope_snapshot_test(ctx: &TestContext<'_>) -> String {
+    let scopes = vec![ctx.semantic.scopes().root_scope_id()].into_iter();
+    // this is a JSON object
+    let scopes = get_scope_snapshot(&ctx.semantic, scopes);
+
+    // pretty-print the results
+    let value: serde_json::Value = serde_json::from_str(scopes.as_str()).unwrap();
+    serde_json::to_string_pretty(&value).unwrap()
+}
+
+fn analyze(path: &Path, source_text: &str, conformance_suite: &SemanticConformance) -> String {
+    /// Separator between snapshot sections
+    const SEP: &str =
+        "================================================================================";
+
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
 
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let semantic = SemanticBuilder::new(source_text).build(&ret.program).semantic;
+    let semantic = SemanticBuilder::new(source_text)
+        .with_check_syntax_error(true)
+        .build(&ret.program)
+        .semantic;
 
-    let scopes = get_scope_snapshot(&semantic, vec![semantic.scopes().root_scope_id()].into_iter());
-    let value: serde_json::Value = serde_json::from_str(scopes.as_str()).unwrap();
-    serde_json::to_string_pretty(&value).unwrap()
+    let ctx = TestContext { path, semantic };
+
+    // scope tests
+    let scope_snapshot = run_scope_snapshot_test(&ctx);
+
+    // conformance tests
+    let mut conformance_snapshot = conformance_suite.run_on_source(&ctx);
+    if conformance_snapshot.is_empty() {
+        conformance_snapshot = "All tests passed.".to_string();
+    }
+
+    format!(
+        "{SEP}
+SCOPES
+{SEP}
+
+{scope_snapshot}
+
+{SEP}
+CONFORMANCE
+{SEP}
+
+{conformance_snapshot}
+"
+    )
 }
 
 /// # Panics
@@ -113,7 +161,8 @@ fn analyze(path: &Path, source_text: &str) -> String {
 fn main() {
     insta::glob!("fixtures/**/*.{js,jsx,ts,tsx}", |path| {
         let source_text = fs::read_to_string(path).unwrap();
-        let snapshot = analyze(path, &source_text);
+        let conformance_suite = conformance::conformance_suite();
+        let snapshot = analyze(path, &source_text, &conformance_suite);
         let name = path.file_stem().unwrap().to_str().unwrap();
         insta::with_settings!({ snapshot_path => path.parent().unwrap(), prepend_module_to_snapshot => false, snapshot_suffix => "", omit_expression => true }, {
             insta::assert_snapshot!(name, snapshot);


### PR DESCRIPTION
# What This PR Does

Enhance's `oxc_semantic`'s integration tests with a regression test suite that ensures semantic's contract guarantees hold over all test cases in typescript-eslint's scope snapshot tests. Each test case checks a separate assumption and runs independently from other test cases.

This PR sets up the code infrastructure for this test suite and adds two test cases to start us off:
1. Reflexivity tests for `IdentifierReference` and `Reference`
2. Symbol declaration reflexivity tests between declarations in `SymbolTable` and their corresponding node in the AST.

Please refer to the doc comments for each of these tests for an in-depth explanation.

## Aren't our existing tests sufficient?
`oxc_semantic` is currently tested directly via
1. scope snapshot tests, ported from `typescript-eslint`
2. Hand-written tests using `SemanticTester` in `tests/integration`

And indirectly via

3. Conformance test suite over Test262/TypeScript/Babel
4. Linter snapshot tests

Shouldn't this be sufficient? I argue not, for two reasons:

## 1. Clarify Contract Ambiguity

When using `Semantic`, I often find myself asking these questions?
* Does `semantic.symbols().get_declaration(id)` point to a `BindingIdentifer`/`BindingPattern` or the declaration that holds an identifier/pattern?
* Will a `Reference`'s `node_id` point me to an `IdentifierReference` or the expression/statement that is holding an `IdentifierReference`?
* When will `BindingIdentifier`'s `symbol_id` get populated? can we guarantee that after semantic analysis it will never be `None`?
* What actually _is_ the node covered by `semantic.symbols().get_span(id)`? This one really messed me up, and resulted in me creating #4739.
* What scope does `Function::scope_id` point to? The one where the function is declared? The one created by its body? The one created by the type annotations but before the function body? Or something else entirely?

**These test cases are meant to answer such questions and guarnatee those answers as test cases**. No other existing testing solution currently upholds such promises: they only tell us if code expecting one answer or another produces an unexpected result. However, those parts of the codebase could always be adjusted to conform to new `Semantic` behavior, meaning no contract guarantees are actually upheld.

## 2. Existing Tests Do Not Test The Same Behavior

I'll cover each above listed test case one-by-one:

1. For starters, these tests only cover scopes. Additionally, they only tell us **how behavior has changed**, not that **behavior is now incorrect**.
2. These _do_ generally cover the same behaviors, but **are not comprehensive and are difficult to maintain**. These are unit tests that should be used hand-in-hand with this new test suite.
3. The most relevant tests here are for the parser. However, these tests **only tell us if a syntax/parse error was produced**, and tell us nothing about the validity of `Semantic`.
4. Relying on lint rule's output is a a mediiocre proxy of `Semantic`'s behavior at best. They can tell us if changes to `Semantic` break assumptions made by lint rules, but they do not tell us if **those assumptions are the ones we want to uphold to external crates consuming `Semantic`.

