### PR TITLE
test(linter): import test cases for `no-empty-character-class`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -130,6 +130,15 @@ fn test() {
         ("var foo = /[\\]]/s;", None),
         ("var foo = /[\\]]/d;", None),
         ("var foo = /\\[]/", None),
+        // ES2024
+        ("var foo = /[[^]]/v;", None),    // { "ecmaVersion": 2024 }
+        ("var foo = /[[\\]]]/v;", None),  // { "ecmaVersion": 2024 }
+        ("var foo = /[[\\[]]/v;", None),  // { "ecmaVersion": 2024 }
+        ("var foo = /[a--b]/v;", None),   // { "ecmaVersion": 2024 }
+        ("var foo = /[a&&b]/v;", None),   // { "ecmaVersion": 2024 }
+        ("var foo = /[[a][b]]/v;", None), // { "ecmaVersion": 2024 }
+        ("var foo = /[\\q{}]/v;", None),  // { "ecmaVersion": 2024 }
+        ("var foo = /[[^]--\\p{ASCII}]/v;", None), // { "ecmaVersion": 2024 }
     ];
 
     let fail = vec![
@@ -143,6 +152,16 @@ fn test() {
         ("var foo = /[]]/d;", None),
         ("var foo = /[[][]]/v;", None),
         ("var foo = /[[]]|[]/v;", None),
+        ("var foo = /[(]\\u{0}*[]/u;", None), // { "ecmaVersion": 2015 }
+        // ES2024
+        ("var foo = /[]/v;", None),           // { "ecmaVersion": 2024 }
+        ("var foo = /[[]]/v;", None),         // { "ecmaVersion": 2024 }
+        ("var foo = /[[a][]]/v;", None),      // { "ecmaVersion": 2024 }
+        ("var foo = /[a[[b[]c]]d]/v;", None), // { "ecmaVersion": 2024 }
+        ("var foo = /[a--[]]/v;", None),      // { "ecmaVersion": 2024 }
+        ("var foo = /[[]--b]/v;", None),      // { "ecmaVersion": 2024 }
+        ("var foo = /[a&&[]]/v;", None),      // { "ecmaVersion": 2024 }
+        ("var foo = /[[]&&b]/v;", None),      // { "ecmaVersion": 2024 }
     ];
 
     Tester::new(NoEmptyCharacterClass::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_empty_character_class.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_character_class.snap
@@ -84,3 +84,66 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──
    ╰────
   help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:21]
+ 1 │ var foo = /[(]\u{0}*[]/u;
+   ·                     ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:12]
+ 1 │ var foo = /[]/v;
+   ·            ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:13]
+ 1 │ var foo = /[[]]/v;
+   ·             ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:16]
+ 1 │ var foo = /[[a][]]/v;
+   ·                ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:17]
+ 1 │ var foo = /[a[[b[]c]]d]/v;
+   ·                 ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:16]
+ 1 │ var foo = /[a--[]]/v;
+   ·                ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:13]
+ 1 │ var foo = /[[]--b]/v;
+   ·             ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:16]
+ 1 │ var foo = /[a&&[]]/v;
+   ·                ──
+   ╰────
+  help: Remove the empty character class: `[]`
+
+  ⚠ eslint(no-empty-character-class): Empty character class will not match anything
+   ╭─[no_empty_character_class.tsx:1:13]
+ 1 │ var foo = /[[]&&b]/v;
+   ·             ──
+   ╰────
+  help: Remove the empty character class: `[]`


### PR DESCRIPTION
improved test coverage for this rule by importing the newer test cases from https://github.com/eslint/eslint/blob/27383226b8c5ead6b7cafc017a8ca12a1512a301/tests/lib/rules/no-empty-character-class.js#L4