### PR TITLE
fix(isolated-declarations): False positive for class private getter with non-inferrable return type

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -310,6 +310,10 @@ impl<'a> IsolatedDeclarations<'a> {
                         entry.1 = Some(&mut first_param.pattern.type_annotation);
                     }
                     MethodDefinitionKind::Get => {
+                        if method.accessibility.is_some_and(TSAccessibility::is_private) {
+                            continue;
+                        }
+
                         let function = &mut method.value;
                         if function.return_type.is_none() {
                             function.return_type = self.infer_function_return_type(function);

--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -58,8 +58,14 @@ export class PrivateFieldsWithConstructorAssignments {
 
 export class PrivateMethodClass {
   private good(a): void {}
+  private get goodGetter() {
+    return {[('x')]: 1};
+  }
 }
 
 export class PublicMethodClass {
   public bad(a): void {}
+  public get badGetter() {
+    return {[('x')]: 1};
+  }
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -53,21 +53,32 @@ export declare class PrivateFieldsWithConstructorAssignments {
 }
 export declare class PrivateMethodClass {
 	private good;
+	private get goodGetter();
 }
 export declare class PublicMethodClass {
 	bad(a): void;
+	get badGetter(): {};
 }
 
 
 ==================== Errors ====================
 
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[69:14]
+ 68 |   public get badGetter() {
+ 69 |     return {[('x')]: 1};
+    :              ^^^^^
+ 70 |   }
+    `----
+
   x TS9011: Parameter must have an explicit type annotation with
   | --isolatedDeclarations.
-    ,-[64:14]
- 63 | export class PublicMethodClass {
- 64 |   public bad(a): void {}
+    ,-[67:14]
+ 66 | export class PublicMethodClass {
+ 67 |   public bad(a): void {}
     :              ^
- 65 | }
+ 68 |   public get badGetter() {
     `----
 
 


### PR DESCRIPTION
Fixes a case missing from https://github.com/oxc-project/oxc/pull/5964