### PR TITLE
fix(oxc_parser): only allow question after type when in none named `tupleElement` context

### DIFF
--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -14,7 +14,7 @@ use pico_args::Arguments;
 fn main() -> Result<(), String> {
     let mut args = Arguments::from_env();
 
-    let name = args.subcommand().ok().flatten().unwrap_or_else(|| String::from("test.ts"));
+    let name = args.subcommand().ok().flatten().unwrap_or_else(|| String::from("test.js"));
     let show_ast = args.contains("--ast");
     let show_comments = args.contains("--comments");
 

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -14,7 +14,7 @@ use pico_args::Arguments;
 fn main() -> Result<(), String> {
     let mut args = Arguments::from_env();
 
-    let name = args.subcommand().ok().flatten().unwrap_or_else(|| String::from("test.js"));
+    let name = args.subcommand().ok().flatten().unwrap_or_else(|| String::from("test.ts"));
     let show_ast = args.contains("--ast");
     let show_comments = args.contains("--comments");
 

--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -48,7 +48,7 @@ bitflags! {
         ///   * ambient class declaration => `declare class C { foo(); } , etc..`
         const Ambient = 1 << 6;
 
-       const QuestionAfterType = 1 << 7;
+       const AllowQuestionAfterType = 1 << 7;
     }
 }
 

--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -47,6 +47,8 @@ bitflags! {
         ///   * ambient variable declaration => `declare var $: any`
         ///   * ambient class declaration => `declare class C { foo(); } , etc..`
         const Ambient = 1 << 6;
+
+       const QuestionAfterType = 1 << 7;
     }
 }
 

--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -48,7 +48,7 @@ bitflags! {
         ///   * ambient class declaration => `declare class C { foo(); } , etc..`
         const Ambient = 1 << 6;
 
-       const AllowQuestionAfterType = 1 << 7;
+       const AllowQuestionMarkAfterType = 1 << 7;
     }
 }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -277,7 +277,6 @@ impl<'a> ParserImpl<'a> {
     fn parse_postfix_type_or_higher(&mut self) -> Result<TSType<'a>> {
         let span = self.start_span();
         let mut ty = self.parse_non_array_type()?;
-        // dbg!(&ty);
 
         while !self.cur_token().is_on_new_line {
             match self.cur_kind() {
@@ -925,7 +924,6 @@ impl<'a> ParserImpl<'a> {
         }
 
         let ty = self.context(extra_context, Context::empty(), Self::parse_ts_type)?;
-        // let ty = self.parse_ts_type()?;
         if let TSType::JSDocNullableType(ty) = ty {
             if ty.span.start == ty.type_annotation.span().start {
                 Ok(self.ast.ts_tuple_element_optional_type(ty.span, ty.unbox().type_annotation))

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -290,7 +290,7 @@ impl<'a> ParserImpl<'a> {
                         /* postfix */ true,
                     );
                 }
-                Kind::Question if self.ctx.contains(Context::AllowQuestionAfterType) => {
+                Kind::Question if self.ctx.contains(Context::AllowQuestionMarkAfterType) => {
                     // If next token is start of a type we have a conditional type
                     if self.lookahead(Self::next_token_is_start_of_type) {
                         return Ok(ty);
@@ -355,7 +355,7 @@ impl<'a> ParserImpl<'a> {
             // // falls through
             // case SyntaxKind.FunctionKeyword:
             // return parseJSDocFunctionType();
-            Kind::Question if self.ctx.contains(Context::AllowQuestionAfterType) => {
+            Kind::Question if self.ctx.contains(Context::AllowQuestionMarkAfterType) => {
                 self.parse_js_doc_unknown_or_nullable_type()
             }
             Kind::Bang => self.parse_js_doc_non_nullable_type(),
@@ -899,7 +899,7 @@ impl<'a> ParserImpl<'a> {
                 ))
             });
         }
-        self.parse_tuple_element_type(Context::AllowQuestionAfterType)
+        self.parse_tuple_element_type(Context::AllowQuestionMarkAfterType)
     }
 
     fn is_tuple_element_name(&mut self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,4 +1,3 @@
-use bitflags::Flags;
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::Result;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -290,7 +290,7 @@ impl<'a> ParserImpl<'a> {
                         /* postfix */ true,
                     );
                 }
-                Kind::Question if self.ctx.contains(Context::QuestionAfterType) => {
+                Kind::Question if self.ctx.contains(Context::AllowQuestionAfterType) => {
                     // If next token is start of a type we have a conditional type
                     if self.lookahead(Self::next_token_is_start_of_type) {
                         return Ok(ty);
@@ -355,7 +355,7 @@ impl<'a> ParserImpl<'a> {
             // // falls through
             // case SyntaxKind.FunctionKeyword:
             // return parseJSDocFunctionType();
-            Kind::Question if self.ctx.contains(Context::QuestionAfterType) => {
+            Kind::Question if self.ctx.contains(Context::AllowQuestionAfterType) => {
                 self.parse_js_doc_unknown_or_nullable_type()
             }
             Kind::Bang => self.parse_js_doc_non_nullable_type(),
@@ -899,7 +899,7 @@ impl<'a> ParserImpl<'a> {
                 ))
             });
         }
-        self.parse_tuple_element_type(Context::QuestionAfterType)
+        self.parse_tuple_element_type(Context::AllowQuestionAfterType)
     }
 
     fn is_tuple_element_name(&mut self) -> bool {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 3bcfee23
 parser_babel Summary:
 AST Parsed     : 2093/2101 (99.62%)
 Positive Passed: 2083/2101 (99.14%)
-Negative Passed: 1382/1493 (92.57%)
+Negative Passed: 1383/1493 (92.63%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -112,7 +112,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/read-only-2/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/read-only-3/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/read-only-4/input.ts
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-required-after-labeled-optional/input.ts
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
@@ -10908,6 +10907,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Expected `,` but found `:`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-invalid-label-2/input.ts:1:15]
  1 │ type T = [x<y>: A];
+   ·               ┬
+   ·               ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `?`
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts:1:15]
+ 1 │ type T = [x: A?];
    ·               ┬
    ·               ╰── `,` expected
    ╰────

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: a709f989
 parser_typescript Summary:
 AST Parsed     : 6469/6479 (99.85%)
 Positive Passed: 6456/6479 (99.65%)
-Negative Passed: 1225/5715 (21.43%)
+Negative Passed: 1228/5715 (21.49%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration10.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration11.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration13.ts
@@ -1664,7 +1664,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSe
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineString.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseImportAttributesError.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNonNullableTypes.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNullableTypes.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parseTypes.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
@@ -4310,10 +4309,8 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tup
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion01.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/indexerWithTuple.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/optionalTupleElements1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/restTupleElements1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/strictTupleLength.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleLengthCheck.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOfTupleTypes1.ts
@@ -10205,6 +10202,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
   help: Try insert a semicolon here
 
   × Unexpected token
+   ╭─[typescript/tests/cases/compiler/parseInvalidNullableTypes.ts:1:30]
+ 1 │ function f1(a: string): a is ?string {
+   ·                              ─
+ 2 │     return true;
+   ╰────
+
+  × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash1.ts:1:4]
  1 │ ~< <
    ·    ─
@@ -14997,13 +15001,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
-    ╭─[typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts:9:9]
-  8 │     @decorator()
-  9 │     c?: *;
-    ·         ─
- 10 │ }
-    ╰────
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts:5:15]
+ 4 │     @decorator()
+ 5 │     a?: string?;
+   ·               ▲
+ 6 │     @decorator()
+   ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnArrowFunction.ts:3:17]
@@ -24253,6 +24258,24 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
      ·                              ────
  166 │ 
      ╰────
+
+  × Expected `,` but found `?`
+    ╭─[typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts:10:35]
+  9 │ 
+ 10 │ export type Opt = [element: string?]; // question mark on element disallowed
+    ·                                   ┬
+    ·                                   ╰── `,` expected
+ 11 │ 
+    ╰────
+
+  × Expected `,` but found `?`
+    ╭─[typescript/tests/cases/conformance/types/tuple/restTupleElements1.ts:10:22]
+  9 │ type T08 = [...string];  // Error
+ 10 │ type T09 = [...string?];  // Error
+    ·                      ┬
+    ·                      ╰── `,` expected
+ 11 │ type T10 = [string, ...[...string[]]];
+    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/types/typeAliases/reservedNamesInAliases.ts:6:5]


### PR DESCRIPTION
Part of #5982 