### PR TITLE
refactor(transformer): arrow function transform: remove unnecessary assertion

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -165,7 +165,6 @@ impl<'a> Traverse<'a> for ArrowFunctions<'a> {
 
     /// Insert `var _this = this;` for the global scope.
     fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        assert!(self.this_var_stack.len() == 1);
         if let Some(this_var) = self.this_var_stack.take() {
             self.insert_this_var_statement_at_the_top_of_statements(&mut program.body, &this_var);
         }


### PR DESCRIPTION
This assertion was required previously for soundness, but now `SparseStack::pop` makes it impossible for `self.this_var_stack.len()` to be 0. Being exactly 1 is not a safety invariant, only that it's not 0.