### PR TITLE
docs(linter): fix incorrect "bad" example in `only-used-in-recursion`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -40,12 +40,8 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts
-    /// function f(a: number, b: number): number {
-    ///     if (a == 0) {
-    ///         return 1
-    ///     } else {
-    ///         return f(a - 1, b + 1)
-    ///     }
+    /// function test(only_used_in_recursion) {
+    ///     return test(only_used_in_recursion);
     /// }
     /// ```
     ///


### PR DESCRIPTION
closes #4811