### PR TITLE
test(transformer): enable tests

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-test = false
+test = true
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
`oxc_transformer` crate has some tests, but they were disabled.