### PR TITLE
fix(semantic): add interfaces and functions to `SymbolFlags::ClassExcludes` 

### DIFF
--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -475,3 +475,18 @@ fn test_module_like_declarations() {
         "A symbol should not be created for global augmentation declarations."
     );
 }
+
+#[test]
+fn test_class_merging() {
+    // classes can be merged with interfaces, resulting in a single symbol
+    SemanticTester::ts(
+        "
+        class Foo {}
+        interface Foo {}
+    ",
+    )
+    .has_root_symbol("Foo")
+    .contains_flags(SymbolFlags::Class)
+    .contains_flags(SymbolFlags::Interface)
+    .test();
+}

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -100,8 +100,10 @@ bitflags! {
         const Ambient                 = 1 << 19;
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
-
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
+
+        const BlockScoped = Self::BlockScopedVariable.bits() | Self::Enum.bits() | Self::Class.bits();
+
         const Value = Self::Variable.bits() | Self::Class.bits() | Self::Enum.bits() | Self::EnumMember.bits() | Self::ValueModule.bits();
         const Type =  Self::Class.bits() | Self::Interface.bits() | Self::Enum.bits() | Self::EnumMember.bits() | Self::TypeLiteral.bits() | Self::TypeParameter.bits()  |  Self::TypeAlias.bits();
 
@@ -113,7 +115,7 @@ bitflags! {
         /// they can not merge with anything in the value space
         const BlockScopedVariableExcludes = Self::Value.bits();
 
-        const ClassExcludes = (Self::Value.bits() | Self::TypeAlias.bits()) & !Self::ValueModule.bits() ;
+        const ClassExcludes = (Self::Value.bits() | Self::TypeAlias.bits()) & !(Self::ValueModule.bits() | Self::Interface.bits() | Self::Function.bits());
         const ImportBindingExcludes = Self::Import.bits() | Self::TypeImport.bits();
         // Type specific excludes
         const TypeAliasExcludes = Self::Type.bits();


### PR DESCRIPTION
This brings ClassExcludes into alignment with TypeScript.