### PR TITLE
feat(ast): allow passing span to `void_0` method

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -127,10 +127,10 @@ impl<'a> AstBuilder<'a> {
 
     /// `void 0`
     #[inline]
-    pub fn void_0(self) -> Expression<'a> {
+    pub fn void_0(self, span: Span) -> Expression<'a> {
         let num = self.number_0();
         Expression::UnaryExpression(self.alloc(self.unary_expression(
-            Span::default(),
+            span,
             UnaryOperator::Void,
             num,
         )))

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::*;
-use oxc_span::SPAN;
+use oxc_span::{GetSpan, SPAN};
 use oxc_syntax::{
     number::NumberBase,
     operator::{BinaryOperator, UnaryOperator},
@@ -101,7 +101,7 @@ impl<'a> PeepholeSubstituteAlternateSyntax {
     /// Transforms `undefined` => `void 0`
     fn compress_undefined(&self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         if ctx.is_expression_undefined(expr) {
-            *expr = ctx.ast.void_0();
+            *expr = ctx.ast.void_0(expr.span());
             return true;
         };
         false

--- a/crates/oxc_minifier/src/ast_passes/remove_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/remove_syntax.rs
@@ -1,5 +1,6 @@
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
+use oxc_span::GetSpan;
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::{CompressOptions, CompressorPass};
@@ -77,7 +78,7 @@ impl<'a> RemoveSyntax {
 
     fn compress_console(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.drop_console && Self::is_console(expr) {
-            *expr = ctx.ast.void_0();
+            *expr = ctx.ast.void_0(expr.span());
         }
     }
 

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -224,7 +224,7 @@ impl<'a> NullishCoalescingOperator<'a> {
             SPAN,
             Self::clone_expression(&reference, ctx),
             op,
-            ctx.ast.void_0(),
+            ctx.ast.void_0(SPAN),
         );
         let test = ctx.ast.expression_logical(SPAN, left, LogicalOperator::And, right);
 

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -676,7 +676,7 @@ impl<'a> ReactJsx<'a> {
             if key_prop.is_some() {
                 arguments.push(Argument::from(self.transform_jsx_attribute_value(key_prop, ctx)));
             } else if is_development {
-                arguments.push(Argument::from(self.ctx.ast.void_0()));
+                arguments.push(Argument::from(self.ctx.ast.void_0(SPAN)));
             }
 
             // isStaticChildren


### PR DESCRIPTION
unblock #6021 

Keep the original expression's `span` to insert comments correctly. Have tested in #6021 and it worked