### PR TITLE
fix(npm/oxlint): make bin/oxc_language_server an executable

### DIFF
--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -12,7 +12,10 @@
     "url": "https://github.com/oxc-project/oxc",
     "directory": "npm/oxlint"
   },
-  "bin": "bin/oxlint",
+  "bin": {
+    "oxlint": "bin/oxlint",
+    "oxc_language_server":"bin/oxc_language_server"
+  },
   "funding": {
     "url": "https://github.com/sponsors/Boshen"
   },


### PR DESCRIPTION
closes #6064