### PR TITLE
fix(linter): fix panic in fixer for `oxc/only-used-in-recursion`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -234,15 +234,13 @@ fn is_function_maybe_reassigned<'a>(
 // skipping whitespace, commas, finds the next character (exclusive)
 #[allow(clippy::cast_possible_truncation)]
 fn skip_to_next_char(s: &str, start: u32) -> u32 {
-    let mut i = start as usize;
-    while i < s.len() {
-        let c = s.chars().nth(i).unwrap();
+    for (i, c) in s.char_indices().skip(start as usize) {
         if !c.is_whitespace() && c != ',' {
-            break;
+            return i as u32;
         }
-        i += 1;
     }
-    i as u32
+
+    s.len() as u32
 }
 
 #[test]
@@ -401,6 +399,8 @@ fn test() {
                 return a(arg0);
             }
         ",
+        "//¿
+function writeChunks(a,callac){writeChunks(m,callac)}writeChunks(i,{})",
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/only_used_in_recursion.snap
+++ b/crates/oxc_linter/src/snapshots/only_used_in_recursion.snap
@@ -72,3 +72,11 @@ source: crates/oxc_linter/src/tester.rs
  3 │                 return a(arg0);
    ╰────
   help: Remove the argument and its usage. Alternatively, use the argument in the function body.
+
+  ⚠ oxc(only-used-in-recursion): Parameter `callac` is only used in recursive calls
+   ╭─[only_used_in_recursion.tsx:2:24]
+ 1 │ //¿
+ 2 │ function writeChunks(a,callac){writeChunks(m,callac)}writeChunks(i,{})
+   ·                        ──────
+   ╰────
+  help: Remove the argument and its usage. Alternatively, use the argument in the function body.


### PR DESCRIPTION
closes #6068