### PR TITLE
refactor(oxc): ban index methods on std::str::Chars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,16 @@ jobs:
         with:
           cache-key: warm
           components: clippy
+          tools: ast-grep
       - run: cargo lint -- -D warnings
+      - name: Check Char and Byte Offset
+        run: |
+          output=$(sg -p '$A.chars().enumerate()' -r '$A.char_indices()' -l rs)
+          echo "Output: $output"
+          if [ -n "$output" ]; then
+            echo "Error: Unexpected output detected"
+            exit 1
+          fi
 
   doc:
     name: Doc

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -133,9 +133,9 @@ fn min_distance(a: &str, b: &str) -> usize {
 
     let mut previous_row: Vec<usize> = (0..=n).collect();
 
-    for (i, s1) in a.chars().enumerate() {
+    for (i, s1) in a.char_indices() {
         let mut current_row = vec![i + 1];
-        for (j, s2) in b.chars().enumerate() {
+        for (j, s2) in b.char_indices() {
             let insertions = previous_row[j + 1] + 1;
             let deletions = current_row[j] + 1;
             let substitutions = previous_row[j] + usize::from(s1 != s2);


### PR DESCRIPTION
closes #6071 

I will gradually improve the remaining code until I understand the usage of the new method.