### PR TITLE
fix(linter): disable all rules in a plugin when that plugin gets turned off

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -116,6 +116,11 @@ impl Linter {
         self.rules.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn rules(&self) -> &Vec<RuleWithSeverity> {
+        &self.rules
+    }
+
     pub fn run<'a>(&self, path: &Path, semantic: Rc<Semantic<'a>>) -> Vec<Message<'a>> {
         let ctx_host =
             Rc::new(ContextHost::new(path, semantic, self.options).with_config(&self.config));


### PR DESCRIPTION
Fixes a bug where rules for a plugin are still added to the linter after that plugin gets disabled.

```rust
// `linter` still has typescript-eslint rules. This PR fixes that.
let linter = LinterBuilder::default()
  .and_plugins(LintPlugins::TYPESCRIPT, false)
  .build();
```