### PR TITLE
feat(linter)!: support plugins in oxlint config files

### DIFF
--- a/apps/oxlint/fixtures/import/.oxlintrc.json
+++ b/apps/oxlint/fixtures/import/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+    "plugins": ["import"],
+    "rules": {
+        "import/no-default-export": "error",
+        "import/namespace": "allow"
+    }
+}

--- a/apps/oxlint/fixtures/import/test.js
+++ b/apps/oxlint/fixtures/import/test.js
@@ -1,0 +1,9 @@
+import * as foo from './foo';
+// ^ import/namespace
+
+console.log(foo);
+
+// import/no-default-export
+export default function foo() {}
+
+

--- a/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
+++ b/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
@@ -1,4 +1,6 @@
 {
+  // NOTE: enabled by default
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "no-loss-of-precision": "off",
     "@typescript-eslint/no-loss-of-precision": "error",

--- a/crates/oxc_linter/src/config/env.rs
+++ b/crates/oxc_linter/src/config/env.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 /// environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
 /// for what environments are available and what each one provides.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct OxlintEnv(FxHashMap<String, bool>);
 
 impl OxlintEnv {

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -23,9 +23,11 @@ type RuleSet = FxHashSet<RuleWithSeverity>;
 // <https://github.com/eslint/eslint/blob/ce838adc3b673e52a151f36da0eedf5876977514/lib/shared/types.js#L12>
 // Note: when update document comment, also update `DummyRuleMap`'s description in this file.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct OxlintRules(Vec<ESLintRule>);
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct ESLintRule {
     pub plugin_name: String,
     pub rule_name: String,

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -8,6 +8,7 @@ use crate::utils::default_true;
 
 // <https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/settings.md>
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct JSDocPluginSettings {
     /// For all rules but NOT apply to `check-access` and `empty-tags` rule
     #[serde(default, rename = "ignorePrivate")]
@@ -181,6 +182,7 @@ impl JSDocPluginSettings {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(untagged)]
 enum TagNamePreference {
     TagNameOnly(String),

--- a/crates/oxc_linter/src/config/settings/jsx_a11y.rs
+++ b/crates/oxc_linter/src/config/settings/jsx_a11y.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 // <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations>
 #[derive(Debug, Deserialize, Default, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct JSXA11yPluginSettings {
     #[serde(rename = "polymorphicPropName")]
     pub polymorphic_prop_name: Option<CompactStr>,

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -13,6 +13,7 @@ use self::{
 
 /// Shared settings for plugins
 #[derive(Debug, Deserialize, Serialize, Default, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct OxlintSettings {
     #[serde(default)]
     #[serde(rename = "jsx-a11y")]

--- a/crates/oxc_linter/src/config/settings/next.rs
+++ b/crates/oxc_linter/src/config/settings/next.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Debug, Deserialize, Default, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NextPluginSettings {
     #[serde(default)]
     #[serde(rename = "rootDir")]

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 // <https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc->
 #[derive(Debug, Deserialize, Default, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct ReactPluginSettings {
     #[serde(default)]
     #[serde(rename = "formComponents")]
@@ -31,6 +32,7 @@ impl ReactPluginSettings {
 // Deserialize helper types
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(untagged)]
 enum CustomComponent {
     NameOnly(CompactStr),

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -35,7 +35,9 @@ pub use crate::{
     context::LintContext,
     fixer::FixKind,
     frameworks::FrameworkFlags,
-    options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind, OxlintOptions},
+    options::{
+        AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind, LintPlugins, OxlintOptions,
+    },
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
 };

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -2,7 +2,7 @@ use std::{env, path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, FixKind, LintFilter, Linter, OxlintOptions};
+use oxc_linter::{FixKind, LinterBuilder};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -34,22 +34,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     .with_cfg(true)
                     .build_module_record(Path::new(""), program)
                     .build(program);
-                let filter = vec![
-                    LintFilter::new(AllowWarnDeny::Deny, "all").unwrap(),
-                    LintFilter::new(AllowWarnDeny::Deny, "nursery").unwrap(),
-                ];
-                let lint_options = OxlintOptions::default()
-                    .with_filter(filter)
-                    .with_fix(FixKind::All)
-                    .with_import_plugin(true)
-                    .with_jsdoc_plugin(true)
-                    .with_jest_plugin(true)
-                    .with_jsx_a11y_plugin(true)
-                    .with_nextjs_plugin(true)
-                    .with_react_perf_plugin(true)
-                    .with_vitest_plugin(true)
-                    .with_node_plugin(true);
-                let linter = Linter::from_options(lint_options).unwrap();
+                let linter = LinterBuilder::all().with_fix(FixKind::All).build();
                 let semantic = Rc::new(semantic_ret.semantic);
                 b.iter(|| linter.run(Path::new(std::ffi::OsStr::new("")), Rc::clone(&semantic)));
             },


### PR DESCRIPTION
> Closes #5046
This PR migrates the linter crate and oxlint app to use the new `LinterBuilder` API. This PR has the following effects:

1. `plugins` in oxlint config files are now supported
2. irons out weirdness when using CLI args and config files together. CLI args are now always applied on top of config file settings, overriding them.

# Breaking Changes
Before, config files would override rules set in CLI arguments. For example, running this command:
```sh
oxlint -A correctness -c oxlintrc.json
```
With this config file
```jsonc
// oxlintrc.json
{
  "rules": {
    "no-const-assign": "error"
  }
}
```
Would result in a single rule, `no-const-assign` being turned on at an error level with all other rules disabled (i.e. set to "allow").

Now, **CLI arguments will override config files**. That same command with the same config file will result with **all rules being disabled**.

## Details

For a more in-depth explanation, assume we are running the below command using the `oxlintrc.json` file above:
```sh
oxlint -A all -W correctness -A all -W suspicious -c oxlintrc.json
```

### Before
> Note: GitHub doesn't seem to like deeply nested lists. Apologies for the formatting.

Here was the config resolution process _before_ this PR:
<details><summary>Before Steps</summary>

1. Start with a default set of filters (["correctness", "warn"]) if no filters were passed to the CLI. Since some were, the filter list starts out empty.
2. Apply each filter taken from the CLI from left to right. When a filter allows a rule or category, it clears the configured set of rules. So applying those filters looks like this
  a. start with an empty list `[]`
  b. `("all", "allow")` -> `[]`
  c. `("correctness", "warn")` -> `[ <correctness rules> ]`
  d. `("all", "allow")` -> `[]`
  e. `("suspicious", "warn")` -> `[ <suspicious rules> ]`. This is the final rule set for this step
3. Apply overrides from `oxlintrc.json`. This is where things get a little funky, as mentioned in point 2 of what this PR does. At this point, all rules in the rules list are only from the CLI.
  a. If a rule is only set in the CLI and is not present in the config file, there's no effect
  b. If a rule is in the config file but not the CLI, it gets inserted into the list.
  c. If a rule is already in the list and in the config file
    i. If the rule is only present once (e.g. `"no-loss-of-precision": "error"`), unconditionally override whatever was in the CLI with what was set in the config file
    ii. If the rule is present twice (e.g. `"no-loss-of-precision": "off", "@typescript-eslint/no-loss-of-precision": "error"`),
      a. if all rules in the config file are set to `allow`, then turn the rule off
      b. If one of them is `warn` or `deny`, then update the currently-set rule's config object, but _leave its severity alone_.

  So, for our example, the final rule set would be `[<all suspicious rules: "warn">, no-const-assign: "error"]`

</details>

### After
Rule filters were completely re-worked in a previous PR. Now, lint filters aren't kept on hand-only the rule list is.

<details><summary>After Steps</summary>

1. Start with the default rule set, which is all correctness rules for all enabled plugins (`[<all correctness rules: "warn">]`)
2. Apply configuration from `oxlintrc.json` _first_.
  a. If the rule is warn/deny exists in the list already, update its severity and config object. If it's not in the list, add it.
  b. If the rule is set to allow, remove it from the list.

  The list is now `[<all correctness rules except no-const-assign: "warn">, no-const-assign: "error"]`.

3. Apply each filter taken from the CLI from left to right. This works the same way as before. So, after they're applied, the list is now `[<suspicous rules: "warn">]`

</details>
