### PR TITLE
refactor(transformer): rename `SparseStack` methods

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -161,7 +161,7 @@ impl<'a> Traverse<'a> for ArrowFunctions<'a> {
 
     /// Insert `var _this = this;` for the global scope.
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        if let Some(this_var) = self.this_var_stack.take() {
+        if let Some(this_var) = self.this_var_stack.take_last() {
             self.insert_this_var_statement_at_the_top_of_statements(
                 &mut program.body,
                 &this_var,
@@ -270,7 +270,7 @@ impl<'a> ArrowFunctions<'a> {
         // `this` can be in scope at a time. We could create a single `_this` UID and reuse it in each
         // scope. But this does not match output for some of Babel's test cases.
         // <https://github.com/oxc-project/oxc/pull/5840>
-        let this_var = self.this_var_stack.get_or_init(|| {
+        let this_var = self.this_var_stack.last_or_init(|| {
             let target_scope_id = ctx
                 .scopes()
                 .ancestors(arrow_scope_id)

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -327,7 +327,7 @@ impl<'a> ExponentiationOperator<'a> {
             let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
             let id = ctx.ast.binding_pattern(id, NONE, false);
             self.var_declarations
-                .get_mut_or_init(|| ctx.ast.vec())
+                .last_mut_or_init(|| ctx.ast.vec())
                 .push(ctx.ast.variable_declarator(SPAN, kind, id, None, false));
         }
 

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -157,7 +157,7 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
         } else {
             let kind = VariableDeclarationKind::Var;
             self.var_declarations
-                .get_mut_or_init(|| ctx.ast.vec())
+                .last_mut_or_init(|| ctx.ast.vec())
                 .push(ctx.ast.variable_declarator(SPAN, kind, id, None, false));
         }
 

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -396,7 +396,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
         let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
         let id = ctx.ast.binding_pattern(id, NONE, false);
         self.var_declarations
-            .get_mut_or_init(|| ctx.ast.vec())
+            .last_mut_or_init(|| ctx.ast.vec())
             .push(ctx.ast.variable_declarator(SPAN, kind, id, None, false));
 
         // _name = name


### PR DESCRIPTION
Pure refactor. Just rename methods.