### PR TITLE
refactor(transformer): pre-allocate more stack space

### DIFF
--- a/crates/oxc_transformer/src/helpers/stack/capacity.rs
+++ b/crates/oxc_transformer/src/helpers/stack/capacity.rs
@@ -37,11 +37,12 @@ pub trait StackCapacity<T> {
 
     /// Default capacity of stack.
     ///
-    /// Same defaults as [`std::vec::Vec`] uses.
+    /// Same defaults as [`std::vec::Vec`] uses, except 16 bytes for types with size 1 (instead of 8).
+    /// Allocators will usually allocate minimum 16 bytes anyway.
     const DEFAULT_CAPACITY: usize = {
         // It's impossible for this to exceed `MAX_CAPACITY` because `size_of::<T>() >= align_of::<T>()`
         match size_of::<T>() {
-            1 => 8,
+            1 => 16,
             size if size <= 1024 => 4,
             _ => 1,
         }
@@ -65,8 +66,8 @@ mod tests {
         impl StackCapacity<bool> for TestStack {}
         assert_eq!(TestStack::MAX_CAPACITY, ISIZE_MAX);
         assert_eq!(TestStack::MAX_CAPACITY_BYTES, ISIZE_MAX);
-        assert_eq!(TestStack::DEFAULT_CAPACITY, 8);
-        assert_eq!(TestStack::DEFAULT_CAPACITY_BYTES, 8);
+        assert_eq!(TestStack::DEFAULT_CAPACITY, 16);
+        assert_eq!(TestStack::DEFAULT_CAPACITY_BYTES, 16);
     }
 
     #[test]

--- a/crates/oxc_transformer/src/helpers/stack/non_empty.rs
+++ b/crates/oxc_transformer/src/helpers/stack/non_empty.rs
@@ -319,8 +319,8 @@ mod tests {
     #[test]
     fn new() {
         let stack = NonEmptyStack::new(true);
-        assert_len_cap_last!(stack, 1, 8, &true);
-        assert_eq!(stack.capacity_bytes(), 8);
+        assert_len_cap_last!(stack, 1, 16, &true);
+        assert_eq!(stack.capacity_bytes(), 16);
 
         let stack = NonEmptyStack::new(10u64);
         assert_len_cap_last!(stack, 1, 4, &10);


### PR DESCRIPTION
Pre-allocate 16 bytes for stacks in transforms that use them. Allocators usually support minimum of 16 bytes for allocations anyway. Now that we're using `SparseStack`, allocating decent capacity is now cheap.