### PR TITLE
docs(linter): improve docs for node/security/tree_shaking rules

### DIFF
--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -40,6 +40,7 @@ pub struct NoExportsAssign;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallows assignment to `exports`.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/security/api_keys/mod.rs
+++ b/crates/oxc_linter/src/rules/security/api_keys/mod.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ### What To Do Instead
+    ///
     /// :::warning
     /// The Oxc team are not security experts. We do not endorse any particular
     /// key management service or strategy. Do your research and choose the best

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -116,12 +116,23 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// ### Example
+    /// Side-effects in module initialization can hinder tree-shaking, which aims to remove
+    /// unused code. If side-effects exist, it's harder for the bundler to safely eliminate
+    /// code, leading to larger bundles and potentially unexpected behavior. Ensuring minimal
+    /// side-effects allows bundlers to optimize code effectively.
     ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// myGlobal = 17; // Cannot determine side-effects of assignment to global variable
     /// const x = { [globalFunction()]: "myString" }; // Cannot determine side-effects of calling global function
-    /// export default 42;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const localVar = 17; // Local variable assignment, no global side-effects
+    /// export default 42; // Pure export with no side-effects
     /// ```
     ///
     /// ### Options


### PR DESCRIPTION
Related to #6050 

As of this PR, all documents of that contain a few rules have been corrected.