### PR TITLE
fix(codegen): missing parentheses if there is a pure comment before a NewExpression as a ComputedMemberExpression's callee

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1328,7 +1328,7 @@ impl<'a> GenExpr for ComputedMemberExpression<'a> {
         // `(let[0] = 100);` -> `(let)[0] = 100`;
         let wrap = self.object.get_identifier_reference().is_some_and(|r| r.name == "let");
         p.wrap(wrap, |p| {
-            self.object.print_expr(p, Precedence::Prefix, ctx.intersection(Context::FORBID_CALL));
+            self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
         });
         if self.optional {
             p.print_str("?.");

--- a/crates/oxc_codegen/tests/integration/pure_comments.rs
+++ b/crates/oxc_codegen/tests/integration/pure_comments.rs
@@ -111,6 +111,8 @@ const builtInSymbols = new Set(
         "#,
         "(/* @__PURE__ */ new Foo()).bar();\n",
         "(/* @__PURE__ */ Foo()).bar();\n",
+        "(/* @__PURE__ */ new Foo())['bar']();\n",
+        "(/* @__PURE__ */ Foo())['bar']();\n",
         // https://github.com/oxc-project/oxc/issues/4843
         r"
 /* #__NO_SIDE_EFFECTS__ */

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -233,6 +233,18 @@ const builtInSymbols = new Set(
 (/* @__PURE__ */ Foo()).bar();
 
 ########## 16
+(/* @__PURE__ */ new Foo())['bar']();
+
+----------
+(/* @__PURE__ */ new Foo())['bar']();
+
+########## 17
+(/* @__PURE__ */ Foo())['bar']();
+
+----------
+(/* @__PURE__ */ Foo())['bar']();
+
+########## 18
 
 /* #__NO_SIDE_EFFECTS__ */
 const defineSSRCustomElement = /* @__NO_SIDE_EFFECTS__ */ (
@@ -247,7 +259,7 @@ const defineSSRCustomElement = /* #__NO_SIDE_EFFECTS__ */ /* @__NO_SIDE_EFFECTS_
 	return /* @__PURE__ */ defineCustomElement(options, extraOptions, hydrate);
 };
 
-########## 17
+########## 19
 
 const defineSSRCustomElement = () => {
   return /* @__PURE__ */ /* @__NO_SIDE_EFFECTS__ */ /* #__NO_SIDE_EFFECTS__ */ defineCustomElement(options, extraOptions, hydrate);


### PR DESCRIPTION
refer to https://github.com/evanw/esbuild/blob/332727499e62315cff4ecaff9fa8b86336555e46/internal/js_printer/js_printer.go#L2544