### PR TITLE
refactor(semantic): fix lint warning in nightly

### DIFF
--- a/crates/oxc_semantic/src/jsdoc/finder.rs
+++ b/crates/oxc_semantic/src/jsdoc/finder.rs
@@ -39,7 +39,7 @@ impl<'a> JSDocFinder<'a> {
         self.attached.get(&span.start).cloned()
     }
 
-    pub fn iter_all<'b>(&'b self) -> impl Iterator<Item = &JSDoc<'a>> + 'b {
+    pub fn iter_all<'b>(&'b self) -> impl Iterator<Item = &'b JSDoc<'a>> + 'b {
         self.attached.values().flatten().chain(self.not_attached.iter())
     }
 }


### PR DESCRIPTION
Fix a lint warning which you only get on nightly (so appears when running Miri).