### PR TITLE
refactor(transformer): share `TransformCtx` with ref not `Rc`

### DIFF
--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -2,7 +2,6 @@ use std::{
     cell::RefCell,
     mem,
     path::{Path, PathBuf},
-    rc::Rc,
 };
 
 use oxc_allocator::Allocator;
@@ -11,8 +10,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::SourceType;
 
 use crate::{helpers::module_imports::ModuleImports, TransformOptions};
-
-pub type Ctx<'a> = Rc<TransformCtx<'a>>;
 
 pub struct TransformCtx<'a> {
     errors: RefCell<Vec<OxcDiagnostic>>,

--- a/crates/oxc_transformer/src/react/display_name.rs
+++ b/crates/oxc_transformer/src/react/display_name.rs
@@ -50,19 +50,19 @@ use oxc_ast::ast::*;
 use oxc_span::{Atom, SPAN};
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
 
-use crate::context::Ctx;
+use crate::TransformCtx;
 
-pub struct ReactDisplayName<'a> {
-    ctx: Ctx<'a>,
+pub struct ReactDisplayName<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
 }
 
-impl<'a> ReactDisplayName<'a> {
-    pub fn new(ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> ReactDisplayName<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx }
     }
 }
 
-impl<'a> Traverse<'a> for ReactDisplayName<'a> {
+impl<'a, 'ctx> Traverse<'a> for ReactDisplayName<'a, 'ctx> {
     fn enter_call_expression(
         &mut self,
         call_expr: &mut CallExpression<'a>,
@@ -129,7 +129,7 @@ impl<'a> Traverse<'a> for ReactDisplayName<'a> {
     }
 }
 
-impl<'a> ReactDisplayName<'a> {
+impl<'a, 'ctx> ReactDisplayName<'a, 'ctx> {
     /// Get the object from `React.createClass({})` or `createReactClass({})`
     fn get_object_from_create_class<'b>(
         call_expr: &'b mut CallExpression<'a>,

--- a/crates/oxc_transformer/src/react/jsx_self.rs
+++ b/crates/oxc_transformer/src/react/jsx_self.rs
@@ -33,21 +33,21 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
 
-use crate::context::Ctx;
+use crate::TransformCtx;
 
 const SELF: &str = "__self";
 
-pub struct ReactJsxSelf<'a> {
-    ctx: Ctx<'a>,
+pub struct ReactJsxSelf<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
 }
 
-impl<'a> ReactJsxSelf<'a> {
-    pub fn new(ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> ReactJsxSelf<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx }
     }
 }
 
-impl<'a> Traverse<'a> for ReactJsxSelf<'a> {
+impl<'a, 'ctx> Traverse<'a> for ReactJsxSelf<'a, 'ctx> {
     fn enter_jsx_opening_element(
         &mut self,
         elem: &mut JSXOpeningElement<'a>,
@@ -57,7 +57,7 @@ impl<'a> Traverse<'a> for ReactJsxSelf<'a> {
     }
 }
 
-impl<'a> ReactJsxSelf<'a> {
+impl<'a, 'ctx> ReactJsxSelf<'a, 'ctx> {
     pub fn report_error(&self, span: Span) {
         let error = OxcDiagnostic::warn("Duplicate __self prop found.").with_label(span);
         self.ctx.error(error);

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -41,24 +41,24 @@ use oxc_traverse::{Traverse, TraverseCtx};
 use ropey::Rope;
 
 use super::utils::get_line_column;
-use crate::{context::Ctx, helpers::bindings::BoundIdentifier};
+use crate::{helpers::bindings::BoundIdentifier, TransformCtx};
 
 const SOURCE: &str = "__source";
 const FILE_NAME_VAR: &str = "jsxFileName";
 
-pub struct ReactJsxSource<'a> {
+pub struct ReactJsxSource<'a, 'ctx> {
     filename_var: Option<BoundIdentifier<'a>>,
     source_rope: Option<Rope>,
-    ctx: Ctx<'a>,
+    ctx: &'ctx TransformCtx<'a>,
 }
 
-impl<'a> ReactJsxSource<'a> {
-    pub fn new(ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { filename_var: None, source_rope: None, ctx }
     }
 }
 
-impl<'a> Traverse<'a> for ReactJsxSource<'a> {
+impl<'a, 'ctx> Traverse<'a> for ReactJsxSource<'a, 'ctx> {
     fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         if let Some(stmt) = self.get_var_file_name_statement() {
             program.body.insert(0, stmt);
@@ -74,7 +74,7 @@ impl<'a> Traverse<'a> for ReactJsxSource<'a> {
     }
 }
 
-impl<'a> ReactJsxSource<'a> {
+impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
     pub fn get_line_column(&mut self, offset: u32) -> (usize, usize) {
         if self.source_rope.is_none() {
             self.source_rope = Some(Rope::from_str(self.ctx.source_text));

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use sha1::{Digest, Sha1};
 
 use super::options::ReactRefreshOptions;
-use crate::context::Ctx;
+use crate::TransformCtx;
 
 /// Parse a string into a `RefreshIdentifierResolver` and convert it into an `Expression`
 #[derive(Debug)]
@@ -94,11 +94,11 @@ impl<'a> RefreshIdentifierResolver<'a> {
 ///
 /// * <https://github.com/facebook/react/issues/16604#issuecomment-528663101>
 /// * <https://github.com/facebook/react/blob/main/packages/react-refresh/src/ReactFreshBabelPlugin.js>
-pub struct ReactRefresh<'a> {
+pub struct ReactRefresh<'a, 'ctx> {
     refresh_reg: RefreshIdentifierResolver<'a>,
     refresh_sig: RefreshIdentifierResolver<'a>,
     emit_full_signatures: bool,
-    ctx: Ctx<'a>,
+    ctx: &'ctx TransformCtx<'a>,
     // States
     registrations: Vec<(SymbolId, Atom<'a>)>,
     signature_declarator_items: Vec<oxc_allocator::Vec<'a, VariableDeclarator<'a>>>,
@@ -111,8 +111,8 @@ pub struct ReactRefresh<'a> {
     non_builtin_hooks_callee: FxHashMap<ScopeId, Vec<Option<Expression<'a>>>>,
 }
 
-impl<'a> ReactRefresh<'a> {
-    pub fn new(options: &ReactRefreshOptions, ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
+    pub fn new(options: &ReactRefreshOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
             refresh_reg: RefreshIdentifierResolver::parse(&options.refresh_reg, ctx.ast),
             refresh_sig: RefreshIdentifierResolver::parse(&options.refresh_sig, ctx.ast),
@@ -128,7 +128,7 @@ impl<'a> ReactRefresh<'a> {
     }
 }
 
-impl<'a> Traverse<'a> for ReactRefresh<'a> {
+impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         let mut new_statements = ctx.ast.vec_with_capacity(program.body.len());
         for mut statement in program.body.drain(..) {
@@ -455,7 +455,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a> {
 }
 
 // Internal Methods
-impl<'a> ReactRefresh<'a> {
+impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
     fn create_registration(
         &mut self,
         persistent_id: Atom<'a>,

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -55,13 +55,13 @@ use oxc_semantic::ReferenceFlags;
 use oxc_span::{Atom, SPAN};
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use crate::context::Ctx;
+use crate::TransformCtx;
 
 mod options;
 pub use options::RegExpOptions;
 
-pub struct RegExp<'a> {
-    ctx: Ctx<'a>,
+pub struct RegExp<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
     unsupported_flags: RegExpFlags,
     some_unsupported_patterns: bool,
     look_behind_assertions: bool,
@@ -69,8 +69,8 @@ pub struct RegExp<'a> {
     unicode_property_escapes: bool,
 }
 
-impl<'a> RegExp<'a> {
-    pub fn new(options: RegExpOptions, ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> RegExp<'a, 'ctx> {
+    pub fn new(options: RegExpOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         // Get unsupported flags
         let mut unsupported_flags = RegExpFlags::empty();
         if options.dot_all_flag {
@@ -111,7 +111,7 @@ impl<'a> RegExp<'a> {
     }
 }
 
-impl<'a> Traverse<'a> for RegExp<'a> {
+impl<'a, 'ctx> Traverse<'a> for RegExp<'a, 'ctx> {
     fn enter_expression(
         &mut self,
         expr: &mut Expression<'a>,
@@ -190,7 +190,7 @@ impl<'a> Traverse<'a> for RegExp<'a> {
     }
 }
 
-impl<'a> RegExp<'a> {
+impl<'a, 'ctx> RegExp<'a, 'ctx> {
     /// Check if the regular expression contains any unsupported syntax.
     ///
     /// Based on parsed regular expression pattern.

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -16,12 +16,12 @@ use oxc_syntax::{
 use oxc_traverse::{Traverse, TraverseCtx};
 use rustc_hash::FxHashSet;
 
-use crate::{context::Ctx, TypeScriptOptions};
+use crate::{TransformCtx, TypeScriptOptions};
 
-pub struct TypeScriptAnnotations<'a> {
+pub struct TypeScriptAnnotations<'a, 'ctx> {
     #[allow(dead_code)]
     options: Rc<TypeScriptOptions>,
-    ctx: Ctx<'a>,
+    ctx: &'ctx TransformCtx<'a>,
     /// Assignments to be added to the constructor body
     assignments: Vec<Assignment<'a>>,
     has_super_call: bool,
@@ -33,8 +33,8 @@ pub struct TypeScriptAnnotations<'a> {
     type_identifier_names: FxHashSet<Atom<'a>>,
 }
 
-impl<'a> TypeScriptAnnotations<'a> {
-    pub fn new(options: Rc<TypeScriptOptions>, ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
+    pub fn new(options: Rc<TypeScriptOptions>, ctx: &'ctx TransformCtx<'a>) -> Self {
         let jsx_element_import_name = if options.jsx_pragma.contains('.') {
             options.jsx_pragma.split('.').next().map(String::from).unwrap()
         } else {
@@ -60,7 +60,8 @@ impl<'a> TypeScriptAnnotations<'a> {
         }
     }
 }
-impl<'a> Traverse<'a> for TypeScriptAnnotations<'a> {
+
+impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         let mut no_modules_remaining = true;
         let mut some_modules_deleted = false;
@@ -548,7 +549,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a> {
     }
 }
 
-impl<'a> TypeScriptAnnotations<'a> {
+impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
     /// Check if the given name is a JSX pragma or fragment pragma import
     /// and if the file contains JSX elements or fragments
     fn is_jsx_imports(&self, name: &str) -> bool {

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -11,20 +11,20 @@ use oxc_syntax::{
 use oxc_traverse::{Traverse, TraverseCtx};
 use rustc_hash::FxHashMap;
 
-use crate::context::Ctx;
+use crate::TransformCtx;
 
-pub struct TypeScriptEnum<'a> {
-    ctx: Ctx<'a>,
+pub struct TypeScriptEnum<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
     enums: FxHashMap<Atom<'a>, FxHashMap<Atom<'a>, ConstantValue>>,
 }
 
-impl<'a> TypeScriptEnum<'a> {
-    pub fn new(ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> TypeScriptEnum<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx, enums: FxHashMap::default() }
     }
 }
 
-impl<'a> Traverse<'a> for TypeScriptEnum<'a> {
+impl<'a, 'ctx> Traverse<'a> for TypeScriptEnum<'a, 'ctx> {
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let new_stmt = match stmt {
             Statement::TSEnumDeclaration(ts_enum_decl) => {
@@ -47,7 +47,7 @@ impl<'a> Traverse<'a> for TypeScriptEnum<'a> {
     }
 }
 
-impl<'a> TypeScriptEnum<'a> {
+impl<'a, 'ctx> TypeScriptEnum<'a, 'ctx> {
     /// ```TypeScript
     /// enum Foo {
     ///   X = 1,
@@ -366,7 +366,7 @@ enum ConstantValue {
     String(String),
 }
 
-impl<'a> TypeScriptEnum<'a> {
+impl<'a, 'ctx> TypeScriptEnum<'a, 'ctx> {
     /// Evaluate the expression to a constant value.
     /// Refer to [babel](https://github.com/babel/babel/blob/610897a9a96c5e344e77ca9665df7613d2f88358/packages/babel-plugin-transform-typescript/src/enum.ts#L241C1-L394C2)
     fn computed_constant_value(

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -4,19 +4,19 @@ use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use crate::context::Ctx;
+use crate::TransformCtx;
 
-pub struct TypeScriptModule<'a> {
-    ctx: Ctx<'a>,
+pub struct TypeScriptModule<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
 }
 
-impl<'a> TypeScriptModule<'a> {
-    pub fn new(ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx }
     }
 }
 
-impl<'a> Traverse<'a> for TypeScriptModule<'a> {
+impl<'a, 'ctx> Traverse<'a> for TypeScriptModule<'a, 'ctx> {
     /// ```TypeScript
     /// import b = babel;
     /// import AliasModule = LongNameModule;
@@ -48,7 +48,7 @@ impl<'a> Traverse<'a> for TypeScriptModule<'a> {
     }
 }
 
-impl<'a> TypeScriptModule<'a> {
+impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
     fn transform_ts_import_equals(
         &self,
         decl: &mut Box<'a, TSImportEqualsDeclaration<'a>>,

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -15,20 +15,20 @@ use super::{
     diagnostics::{ambient_module_nested, namespace_exporting_non_const, namespace_not_supported},
     TypeScriptOptions,
 };
-use crate::context::Ctx;
+use crate::TransformCtx;
 
-pub struct TypeScriptNamespace<'a> {
-    ctx: Ctx<'a>,
+pub struct TypeScriptNamespace<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
     options: Rc<TypeScriptOptions>,
 }
 
-impl<'a> TypeScriptNamespace<'a> {
-    pub fn new(options: Rc<TypeScriptOptions>, ctx: Ctx<'a>) -> Self {
+impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
+    pub fn new(options: Rc<TypeScriptOptions>, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx, options }
     }
 }
 
-impl<'a> Traverse<'a> for TypeScriptNamespace<'a> {
+impl<'a, 'ctx> Traverse<'a> for TypeScriptNamespace<'a, 'ctx> {
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         // namespace declaration is only allowed at the top level
@@ -139,7 +139,7 @@ impl<'a> Traverse<'a> for TypeScriptNamespace<'a> {
     }
 }
 
-impl<'a> TypeScriptNamespace<'a> {
+impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
     fn handle_nested(
         &self,
         decl: TSModuleDeclaration<'a>,


### PR DESCRIPTION
Many transforms share `TransformCtx`. Currently it's shared with `Rc`, which has a cost as the `Rc` has to be cloned many times, and it also makes dropping `Transformer` more expensive.

The PR changes that to share it as a normal reference `&TransformCtx` instead.

This requires adding an inner `TransformerImpl`. `Transformer` is now just a facade which creates the `TransformCtx` and stores options. `Transformer::build_with_symbols_and_scopes` constructs `TransformerImpl` and runs the visitor on it.

Unlikely to have any perf impact on larger files, but for small files where setup/teardown is a larger % of the overall workload, it may help a little.