### PR TITLE
refactor(transformer): share `TypeScriptOptions` with ref not `Rc`

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -73,10 +73,13 @@ impl<'a> Transformer<'a> {
         source_type: SourceType,
         source_text: &'a str,
         trivias: Trivias,
-        options: TransformOptions,
+        mut options: TransformOptions,
     ) -> Self {
         let ctx =
             TransformCtx::new(allocator, source_path, source_type, source_text, trivias, &options);
+
+        options.typescript.update_with_comments(&ctx);
+
         Self { ctx, options }
     }
 
@@ -89,7 +92,7 @@ impl<'a> Transformer<'a> {
         let allocator = self.ctx.ast.allocator;
 
         let mut transformer = TransformerImpl {
-            x0_typescript: TypeScript::new(self.options.typescript, &self.ctx),
+            x0_typescript: TypeScript::new(&self.options.typescript, &self.ctx),
             x1_react: React::new(self.options.react, &self.ctx),
             x2_es2021: ES2021::new(self.options.es2021),
             x2_es2020: ES2020::new(self.options.es2020),

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unused_self)]
 
-use std::{cell::Cell, rc::Rc};
+use std::cell::Cell;
 
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
@@ -20,7 +20,7 @@ use crate::{TransformCtx, TypeScriptOptions};
 
 pub struct TypeScriptAnnotations<'a, 'ctx> {
     #[allow(dead_code)]
-    options: Rc<TypeScriptOptions>,
+    options: &'ctx TypeScriptOptions,
     ctx: &'ctx TransformCtx<'a>,
     /// Assignments to be added to the constructor body
     assignments: Vec<Assignment<'a>>,
@@ -34,7 +34,7 @@ pub struct TypeScriptAnnotations<'a, 'ctx> {
 }
 
 impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
-    pub fn new(options: Rc<TypeScriptOptions>, ctx: &'ctx TransformCtx<'a>) -> Self {
+    pub fn new(options: &'ctx TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         let jsx_element_import_name = if options.jsx_pragma.contains('.') {
             options.jsx_pragma.split('.').next().map(String::from).unwrap()
         } else {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -6,8 +6,6 @@ mod namespace;
 mod options;
 mod rewrite_extensions;
 
-use std::rc::Rc;
-
 use module::TypeScriptModule;
 use namespace::TypeScriptNamespace;
 use oxc_allocator::Vec;
@@ -41,7 +39,7 @@ use crate::TransformCtx;
 /// In:  `const x: number = 0;`
 /// Out: `const x = 0;`
 pub struct TypeScript<'a, 'ctx> {
-    options: Rc<TypeScriptOptions>,
+    options: &'ctx TypeScriptOptions,
     ctx: &'ctx TransformCtx<'a>,
 
     annotations: TypeScriptAnnotations<'a, 'ctx>,
@@ -52,16 +50,14 @@ pub struct TypeScript<'a, 'ctx> {
 }
 
 impl<'a, 'ctx> TypeScript<'a, 'ctx> {
-    pub fn new(options: TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
-        let options = Rc::new(options.update_with_comments(ctx));
-
+    pub fn new(options: &'ctx TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
-            annotations: TypeScriptAnnotations::new(Rc::clone(&options), ctx),
+            annotations: TypeScriptAnnotations::new(options, ctx),
             r#enum: TypeScriptEnum::new(ctx),
             rewrite_extensions: TypeScriptRewriteExtensions::new(
                 options.rewrite_import_extensions.clone().unwrap_or_default(),
             ),
-            namespace: TypeScriptNamespace::new(Rc::clone(&options), ctx),
+            namespace: TypeScriptNamespace::new(options, ctx),
             module: TypeScriptModule::new(ctx),
             options,
             ctx,

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{ast::*, syntax_directed_operations::BoundNames, NONE};
 use oxc_span::{Atom, CompactStr, SPAN};
@@ -19,11 +17,11 @@ use crate::TransformCtx;
 
 pub struct TypeScriptNamespace<'a, 'ctx> {
     ctx: &'ctx TransformCtx<'a>,
-    options: Rc<TypeScriptOptions>,
+    options: &'ctx TypeScriptOptions,
 }
 
 impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
-    pub fn new(options: Rc<TypeScriptOptions>, ctx: &'ctx TransformCtx<'a>) -> Self {
+    pub fn new(options: &'ctx TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self { ctx, options }
     }
 }

--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -70,7 +70,7 @@ impl TypeScriptOptions {
     /// otherwise `JSDoc` could be used instead.
     ///
     /// This behavior is aligned with babel.
-    pub(crate) fn update_with_comments(mut self, ctx: &TransformCtx) -> Self {
+    pub(crate) fn update_with_comments(&mut self, ctx: &TransformCtx) {
         for comment in ctx.trivias.comments() {
             let mut comment = comment.span.source_text(ctx.source_text).trim_start();
             // strip leading jsdoc comment `*` and then whitespaces
@@ -92,8 +92,6 @@ impl TypeScriptOptions {
                 self.jsx_pragma = Cow::from(pragma.to_string());
             }
         }
-
-        self
     }
 }
 


### PR DESCRIPTION
Similar to #6118.

Share `TypeScriptOptions` between transforms as a plain `&` reference, rather than an `Rc`, to reduce setup/teardown time.

The code to parse pragmas from comments is moved into `Transformer::new`. This isn't the ideal place for it, but it means `TypeScriptOptions` can be shared with the existing `'ctx` lifetime, rather than having to have a 3rd lifetime `TypeScript<'a, 'ctx, 'options>`.