### PR TITLE
refactor(transformer): exponentiation operator: convert to match

### DIFF
--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -95,24 +95,28 @@ impl<'a> Traverse<'a> for ExponentiationOperator<'a> {
 
     // NOTE: Bail bigint arguments to `Math.pow`, which are runtime errors.
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // left ** right
-        if let Expression::BinaryExpression(binary_expr) = expr {
-            if binary_expr.operator == BinaryOperator::Exponential {
-                if binary_expr.left.is_big_int_literal() || binary_expr.right.is_big_int_literal() {
+        match expr {
+            // left ** right
+            Expression::BinaryExpression(binary_expr) => {
+                if binary_expr.operator != BinaryOperator::Exponential
+                    || binary_expr.left.is_big_int_literal()
+                    || binary_expr.right.is_big_int_literal()
+                {
                     return;
                 }
+
                 let left = ctx.ast.move_expression(&mut binary_expr.left);
                 let right = ctx.ast.move_expression(&mut binary_expr.right);
                 *expr = Self::math_pow(left, right, ctx);
             }
-        }
-
-        // left **= right
-        if let Expression::AssignmentExpression(assign_expr) = expr {
-            if assign_expr.operator == AssignmentOperator::Exponential {
-                if assign_expr.right.is_big_int_literal() {
+            // left **= right
+            Expression::AssignmentExpression(assign_expr) => {
+                if assign_expr.operator != AssignmentOperator::Exponential
+                    || assign_expr.right.is_big_int_literal()
+                {
                     return;
                 }
+
                 let mut nodes = ctx.ast.vec();
                 let Some(Exploded { reference, uid }) =
                     self.explode(&mut assign_expr.left, &mut nodes, ctx)
@@ -130,6 +134,7 @@ impl<'a> Traverse<'a> for ExponentiationOperator<'a> {
                 nodes.push(assign_expr);
                 *expr = ctx.ast.expression_sequence(SPAN, nodes);
             }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
In exponentiation operator transform, the first branch handling `**` was "falling through" to also run the 2nd branch which handles `**=`. The first branch replaces `**` with `Math.pow`, so it can never match on the 2nd branch.

Convert it to a `match` instead, so it only executes one branch or the other.