### PR TITLE
refactor(transformer): TS transforms only store options they need

### DIFF
--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -39,28 +39,24 @@ use crate::TransformCtx;
 /// In:  `const x: number = 0;`
 /// Out: `const x = 0;`
 pub struct TypeScript<'a, 'ctx> {
-    options: &'ctx TypeScriptOptions,
     ctx: &'ctx TransformCtx<'a>,
 
     annotations: TypeScriptAnnotations<'a, 'ctx>,
     r#enum: TypeScriptEnum<'a, 'ctx>,
     namespace: TypeScriptNamespace<'a, 'ctx>,
     module: TypeScriptModule<'a, 'ctx>,
-    rewrite_extensions: TypeScriptRewriteExtensions,
+    rewrite_extensions: Option<TypeScriptRewriteExtensions>,
 }
 
 impl<'a, 'ctx> TypeScript<'a, 'ctx> {
-    pub fn new(options: &'ctx TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
+    pub fn new(options: &TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
+            ctx,
             annotations: TypeScriptAnnotations::new(options, ctx),
             r#enum: TypeScriptEnum::new(ctx),
-            rewrite_extensions: TypeScriptRewriteExtensions::new(
-                options.rewrite_import_extensions.clone().unwrap_or_default(),
-            ),
             namespace: TypeScriptNamespace::new(options, ctx),
             module: TypeScriptModule::new(ctx),
-            options,
-            ctx,
+            rewrite_extensions: TypeScriptRewriteExtensions::new(options),
         }
     }
 }
@@ -263,8 +259,8 @@ impl<'a, 'ctx> Traverse<'a> for TypeScript<'a, 'ctx> {
         node: &mut ImportDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if self.options.rewrite_import_extensions.is_some() {
-            self.rewrite_extensions.enter_import_declaration(node, ctx);
+        if let Some(rewrite_extensions) = &mut self.rewrite_extensions {
+            rewrite_extensions.enter_import_declaration(node, ctx);
         }
     }
 
@@ -273,8 +269,8 @@ impl<'a, 'ctx> Traverse<'a> for TypeScript<'a, 'ctx> {
         node: &mut ExportAllDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if self.options.rewrite_import_extensions.is_some() {
-            self.rewrite_extensions.enter_export_all_declaration(node, ctx);
+        if let Some(rewrite_extensions) = &mut self.rewrite_extensions {
+            rewrite_extensions.enter_export_all_declaration(node, ctx);
         }
     }
 
@@ -283,8 +279,8 @@ impl<'a, 'ctx> Traverse<'a> for TypeScript<'a, 'ctx> {
         node: &mut ExportNamedDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if self.options.rewrite_import_extensions.is_some() {
-            self.rewrite_extensions.enter_export_named_declaration(node, ctx);
+        if let Some(rewrite_extensions) = &mut self.rewrite_extensions {
+            rewrite_extensions.enter_export_named_declaration(node, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -17,12 +17,14 @@ use crate::TransformCtx;
 
 pub struct TypeScriptNamespace<'a, 'ctx> {
     ctx: &'ctx TransformCtx<'a>,
-    options: &'ctx TypeScriptOptions,
+
+    // Options
+    allow_namespaces: bool,
 }
 
 impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
-    pub fn new(options: &'ctx TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
-        Self { ctx, options }
+    pub fn new(options: &TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
+        Self { ctx, allow_namespaces: options.allow_namespaces }
     }
 }
 
@@ -47,7 +49,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptNamespace<'a, 'ctx> {
             match stmt {
                 Statement::TSModuleDeclaration(decl) => {
                     if !decl.declare {
-                        if !self.options.allow_namespaces {
+                        if !self.allow_namespaces {
                             self.ctx.error(namespace_not_supported(decl.span));
                         }
 
@@ -75,7 +77,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptNamespace<'a, 'ctx> {
                     match &export_decl.declaration {
                         Some(Declaration::TSModuleDeclaration(decl)) => {
                             if !decl.declare {
-                                if !self.options.allow_namespaces {
+                                if !self.allow_namespaces {
                                     self.ctx.error(namespace_not_supported(decl.span));
                                 }
 

--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -109,7 +109,7 @@ impl Default for TypeScriptOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum RewriteExtensionsMode {
     /// Rewrite `.ts`/`.mts`/`.cts` extensions in import/export declarations to `.js`/`.mjs`/`.cjs`.
     #[default]

--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -10,6 +10,8 @@ use oxc_ast::ast::{
 };
 use oxc_traverse::{Traverse, TraverseCtx};
 
+use crate::TypeScriptOptions;
+
 use super::options::RewriteExtensionsMode;
 
 pub struct TypeScriptRewriteExtensions {
@@ -17,8 +19,8 @@ pub struct TypeScriptRewriteExtensions {
 }
 
 impl TypeScriptRewriteExtensions {
-    pub fn new(mode: RewriteExtensionsMode) -> Self {
-        Self { mode }
+    pub fn new(options: &TypeScriptOptions) -> Option<Self> {
+        options.rewrite_import_extensions.map(|mode| Self { mode })
     }
 
     pub fn rewrite_extensions<'a>(


### PR DESCRIPTION
All TS transforms only need a subset of the options in `TypeScriptOptions` - mostly just a single `bool`. Store these specific options in the transforms, not the whole `TypeScriptOptions` object.

This makes the transformer types smaller, and also checking the option is cheaper as it doesn't involve going through a double-reference.

e.g. Accessing `only_remove_type_imports` option with Rust's deref sugar made explicit:

Before: `*(&*self.options).only_remove_type_imports`
After: `*self.only_remove_type_imports`
