### PR TITLE
refactor(transformer): move parsing pragmas into TS transform

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -73,13 +73,10 @@ impl<'a> Transformer<'a> {
         source_type: SourceType,
         source_text: &'a str,
         trivias: Trivias,
-        mut options: TransformOptions,
+        options: TransformOptions,
     ) -> Self {
         let ctx =
             TransformCtx::new(allocator, source_path, source_type, source_text, trivias, &options);
-
-        options.typescript.update_with_comments(&ctx);
-
         Self { ctx, options }
     }
 
@@ -92,7 +89,7 @@ impl<'a> Transformer<'a> {
         let allocator = self.ctx.ast.allocator;
 
         let mut transformer = TransformerImpl {
-            x0_typescript: TypeScript::new(&self.options.typescript, &self.ctx),
+            x0_typescript: TypeScript::new(self.options.typescript, &self.ctx),
             x1_react: React::new(self.options.react, &self.ctx),
             x2_es2021: ES2021::new(self.options.es2021),
             x2_es2020: ES2020::new(self.options.es2020),

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -49,14 +49,15 @@ pub struct TypeScript<'a, 'ctx> {
 }
 
 impl<'a, 'ctx> TypeScript<'a, 'ctx> {
-    pub fn new(options: &TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
+    pub fn new(mut options: TypeScriptOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
+        options.update_with_comments(ctx);
         Self {
             ctx,
-            annotations: TypeScriptAnnotations::new(options, ctx),
+            annotations: TypeScriptAnnotations::new(&options, ctx),
             r#enum: TypeScriptEnum::new(ctx),
-            namespace: TypeScriptNamespace::new(options, ctx),
+            namespace: TypeScriptNamespace::new(&options, ctx),
             module: TypeScriptModule::new(ctx),
-            rewrite_extensions: TypeScriptRewriteExtensions::new(options),
+            rewrite_extensions: TypeScriptRewriteExtensions::new(&options),
         }
     }
 }


### PR DESCRIPTION
It's more natural for this code to live in TS transform.