### PR TITLE
fix(transformer/react): should not collect use-hooks if it's a nested member expression

### DIFF
--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -384,10 +384,11 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
         }
 
         if !is_builtin_hook(&hook_name) {
+            // Check if a corresponding binding exists where we emit the signature.
             let (binding_name, is_member_expression) = match &call_expr.callee {
                 Expression::Identifier(ident) => (Some(ident.name.clone()), false),
                 Expression::StaticMemberExpression(member) => {
-                    if let Expression::Identifier(object) = member.get_first_object() {
+                    if let Expression::Identifier(object) = &member.object {
                         (Some(object.name.clone()), true)
                     } else {
                         (None, false)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/nested-member-expression-with-hooks/output.js
@@ -3,7 +3,7 @@ export function Bar() {
     _s();
     A.B.C.useHook();
 }
-_s(Bar, "useHook{}", true);
+_s(Bar, "useHook{}");
 _c = Bar;
 var _c;
 $RefreshReg$(_c, "Bar");


### PR DESCRIPTION
close: #6139 

I still remember this logic and I call `get_first_object` for it intentionally 🥲