### PR TITLE
fix(just): use `powershell` compatible env variable

### DIFF
--- a/justfile
+++ b/justfile
@@ -76,8 +76,13 @@ test:
 lint:
   cargo lint -- --deny warnings
 
+[unix]
 doc:
   RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items
+
+[windows]
+doc:
+  $Env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps --document-private-items
 
 # Fix all auto-fixable format and lint issues. Make sure your working tree is clean first.
 fix:


### PR DESCRIPTION
Hello,

I was following the guide https://oxc.rs/docs/contribute/development.html and executed `just ready` as said.
I got an error on Windows on the `doc` command because it sets the env variable in a way that is not compatible with `powershell`.

I've used [attributes](https://just.systems/man/en/attributes.html#attributes) to fix the issue.
I never used `just` so I don't know if there's a better way to fix the issue.