### PR TITLE
fix(transformer): `NonEmptyStack::push` write value before updating cursor

### DIFF
--- a/crates/oxc_transformer/src/helpers/stack/non_empty.rs
+++ b/crates/oxc_transformer/src/helpers/stack/non_empty.rs
@@ -206,12 +206,12 @@ impl<T> NonEmptyStack<T> {
             unsafe { self.push_slow(value) };
         } else {
             // Capacity for at least 1 more entry
-            self.cursor = new_cursor;
             // SAFETY: We checked there is capacity for 1 more entry, so `self.cursor` is in bounds.
             // `self.cursor` was aligned for `T`, and we added `size_of::<T>()` to pointer.
             // `size_of::<T>()` is always a multiple of `T`'s alignment, so `self.cursor` must still be
             // aligned for `T`.
-            unsafe { self.cursor.as_ptr().write(value) };
+            unsafe { new_cursor.as_ptr().write(value) };
+            self.cursor = new_cursor;
         }
     }
 


### PR DESCRIPTION
`NonEmptyStack::push` was previously updating `cursor` before writing the value to stack. This could be UB if the type `T` is `Drop`, and writing the value panicked - as then `drop` would attempt to drop an uninitialized `T`.

I think `ptr::write` is infallible (can't panic), so it shouldn't matter. But *maybe* in debug mode it can panic if some invariant is broken (e.g. pointer not aligned). So play it safe and write the value first and update the cursor after.