### PR TITLE
refactor(transformer/react): don't follow the Babel's imports order

### DIFF
--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -59,16 +59,12 @@ impl<'a> ModuleImports<'a> {
     }
 
     /// Add `var named_import from 'source'`
-    pub fn add_require(&self, source: Atom<'a>, import: NamedImport<'a>, front: bool) {
-        let len = self.imports.borrow().len();
+    pub fn add_require(&self, source: Atom<'a>, import: NamedImport<'a>) {
         self.imports
             .borrow_mut()
             .entry(ImportType::new(ImportKind::Require, source))
             .or_default()
             .push(import);
-        if front {
-            self.imports.borrow_mut().move_index(len, 0);
-        }
     }
 
     pub fn get_import_statements(&self, ctx: &mut TraverseCtx<'a>) -> Vec<'a, Statement<'a>> {

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -21130,7 +21130,7 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): []
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
 semantic error: Bindings mismatch:
@@ -21370,7 +21370,7 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(3)]
 Unresolved references mismatch:
 after transform: ["Parameters", "Partial"]
 rebuilt        : []

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 333/1022
+Passed: 327/1022
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -3324,7 +3324,19 @@ after transform: ["T", "f"]
 rebuilt        : ["f"]
 
 
-# babel-plugin-transform-react-jsx (124/144)
+# babel-plugin-transform-react-jsx (119/144)
+* autoImport/after-polyfills/input.mjs
+x Output mismatch
+
+* autoImport/after-polyfills-2/input.mjs
+x Output mismatch
+
+* autoImport/auto-import-react-source-type-script/input.js
+x Output mismatch
+
+* autoImport/react-defined/input.js
+x Output mismatch
+
 * pure/false-pragma-comment-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 
@@ -3385,6 +3397,9 @@ importSource cannot be set when runtime is classic.
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
 
+* react-automatic/handle-fragments-with-key/input.js
+x Output mismatch
+
 * react-automatic/should-disallow-spread-children/input.js
 Spread children are not supported in React.
 
@@ -3428,7 +3443,10 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx-development (8/11)
+# babel-plugin-transform-react-jsx-development (7/11)
+* cross-platform/auto-import-dev/input.js
+x Output mismatch
+
 * cross-platform/disallow-__self-as-jsx-attribute/input.js
   ! Duplicate __self prop found.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/input.js:1:14]

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 56/65
+Passed: 53/65
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator
@@ -165,11 +165,20 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (29/31)
+# babel-plugin-transform-react-jsx (26/31)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
 x Output mismatch
 
+* refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
+x Output mismatch
+
+* refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
+x Output mismatch
+
 * refresh/supports-typescript-namespace-syntax/input.tsx
+x Output mismatch
+
+* static-children/input.jsx
 x Output mismatch
 
 


### PR DESCRIPTION
The `ImportDeclaration` orders are not matter, they are always hoisted. Previously to 100% match Babel's output to pass the tests, we did some weird logic in our implementation. In this PR I removed them, and always inserted the imports at the top of the statements. The reason for doing this is I am moving `ModuleImports` to https://github.com/oxc-project/oxc/blob/5b5aad856213df18f09bf1972f6e3a13a5302a15/crates/oxc_transformer/src/common/mod.rs#L14-16

After being moved to `common`,  the `NamedImports` will only insert imports once in `common` instead of inserting in each plugin that used it. 