### PR TITLE
refactor(transformer): shorten import

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -20,7 +20,7 @@ use oxc_span::SPAN;
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use crate::{context::TransformCtx, helpers::stack::SparseStack};
+use crate::{helpers::stack::SparseStack, TransformCtx};
 
 /// Transform that maintains the stack of `Vec<VariableDeclarator>`s, and adds a `var` statement
 /// to top of a statement block if another transform has requested that.


### PR DESCRIPTION
Tiny change. Import with `use crate::TransformCtx` not `use crate::context::TransformCtx`.