### PR TITLE
chore(linter): add category to completed rules

### DIFF
--- a/apps/oxlint/fixtures/svelte/eslintrc.json
+++ b/apps/oxlint/fixtures/svelte/eslintrc.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "no-console": "off",
     "no-undef": "off"
   }
 }

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -524,7 +524,7 @@ mod test {
 
     #[test]
     fn lint_svelte_file() {
-        let args = &["fixtures/svelte/debugger.svelte"];
+        let args = &["-c", "fixtures/svelte/eslintrc.json", "fixtures/svelte/debugger.svelte"];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
         assert_eq!(result.number_of_warnings, 2);

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     GetterReturn,
-    nursery
+    correctness
 );
 
 impl Rule for GetterReturn {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     /// var bar = a + 1;
     /// ```
     NoUndef,
-    nursery
+    correctness
 );
 
 impl Rule for NoUndef {

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     /// Disallow unreachable code after `return`, `throw`, `continue`, and `break` statements
     ///
     NoUnreachable,
-    nursery
+    correctness
 );
 
 impl Rule for NoUnreachable {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     /// export * from "./export-all"; // No conflict if export-all.js also exports foo
     /// ```
     Export,
-    nursery
+    correctness
 );
 
 impl Rule for Export {

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     /// Promise.resolve(1).finally(() => { console.log(2) })
     /// ```
     NoReturnInFinally,
-    nursery,
+    correctness,
 );
 
 impl Rule for NoReturnInFinally {

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     RequireRenderReturn,
-    nursery
+    correctness
 );
 
 impl Rule for RequireRenderReturn {

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -104,7 +104,7 @@ declare_oxc_lint!(
     /// <https://reactjs.org/docs/hooks-rules.html>
     ///
     RulesOfHooks,
-    nursery
+    correctness
 );
 
 impl Rule for RulesOfHooks {

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -188,7 +188,7 @@ declare_oxc_lint!(
     /// /*@__PURE__*/ x();
     /// ```
     NoSideEffectsInInitialization,
-    nursery
+    perf
 );
 
 impl Rule for NoSideEffectsInInitialization {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -102,7 +102,7 @@ declare_oxc_lint!(
     /// type S = import("Foo");
     /// ```
     ConsistentTypeImports,
-    nursery,
+    style,
     conditional_fix
 );
 


### PR DESCRIPTION
I noticed that some rules have been completed, but their category is still set to `nursery`.