### PR TITLE
refactor(transformer): export `var_declarations` module from `common` module

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -6,10 +6,9 @@ use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::TransformCtx;
 
-mod var_declarations;
+pub mod var_declarations;
 
 use var_declarations::VarDeclarations;
-pub use var_declarations::VarDeclarationsStore;
 
 pub struct Common<'a, 'ctx> {
     var_declarations: VarDeclarations<'a, 'ctx>,

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -10,7 +10,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::SourceType;
 
 use crate::{
-    common::VarDeclarationsStore, helpers::module_imports::ModuleImports, TransformOptions,
+    common::var_declarations::VarDeclarationsStore, helpers::module_imports::ModuleImports,
+    TransformOptions,
 };
 
 pub struct TransformCtx<'a> {


### PR DESCRIPTION
Tiny refactor. Export `var_declarations` module from `common`, rather than `var_declarations::VarDeclarationsStore`. Once we have more common transforms, the namespace of `common` module will become crowded.