### PR TITLE
refactor(transformer): rename `VarDeclarationsStore` methods

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -82,7 +82,7 @@ impl<'a> VarDeclarationsStore<'a> {
 impl<'a> VarDeclarationsStore<'a> {
     /// Add a `VariableDeclarator` to be inserted at top of current enclosing statement block,
     /// given `name` and `symbol_id`.
-    pub fn insert_declarator(
+    pub fn insert(
         &self,
         name: Atom<'a>,
         symbol_id: SymbolId,
@@ -92,12 +92,12 @@ impl<'a> VarDeclarationsStore<'a> {
         let ident = BindingIdentifier::new_with_symbol_id(SPAN, name, symbol_id);
         let ident = ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
         let ident = ctx.ast.binding_pattern(ident, NONE, false);
-        self.insert_declarator_binding_pattern(ident, init, ctx);
+        self.insert_binding_pattern(ident, init, ctx);
     }
 
     /// Add a `VariableDeclarator` to be inserted at top of current enclosing statement block,
     /// given a `BindingPattern`.
-    pub fn insert_declarator_binding_pattern(
+    pub fn insert_binding_pattern(
         &self,
         ident: BindingPattern<'a>,
         init: Option<Expression<'a>>,
@@ -105,6 +105,11 @@ impl<'a> VarDeclarationsStore<'a> {
     ) {
         let declarator =
             ctx.ast.variable_declarator(SPAN, VariableDeclarationKind::Var, ident, init, false);
+        self.insert_declarator(declarator, ctx);
+    }
+
+    /// Add a `VariableDeclarator` to be inserted at top of current enclosing statement block.
+    pub fn insert_declarator(&self, declarator: VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
         let mut declarators = self.declarators.borrow_mut();
         declarators.last_mut_or_init(|| ctx.ast.vec()).push(declarator);
     }

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -295,7 +295,7 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
         let symbol_name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
 
         // var _name;
-        self.ctx.var_declarations.insert_declarator(symbol_name.clone(), symbol_id, None, ctx);
+        self.ctx.var_declarations.insert(symbol_name.clone(), symbol_id, None, ctx);
 
         let ident =
             ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -125,7 +125,7 @@ impl<'a, 'ctx> Traverse<'a> for NullishCoalescingOperator<'a, 'ctx> {
             // `(x) => x;` -> `((x) => x)();`
             new_expr = ctx.ast.expression_call(SPAN, arrow_function, NONE, ctx.ast.vec(), false);
         } else {
-            self.ctx.var_declarations.insert_declarator_binding_pattern(id, None, ctx);
+            self.ctx.var_declarations.insert_binding_pattern(id, None, ctx);
         }
 
         *expr = new_expr;

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -359,7 +359,7 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         let symbol_name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
 
         // var _name;
-        self.ctx.var_declarations.insert_declarator(symbol_name.clone(), symbol_id, None, ctx);
+        self.ctx.var_declarations.insert(symbol_name.clone(), symbol_id, None, ctx);
 
         // _name = name
         Some(ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Write))


### PR DESCRIPTION
Pure refactor. Shorten the names of `VarDeclarationsStore`'s public methods and add new `insert_declarator` method.