### PR TITLE
refactor(transformer): introduce `TopLevelStatements` common transform

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -6,24 +6,30 @@ use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::TransformCtx;
 
+pub mod top_level_statements;
 pub mod var_declarations;
 
+use top_level_statements::TopLevelStatements;
 use var_declarations::VarDeclarations;
 
 pub struct Common<'a, 'ctx> {
     var_declarations: VarDeclarations<'a, 'ctx>,
+    top_level_statements: TopLevelStatements<'a, 'ctx>,
 }
 
 impl<'a, 'ctx> Common<'a, 'ctx> {
     pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
-        Self { var_declarations: VarDeclarations::new(ctx) }
+        Self {
+            var_declarations: VarDeclarations::new(ctx),
+            top_level_statements: TopLevelStatements::new(ctx),
+        }
     }
 }
 
 impl<'a, 'ctx> Traverse<'a> for Common<'a, 'ctx> {
-    #[inline] // Inline because it's no-op in release mode
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.var_declarations.exit_program(program, ctx);
+        self.top_level_statements.exit_program(program, ctx);
     }
 
     fn enter_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_transformer/src/common/top_level_statements.rs
+++ b/crates/oxc_transformer/src/common/top_level_statements.rs
@@ -1,0 +1,70 @@
+//! Utility transform to add statements to top of program.
+//!
+//! `TopLevelStatementsStore` contains a `Vec<Statement>`. It is stored on `TransformCtx`.
+//!
+//! `TopLevelStatements` transform inserts those statements at top of program.
+//!
+//! Other transforms can add statements to the store with `TopLevelStatementsStore::insert_statement`:
+//!
+//! ```rs
+//! self.ctx.top_level_statements.insert_statement(stmt);
+//! ```
+
+use std::cell::RefCell;
+
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
+/// Transform that inserts any statements which have been requested insertion via `TopLevelStatementsStore`
+/// to top of the program.
+///
+/// Insertions are made after any existing `import` statements.
+///
+/// Must run after all other transforms.
+pub struct TopLevelStatements<'a, 'ctx> {
+    ctx: &'ctx TransformCtx<'a>,
+}
+
+impl<'a, 'ctx> TopLevelStatements<'a, 'ctx> {
+    pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
+        Self { ctx }
+    }
+}
+
+impl<'a, 'ctx> Traverse<'a> for TopLevelStatements<'a, 'ctx> {
+    fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        let mut stmts = self.ctx.top_level_statements.stmts.borrow_mut();
+        if stmts.is_empty() {
+            return;
+        }
+
+        // Insert statements after any existing `import` statements
+        let index = program
+            .body
+            .iter()
+            .rposition(|stmt| matches!(stmt, Statement::ImportDeclaration(_)))
+            .map_or(0, |i| i + 1);
+
+        program.body.splice(index..index, stmts.drain(..));
+    }
+}
+
+/// Store for statements to be added at top of program
+pub struct TopLevelStatementsStore<'a> {
+    stmts: RefCell<Vec<Statement<'a>>>,
+}
+
+impl<'a> TopLevelStatementsStore<'a> {
+    pub fn new() -> Self {
+        Self { stmts: RefCell::new(vec![]) }
+    }
+}
+
+impl<'a> TopLevelStatementsStore<'a> {
+    /// Add a statement to be inserted at top of program.
+    pub fn insert_statement(&self, stmt: Statement<'a>) {
+        self.stmts.borrow_mut().push(stmt);
+    }
+}

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -10,7 +10,10 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::SourceType;
 
 use crate::{
-    common::var_declarations::VarDeclarationsStore, helpers::module_imports::ModuleImports,
+    common::{
+        top_level_statements::TopLevelStatementsStore, var_declarations::VarDeclarationsStore,
+    },
+    helpers::module_imports::ModuleImports,
     TransformOptions,
 };
 
@@ -36,6 +39,8 @@ pub struct TransformCtx<'a> {
     pub module_imports: ModuleImports<'a>,
     /// Manage inserting `var` statements globally
     pub var_declarations: VarDeclarationsStore<'a>,
+    /// Manage inserting statements at top of program globally
+    pub top_level_statements: TopLevelStatementsStore<'a>,
 }
 
 impl<'a> TransformCtx<'a> {
@@ -65,6 +70,7 @@ impl<'a> TransformCtx<'a> {
             trivias,
             module_imports: ModuleImports::new(),
             var_declarations: VarDeclarationsStore::new(),
+            top_level_statements: TopLevelStatementsStore::new(),
         }
     }
 


### PR DESCRIPTION
Introduce `TopLevelStatements` common transform. It holds a `Vec` of statements to be inserted at the top of the program, and other transforms can push statements to it.

All statements will be inserted in one go at the end of traversal, to avoid shuffling up the `Vec<Statement>` multiple times, which can be slow with large files.