### PR TITLE
refactor(transformer): rename methods

### DIFF
--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -447,7 +447,7 @@ impl<'a, 'ctx> ReactJsx<'a, 'ctx> {
 
 impl<'a, 'ctx> Traverse<'a> for ReactJsx<'a, 'ctx> {
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.insert_var_file_name_statement(ctx);
+        self.insert_filename_var_statement(ctx);
     }
 
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -470,8 +470,8 @@ impl<'a, 'ctx> ReactJsx<'a, 'ctx> {
         self.ctx.ast
     }
 
-    fn insert_var_file_name_statement(&mut self, ctx: &mut TraverseCtx<'a>) {
-        let Some(declarator) = self.jsx_source.get_var_file_name_declarator() else { return };
+    fn insert_filename_var_statement(&mut self, ctx: &mut TraverseCtx<'a>) {
+        let Some(declarator) = self.jsx_source.get_filename_var_declarator() else { return };
 
         // If is a module, add filename statements before `import`s. If script, then after `require`s.
         // This is the same behavior as Babel.

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -60,7 +60,7 @@ impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
 
 impl<'a, 'ctx> Traverse<'a> for ReactJsxSource<'a, 'ctx> {
     fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
-        if let Some(stmt) = self.get_var_file_name_statement() {
+        if let Some(stmt) = self.get_filename_var_statement() {
             self.ctx.top_level_statements.insert_statement(stmt);
         }
     }
@@ -190,8 +190,8 @@ impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
         self.ctx.ast.expression_object(SPAN, properties, None)
     }
 
-    pub fn get_var_file_name_statement(&self) -> Option<Statement<'a>> {
-        let decl = self.get_var_file_name_declarator()?;
+    pub fn get_filename_var_statement(&self) -> Option<Statement<'a>> {
+        let decl = self.get_filename_var_declarator()?;
 
         let var_decl = Statement::VariableDeclaration(self.ctx.ast.alloc_variable_declaration(
             SPAN,
@@ -202,7 +202,7 @@ impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
         Some(var_decl)
     }
 
-    pub fn get_var_file_name_declarator(&self) -> Option<VariableDeclarator<'a>> {
+    pub fn get_filename_var_declarator(&self) -> Option<VariableDeclarator<'a>> {
         let filename_var = self.filename_var.as_ref()?;
 
         let var_kind = VariableDeclarationKind::Var;


### PR DESCRIPTION
Pure refactor. Rename a few methods when had `file_name` in their name. Convention throughout codebase appears to be `filename` (without the `_`).