### PR TITLE
feat(linter): allow fixing in files with source offsets

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -288,12 +288,12 @@ impl IsolatedLintHandler {
                         range: Range {
                             start: offset_to_position(
                                 (f.span.start + start) as usize,
-                                javascript_source_text,
+                                source_text.as_str(),
                             )
                             .unwrap_or_default(),
                             end: offset_to_position(
                                 (f.span.end + start) as usize,
-                                javascript_source_text,
+                                source_text.as_str(),
                             )
                             .unwrap_or_default(),
                         },


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/5913

This PR fixes the calculation of spans when dealing with files that have multiple sources and non-zero source start offsets. This is almost always the case for `.vue`, `.astro`, and `.svelte` files. This enables us to correctly apply fixes for these file types both in the CLI with `oxlint` and also in editors like VS Code.


https://github.com/user-attachments/assets/2836c8bd-09be-4e59-801d-7c95f8c2491f



I'm open to ideas on how to improve testing in this area, as I don't think that we currently have any tests for fixing files end-to-end (beyond what the linter rules check). I did run this locally on the gitlab repository (which is written in Vue) and all of the fixes appeared to be applied correctly. 