### PR TITLE
feat(minifier): support bitwise unary folding.

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -139,7 +139,7 @@ impl<'a> PeepholeFoldConstants {
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         fn is_within_i32_range(x: f64) -> bool {
-            x.is_finite() && x.fract() == 0.0 && x >= i32::MIN as f64 && x <= i32::MAX as f64
+            x.is_finite() && x.fract() == 0.0 && x >= f64::from(i32::MIN) && x <= f64::from(i32::MAX)
         }
         match expr.operator {
             UnaryOperator::Void => self.try_reduce_void(expr, ctx),

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -1,3 +1,14 @@
+use std::cmp::Ordering;
+
+use num_bigint::BigInt;
+use oxc_ast::ast::*;
+use oxc_span::{GetSpan, Span, SPAN};
+use oxc_syntax::{
+    number::{NumberBase, ToJsInt32},
+    operator::{BinaryOperator, LogicalOperator, UnaryOperator},
+};
+use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+
 use crate::{
     node_util::{
         is_exact_int64, IsLiteralValue, MayHaveSideEffects, NodeUtil, NumberValue, ValueType,
@@ -6,16 +17,6 @@ use crate::{
     ty::Ty,
     CompressorPass,
 };
-use num_bigint::BigInt;
-use oxc_ast::ast::*;
-use oxc_span::{GetSpan, Span, SPAN};
-use oxc_syntax::number::ToJsInt32;
-use oxc_syntax::{
-    number::NumberBase,
-    operator::{BinaryOperator, LogicalOperator, UnaryOperator},
-};
-use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
-use std::cmp::Ordering;
 
 /// Constant Folding
 ///

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -139,7 +139,10 @@ impl<'a> PeepholeFoldConstants {
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         fn is_within_i32_range(x: f64) -> bool {
-            x.is_finite() && x.fract() == 0.0 && x >= f64::from(i32::MIN) && x <= f64::from(i32::MAX)
+            x.is_finite()
+                && x.fract() == 0.0
+                && x >= f64::from(i32::MIN)
+                && x <= f64::from(i32::MAX)
         }
         match expr.operator {
             UnaryOperator::Void => self.try_reduce_void(expr, ctx),

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -1352,6 +1352,8 @@ mod test {
         test("a = ~0x3", "a = -4"); // Hexadecimal number
         test("a = ~9", "a = -10"); // Despite `-10` is longer than `~9`, the compiler still folds it.
         test_same("a = ~b");
+        test_same("a = ~NaN");
+        test_same("a = ~-Infinity");
         // TODO(7086cmd) We preserve it right now, since exceeded data's ~ calculation
         // is hard to implement within one PR.
         // test("x = ~2147483658.0", "x = 2147483647");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -2,7 +2,7 @@ Original   | Minified   | esbuild    | Gzip       | esbuild
 
 72.14 kB   | 24.47 kB   | 23.70 kB   | 8.65 kB    | 8.54 kB    | react.development.js
 
-173.90 kB  | 61.71 kB   | 59.82 kB   | 19.56 kB   | 19.33 kB   | moment.js 
+173.90 kB  | 61.70 kB   | 59.82 kB   | 19.54 kB   | 19.33 kB   | moment.js 
 
 287.63 kB  | 92.83 kB   | 90.07 kB   | 32.29 kB   | 31.95 kB   | jquery.js 
 
@@ -10,17 +10,17 @@ Original   | Minified   | esbuild    | Gzip       | esbuild
 
 544.10 kB  | 74.13 kB   | 72.48 kB   | 26.23 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 278.71 kB  | 270.13 kB  | 91.40 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 278.70 kB  | 270.13 kB  | 91.39 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 470.11 kB  | 458.89 kB  | 126.97 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 671.02 kB  | 646.76 kB  | 164.72 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 756.70 kB  | 724.14 kB  | 182.87 kB  | 181.07 kB  | victory.js
+2.14 MB    | 756.69 kB  | 724.14 kB  | 182.87 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.05 MB    | 1.01 MB    | 334.11 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.44 MB    | 2.31 MB    | 498.90 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.59 MB    | 3.49 MB    | 913.91 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.59 MB    | 3.49 MB    | 913.94 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
Related expr: https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%2540compilation_level%2520SIMPLE_OPTIMIZATIONS%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250Ax%2520%253D%2520~434.2543%250Ax%2520%253D%2520~-0x3%250Ax%2520%253D%2520~9.

Don't support folding non-digit numbers, which is opt-in and throws an warning in closure compiler. Let's do it in a seprate one.