### PR TITLE
refactor(allocator): remove unnecessary `Vec` impl

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -143,14 +143,6 @@ impl<'alloc, T> ops::Index<usize> for Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T> ops::Index<usize> for &'alloc Vec<'alloc, T> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
 // Unused right now.
 // impl<'alloc, T> ops::IndexMut<usize> for Vec<'alloc, T> {
 // fn index_mut(&mut self, index: usize) -> &mut Self::Output {


### PR DESCRIPTION
This is unnecessary:

```rs
impl<'alloc, T> Index<usize> for &'alloc Vec<'alloc, T>
```

because we already have:

```rs
impl<'alloc, T> Index<usize> for Vec<'alloc, T>
```

(its `index` method takes a `&Vec<'alloc, T>`)