### PR TITLE
refactor(data_structures): add `len` method to `StackCommon` trait

### DIFF
--- a/crates/oxc_data_structures/src/stack/common.rs
+++ b/crates/oxc_data_structures/src/stack/common.rs
@@ -11,13 +11,16 @@ use assert_unchecked::assert_unchecked;
 use super::{NonNull, StackCapacity};
 
 pub trait StackCommon<T>: StackCapacity<T> {
-    // Getter setter methods defined by implementer
+    // Getter + setter methods defined by implementer
     fn start(&self) -> NonNull<T>;
     fn end(&self) -> NonNull<T>;
     fn cursor(&self) -> NonNull<T>;
     fn set_start(&mut self, start: NonNull<T>);
     fn set_end(&mut self, end: NonNull<T>);
     fn set_cursor(&mut self, cursor: NonNull<T>);
+
+    // Defined by implementer
+    fn len(&self) -> usize;
 
     /// Make allocation of `capacity_bytes` bytes, aligned for `T`.
     ///
@@ -98,12 +101,12 @@ pub trait StackCommon<T>: StackCapacity<T> {
     ///
     /// # SAFETY
     /// * Stack must be allocated.
-    /// * Stack must contain `len` initialized entries, starting at `self.start()`.
+    /// * Stack must contain `self.len()` initialized entries, starting at `self.start()`.
     #[inline]
-    unsafe fn drop_contents(&self, len: usize) {
+    unsafe fn drop_contents(&self) {
         // Drop contents. Next line copied from `std`'s `Vec`.
         // SAFETY: Caller guarantees stack contains `len` initialized entries, starting at `start`.
-        ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.start().as_ptr(), len));
+        ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.start().as_ptr(), self.len()));
     }
 
     /// Get layout for allocation of `capacity_bytes` bytes.


### PR DESCRIPTION
`len` method is in common between all stack types. Move it into `StackCommon` trait.