### PR TITLE
refactor(traverse): `TraverseAncestry` use `NonEmptyStack`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "memoffset",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_data_structures",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -25,6 +25,7 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_data_structures = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }


### PR DESCRIPTION
#6206 moved stack types into a shared crate. So now we can use it for the stack in `TraverseAncestry`.