### PR TITLE
refactor(data_structures): remove `is_empty` methods for non-empty stacks

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -294,9 +294,12 @@ impl<T> NonEmptyStack<T> {
         <Self as StackCommon<T>>::len(self)
     }
 
+    /// Get if stack is empty. Always returns `false`.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        // This method is pointless, as the stack is never empty. But provide it to override
+        // the default method from `slice::is_empty` which is inherited via `Deref`
+        false
     }
 
     /// Get capacity.

--- a/crates/oxc_data_structures/src/stack/sparse.rs
+++ b/crates/oxc_data_structures/src/stack/sparse.rs
@@ -187,13 +187,9 @@ impl<T> SparseStack<T> {
     ///
     /// Number of entries is always at least 1. Stack is never empty.
     #[inline]
+    #[expect(clippy::len_without_is_empty)] // `is_empty` method is pointless. It's never empty.
     pub fn len(&self) -> usize {
         self.has_values.len()
-    }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.has_values.len() == 0
     }
 
     /// Get capacity of stack for any entries (either `Some` or `None`).


### PR DESCRIPTION
Remove `SparseStack::is_empty` method. It's pointless as the stack is never empty.

Add a dummy `NonEmptyStack::is_empty` method that always returns `false`. This is also pointless, but it overrides `slice::is_empty` which is otherwise accessible via `Deref`.