### PR TITLE
refactor(data_structures): `NonEmptyStack::len` hint that `len` is never 0

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -100,7 +100,9 @@ impl<T> StackCommon<T> for NonEmptyStack<T> {
         // When stack has 1 entry, `start - cursor == 0`, so add 1 to get number of entries.
         // SAFETY: Capacity cannot exceed `Self::MAX_CAPACITY`, which is `<= isize::MAX`,
         // and offset can't exceed capacity, so `+ 1` cannot wrap around.
-        offset + 1
+        // `checked_add(1).unwrap_unchecked()` instead of just `+ 1` to hint to compiler
+        // that return value can never be zero.
+        unsafe { offset.checked_add(1).unwrap_unchecked() }
     }
 }
 


### PR DESCRIPTION
Tiny optimization. Make sure compiler knows that `NonEmptyStack::len` can never return 0.