### PR TITLE
ci(minifier): minifier benchmark measure only the minifier itself

### DIFF
--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -118,7 +118,14 @@ transformer = [
   "dep:oxc_transformer",
 ]
 semantic = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_semantic", "dep:oxc_span", "dep:oxc_tasks_common"]
-minifier = ["dep:oxc_allocator", "dep:oxc_minifier", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
+minifier = [
+  "dep:oxc_allocator",
+  "dep:oxc_minifier",
+  "dep:oxc_parser",
+  "dep:oxc_semantic",
+  "dep:oxc_span",
+  "dep:oxc_tasks_common",
+]
 codegen = ["dep:oxc_allocator", "dep:oxc_codegen", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
 sourcemap = [
   "dep:oxc_allocator",

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -2,28 +2,45 @@ use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_minifier::{CompressOptions, Compressor};
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
 
 fn bench_minifier(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("minifier");
+
     for file in TestFiles::minimal().files() {
+        let id = BenchmarkId::from_parameter(&file.file_name);
         let source_type = SourceType::from_path(&file.file_name).unwrap();
-        group.bench_with_input(
-            BenchmarkId::from_parameter(&file.file_name),
-            &file.source_text,
-            |b, source_text| {
+        let source_text = file.source_text.as_str();
+
+        // Create `Allocator` outside of `bench_function`, so same allocator is used for
+        // both the warmup and measurement phases
+        let mut allocator = Allocator::default();
+
+        group.bench_function(id, |b| {
+            b.iter_with_setup_wrapper(|runner| {
+                // Reset allocator at start of each iteration
+                allocator.reset();
+
+                // Create fresh AST + semantic data for each iteration
+                let program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let program = allocator.alloc(program);
+                let (symbols, scopes) = SemanticBuilder::new(source_text)
+                    .build(program)
+                    .semantic
+                    .into_symbol_table_and_scope_tree();
+
                 let options = CompressOptions::all_true();
-                b.iter_with_large_drop(|| {
-                    let allocator = Allocator::default();
-                    let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                    let program = allocator.alloc(program);
-                    Compressor::new(&allocator, options).build(program);
-                    allocator
+
+                runner.run(|| {
+                    Compressor::new(&allocator, options)
+                        .build_with_symbols_and_scopes(symbols, scopes, program);
                 });
-            },
-        );
+            });
+        });
     }
+
     group.finish();
 }
 


### PR DESCRIPTION
Minifier benchmark currently includes the time to run parser and semantic as well as the minifier itself. Similar to transformer benchmark, only measure the minifier itself in the benchmark.

This will give us a clearer picture of performance changes, and should also reduce variance in the benchmarks.