### PR TITLE
ci(miri): run Miri on changes to more crates

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -5,15 +5,19 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "crates/oxc_parser/**"
       - "crates/oxc_allocator/**"
+      - "crates/oxc_data_structures/**"
+      - "crates/oxc_parser/**"
+      - "crates/oxc_traverse/**"
       - ".github/workflows/miri.yml"
   push:
     branches:
       - main
     paths:
-      - "crates/oxc_parser/**"
       - "crates/oxc_allocator/**"
+      - "crates/oxc_data_structures/**"
+      - "crates/oxc_parser/**"
+      - "crates/oxc_traverse/**"
       - ".github/workflows/miri.yml"
 
 concurrency:


### PR DESCRIPTION
Run Miri when changes are made to crates which contain a lot of unsafe code.