### PR TITLE
fix(transformer): fix memory leak in `ReplaceGlobalDefines`

### DIFF
--- a/crates/oxc_transformer/src/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/src/plugins/replace_global_defines.rs
@@ -206,7 +206,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
     // Construct a new expression because we don't have ast clone right now.
     fn parse_value(&self, source_text: &str) -> Expression<'a> {
         // Allocate the string lazily because replacement happens rarely.
-        let source_text = self.allocator.alloc(source_text.to_string());
+        let source_text = self.allocator.alloc_str(source_text);
         // Unwrapping here, it should already be checked by [ReplaceGlobalDefinesConfig::new].
         Parser::new(self.allocator, source_text, SourceType::default()).parse_expression().unwrap()
     }


### PR DESCRIPTION
`ReplaceGlobalDefines` was putting a `String` into the arena. `String` allocates on the heap, so this was a memory leak because it didn't get dropped when the allocator is dropped. This was caught by Miri.

Allocate a string slice instead.