### PR TITLE
fix(minifier): collapse variables when `join_vars` option is `true`

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
@@ -37,7 +37,7 @@ impl<'a> CollapseVariableDeclarations {
 
     /// Join consecutive var statements
     fn join_vars(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        if self.options.join_vars {
+        if !self.options.join_vars {
             return;
         }
         // Collect all the consecutive ranges that contain joinable vars.

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -2,4 +2,8 @@ commit: d62fa93c
 
 minifier_test262 Summary:
 AST Parsed     : 43765/43765 (100.00%)
-Positive Passed: 43765/43765 (100.00%)
+Positive Passed: 43761/43765 (99.99%)
+Compress: tasks/coverage/test262/test/language/expressions/void/S11.4.2_A2_T1.js
+Compress: tasks/coverage/test262/test/language/expressions/void/S11.4.2_A4_T1.js
+Compress: tasks/coverage/test262/test/language/expressions/void/S11.4.2_A4_T2.js
+Compress: tasks/coverage/test262/test/language/expressions/void/S11.4.2_A4_T3.js

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,26 +1,26 @@
 Original   | Minified   | esbuild    | Gzip       | esbuild   
 
-72.14 kB   | 24.47 kB   | 23.70 kB   | 8.65 kB    | 8.54 kB    | react.development.js
+72.14 kB   | 24.13 kB   | 23.70 kB   | 8.62 kB    | 8.54 kB    | react.development.js
 
-173.90 kB  | 61.70 kB   | 59.82 kB   | 19.54 kB   | 19.33 kB   | moment.js 
+173.90 kB  | 61.69 kB   | 59.82 kB   | 19.54 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 92.83 kB   | 90.07 kB   | 32.29 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 92.71 kB   | 90.07 kB   | 32.27 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 124.14 kB  | 118.14 kB  | 44.81 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 121.98 kB  | 118.14 kB  | 44.60 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 74.13 kB   | 72.48 kB   | 26.23 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 73.49 kB   | 72.48 kB   | 26.13 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 278.70 kB  | 270.13 kB  | 91.39 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 276.78 kB  | 270.13 kB  | 91.13 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 470.11 kB  | 458.89 kB  | 126.97 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 467.67 kB  | 458.89 kB  | 126.76 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 671 kB     | 646.76 kB  | 164.72 kB  | 163.73 kB  | three.js  
+1.25 MB    | 662.96 kB  | 646.76 kB  | 164.00 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 756.69 kB  | 724.14 kB  | 182.87 kB  | 181.07 kB  | victory.js
+2.14 MB    | 741.79 kB  | 724.14 kB  | 181.49 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.05 MB    | 1.01 MB    | 334.11 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.02 MB    | 1.01 MB    | 331.96 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.44 MB    | 2.31 MB    | 498.90 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.39 MB    | 2.31 MB    | 496.14 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.59 MB    | 3.49 MB    | 913.94 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.56 MB    | 3.49 MB    | 911.28 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
The variable collapse AST pass was only collapsing declarations when `CompressOptions::join_vars` was `true`, and skipping when `false`. This does not follow the behavior documented for this option. This PR fixes this. 