### PR TITLE
perf(transformer): common transforms store state in `UnsafeCell`

### DIFF
--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -24,7 +24,7 @@
 //! Based on `@babel/helper-module-imports`
 //! <https://github.com/nicolo-ribaudo/babel/tree/main/packages/babel-helper-module-imports>
 
-use std::cell::RefCell;
+use std::cell::UnsafeCell;
 
 use indexmap::{map::Entry as IndexMapEntry, IndexMap};
 
@@ -69,15 +69,13 @@ impl<'a> NamedImport<'a> {
 /// TODO(improve-on-babel): Insertion order does not matter. We only have to use `IndexMap`
 /// to produce output that's the same as Babel's.
 /// Substitute `FxHashMap` once we don't need to match Babel's output exactly.
-pub struct ModuleImportsStore<'a> {
-    imports: RefCell<IndexMap<Atom<'a>, Vec<NamedImport<'a>>>>,
-}
+pub struct ModuleImportsStore<'a>(UnsafeCell<ModuleImportsState<'a>>);
 
 // Public methods
 impl<'a> ModuleImportsStore<'a> {
     /// Create new `ModuleImportsStore`.
     pub fn new() -> Self {
-        Self { imports: RefCell::new(IndexMap::default()) }
+        Self(UnsafeCell::new(ModuleImportsState::new()))
     }
 
     /// Add `import` or `require` to top of program.
@@ -91,7 +89,57 @@ impl<'a> ModuleImportsStore<'a> {
     /// TODO(improve-on-babel): `front` option is only required to pass one of Babel's tests. Output
     /// without it is still valid. Remove this once our output doesn't need to match Babel exactly.
     pub fn add_import(&self, source: Atom<'a>, import: NamedImport<'a>, front: bool) {
-        match self.imports.borrow_mut().entry(source) {
+        // SAFETY: We only borrow state once during this function and borrow expires before exiting it
+        let state = unsafe { &mut *self.0.get() };
+        state.add_import(source, import, front);
+    }
+
+    /// Returns `true` if no imports have been scheduled for insertion.
+    pub fn is_empty(&self) -> bool {
+        // SAFETY: We only borrow state once during this function and borrow expires before exiting it
+        let state = unsafe { &*self.0.get() };
+        state.is_empty()
+    }
+}
+
+// Private methods
+impl<'a> ModuleImportsStore<'a> {
+    /// Insert `import` / `require` statements at top of program.
+    fn insert_into_program(&self, transform_ctx: &TransformCtx<'a>, ctx: &mut TraverseCtx<'a>) {
+        // SAFETY: We only borrow state once during this function and borrow expires before exiting it
+        let state = unsafe { &mut *self.0.get() };
+        state.insert_into_program(transform_ctx, ctx);
+    }
+}
+
+/// Store for `import` / `require` statements to be added at top of program.
+///
+/// TODO(improve-on-babel): Insertion order does not matter. We only have to use `IndexMap`
+/// to produce output that's the same as Babel's.
+/// Substitute `FxHashMap` once we don't need to match Babel's output exactly.
+struct ModuleImportsState<'a> {
+    imports: IndexMap<Atom<'a>, Vec<NamedImport<'a>>>,
+}
+
+// Public methods
+impl<'a> ModuleImportsState<'a> {
+    /// Create new `ModuleImportsState`.
+    pub fn new() -> Self {
+        Self { imports: IndexMap::default() }
+    }
+
+    /// Add `import` or `require` to top of program.
+    ///
+    /// Which it will be depends on the source type.
+    ///
+    /// * `import { named_import } from 'source';` or
+    /// * `var named_import = require('source');`
+    ///
+    /// If `front` is `true`, `import`/`require` is added to front of the `import`s/`require`s.
+    /// TODO(improve-on-babel): `front` option is only required to pass one of Babel's tests. Output
+    /// without it is still valid. Remove this once our output doesn't need to match Babel exactly.
+    pub fn add_import(&mut self, source: Atom<'a>, import: NamedImport<'a>, front: bool) {
+        match self.imports.entry(source) {
             IndexMapEntry::Occupied(mut entry) => {
                 entry.get_mut().push(import);
                 if front && entry.index() != 0 {
@@ -111,14 +159,14 @@ impl<'a> ModuleImportsStore<'a> {
 
     /// Returns `true` if no imports have been scheduled for insertion.
     pub fn is_empty(&self) -> bool {
-        self.imports.borrow().is_empty()
+        self.imports.is_empty()
     }
 }
 
 // Internal methods
-impl<'a> ModuleImportsStore<'a> {
+impl<'a> ModuleImportsState<'a> {
     /// Insert `import` / `require` statements at top of program.
-    fn insert_into_program(&self, transform_ctx: &TransformCtx<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn insert_into_program(&mut self, transform_ctx: &TransformCtx<'a>, ctx: &mut TraverseCtx<'a>) {
         if transform_ctx.source_type.is_script() {
             self.insert_require_statements(transform_ctx, ctx);
         } else {
@@ -127,28 +175,29 @@ impl<'a> ModuleImportsStore<'a> {
     }
 
     fn insert_import_statements(
-        &self,
+        &mut self,
         transform_ctx: &TransformCtx<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut imports = self.imports.borrow_mut();
-        let stmts =
-            imports.drain(..).map(|(source, names)| Self::get_named_import(source, names, ctx));
+        let stmts = self
+            .imports
+            .drain(..)
+            .map(|(source, names)| Self::get_named_import(source, names, ctx));
         transform_ctx.top_level_statements.insert_statements(stmts);
     }
 
     fn insert_require_statements(
-        &self,
+        &mut self,
         transform_ctx: &TransformCtx<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let mut imports = self.imports.borrow_mut();
-        if imports.is_empty() {
+        if self.imports.is_empty() {
             return;
         }
 
         let require_symbol_id = ctx.scopes().get_root_binding("require");
-        let stmts = imports
+        let stmts = self
+            .imports
             .drain(..)
             .map(|(source, names)| Self::get_require(source, names, require_symbol_id, ctx));
         transform_ctx.top_level_statements.insert_statements(stmts);


### PR DESCRIPTION
Experiment. Not for merging.

As an alternative to oxc-project/oxc#11742, we could wrap state in common transforms in `UnsafeCell` instead of `RefCell`. We'd need a nice way to do that (probably would have to be a proc macro, unfortunately). This PR just does it manually with an ugly method, to see what the perf gain is, and so how worthwhile it would be to do it properly.