### PR TITLE
refactor(parser)!: treat unambiguous files containing TS export assignments as modules

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -187,6 +187,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Eq)?;
         let expression = self.parse_assignment_expression_or_higher()?;
         self.asi()?;
+        self.set_source_type_to_module_if_unambiguous();
         Ok(self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression))
     }
 


### PR DESCRIPTION
An "unambiguous" TS source which contains an `export = <value>;` statement should be interpreted as an ES module.

This is in line with [this Babel test case](https://github.com/babel/babel/tree/94e166782a37074d8c0031fc869f37e1b456194f/packages/babel-parser/test/fixtures/typescript/export/equals-in-unambiguous) which has [input option of `sourceType: "unambiguous"`](https://github.com/babel/babel/blob/94e166782a37074d8c0031fc869f37e1b456194f/packages/babel-parser/test/fixtures/typescript/export/equals-in-unambiguous/options.json#L2), and [outputs an AST with `sourceType: "module"`](https://github.com/babel/babel/blob/94e166782a37074d8c0031fc869f37e1b456194f/packages/babel-parser/test/fixtures/typescript/export/equals-in-unambiguous/output.json#L7).
