### PR TITLE
fix(transform): ensure consistent naming for `ES2015BindingOptions` in `index.d.ts`

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -12,7 +12,7 @@ export interface ArrowFunctionsBindingOptions {
   spec?: boolean
 }
 
-export interface Es2015BindingOptions {
+export interface ES2015BindingOptions {
   /** Transform arrow functions into function expressions. */
   arrowFunction?: ArrowFunctionsBindingOptions
 }
@@ -202,7 +202,7 @@ export interface TransformOptions {
   /** Configure how TSX and JSX are transformed. */
   jsx?: JsxOptions
   /** Enable ES2015 transformations. */
-  es2015?: Es2015BindingOptions
+  es2015?: ES2015BindingOptions
   /** Define Plugin */
   define?: Record<string, string>
   /** Inject Plugin */

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -202,7 +202,7 @@ export interface TransformOptions {
   /** Configure how TSX and JSX are transformed. */
   jsx?: JsxOptions
   /** Enable ES2015 transformations. */
-  es2015?: ES2015BindingOptions
+  es2015?: Es2015BindingOptions
   /** Define Plugin */
   define?: Record<string, string>
   /** Inject Plugin */

--- a/napi/transform/src/options.rs
+++ b/napi/transform/src/options.rs
@@ -39,7 +39,7 @@ pub struct TransformOptions {
     pub jsx: Option<JsxOptions>,
 
     /// Enable ES2015 transformations.
-    pub es2015: Option<Es2015BindingOptions>,
+    pub es2015: Option<ES2015BindingOptions>,
 
     /// Define Plugin
     #[napi(ts_type = "Record<string, string>")]
@@ -274,14 +274,14 @@ impl From<ArrowFunctionsBindingOptions> for ArrowFunctionsOptions {
     }
 }
 
-#[napi(object)]
-pub struct Es2015BindingOptions {
+#[napi(object, js_name = "ES2015BindingOptions")]
+pub struct ES2015BindingOptions {
     /// Transform arrow functions into function expressions.
     pub arrow_function: Option<ArrowFunctionsBindingOptions>,
 }
 
-impl From<Es2015BindingOptions> for ES2015Options {
-    fn from(options: Es2015BindingOptions) -> Self {
+impl From<ES2015BindingOptions> for ES2015Options {
+    fn from(options: ES2015BindingOptions) -> Self {
         ES2015Options { arrow_function: options.arrow_function.map(Into::into) }
     }
 }

--- a/napi/transform/src/options.rs
+++ b/napi/transform/src/options.rs
@@ -39,7 +39,7 @@ pub struct TransformOptions {
     pub jsx: Option<JsxOptions>,
 
     /// Enable ES2015 transformations.
-    pub es2015: Option<ES2015BindingOptions>,
+    pub es2015: Option<Es2015BindingOptions>,
 
     /// Define Plugin
     #[napi(ts_type = "Record<string, string>")]
@@ -275,13 +275,13 @@ impl From<ArrowFunctionsBindingOptions> for ArrowFunctionsOptions {
 }
 
 #[napi(object)]
-pub struct ES2015BindingOptions {
+pub struct Es2015BindingOptions {
     /// Transform arrow functions into function expressions.
     pub arrow_function: Option<ArrowFunctionsBindingOptions>,
 }
 
-impl From<ES2015BindingOptions> for ES2015Options {
-    fn from(options: ES2015BindingOptions) -> Self {
+impl From<Es2015BindingOptions> for ES2015Options {
+    fn from(options: Es2015BindingOptions) -> Self {
         ES2015Options { arrow_function: options.arrow_function.map(Into::into) }
     }
 }


### PR DESCRIPTION
closes #6254 