### PR TITLE
fix(semantic): enter scope after `check_type` for `TSConditionalType`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -345,12 +345,36 @@ pub struct TSConditionalType<'a> {
     #[serde(flatten)]
     pub span: Span,
     /// The type before `extends` in the test expression.
+    ///
+    /// ## Example
+    /// ```ts
+    /// type F<T> = T extends string ? string : number;
+    /// //          ^
+    /// ```
     pub check_type: TSType<'a>,
     /// The type `check_type` is being tested against.
+    ///
+    /// ## Example
+    /// ```ts
+    /// type F<T> = T extends string ? string : number;
+    /// //                    ^^^^^^
+    /// ```
     pub extends_type: TSType<'a>,
     /// The type evaluated to if the test is true.
+    ///
+    /// ## Example
+    /// ```ts
+    /// type F<T> = T extends string ? string : number;
+    /// //                             ^^^^^^
+    /// ```
     pub true_type: TSType<'a>,
     /// The type evaluated to if the test is false.
+    ///
+    /// ## Example
+    /// ```ts
+    /// type F<T> = T extends string ? string : number;
+    /// //                                      ^^^^^^
+    /// ```
     pub false_type: TSType<'a>,
     #[serde(skip)]
     #[clone_in(default)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -982,6 +982,10 @@ fn test_type_references() {
             accessor y!: Foo
         }
         ",
+        "
+        type S<A> = A extends (infer B extends number ? string : never) ? B : false;
+        export { S };
+        ",
     ];
 
     let fail = vec![

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1740,6 +1740,18 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
         self.leave_scope();
     }
+
+    fn visit_ts_conditional_type(&mut self, it: &TSConditionalType<'a>) {
+        let kind = AstKind::TSConditionalType(self.alloc(it));
+        self.enter_node(kind);
+        self.visit_ts_type(&it.check_type);
+        self.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        self.visit_ts_type(&it.extends_type);
+        self.visit_ts_type(&it.true_type);
+        self.leave_scope();
+        self.visit_ts_type(&it.false_type);
+        self.leave_node(kind);
+    }
 }
 
 impl<'a> SemanticBuilder<'a> {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -12,30 +12,7 @@ SCOPES
       {
         "children": [
           {
-            "children": [
-              {
-                "children": [],
-                "flags": "ScopeFlags(StrictMode)",
-                "id": 3,
-                "node": "TSConditionalType",
-                "symbols": [
-                  {
-                    "flags": "SymbolFlags(TypeParameter)",
-                    "id": 3,
-                    "name": "U",
-                    "node": "TSTypeParameter(U)",
-                    "references": [
-                      {
-                        "flags": "ReferenceFlags(Type)",
-                        "id": 5,
-                        "name": "U",
-                        "node_id": 33
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
+            "children": [],
             "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
@@ -51,6 +28,28 @@ SCOPES
                     "id": 2,
                     "name": "U",
                     "node_id": 19
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "TSConditionalType",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(TypeParameter)",
+                "id": 3,
+                "name": "U",
+                "node": "TSTypeParameter(U)",
+                "references": [
+                  {
+                    "flags": "ReferenceFlags(Type)",
+                    "id": 5,
+                    "name": "U",
+                    "node_id": 33
                   }
                 ]
               }

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -239,3 +239,25 @@ fn get_child_ids() {
     let child_scope_ids = scopes.get_child_ids(child_scope_ids[0]);
     assert!(child_scope_ids.is_empty());
 }
+
+#[test]
+fn test_ts_conditional_types() {
+    SemanticTester::ts("type A<T> = T extends string ? T : false;")
+        .has_some_symbol("T")
+        .has_number_of_references(2)
+        .test();
+
+    // Conditional types create a new scope after check_type.
+    SemanticTester::ts(
+        "type S<A> = A extends (infer B extends number ? string : never) ? B : false;",
+    )
+    .has_some_symbol("B")
+    .has_number_of_references(1)
+    .test();
+
+    // Inferred type parameter is only available within true branch
+    SemanticTester::ts("type S<A> = A extends infer R ? never : R")
+        .has_some_symbol("R")
+        .has_number_of_references(0)
+        .test();
+}

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -3897,13 +3897,13 @@ Bindings mismatch:
 after transform: ScopeId(2): ["P", "attrs"]
 rebuilt        : ScopeId(1): ["attrs"]
 Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
+after transform: ScopeId(2): [ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(6): ["P", "attrs"]
 rebuilt        : ScopeId(2): ["attrs"]
 Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
+after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(9): ["P", "attrs"]
@@ -8852,7 +8852,7 @@ Bindings mismatch:
 after transform: ScopeId(3): ["D", "clientDef"]
 rebuilt        : ScopeId(1): ["clientDef"]
 Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
+after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
 after transform: ["Record"]
@@ -17164,7 +17164,7 @@ Scope children mismatch:
 after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(15)]
+after transform: SymbolId(9): [ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(15)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Unresolved references mismatch:
 after transform: ["State", "true"]


### PR DESCRIPTION
When visiting a `TSConditionalType`, enter a new scope after visiting the `check_type`, and exit before entering the `false_type`.

Fixes this case, where `B` should have a reference. I can't find the issue that was reported with this, if someone finds it please link it to this PR.
```typescript
type S<A> = A extends /* enter scope */ (infer B extends number ? string : never)
  ? B 
  : /* exit scope before false branch */ false;
```

Ideally we'd update `ast_tools` to let us configure the order of enter/leave scopes. CC: @overlookmotel.