### PR TITLE
refactor(linter): make jest/vitest rule mapping more clear

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -145,7 +145,7 @@ impl<'a> ContextHost<'a> {
     /// Creates a new [`LintContext`] for a specific rule.
     pub fn spawn(self: Rc<Self>, rule: &RuleWithSeverity) -> LintContext<'a> {
         let rule_name = rule.name();
-        let plugin_name = self.map_jest(rule.plugin_name(), rule_name);
+        let plugin_name = self.map_jest_rule_to_vitest(rule);
 
         LintContext {
             parent: self,
@@ -176,10 +176,11 @@ impl<'a> ContextHost<'a> {
     ///
     /// Many Vitest rules are essentially ports of the Jest plugin rules with minor modifications.
     /// For these rules, we use the corresponding jest rules with some adjustments for compatibility.
-    fn map_jest(&self, plugin_name: &'static str, rule_name: &str) -> &'static str {
+    fn map_jest_rule_to_vitest(&self, rule: &RuleWithSeverity) -> &'static str {
+        let plugin_name = rule.plugin_name();
         if self.plugins.has_vitest()
             && plugin_name == "jest"
-            && utils::is_jest_rule_adapted_to_vitest(rule_name)
+            && utils::is_jest_rule_adapted_to_vitest(rule.name())
         {
             "vitest"
         } else {

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -17,28 +17,29 @@ pub use self::{
     tree_shaking::*, unicorn::*, vitest::*,
 };
 
+/// List of Jest rules that have Vitest equivalents.
+const VITEST_COMPATIBLE_JEST_RULES: phf::Set<&'static str> = phf::phf_set! {
+    "consistent-test-it",
+    "expect-expect",
+    "no-alias-methods",
+    "no-conditional-expect",
+    "no-conditional-in-test",
+    "no-commented-out-tests",
+    "no-disabled-tests",
+    "no-focused-tests",
+    "no-identical-title",
+    "no-restricted-jest-methods",
+    "no-test-prefixes",
+    "prefer-hooks-in-order",
+    "valid-describe-callback",
+    "valid-expect",
+};
+
 /// Check if the Jest rule is adapted to Vitest.
 /// Many Vitest rule are essentially ports of Jest plugin rules with minor modifications.
 /// For these rules, we use the corresponding jest rules with some adjustments for compatibility.
 pub fn is_jest_rule_adapted_to_vitest(rule_name: &str) -> bool {
-    let jest_rules: &[&str] = &[
-        "consistent-test-it",
-        "expect-expect",
-        "no-alias-methods",
-        "no-conditional-expect",
-        "no-conditional-in-test",
-        "no-commented-out-tests",
-        "no-disabled-tests",
-        "no-focused-tests",
-        "no-identical-title",
-        "no-restricted-jest-methods",
-        "no-test-prefixes",
-        "prefer-hooks-in-order",
-        "valid-describe-callback",
-        "valid-expect",
-    ];
-
-    jest_rules.contains(&rule_name)
+    VITEST_COMPATIBLE_JEST_RULES.contains(rule_name)
 }
 
 pub fn read_to_string(path: &Path) -> io::Result<String> {


### PR DESCRIPTION
- Renamed the `map_jest` method to make it more clear what it does, now called `map_jest_rule_to_vitest`
- Tried to use a `phf_set!` over a list of strings for checking if we should map rules. Probably not faster, but should be simpler a constant amount of work if we expand the list of rules in the future.
- Made it easier to not mess up the arguments to the `map_jest` function by making it accept a `RuleWithSeverity` instead of just strings.