### PR TITLE
refactor(transformer): prefer `create_bound_reference_id` to `create_reference_id`

### DIFF
--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -125,7 +125,7 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let ident_math =
-            ctx.create_reference_id(SPAN, ctx.ast.atom("Math"), None, ReferenceFlags::Read);
+            ctx.create_unbound_reference_id(SPAN, ctx.ast.atom("Math"), ReferenceFlags::Read);
         let object = ctx.ast.expression_from_identifier_reference(ident_math);
         let property = ctx.ast.identifier_name(SPAN, "pow");
         let callee =
@@ -298,7 +298,7 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
         self.ctx.var_declarations.insert(symbol_name.clone(), symbol_id, None, ctx);
 
         let ident =
-            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);
+            ctx.create_bound_reference_id(SPAN, symbol_name, symbol_id, ReferenceFlags::Read);
 
         // let ident = self.create_new_var_with_expression(&expr);
         // Add new reference `_name = name` to nodes

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -161,7 +161,7 @@ impl<'a, 'ctx> NullishCoalescingOperator<'a, 'ctx> {
         let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
         let id = ctx.ast.binding_pattern(id, NONE, false);
         let reference =
-            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);
+            ctx.create_bound_reference_id(SPAN, symbol_name, symbol_id, ReferenceFlags::Read);
 
         (id, reference)
     }

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -362,6 +362,6 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         self.ctx.var_declarations.insert(symbol_name.clone(), symbol_id, None, ctx);
 
         // _name = name
-        Some(ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Write))
+        Some(ctx.create_bound_reference_id(SPAN, symbol_name, symbol_id, ReferenceFlags::Write))
     }
 }

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -275,10 +275,10 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
                 let id = declarator.id().get_binding_identifier().unwrap();
                 let symbol_id = id.symbol_id.get().unwrap();
                 let first_argument = Argument::from(ctx.ast.expression_from_identifier_reference(
-                    ctx.create_reference_id(
+                    ctx.create_bound_reference_id(
                         SPAN,
                         id.name.clone(),
-                        Some(symbol_id),
+                        symbol_id,
                         ReferenceFlags::Read,
                     ),
                 ));
@@ -409,10 +409,10 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
                             binding_name.as_str(),
                         )
                         .map(|symbol_id| {
-                            let ident = ctx.create_reference_id(
+                            let ident = ctx.create_bound_reference_id(
                                 SPAN,
                                 binding_name,
-                                Some(symbol_id),
+                                symbol_id,
                                 ReferenceFlags::Read,
                             );
                             let mut expr = ctx.ast.expression_from_identifier_reference(ident);
@@ -470,7 +470,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         let symbol_id = ctx.generate_uid_in_root_scope("c", SymbolFlags::FunctionScopedVariable);
         self.registrations.push((symbol_id, persistent_id));
         let name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
-        let ident = ctx.create_reference_id(SPAN, name, Some(symbol_id), reference_flags);
+        let ident = ctx.create_bound_reference_id(SPAN, name, symbol_id, reference_flags);
         let ident = ctx.ast.simple_assignment_target_from_identifier_reference(ident);
         ctx.ast.assignment_target_simple(ident)
     }
@@ -569,10 +569,10 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         id: &BindingIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        ctx.ast.expression_from_identifier_reference(ctx.create_reference_id(
+        ctx.ast.expression_from_identifier_reference(ctx.create_bound_reference_id(
             SPAN,
             id.name.clone(),
-            id.symbol_id.get(),
+            id.symbol_id.get().unwrap(),
             ReferenceFlags::Read,
         ))
     }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -192,10 +192,10 @@ impl<'a> TypeScriptEnum<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Vec<'a, Statement<'a>> {
         let create_identifier_reference = |ctx: &mut TraverseCtx<'a>| {
-            let ident = ctx.create_reference_id(
+            let ident = ctx.create_bound_reference_id(
                 param.span,
                 param.name.clone(),
-                param.symbol_id.get(),
+                param.symbol_id.get().unwrap(),
                 ReferenceFlags::Read,
             );
             ctx.ast.expression_from_identifier_reference(ident)


### PR DESCRIPTION
`TraverseCtx::create_reference_id` is intended for when you don't know if a reference is bound or not. Replace uses of it with the more specific `create_bound_reference_id` and `create_unbound_reference_id`.