### PR TITLE
fix(minifier): correct the reference link

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
@@ -7,6 +7,7 @@ use crate::{CompressOptions, CompressorPass};
 /// Collapse variable declarations.
 ///
 /// `var a; var b = 1; var c = 2` => `var a, b = 1; c = 2`
+/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java>
 pub struct CollapseVariableDeclarations {
     options: CompressOptions,
 
@@ -99,7 +100,7 @@ impl<'a> CollapseVariableDeclarations {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/CollapseVariableDeclarations.java>
+/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
+++ b/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
@@ -29,6 +29,7 @@ impl ExploitAssigns {
     }
 }
 
+/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/ExploitAssignsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -867,7 +867,7 @@ impl<'a> PeepholeFoldConstants {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeFoldConstants.java>
+/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
@@ -4,7 +4,7 @@ use oxc_traverse::{Traverse, TraverseCtx};
 use crate::CompressorPass;
 
 /// Minimize With Known Methods
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeMinimizeReplacements.java>
+/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java>
 pub struct PeepholeReplaceKnownMethods {
     changed: bool,
 }

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -12,6 +12,7 @@ use crate::{node_util::NodeUtil, CompressOptions, CompressorPass};
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
 /// with literals, and simplifying returns.
+/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java>
 pub struct PeepholeSubstituteAlternateSyntax {
     options: CompressOptions,
     in_define_export: bool,
@@ -329,7 +330,7 @@ impl<'a> PeepholeSubstituteAlternateSyntax {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java>
+/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;


### PR DESCRIPTION
These are minor changes, and recently I’ve been learning and trying to implement some features of `oxc_minifier`, which feels a bit complex.

By the way, I’m wondering whether we should gradually add test cases during the feature implementation process or just copy all the corresponding tests directly? Perhaps we could implement something like `rulegen` similar to `linter`?