### PR TITLE
ci(transformer): move post-transform checker to tasks crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
  "oxc",
  "oxc_prettier",
  "oxc_tasks_common",
+ "oxc_tasks_transform_checker",
  "phf 0.11.2",
  "pico-args",
  "rayon",
@@ -1957,6 +1958,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_tasks_transform_checker"
+version = "0.0.0"
+dependencies = [
+ "indexmap",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_diagnostics",
+ "oxc_semantic",
+ "oxc_span",
+ "oxc_syntax",
+ "rustc-hash",
+]
+
+[[package]]
 name = "oxc_transform_conformance"
 version = "0.0.0"
 dependencies = [
@@ -1964,6 +1979,7 @@ dependencies = [
  "indexmap",
  "oxc",
  "oxc_tasks_common",
+ "oxc_tasks_transform_checker",
  "pico-args",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ oxc_linter = { path = "crates/oxc_linter" }
 oxc_macros = { path = "crates/oxc_macros" }
 oxc_prettier = { path = "crates/oxc_prettier" }
 oxc_tasks_common = { path = "tasks/common" }
+oxc_tasks_transform_checker = { path = "tasks/transform_checker" }
 
 napi = "3.0.0-alpha"
 napi-build = "2.1.3"

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -17,7 +17,6 @@ pub use oxc_syntax::{
 };
 
 pub mod dot;
-pub mod post_transform_checker;
 
 mod binder;
 mod builder;

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -25,6 +25,7 @@ doctest = false
 oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "sourcemap"] }
 oxc_prettier = { workspace = true }
 oxc_tasks_common = { workspace = true }
+oxc_tasks_transform_checker = { workspace = true }
 
 console = { workspace = true }
 encoding_rs = { workspace = true }

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -1,5 +1,7 @@
 use std::{ops::ControlFlow, path::PathBuf};
 
+use rustc_hash::FxHashSet;
+
 use oxc::{
     allocator::Allocator,
     ast::{ast::Program, Trivias},
@@ -8,15 +10,12 @@ use oxc::{
     minifier::CompressOptions,
     parser::{ParseOptions, ParserReturn},
     regular_expression::{Parser, ParserOptions},
-    semantic::{
-        post_transform_checker::{check_semantic_after_transform, check_semantic_ids},
-        Semantic, SemanticBuilderReturn,
-    },
+    semantic::{Semantic, SemanticBuilderReturn},
     span::{SourceType, Span},
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
 };
-use rustc_hash::FxHashSet;
+use oxc_tasks_transform_checker::{check_semantic_after_transform, check_semantic_ids};
 
 use crate::suite::TestResult;
 

--- a/tasks/transform_checker/Cargo.toml
+++ b/tasks/transform_checker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxc_tasks_transform_checker"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+test = false
+doctest = false
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_semantic = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
+
+indexmap = { workspace = true }
+rustc-hash = { workspace = true }

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -95,17 +95,16 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 
 use oxc_allocator::{Allocator, CloneIn};
-#[allow(clippy::wildcard_imports)]
+#[allow(clippy::wildcard_imports, clippy::allow_attributes)]
 use oxc_ast::{ast::*, visit::walk, Visit};
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::{ScopeTree, SemanticBuilder, SymbolTable};
 use oxc_span::CompactStr;
 use oxc_syntax::{
     reference::ReferenceId,
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolId,
 };
-
-use crate::{ScopeTree, SemanticBuilder, SymbolTable};
 
 type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -24,6 +24,7 @@ doctest = false
 [dependencies]
 oxc = { workspace = true, features = ["full"] }
 oxc_tasks_common = { workspace = true }
+oxc_tasks_transform_checker = { workspace = true }
 
 cow-utils = { workspace = true }
 indexmap = { workspace = true }

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -6,11 +6,11 @@ use oxc::{
     codegen::{CodeGenerator, CodegenOptions},
     diagnostics::OxcDiagnostic,
     mangler::Mangler,
-    semantic::post_transform_checker::check_semantic_after_transform,
     span::SourceType,
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
 };
+use oxc_tasks_transform_checker::check_semantic_after_transform;
 
 pub struct Driver {
     check_semantic: bool,


### PR DESCRIPTION
Move post-transform checker into a `tasks` crate. It doesn't feel like it belongs in `oxc_semantic`. It also feels like too heavy a lump of code to put in `tasks/common`.