### PR TITLE
refactor(semantic): rename vars from `ast_node_id` to `node_id`

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -408,8 +408,8 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     let is_declare = ctx.class_table_builder.current_class_id.map_or(
         ctx.source_type.is_typescript_definition(),
         |id| {
-            let ast_node_id = ctx.class_table_builder.classes.declarations[id];
-            let AstKind::Class(class) = ctx.nodes.get_node(ast_node_id).kind() else {
+            let node_id = ctx.class_table_builder.classes.declarations[id];
+            let AstKind::Class(class) = ctx.nodes.get_node(node_id).kind() else {
                 #[cfg(debug_assertions)]
                 panic!("current_class_id is set, but does not point to a Class node.");
                 #[cfg(not(debug_assertions))]

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -102,8 +102,8 @@ impl ClassTable {
         self.elements[class_id].iter().any(|p| p.is_private && p.name == name)
     }
 
-    pub fn declare_class(&mut self, parent_id: Option<ClassId>, ast_node_id: NodeId) -> ClassId {
-        let class_id = self.declarations.push(ast_node_id);
+    pub fn declare_class(&mut self, parent_id: Option<ClassId>, node_id: NodeId) -> ClassId {
+        let class_id = self.declarations.push(node_id);
         if let Some(parent_id) = parent_id {
             self.parent_ids.insert(class_id, parent_id);
         };

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -151,34 +151,34 @@ impl<'a> AstNodes<'a> {
     /// ));
     /// ```
     #[inline]
-    pub fn kind(&self, ast_node_id: NodeId) -> AstKind<'a> {
-        self.nodes[ast_node_id].kind
+    pub fn kind(&self, node_id: NodeId) -> AstKind<'a> {
+        self.nodes[node_id].kind
     }
 
     /// Get id of this node's parent.
     #[inline]
-    pub fn parent_id(&self, ast_node_id: NodeId) -> Option<NodeId> {
-        self.parent_ids[ast_node_id]
+    pub fn parent_id(&self, node_id: NodeId) -> Option<NodeId> {
+        self.parent_ids[node_id]
     }
 
     /// Get the kind of the parent node.
-    pub fn parent_kind(&self, ast_node_id: NodeId) -> Option<AstKind<'a>> {
-        self.parent_id(ast_node_id).map(|node_id| self.kind(node_id))
+    pub fn parent_kind(&self, node_id: NodeId) -> Option<AstKind<'a>> {
+        self.parent_id(node_id).map(|node_id| self.kind(node_id))
     }
 
     /// Get a reference to a node's parent.
-    pub fn parent_node(&self, ast_node_id: NodeId) -> Option<&AstNode<'a>> {
-        self.parent_id(ast_node_id).map(|node_id| self.get_node(node_id))
+    pub fn parent_node(&self, node_id: NodeId) -> Option<&AstNode<'a>> {
+        self.parent_id(node_id).map(|node_id| self.get_node(node_id))
     }
 
     #[inline]
-    pub fn get_node(&self, ast_node_id: NodeId) -> &AstNode<'a> {
-        &self.nodes[ast_node_id]
+    pub fn get_node(&self, node_id: NodeId) -> &AstNode<'a> {
+        &self.nodes[node_id]
     }
 
     #[inline]
-    pub fn get_node_mut(&mut self, ast_node_id: NodeId) -> &mut AstNode<'a> {
-        &mut self.nodes[ast_node_id]
+    pub fn get_node_mut(&mut self, node_id: NodeId) -> &mut AstNode<'a> {
+        &mut self.nodes[node_id]
     }
 
     /// Get the root [`NodeId`]. This always points to a [`Program`] node.
@@ -220,9 +220,9 @@ impl<'a> AstNodes<'a> {
     /// pointed to by `node_id`. The last node will always be a [`Program`].
     ///
     /// [`Program`]: oxc_ast::ast::Program
-    pub fn ancestors(&self, ast_node_id: NodeId) -> impl Iterator<Item = NodeId> + '_ {
+    pub fn ancestors(&self, node_id: NodeId) -> impl Iterator<Item = NodeId> + '_ {
         let parent_ids = &self.parent_ids;
-        std::iter::successors(Some(ast_node_id), |&node_id| parent_ids[node_id])
+        std::iter::successors(Some(node_id), |&node_id| parent_ids[node_id])
     }
 
     /// Create and add an [`AstNode`] to the [`AstNodes`] tree and get its [`NodeId`].
@@ -239,10 +239,10 @@ impl<'a> AstNodes<'a> {
         cfg_id: BasicBlockId,
         flags: NodeFlags,
     ) -> NodeId {
-        let ast_node_id = self.parent_ids.push(Some(parent_node_id));
-        let node = AstNode::new(kind, scope_id, cfg_id, flags, ast_node_id);
+        let node_id = self.parent_ids.push(Some(parent_node_id));
+        let node = AstNode::new(kind, scope_id, cfg_id, flags, node_id);
         self.nodes.push(node);
-        ast_node_id
+        node_id
     }
 
     /// Create and add an [`AstNode`] to the [`AstNodes`] tree and get its [`NodeId`].
@@ -253,11 +253,11 @@ impl<'a> AstNodes<'a> {
         cfg_id: BasicBlockId,
         flags: NodeFlags,
     ) -> NodeId {
-        let ast_node_id = self.parent_ids.push(None);
-        self.root = Some(ast_node_id);
-        let node = AstNode::new(kind, scope_id, cfg_id, flags, ast_node_id);
+        let node_id = self.parent_ids.push(None);
+        self.root = Some(node_id);
+        let node = AstNode::new(kind, scope_id, cfg_id, flags, node_id);
         self.nodes.push(node);
-        ast_node_id
+        node_id
     }
 
     /// Reserve space for at least `additional` more nodes.

--- a/crates/oxc_semantic/tests/integration/util/class_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/class_tester.rs
@@ -11,8 +11,8 @@ pub struct ClassTester<'a> {
 
 impl<'a> ClassTester<'a> {
     pub(super) fn has_class(semantic: Semantic<'a>, name: &str) -> Self {
-        let class_id = semantic.classes().iter_enumerated().find_map(|(class_id, &ast_node_id)| {
-            let kind = semantic.nodes().kind(ast_node_id);
+        let class_id = semantic.classes().iter_enumerated().find_map(|(class_id, &node_id)| {
+            let kind = semantic.nodes().kind(node_id);
             let class = kind.as_class()?;
 
             if class.id.clone().is_some_and(|id| id.name == name) {


### PR DESCRIPTION
Style nit. We renamed `AstNodeId` to `NodeId`, so rename vars from `ast_node_id` to `node_id` too.