### PR TITLE
refactor(linter): rename vars from `ast_node_id` to `node_id`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -98,8 +98,8 @@ impl Rule for MaxClassesPerFile {
             return;
         }
 
-        let ast_node_id = ctx.semantic().classes().get_node_id(ClassId::from(self.max));
-        let span = if let AstKind::Class(class) = ctx.nodes().kind(ast_node_id) {
+        let node_id = ctx.semantic().classes().get_node_id(ClassId::from(self.max));
+        let span = if let AstKind::Class(class) = ctx.nodes().kind(node_id) {
             class.span
         } else {
             Span::new(0, 0)

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -142,12 +142,12 @@ impl NoDuplicateHooks {
         }
 
         let hook_name = jest_fn_call.name.to_string();
-        let parent_ast_node_id =
+        let parent_node_id =
             match ctx.nodes().ancestors(node.id()).find(|n| hook_contexts.contains_key(n)) {
                 Some(n) => Some(n),
                 _ => Some(root_node_id),
             };
-        let Some(parent_id) = parent_ast_node_id else {
+        let Some(parent_id) = parent_node_id else {
             return;
         };
 


### PR DESCRIPTION
Style nit. We renamed `AstNodeId` to `NodeId`, so rename vars from `ast_node_id` to `node_id` too.