### PR TITLE
fix(transformer): exponentiation transform: do not replace object when private property

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 56/65
+Passed: 57/66
 
 # All Passed:
 * babel-plugin-transform-nullish-coalescing-operator

--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/input.js
@@ -1,0 +1,9 @@
+class C {
+    #p = 1;
+
+    method(obj) {
+        obj.x **= 2; // Transform
+        obj['y'] **= 3; // Transform
+        obj.#p **= 4; // Bail
+    }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/output.js
@@ -1,0 +1,9 @@
+class C {
+    #p = 1;
+
+    method(obj) {
+        obj["x"] = Math.pow(obj["x"], 2);
+        obj["y"] = Math.pow(obj["y"], 3);
+        obj.#p **= 4;
+    }
+}


### PR DESCRIPTION
Fix exponentiation operator transform to bail out early if a private class property.

We can't transform this:

```js
class C {
    #p;
    method() {
        this.#p **= 2;
    }
}
```

But we should at least leave it alone. Previously `get_obj_ref` called `ast.move_expression(expr)` on the member expression's object before bailing out, so example above was transformed to:

```js
class C {
    #p;
    method() {
        null.#p **= 2; // <-- `null`
    }
}
```

This PR makes it spot this case early and bail out *before* calling `ast.move_expression(expr)`.