### PR TITLE
feat(transformer): exponentiation transform: support private fields

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/input.js
@@ -1,9 +1,0 @@
-class C {
-    #p = 1;
-
-    method(obj) {
-        obj.x **= 2; // Transform
-        obj['y'] **= 3; // Transform
-        obj.#p **= 4; // Bail
-    }
-}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/bail-private-properties/output.js
@@ -1,9 +1,0 @@
-class C {
-    #p = 1;
-
-    method(obj) {
-        obj["x"] = Math.pow(obj["x"], 2);
-        obj["y"] = Math.pow(obj["y"], 3);
-        obj.#p **= 4;
-    }
-}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/private-properties/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/private-properties/input.js
@@ -1,0 +1,11 @@
+class C {
+    #p = 1;
+
+    method(obj) {
+        this.#p **= 1;
+        obj.#p **= 2;
+        this.x.y.z.#p **= 3;
+        obj.x.y.z.#p **= 4;
+        fn().x.y.z.#p **= 5;
+    }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/private-properties/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-exponentiation-operator/test/fixtures/private-properties/output.js
@@ -1,0 +1,12 @@
+class C {
+    #p = 1;
+
+    method(obj) {
+        var _this, _this$x$y$z, _obj$x$y$z, _fn$x$y$z;
+        _this = this, _this.#p = Math.pow(_this.#p, 1);
+        obj.#p = Math.pow(obj.#p, 2);
+        _this$x$y$z = this.x.y.z, _this$x$y$z.#p = Math.pow(_this$x$y$z.#p, 3);
+        _obj$x$y$z = obj.x.y.z, _obj$x$y$z.#p = Math.pow(_obj$x$y$z.#p, 4);
+        _fn$x$y$z = fn().x.y.z, _fn$x$y$z.#p = Math.pow(_fn$x$y$z.#p, 5);
+    }
+}


### PR DESCRIPTION
Babel doesn't support private fields in this transform, but there's no reason not to. So we can.