### PR TITLE
feat(ast_tools): support `#[scope(exit_before)]`

### DIFF
--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -64,7 +64,10 @@ pub struct VisitMarkers {
 /// A struct representing `#[scope(...)]` markers
 #[derive(Default, Debug)]
 pub struct ScopeMarkers {
+    /// `#[scope(enter_before)]`
     pub enter_before: bool,
+    /// `#[scope(exit_before)]`
+    pub exit_before: bool,
 }
 
 /// A struct representing all the helper attributes that might be used with `#[generate_derive(...)]`
@@ -204,7 +207,10 @@ where
         || Ok(ScopeMarkers::default()),
         |attr| {
             attr.parse_args_with(Ident::parse)
-                .map(|id| ScopeMarkers { enter_before: id == "enter_before" })
+                .map(|id| ScopeMarkers {
+                    enter_before: id == "enter_before",
+                    exit_before: id == "exit_before",
+                })
                 .normalize()
         },
     )


### PR DESCRIPTION
Closes #6311.

Adds support for `#[scope(exit_before)]`, which is the opposite of `#[scope(enter_before)]`