### PR TITLE
fix(parser): string `ImportSpecifier`s for type imports

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -433,7 +433,7 @@ impl<'a> ParserImpl<'a> {
                 } else if !self.nth_kind(2).is_identifier_name() {
                     import_kind = ImportOrExportKind::Type;
                 }
-            } else if peek_kind.is_identifier_name() {
+            } else if peek_kind.is_identifier_name() || matches!(peek_kind, Kind::Str) {
                 import_kind = ImportOrExportKind::Type;
             }
         }

--- a/crates/oxc_semantic/tests/integration/modules.rs
+++ b/crates/oxc_semantic/tests/integration/modules.rs
@@ -250,3 +250,11 @@ fn test_import_assignment() {
         .contains_flags(SymbolFlags::Import)
         .test();
 }
+
+#[test]
+fn test_import_type() {
+    SemanticTester::ts(r#"import { type "<A>" as someA } from './a'; "#)
+        .has_root_symbol("someA")
+        .contains_flags(SymbolFlags::TypeImport)
+        .test();
+}

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,8 +1,8 @@
 commit: a709f989
 
 parser_typescript Summary:
-AST Parsed     : 6469/6479 (99.85%)
-Positive Passed: 6458/6479 (99.68%)
+AST Parsed     : 6470/6479 (99.86%)
+Positive Passed: 6459/6479 (99.69%)
 Negative Passed: 1234/5715 (21.59%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration10.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration11.ts
@@ -4666,16 +4666,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es2019/import
  3 │ export let z = import.import.import.malkovich;
    ·                ─────────────
    ╰────
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
-
-  × Expected `,` but found `string`
-    ╭─[typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts:19:15]
- 18 │ export { type someType as "<A>" };
- 19 │ import { type "<A>" as typeA } from "./arbitraryModuleNamespaceIdentifiers_module";
-    ·               ──┬──
-    ·                 ╰── `,` expected
- 20 │ const importTest: typeA = "expect error about someType";
-    ╰────
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts
 
   × 'with' statements are not allowed

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -41863,7 +41863,12 @@ after transform: []
 rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
-semantic error: Expected `,` but found `string`
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["importStarTestA", "importTest", "otherType", "reimportTest", "someType", "someValue", "typeA", "typeB", "typeC", "valueX", "valueY", "valueZ"]
+rebuilt        : ScopeId(0): ["importStarTestA", "importTest", "reimportTest", "someValue", "valueX", "valueY", "valueZ"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
 semantic error: Unresolved references mismatch:


### PR DESCRIPTION
Fixes a parse failure on imports like this:
```ts
import { type "<A>" as typeA } from "./arbitraryModuleNamespaceIdentifiers_module";
```