### PR TITLE
fix(parser): should regard comments where after `=` as leading comments of next token

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -218,7 +218,7 @@ impl<'a> Lexer<'a> {
         self.token.end = self.offset();
         debug_assert!(self.token.start <= self.token.end);
         let token = self.token;
-        self.trivia_builder.handle_token(token.start);
+        self.trivia_builder.handle_token(token);
         self.token = Token::default();
         token
     }


### PR DESCRIPTION
A part of fixing https://github.com/rolldown/rolldown/pull/2375/files#r1789011257

### Compare to `Babel`
This is also among its behavior, see

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/1b1f9c78-3e44-495d-b2f7-38e6c3bc8bf1">

### Compare to `esbuild`

I haven't looked through related code from esbuild, from its playground, the behavior looks the same

https://esbuild.github.io/try/#dAAwLjI0LjAAAGNvbnN0IEEgPSAvLyBzZGRkZGQKKCkgPT4ge30