### PR TITLE
fix(codegen): converts line comment to block comment if it is a `PURE` comment

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -140,7 +140,13 @@ impl<'a> Codegen<'a> {
             if !Self::is_annotation_comment(&comment, source_text) {
                 continue;
             }
-            self.print_str(comment.real_span().source_text(source_text));
+            if comment.is_line() {
+                self.print_str("/*");
+                self.print_str(comment.span.source_text(source_text));
+                self.print_str("*/");
+            } else {
+                self.print_str(comment.real_span().source_text(source_text));
+            }
             self.print_hard_space();
         }
     }

--- a/crates/oxc_codegen/tests/integration/pure_comments.rs
+++ b/crates/oxc_codegen/tests/integration/pure_comments.rs
@@ -129,6 +129,10 @@ const defineSSRCustomElement = () => {
   return /* @__PURE__ */ /* @__NO_SIDE_EFFECTS__ */ /* #__NO_SIDE_EFFECTS__ */ defineCustomElement(options, extraOptions, hydrate);
 };
         ",
+        "
+        const Component = // #__PURE__
+        React.forwardRef((props, ref) => {});
+        ",
     ];
 
     snapshot("pure_comments", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -269,3 +269,11 @@ const defineSSRCustomElement = () => {
 const defineSSRCustomElement = () => {
 	return /* @__PURE__ */ /* @__NO_SIDE_EFFECTS__ */ /* #__NO_SIDE_EFFECTS__ */ defineCustomElement(options, extraOptions, hydrate);
 };
+
+########## 20
+
+        const Component = // #__PURE__
+        React.forwardRef((props, ref) => {});
+        
+----------
+const Component = /* #__PURE__*/ React.forwardRef((props, ref) => {});


### PR DESCRIPTION
The last part of fixing https://github.com/rolldown/rolldown/pull/2375/files#r1789011257

In the following case, the pure comment was written by `//`
```ts
const Component = // #__PURE__
React.forwardRef((props, ref) => {});
```

The printed code looks like this
```ts
const Component = 
// #__PURE__ React.forwardRef((props, ref) => {});
```

As you can see, it is broken because the code also commented, so we need to replace `//` with `/* */`