### PR TITLE
fix(linter): move `eslint/sort-keys` to `style` category

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -84,7 +84,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     SortKeys,
-    pedantic,
+    style,
     pending
 );
 


### PR DESCRIPTION
Closes #6363