### PR TITLE
fix(transformer): arrow function transform: correctly resolve `this` in class accessor properties

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -15,6 +15,9 @@
 //!   Babel gets this wrong: <https://babeljs.io/repl#?code_lz=GYVwdgxgLglg9mABMOcAUAPRBeRaCUOAfIlABYwDOhA3gL5A&presets=&externalPlugins=%40babel%2Fplugin-transform-arrow-functions%407.24.7>
 //! * Error on arrow functions in class properties.
 //!   <https://babeljs.io/repl#?code_lz=MYGwhgzhAEDC0G8BQ1oDMD2HoF5oAoBKXAPmgBcALASwgG4kBfJIA&presets=&externalPlugins=%40babel%2Fplugin-transform-arrow-functions%407.24.7>
+//!   or we can support it:
+//!     `class C { x = () => this; }`
+//!     -> `class C { x = (function(_this) { return () => _this; })(this); }`
 //! * Error on `super` in arrow functions.
 //!   <https://babeljs.io/repl#?code_lz=MYGwhgzhAEBiD29oG8C-AoUkYCEwCdoBTADwBciA7AExgSWXWmgFsiyALeagCgEoUTZtHzsArvkrR-0ALwA-aBDEAHIvgB0AM0QBuIRgxA&presets=&externalPlugins=%40babel%2Fplugin-transform-arrow-functions%407.24.7>
 //!
@@ -296,6 +299,7 @@ impl<'a> ArrowFunctions<'a> {
         // * `extends` clause
         // * Computed method key
         // * Computed property key
+        // * Computed accessor property key (but `this` in this position is not legal TS)
         //
         // ```js
         // // All these `this` refer to global `this`
@@ -304,6 +308,8 @@ impl<'a> ArrowFunctions<'a> {
         //     static [this] = 123;
         //     [this]() {}
         //     static [this]() {}
+        //     accessor [this] = 123;
+        //     static accessor [this] = 123;
         // }
         // ```
         //
@@ -323,6 +329,8 @@ impl<'a> ArrowFunctions<'a> {
         //     static e() { this }
         //     #f() { this }
         //     g(x = this) {}
+        //     accessor h = this;
+        //     static accessor i = this;
         //     static { this }
         // }
         // ```
@@ -337,8 +345,11 @@ impl<'a> ArrowFunctions<'a> {
                 | Ancestor::FunctionBody(_)
                 // Class property body
                 | Ancestor::PropertyDefinitionValue(_)
+                // Class accessor property body
+                | Ancestor::AccessorPropertyValue(_)
                 // Class static block
                 | Ancestor::StaticBlockBody(_) => return None,
+                // Arrow function
                 Ancestor::ArrowFunctionExpressionParams(func) => {
                     return Some(func.scope_id().get().unwrap())
                 }


### PR DESCRIPTION
Correctly resolve scope of `this` in class accessor properties.

The omission of this case became clear from examining Babel's `environmentVisitor`:

https://github.com/babel/babel/blob/f343c499b07341ddb1a8e90add60e5ef45011664/packages/babel-traverse/src/visitors.ts#L398-L436
