### PR TITLE
refactor(ast): type params field before params in TS function declaration types

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1147,10 +1147,10 @@ pub struct TSIndexSignature<'a> {
 pub struct TSCallSignatureDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub this_param: Option<TSThisParameter<'a>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
 }
 
 #[ast]
@@ -1188,10 +1188,10 @@ pub struct TSMethodSignature<'a> {
     pub computed: bool,
     pub optional: bool,
     pub kind: TSMethodSignatureKind,
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[serde(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1207,9 +1207,9 @@ pub struct TSMethodSignature<'a> {
 pub struct TSConstructSignatureDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[serde(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1562,10 +1562,17 @@ pub enum TSImportAttributeName<'a> {
 pub struct TSFunctionType<'a> {
     #[serde(flatten)]
     pub span: Span,
+    /// Generic type parameters
+    ///
+    /// ```ts
+    /// type T = <U>(x: U) => U;
+    /// //        ^
+    /// ```
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     /// `this` parameter
     ///
     /// ```ts
-    /// type T = (this: string, a: number) => void
+    /// type T = (this: string, a: number) => void;
     /// //        ^^^^^^^^^^^^
     /// ```
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
@@ -1573,17 +1580,10 @@ pub struct TSFunctionType<'a> {
     pub params: Box<'a, FormalParameters<'a>>,
     /// Return type of the function.
     /// ```ts
-    /// type T = () => void
+    /// type T = () => void;
     /// //             ^^^^
     /// ```
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
-    /// Generic type parameters
-    ///
-    /// ```ts
-    /// type T = <T>(x: T) => T
-    /// //        ^
-    /// ```
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
 }
 
 #[ast(visit)]
@@ -1595,9 +1595,9 @@ pub struct TSConstructorType<'a> {
     #[serde(flatten)]
     pub span: Span,
     pub r#abstract: bool,
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
 }
 
 /// TypeScript Mapped Type

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1042,10 +1042,10 @@ const _: () = {
     assert!(size_of::<TSCallSignatureDeclaration>() == 64usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8usize);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 40usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 48usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 56usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 8usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 16usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 48usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 56usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
@@ -1057,18 +1057,18 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, computed) == 24usize);
     assert!(offset_of!(TSMethodSignature, optional) == 25usize);
     assert!(offset_of!(TSMethodSignature, kind) == 26usize);
-    assert!(offset_of!(TSMethodSignature, this_param) == 32usize);
-    assert!(offset_of!(TSMethodSignature, params) == 40usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 48usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 56usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 32usize);
+    assert!(offset_of!(TSMethodSignature, this_param) == 40usize);
+    assert!(offset_of!(TSMethodSignature, params) == 48usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 56usize);
     assert!(offset_of!(TSMethodSignature, scope_id) == 64usize);
 
     assert!(size_of::<TSConstructSignatureDeclaration>() == 40usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 8usize);
     assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 8usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 16usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 24usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 8usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 16usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 24usize);
     assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 32usize);
 
     assert!(size_of::<TSIndexSignatureName>() == 32usize);
@@ -1163,18 +1163,18 @@ const _: () = {
     assert!(size_of::<TSFunctionType>() == 40usize);
     assert!(align_of::<TSFunctionType>() == 8usize);
     assert!(offset_of!(TSFunctionType, span) == 0usize);
-    assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 16usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 24usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 32usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 8usize);
+    assert!(offset_of!(TSFunctionType, this_param) == 16usize);
+    assert!(offset_of!(TSFunctionType, params) == 24usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 32usize);
 
     assert!(size_of::<TSConstructorType>() == 40usize);
     assert!(align_of::<TSConstructorType>() == 8usize);
     assert!(offset_of!(TSConstructorType, span) == 0usize);
     assert!(offset_of!(TSConstructorType, r#abstract) == 8usize);
-    assert!(offset_of!(TSConstructorType, params) == 16usize);
-    assert!(offset_of!(TSConstructorType, return_type) == 24usize);
-    assert!(offset_of!(TSConstructorType, type_parameters) == 32usize);
+    assert!(offset_of!(TSConstructorType, type_parameters) == 16usize);
+    assert!(offset_of!(TSConstructorType, params) == 24usize);
+    assert!(offset_of!(TSConstructorType, return_type) == 32usize);
 
     assert!(size_of::<TSMappedType>() == 56usize);
     assert!(align_of::<TSMappedType>() == 8usize);
@@ -2601,10 +2601,10 @@ const _: () = {
     assert!(size_of::<TSCallSignatureDeclaration>() == 44usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4usize);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 32usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 36usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 40usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 8usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 12usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 36usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 40usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
@@ -2616,18 +2616,18 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, computed) == 16usize);
     assert!(offset_of!(TSMethodSignature, optional) == 17usize);
     assert!(offset_of!(TSMethodSignature, kind) == 18usize);
-    assert!(offset_of!(TSMethodSignature, this_param) == 20usize);
-    assert!(offset_of!(TSMethodSignature, params) == 24usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 28usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 32usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 20usize);
+    assert!(offset_of!(TSMethodSignature, this_param) == 24usize);
+    assert!(offset_of!(TSMethodSignature, params) == 28usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 32usize);
     assert!(offset_of!(TSMethodSignature, scope_id) == 36usize);
 
     assert!(size_of::<TSConstructSignatureDeclaration>() == 24usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 4usize);
     assert!(offset_of!(TSConstructSignatureDeclaration, span) == 0usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 8usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 12usize);
-    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 16usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, type_parameters) == 8usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, params) == 12usize);
+    assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 16usize);
     assert!(offset_of!(TSConstructSignatureDeclaration, scope_id) == 20usize);
 
     assert!(size_of::<TSIndexSignatureName>() == 20usize);
@@ -2722,18 +2722,18 @@ const _: () = {
     assert!(size_of::<TSFunctionType>() == 24usize);
     assert!(align_of::<TSFunctionType>() == 4usize);
     assert!(offset_of!(TSFunctionType, span) == 0usize);
-    assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 12usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 16usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 20usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 8usize);
+    assert!(offset_of!(TSFunctionType, this_param) == 12usize);
+    assert!(offset_of!(TSFunctionType, params) == 16usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 20usize);
 
     assert!(size_of::<TSConstructorType>() == 24usize);
     assert!(align_of::<TSConstructorType>() == 4usize);
     assert!(offset_of!(TSConstructorType, span) == 0usize);
     assert!(offset_of!(TSConstructorType, r#abstract) == 8usize);
-    assert!(offset_of!(TSConstructorType, params) == 12usize);
-    assert!(offset_of!(TSConstructorType, return_type) == 16usize);
-    assert!(offset_of!(TSConstructorType, type_parameters) == 20usize);
+    assert!(offset_of!(TSConstructorType, type_parameters) == 12usize);
+    assert!(offset_of!(TSConstructorType, params) == 16usize);
+    assert!(offset_of!(TSConstructorType, return_type) == 20usize);
 
     assert!(size_of::<TSMappedType>() == 36usize);
     assert!(align_of::<TSMappedType>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8781,29 +8781,29 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// - span: The [`Span`] covering this node
     /// - r#abstract
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_type_constructor_type<T1, T2, T3>(
         self,
         span: Span,
         r#abstract: bool,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSConstructorType(self.alloc(self.ts_constructor_type(
             span,
             r#abstract,
+            type_parameters,
             params,
             return_type,
-            type_parameters,
         )))
     }
 
@@ -8822,31 +8822,31 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters: Generic type parameters
     /// - this_param: `this` parameter
     /// - params: Function parameters. Akin to [`Function::params`].
     /// - return_type: Return type of the function.
-    /// - type_parameters: Generic type parameters
     #[inline]
     pub fn ts_type_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSFunctionType(self.alloc(self.ts_function_type(
             span,
+            type_parameters,
             this_param,
             params,
             return_type,
-            type_parameters,
         )))
     }
 
@@ -10799,30 +10799,30 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_signature_call_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
+        type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        params: T2,
+        return_type: T3,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSCallSignatureDeclaration(self.alloc(self.ts_call_signature_declaration(
             span,
+            type_parameters,
             this_param,
             params,
             return_type,
-            type_parameters,
         )))
     }
 
@@ -10841,24 +10841,24 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_signature_construct_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSConstructSignatureDeclaration(self.alloc(
-            self.ts_construct_signature_declaration(span, params, return_type, type_parameters),
+            self.ts_construct_signature_declaration(span, type_parameters, params, return_type),
         ))
     }
 
@@ -10884,10 +10884,10 @@ impl<'a> AstBuilder<'a> {
     /// - computed
     /// - optional
     /// - kind
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_signature_method_signature<T1, T2, T3, T4>(
         self,
@@ -10896,16 +10896,16 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSMethodSignature(self.alloc(self.ts_method_signature(
             span,
@@ -10913,10 +10913,10 @@ impl<'a> AstBuilder<'a> {
             computed,
             optional,
             kind,
+            type_parameters,
             this_param,
             params,
             return_type,
-            type_parameters,
         )))
     }
 
@@ -10989,30 +10989,30 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_call_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
+        type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        params: T2,
+        return_type: T3,
     ) -> TSCallSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
             span,
+            type_parameters: type_parameters.into_in(self.allocator),
             this_param,
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
-            type_parameters: type_parameters.into_in(self.allocator),
         }
     }
 
@@ -11022,31 +11022,31 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn alloc_ts_call_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
+        type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        params: T2,
+        return_type: T3,
     ) -> Box<'a, TSCallSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         Box::new_in(
             self.ts_call_signature_declaration(
                 span,
+                type_parameters,
                 this_param,
                 params,
                 return_type,
-                type_parameters,
             ),
             self.allocator,
         )
@@ -11062,10 +11062,10 @@ impl<'a> AstBuilder<'a> {
     /// - computed
     /// - optional
     /// - kind
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_method_signature<T1, T2, T3, T4>(
         self,
@@ -11074,16 +11074,16 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSMethodSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSMethodSignature {
             span,
@@ -11091,10 +11091,10 @@ impl<'a> AstBuilder<'a> {
             computed,
             optional,
             kind,
+            type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
-            type_parameters: type_parameters.into_in(self.allocator),
             scope_id: Default::default(),
         }
     }
@@ -11109,10 +11109,10 @@ impl<'a> AstBuilder<'a> {
     /// - computed
     /// - optional
     /// - kind
+    /// - type_parameters
     /// - this_param
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn alloc_ts_method_signature<T1, T2, T3, T4>(
         self,
@@ -11121,16 +11121,16 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> Box<'a, TSMethodSignature<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         Box::new_in(
             self.ts_method_signature(
@@ -11139,10 +11139,10 @@ impl<'a> AstBuilder<'a> {
                 computed,
                 optional,
                 kind,
+                type_parameters,
                 this_param,
                 params,
                 return_type,
-                type_parameters,
             ),
             self.allocator,
         )
@@ -11154,27 +11154,27 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_construct_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> TSConstructSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSConstructSignatureDeclaration {
             span,
+            type_parameters: type_parameters.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
-            type_parameters: type_parameters.into_in(self.allocator),
             scope_id: Default::default(),
         }
     }
@@ -11185,24 +11185,24 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn alloc_ts_construct_signature_declaration<T1, T2, T3>(
         self,
         span: Span,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> Box<'a, TSConstructSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         Box::new_in(
-            self.ts_construct_signature_declaration(span, params, return_type, type_parameters),
+            self.ts_construct_signature_declaration(span, type_parameters, params, return_type),
             self.allocator,
         )
     }
@@ -11972,31 +11972,31 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters: Generic type parameters
     /// - this_param: `this` parameter
     /// - params: Function parameters. Akin to [`Function::params`].
     /// - return_type: Return type of the function.
-    /// - type_parameters: Generic type parameters
     #[inline]
     pub fn ts_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSFunctionType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSFunctionType {
             span,
+            type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
-            type_parameters: type_parameters.into_in(self.allocator),
         }
     }
 
@@ -12006,27 +12006,27 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
+    /// - type_parameters: Generic type parameters
     /// - this_param: `this` parameter
     /// - params: Function parameters. Akin to [`Function::params`].
     /// - return_type: Return type of the function.
-    /// - type_parameters: Generic type parameters
     #[inline]
     pub fn alloc_ts_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: T1,
-        params: T2,
-        return_type: T3,
-        type_parameters: T4,
+        type_parameters: T1,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> Box<'a, TSFunctionType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         Box::new_in(
-            self.ts_function_type(span, this_param, params, return_type, type_parameters),
+            self.ts_function_type(span, type_parameters, this_param, params, return_type),
             self.allocator,
         )
     }
@@ -12038,29 +12038,29 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// - span: The [`Span`] covering this node
     /// - r#abstract
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn ts_constructor_type<T1, T2, T3>(
         self,
         span: Span,
         r#abstract: bool,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> TSConstructorType<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSConstructorType {
             span,
             r#abstract,
+            type_parameters: type_parameters.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
-            type_parameters: type_parameters.into_in(self.allocator),
         }
     }
 
@@ -12071,25 +12071,25 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// - span: The [`Span`] covering this node
     /// - r#abstract
+    /// - type_parameters
     /// - params
     /// - return_type
-    /// - type_parameters
     #[inline]
     pub fn alloc_ts_constructor_type<T1, T2, T3>(
         self,
         span: Span,
         r#abstract: bool,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
     ) -> Box<'a, TSConstructorType<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         Box::new_in(
-            self.ts_constructor_type(span, r#abstract, params, return_type, type_parameters),
+            self.ts_constructor_type(span, r#abstract, type_parameters, params, return_type),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3383,10 +3383,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSCallSignatureDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3411,10 +3411,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'old_allo
             computed: CloneIn::clone_in(&self.computed, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3425,9 +3425,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclara
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructSignatureDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             scope_id: Default::default(),
         }
     }
@@ -3646,10 +3646,10 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'old_alloc> 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSFunctionType {
             span: CloneIn::clone_in(&self.span, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }
@@ -3660,9 +3660,9 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'old_allo
         TSConstructorType {
             span: CloneIn::clone_in(&self.span, allocator),
             r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
             return_type: CloneIn::clone_in(&self.return_type, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -3460,10 +3460,10 @@ impl<'a> ContentEq for TSIndexSignature<'a> {
 
 impl<'a> ContentEq for TSCallSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
@@ -3479,18 +3479,18 @@ impl<'a> ContentEq for TSMethodSignature<'a> {
             && ContentEq::content_eq(&self.computed, &other.computed)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.kind, &other.kind)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSConstructSignatureDeclaration<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.params, &other.params)
+        ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
@@ -3662,19 +3662,19 @@ impl<'a> ContentEq for TSImportAttributeName<'a> {
 
 impl<'a> ContentEq for TSFunctionType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.this_param, &other.this_param)
+        ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.this_param, &other.this_param)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 
 impl<'a> ContentEq for TSConstructorType<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.params, &other.params)
             && ContentEq::content_eq(&self.return_type, &other.return_type)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -1851,10 +1851,10 @@ impl<'a> ContentHash for TSIndexSignature<'a> {
 
 impl<'a> ContentHash for TSCallSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
-        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -1870,18 +1870,18 @@ impl<'a> ContentHash for TSMethodSignature<'a> {
         ContentHash::content_hash(&self.computed, state);
         ContentHash::content_hash(&self.optional, state);
         ContentHash::content_hash(&self.kind, state);
+        ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
-        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSConstructSignatureDeclaration<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
-        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
@@ -2025,19 +2025,19 @@ impl<'a> ContentHash for TSImportAttributeName<'a> {
 
 impl<'a> ContentHash for TSFunctionType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.this_param, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
-        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 
 impl<'a> ContentHash for TSConstructorType<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&self.r#abstract, state);
+        ContentHash::content_hash(&self.type_parameters, state);
         ContentHash::content_hash(&self.params, state);
         ContentHash::content_hash(&self.return_type, state);
-        ContentHash::content_hash(&self.type_parameters, state);
     }
 }
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -1925,11 +1925,11 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_constructor_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConstructorType<'a>) {
         // NOTE: AstKind doesn't exists!
-        visitor.visit_formal_parameters(&it.params);
-        visitor.visit_ts_type_annotation(&it.return_type);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_formal_parameters(&it.params);
+        visitor.visit_ts_type_annotation(&it.return_type);
     }
 
     #[inline]
@@ -2090,14 +2090,14 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_function_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSFunctionType<'a>) {
         // NOTE: AstKind doesn't exists!
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&it.params);
         visitor.visit_ts_type_annotation(&it.return_type);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
     }
 
     #[inline]
@@ -2423,15 +2423,15 @@ pub mod walk {
         it: &TSCallSignatureDeclaration<'a>,
     ) {
         // NOTE: AstKind doesn't exists!
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&it.params);
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
     }
 
@@ -2443,12 +2443,12 @@ pub mod walk {
         let kind = AstKind::TSConstructSignatureDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         visitor.visit_formal_parameters(&it.params);
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);
@@ -2460,15 +2460,15 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_property_key(&it.key);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&it.params);
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -1971,11 +1971,11 @@ pub mod walk_mut {
         it: &mut TSConstructorType<'a>,
     ) {
         // NOTE: AstType doesn't exists!
-        visitor.visit_formal_parameters(&mut it.params);
-        visitor.visit_ts_type_annotation(&mut it.return_type);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_formal_parameters(&mut it.params);
+        visitor.visit_ts_type_annotation(&mut it.return_type);
     }
 
     #[inline]
@@ -2157,14 +2157,14 @@ pub mod walk_mut {
         it: &mut TSFunctionType<'a>,
     ) {
         // NOTE: AstType doesn't exists!
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &mut it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&mut it.params);
         visitor.visit_ts_type_annotation(&mut it.return_type);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
     }
 
     #[inline]
@@ -2514,15 +2514,15 @@ pub mod walk_mut {
         it: &mut TSCallSignatureDeclaration<'a>,
     ) {
         // NOTE: AstType doesn't exists!
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &mut it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&mut it.params);
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
     }
 
@@ -2534,12 +2534,12 @@ pub mod walk_mut {
         let kind = AstType::TSConstructSignatureDeclaration;
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         visitor.visit_formal_parameters(&mut it.params);
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);
@@ -2554,15 +2554,15 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_property_key(&mut it.key);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
         if let Some(this_param) = &mut it.this_param {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&mut it.params);
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -30,11 +30,11 @@ impl<'a> IsolatedDeclarations<'a> {
             self.ast.ts_type_function_type(
                 func.span,
                 // SAFETY: `ast.copy` is unsound! We need to fix.
+                unsafe { self.ast.copy(&func.type_parameters) },
+                // SAFETY: `ast.copy` is unsound! We need to fix.
                 unsafe { self.ast.copy(&func.this_param) },
                 params,
                 return_type,
-                // SAFETY: `ast.copy` is unsound! We need to fix.
-                unsafe { self.ast.copy(&func.type_parameters) },
             )
         })
     }
@@ -57,11 +57,11 @@ impl<'a> IsolatedDeclarations<'a> {
         return_type.map(|return_type| {
             self.ast.ts_type_function_type(
                 func.span,
+                // SAFETY: `ast.copy` is unsound! We need to fix.
+                unsafe { self.ast.copy(&func.type_parameters) },
                 NONE,
                 params,
                 return_type,
-                // SAFETY: `ast.copy` is unsound! We need to fix.
-                unsafe { self.ast.copy(&func.type_parameters) },
             )
         })
     }
@@ -107,11 +107,11 @@ impl<'a> IsolatedDeclarations<'a> {
                                 false,
                                 TSMethodSignatureKind::Method,
                                 // SAFETY: `ast.copy` is unsound! We need to fix.
+                                unsafe { self.ast.copy(&function.type_parameters) },
+                                // SAFETY: `ast.copy` is unsound! We need to fix.
                                 unsafe { self.ast.copy(&function.this_param) },
                                 params,
                                 return_type,
-                                // SAFETY: `ast.copy` is unsound! We need to fix.
-                                unsafe { self.ast.copy(&function.type_parameters) },
                             ));
                         }
                     }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -75,12 +75,12 @@ impl<'a> ParserImpl<'a> {
             self.ast.ts_type_constructor_type(
                 span,
                 r#abstract,
+                type_parameters,
                 params,
                 return_type,
-                type_parameters,
             )
         } else {
-            self.ast.ts_type_function_type(span, this_param, params, return_type, type_parameters)
+            self.ast.ts_type_function_type(span, type_parameters, this_param, params, return_type)
         })
     }
 
@@ -1141,10 +1141,10 @@ impl<'a> ParserImpl<'a> {
         self.bump(Kind::Semicolon);
         Ok(self.ast.ts_signature_call_signature_declaration(
             self.end_span(span),
+            type_parameters,
             this_patam,
             params,
             return_type,
-            type_parameters,
         ))
     }
 
@@ -1162,10 +1162,10 @@ impl<'a> ParserImpl<'a> {
             computed,
             /* optional */ false,
             TSMethodSignatureKind::Get,
+            NONE,
             this_param,
             params,
             return_type,
-            NONE,
         ))
     }
 
@@ -1188,10 +1188,10 @@ impl<'a> ParserImpl<'a> {
             computed,
             /* optional */ false,
             TSMethodSignatureKind::Set,
+            NONE,
             this_param,
             params,
             return_type,
-            NONE,
         ))
     }
 
@@ -1223,10 +1223,10 @@ impl<'a> ParserImpl<'a> {
                 computed,
                 optional,
                 TSMethodSignatureKind::Method,
+                call_signature.type_parameters,
                 call_signature.this_param,
                 call_signature.params,
                 call_signature.return_type,
-                call_signature.type_parameters,
             ))
         } else {
             let type_annotation = self.parse_ts_type_annotation()?;
@@ -1261,9 +1261,9 @@ impl<'a> ParserImpl<'a> {
 
         Ok(self.ast.ts_signature_construct_signature_declaration(
             self.end_span(span),
+            type_parameters,
             params,
             return_type,
-            type_parameters,
         ))
     }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -32,7 +32,7 @@ SCOPES
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 13
+                "node_id": 16
               }
             ]
           }
@@ -53,7 +53,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 17
+            "node_id": 20
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -32,7 +32,7 @@ SCOPES
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 13
+                "node_id": 16
               }
             ]
           }
@@ -53,7 +53,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 17
+            "node_id": 20
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -32,7 +32,7 @@ SCOPES
                 "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
-                "node_id": 14
+                "node_id": 17
               }
             ]
           }
@@ -53,7 +53,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 18
+            "node_id": 21
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -34,7 +34,7 @@ SCOPES
                     "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
-                    "node_id": 15
+                    "node_id": 18
                   }
                 ]
               }
@@ -61,7 +61,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 19
+            "node_id": 22
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -34,7 +34,7 @@ SCOPES
                     "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "U",
-                    "node_id": 21
+                    "node_id": 24
                   }
                 ]
               }
@@ -61,7 +61,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
-            "node_id": 17
+            "node_id": 20
           }
         ]
       },

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -258,18 +258,18 @@ pub(crate) enum AncestorType {
     TSPropertySignatureTypeAnnotation = 230,
     TSIndexSignatureParameters = 231,
     TSIndexSignatureTypeAnnotation = 232,
-    TSCallSignatureDeclarationThisParam = 233,
-    TSCallSignatureDeclarationParams = 234,
-    TSCallSignatureDeclarationReturnType = 235,
-    TSCallSignatureDeclarationTypeParameters = 236,
+    TSCallSignatureDeclarationTypeParameters = 233,
+    TSCallSignatureDeclarationThisParam = 234,
+    TSCallSignatureDeclarationParams = 235,
+    TSCallSignatureDeclarationReturnType = 236,
     TSMethodSignatureKey = 237,
-    TSMethodSignatureThisParam = 238,
-    TSMethodSignatureParams = 239,
-    TSMethodSignatureReturnType = 240,
-    TSMethodSignatureTypeParameters = 241,
-    TSConstructSignatureDeclarationParams = 242,
-    TSConstructSignatureDeclarationReturnType = 243,
-    TSConstructSignatureDeclarationTypeParameters = 244,
+    TSMethodSignatureTypeParameters = 238,
+    TSMethodSignatureThisParam = 239,
+    TSMethodSignatureParams = 240,
+    TSMethodSignatureReturnType = 241,
+    TSConstructSignatureDeclarationTypeParameters = 242,
+    TSConstructSignatureDeclarationParams = 243,
+    TSConstructSignatureDeclarationReturnType = 244,
     TSIndexSignatureNameTypeAnnotation = 245,
     TSInterfaceHeritageExpression = 246,
     TSInterfaceHeritageTypeParameters = 247,
@@ -291,13 +291,13 @@ pub(crate) enum AncestorType {
     TSImportAttributesElements = 263,
     TSImportAttributeName = 264,
     TSImportAttributeValue = 265,
-    TSFunctionTypeThisParam = 266,
-    TSFunctionTypeParams = 267,
-    TSFunctionTypeReturnType = 268,
-    TSFunctionTypeTypeParameters = 269,
-    TSConstructorTypeParams = 270,
-    TSConstructorTypeReturnType = 271,
-    TSConstructorTypeTypeParameters = 272,
+    TSFunctionTypeTypeParameters = 266,
+    TSFunctionTypeThisParam = 267,
+    TSFunctionTypeParams = 268,
+    TSFunctionTypeReturnType = 269,
+    TSConstructorTypeTypeParameters = 270,
+    TSConstructorTypeParams = 271,
+    TSConstructorTypeReturnType = 272,
     TSMappedTypeTypeParameter = 273,
     TSMappedTypeNameType = 274,
     TSMappedTypeTypeAnnotation = 275,
@@ -764,33 +764,33 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSIndexSignatureParameters as u16,
     TSIndexSignatureTypeAnnotation(TSIndexSignatureWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSIndexSignatureTypeAnnotation as u16,
+    TSCallSignatureDeclarationTypeParameters(
+        TSCallSignatureDeclarationWithoutTypeParameters<'a, 't>,
+    ) = AncestorType::TSCallSignatureDeclarationTypeParameters as u16,
     TSCallSignatureDeclarationThisParam(TSCallSignatureDeclarationWithoutThisParam<'a, 't>) =
         AncestorType::TSCallSignatureDeclarationThisParam as u16,
     TSCallSignatureDeclarationParams(TSCallSignatureDeclarationWithoutParams<'a, 't>) =
         AncestorType::TSCallSignatureDeclarationParams as u16,
     TSCallSignatureDeclarationReturnType(TSCallSignatureDeclarationWithoutReturnType<'a, 't>) =
         AncestorType::TSCallSignatureDeclarationReturnType as u16,
-    TSCallSignatureDeclarationTypeParameters(
-        TSCallSignatureDeclarationWithoutTypeParameters<'a, 't>,
-    ) = AncestorType::TSCallSignatureDeclarationTypeParameters as u16,
     TSMethodSignatureKey(TSMethodSignatureWithoutKey<'a, 't>) =
         AncestorType::TSMethodSignatureKey as u16,
+    TSMethodSignatureTypeParameters(TSMethodSignatureWithoutTypeParameters<'a, 't>) =
+        AncestorType::TSMethodSignatureTypeParameters as u16,
     TSMethodSignatureThisParam(TSMethodSignatureWithoutThisParam<'a, 't>) =
         AncestorType::TSMethodSignatureThisParam as u16,
     TSMethodSignatureParams(TSMethodSignatureWithoutParams<'a, 't>) =
         AncestorType::TSMethodSignatureParams as u16,
     TSMethodSignatureReturnType(TSMethodSignatureWithoutReturnType<'a, 't>) =
         AncestorType::TSMethodSignatureReturnType as u16,
-    TSMethodSignatureTypeParameters(TSMethodSignatureWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSMethodSignatureTypeParameters as u16,
+    TSConstructSignatureDeclarationTypeParameters(
+        TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't>,
+    ) = AncestorType::TSConstructSignatureDeclarationTypeParameters as u16,
     TSConstructSignatureDeclarationParams(TSConstructSignatureDeclarationWithoutParams<'a, 't>) =
         AncestorType::TSConstructSignatureDeclarationParams as u16,
     TSConstructSignatureDeclarationReturnType(
         TSConstructSignatureDeclarationWithoutReturnType<'a, 't>,
     ) = AncestorType::TSConstructSignatureDeclarationReturnType as u16,
-    TSConstructSignatureDeclarationTypeParameters(
-        TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't>,
-    ) = AncestorType::TSConstructSignatureDeclarationTypeParameters as u16,
     TSIndexSignatureNameTypeAnnotation(TSIndexSignatureNameWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSIndexSignatureNameTypeAnnotation as u16,
     TSInterfaceHeritageExpression(TSInterfaceHeritageWithoutExpression<'a, 't>) =
@@ -832,20 +832,20 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSImportAttributeName as u16,
     TSImportAttributeValue(TSImportAttributeWithoutValue<'a, 't>) =
         AncestorType::TSImportAttributeValue as u16,
+    TSFunctionTypeTypeParameters(TSFunctionTypeWithoutTypeParameters<'a, 't>) =
+        AncestorType::TSFunctionTypeTypeParameters as u16,
     TSFunctionTypeThisParam(TSFunctionTypeWithoutThisParam<'a, 't>) =
         AncestorType::TSFunctionTypeThisParam as u16,
     TSFunctionTypeParams(TSFunctionTypeWithoutParams<'a, 't>) =
         AncestorType::TSFunctionTypeParams as u16,
     TSFunctionTypeReturnType(TSFunctionTypeWithoutReturnType<'a, 't>) =
         AncestorType::TSFunctionTypeReturnType as u16,
-    TSFunctionTypeTypeParameters(TSFunctionTypeWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSFunctionTypeTypeParameters as u16,
+    TSConstructorTypeTypeParameters(TSConstructorTypeWithoutTypeParameters<'a, 't>) =
+        AncestorType::TSConstructorTypeTypeParameters as u16,
     TSConstructorTypeParams(TSConstructorTypeWithoutParams<'a, 't>) =
         AncestorType::TSConstructorTypeParams as u16,
     TSConstructorTypeReturnType(TSConstructorTypeWithoutReturnType<'a, 't>) =
         AncestorType::TSConstructorTypeReturnType as u16,
-    TSConstructorTypeTypeParameters(TSConstructorTypeWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSConstructorTypeTypeParameters as u16,
     TSMappedTypeTypeParameter(TSMappedTypeWithoutTypeParameter<'a, 't>) =
         AncestorType::TSMappedTypeTypeParameter as u16,
     TSMappedTypeNameType(TSMappedTypeWithoutNameType<'a, 't>) =
@@ -1658,10 +1658,10 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_call_signature_declaration(self) -> bool {
         matches!(
             self,
-            Self::TSCallSignatureDeclarationThisParam(_)
+            Self::TSCallSignatureDeclarationTypeParameters(_)
+                | Self::TSCallSignatureDeclarationThisParam(_)
                 | Self::TSCallSignatureDeclarationParams(_)
                 | Self::TSCallSignatureDeclarationReturnType(_)
-                | Self::TSCallSignatureDeclarationTypeParameters(_)
         )
     }
 
@@ -1670,10 +1670,10 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::TSMethodSignatureKey(_)
+                | Self::TSMethodSignatureTypeParameters(_)
                 | Self::TSMethodSignatureThisParam(_)
                 | Self::TSMethodSignatureParams(_)
                 | Self::TSMethodSignatureReturnType(_)
-                | Self::TSMethodSignatureTypeParameters(_)
         )
     }
 
@@ -1681,9 +1681,9 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_construct_signature_declaration(self) -> bool {
         matches!(
             self,
-            Self::TSConstructSignatureDeclarationParams(_)
+            Self::TSConstructSignatureDeclarationTypeParameters(_)
+                | Self::TSConstructSignatureDeclarationParams(_)
                 | Self::TSConstructSignatureDeclarationReturnType(_)
-                | Self::TSConstructSignatureDeclarationTypeParameters(_)
         )
     }
 
@@ -1761,10 +1761,10 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_function_type(self) -> bool {
         matches!(
             self,
-            Self::TSFunctionTypeThisParam(_)
+            Self::TSFunctionTypeTypeParameters(_)
+                | Self::TSFunctionTypeThisParam(_)
                 | Self::TSFunctionTypeParams(_)
                 | Self::TSFunctionTypeReturnType(_)
-                | Self::TSFunctionTypeTypeParameters(_)
         )
     }
 
@@ -1772,9 +1772,9 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_constructor_type(self) -> bool {
         matches!(
             self,
-            Self::TSConstructorTypeParams(_)
+            Self::TSConstructorTypeTypeParameters(_)
+                | Self::TSConstructorTypeParams(_)
                 | Self::TSConstructorTypeReturnType(_)
-                | Self::TSConstructorTypeTypeParameters(_)
         )
     }
 
@@ -10865,134 +10865,14 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
 
 pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN: usize =
     offset_of!(TSCallSignatureDeclaration, span);
+pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS: usize =
+    offset_of!(TSCallSignatureDeclaration, type_parameters);
 pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM: usize =
     offset_of!(TSCallSignatureDeclaration, this_param);
 pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS: usize =
     offset_of!(TSCallSignatureDeclaration, params);
 pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE: usize =
     offset_of!(TSCallSignatureDeclaration, return_type);
-pub(crate) const OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS: usize =
-    offset_of!(TSCallSignatureDeclaration, type_parameters);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSCallSignatureDeclarationWithoutThisParam<'a, 't>(
-    pub(crate) *const TSCallSignatureDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSCallSignatureDeclarationWithoutParams<'a, 't>(
-    pub(crate) *const TSCallSignatureDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSCallSignatureDeclarationWithoutReturnType<'a, 't>(
-    pub(crate) *const TSCallSignatureDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -11034,6 +10914,126 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 }
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSCallSignatureDeclarationWithoutThisParam<'a, 't>(
+    pub(crate) *const TSCallSignatureDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSCallSignatureDeclarationWithoutParams<'a, 't>(
+    pub(crate) *const TSCallSignatureDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
+                as *const Option<TSThisParameter<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSCallSignatureDeclarationWithoutReturnType<'a, 't>(
+    pub(crate) *const TSCallSignatureDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
+                as *const Option<TSThisParameter<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+}
+
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_SPAN: usize = offset_of!(TSMethodSignature, span);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_KEY: usize = offset_of!(TSMethodSignature, key);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_COMPUTED: usize =
@@ -11041,13 +11041,13 @@ pub(crate) const OFFSET_TS_METHOD_SIGNATURE_COMPUTED: usize =
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_OPTIONAL: usize =
     offset_of!(TSMethodSignature, optional);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_KIND: usize = offset_of!(TSMethodSignature, kind);
+pub(crate) const OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS: usize =
+    offset_of!(TSMethodSignature, type_parameters);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM: usize =
     offset_of!(TSMethodSignature, this_param);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_PARAMS: usize = offset_of!(TSMethodSignature, params);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE: usize =
     offset_of!(TSMethodSignature, return_type);
-pub(crate) const OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS: usize =
-    offset_of!(TSMethodSignature, type_parameters);
 pub(crate) const OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID: usize =
     offset_of!(TSMethodSignature, scope_id);
 
@@ -11083,6 +11083,14 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
@@ -11103,227 +11111,6 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSMethodSignatureWithoutThisParam<'a, 't>(
-    pub(crate) *const TSMethodSignature<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn key(self) -> &'t PropertyKey<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn computed(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
-    }
-
-    #[inline]
-    pub fn optional(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
-    }
-
-    #[inline]
-    pub fn kind(self) -> &'t TSMethodSignatureKind {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
-                as *const TSMethodSignatureKind)
-        }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSMethodSignatureWithoutParams<'a, 't>(
-    pub(crate) *const TSMethodSignature<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn key(self) -> &'t PropertyKey<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn computed(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
-    }
-
-    #[inline]
-    pub fn optional(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
-    }
-
-    #[inline]
-    pub fn kind(self) -> &'t TSMethodSignatureKind {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
-                as *const TSMethodSignatureKind)
-        }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSMethodSignatureWithoutReturnType<'a, 't>(
-    pub(crate) *const TSMethodSignature<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn key(self) -> &'t PropertyKey<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn computed(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
-    }
-
-    #[inline]
-    pub fn optional(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
-    }
-
-    #[inline]
-    pub fn kind(self) -> &'t TSMethodSignatureKind {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
-                as *const TSMethodSignatureKind)
-        }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -11407,98 +11194,229 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN: usize =
-    offset_of!(TSConstructSignatureDeclaration, span);
-pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS: usize =
-    offset_of!(TSConstructSignatureDeclaration, params);
-pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE: usize =
-    offset_of!(TSConstructSignatureDeclaration, return_type);
-pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS: usize =
-    offset_of!(TSConstructSignatureDeclaration, type_parameters);
-pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID: usize =
-    offset_of!(TSConstructSignatureDeclaration, scope_id);
-
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSConstructSignatureDeclarationWithoutParams<'a, 't>(
-    pub(crate) *const TSConstructSignatureDeclaration<'a>,
+pub struct TSMethodSignatureWithoutThisParam<'a, 't>(
+    pub(crate) *const TSMethodSignature<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
+impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn key(self) -> &'t PropertyKey<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN)
-                as *const Span)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn computed(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
+    }
+
+    #[inline]
+    pub fn optional(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
+    }
+
+    #[inline]
+    pub fn kind(self) -> &'t TSMethodSignatureKind {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
+                as *const TSMethodSignatureKind)
         }
     }
 
     #[inline]
     pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSConstructSignatureDeclarationWithoutReturnType<'a, 't>(
-    pub(crate) *const TSConstructSignatureDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN)
-                as *const Span)
         }
     }
 
     #[inline]
     pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
                 as *const Box<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
     pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
     }
 }
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSMethodSignatureWithoutParams<'a, 't>(
+    pub(crate) *const TSMethodSignature<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn key(self) -> &'t PropertyKey<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn computed(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
+    }
+
+    #[inline]
+    pub fn optional(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
+    }
+
+    #[inline]
+    pub fn kind(self) -> &'t TSMethodSignatureKind {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
+                as *const TSMethodSignatureKind)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSMethodSignatureWithoutReturnType<'a, 't>(
+    pub(crate) *const TSMethodSignature<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn key(self) -> &'t PropertyKey<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KEY) as *const PropertyKey<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn computed(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_COMPUTED) as *const bool) }
+    }
+
+    #[inline]
+    pub fn optional(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_OPTIONAL) as *const bool) }
+    }
+
+    #[inline]
+    pub fn kind(self) -> &'t TSMethodSignatureKind {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_KIND)
+                as *const TSMethodSignatureKind)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN: usize =
+    offset_of!(TSConstructSignatureDeclaration, span);
+pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS: usize =
+    offset_of!(TSConstructSignatureDeclaration, type_parameters);
+pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS: usize =
+    offset_of!(TSConstructSignatureDeclaration, params);
+pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE: usize =
+    offset_of!(TSConstructSignatureDeclaration, return_type);
+pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID: usize =
+    offset_of!(TSConstructSignatureDeclaration, scope_id);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -11529,6 +11447,88 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSConstructSignatureDeclarationWithoutParams<'a, 't>(
+    pub(crate) *const TSConstructSignatureDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN)
+                as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSConstructSignatureDeclarationWithoutReturnType<'a, 't>(
+    pub(crate) *const TSConstructSignatureDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN)
+                as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
         }
     }
 
@@ -12186,126 +12186,12 @@ impl<'a, 't> TSImportAttributeWithoutValue<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_FUNCTION_TYPE_SPAN: usize = offset_of!(TSFunctionType, span);
+pub(crate) const OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS: usize =
+    offset_of!(TSFunctionType, type_parameters);
 pub(crate) const OFFSET_TS_FUNCTION_TYPE_THIS_PARAM: usize = offset_of!(TSFunctionType, this_param);
 pub(crate) const OFFSET_TS_FUNCTION_TYPE_PARAMS: usize = offset_of!(TSFunctionType, params);
 pub(crate) const OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE: usize =
     offset_of!(TSFunctionType, return_type);
-pub(crate) const OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS: usize =
-    offset_of!(TSFunctionType, type_parameters);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSFunctionTypeWithoutThisParam<'a, 't>(
-    pub(crate) *const TSFunctionType<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSFunctionTypeWithoutParams<'a, 't>(
-    pub(crate) *const TSFunctionType<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSFunctionTypeWithoutReturnType<'a, 't>(
-    pub(crate) *const TSFunctionType<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -12345,84 +12231,128 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_SPAN: usize = offset_of!(TSConstructorType, span);
-pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT: usize =
-    offset_of!(TSConstructorType, r#abstract);
-pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS: usize = offset_of!(TSConstructorType, params);
-pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE: usize =
-    offset_of!(TSConstructorType, return_type);
-pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS: usize =
-    offset_of!(TSConstructorType, type_parameters);
-
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSConstructorTypeWithoutParams<'a, 't>(
-    pub(crate) *const TSConstructorType<'a>,
+pub struct TSFunctionTypeWithoutThisParam<'a, 't>(
+    pub(crate) *const TSFunctionType<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
+impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn r#abstract(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT) as *const bool) }
-    }
-
-    #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
-        }
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
     }
 
     #[inline]
     pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
         }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSConstructorTypeWithoutReturnType<'a, 't>(
-    pub(crate) *const TSConstructorType<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn r#abstract(self) -> &'t bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT) as *const bool) }
     }
 
     #[inline]
     pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
                 as *const Box<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
+                as *const Box<'a, TSTypeAnnotation<'a>>)
         }
     }
 }
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSFunctionTypeWithoutParams<'a, 't>(
+    pub(crate) *const TSFunctionType<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
+                as *const Box<'a, TSTypeAnnotation<'a>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSFunctionTypeWithoutReturnType<'a, 't>(
+    pub(crate) *const TSFunctionType<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+}
+
+pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_SPAN: usize = offset_of!(TSConstructorType, span);
+pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT: usize =
+    offset_of!(TSConstructorType, r#abstract);
+pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS: usize =
+    offset_of!(TSConstructorType, type_parameters);
+pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS: usize = offset_of!(TSConstructorType, params);
+pub(crate) const OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE: usize =
+    offset_of!(TSConstructorType, return_type);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -12455,6 +12385,76 @@ impl<'a, 't> TSConstructorTypeWithoutTypeParameters<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
                 as *const Box<'a, TSTypeAnnotation<'a>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSConstructorTypeWithoutParams<'a, 't>(
+    pub(crate) *const TSConstructorType<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn r#abstract(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT) as *const bool) }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
+                as *const Box<'a, TSTypeAnnotation<'a>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct TSConstructorTypeWithoutReturnType<'a, 't>(
+    pub(crate) *const TSConstructorType<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn r#abstract(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_ABSTRACT) as *const bool) }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4732,13 +4732,20 @@ pub(crate) unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_call_signature_declaration(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSCallSignatureDeclarationThisParam(
-        ancestor::TSCallSignatureDeclarationWithoutThisParam(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSCallSignatureDeclarationTypeParameters(
+        ancestor::TSCallSignatureDeclarationWithoutTypeParameters(node, PhantomData),
     ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
         as *mut Option<TSThisParameter>)
     {
+        ctx.retag_stack(AncestorType::TSCallSignatureDeclarationThisParam);
         walk_ts_this_parameter(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSCallSignatureDeclarationParams);
@@ -4754,13 +4761,6 @@ pub(crate) unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
-    }
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::TSCallSignatureDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_call_signature_declaration(&mut *node, ctx);
@@ -4788,6 +4788,13 @@ pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
         as *mut Option<Box<TSThisParameter>>)
     {
@@ -4808,13 +4815,6 @@ pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::TSMethodSignatureReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
-    }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
     traverser.exit_ts_method_signature(&mut *node, ctx);
@@ -4833,9 +4833,16 @@ pub(crate) unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a
             .get()
             .unwrap(),
     );
-    let pop_token = ctx.push_stack(Ancestor::TSConstructSignatureDeclarationParams(
-        ancestor::TSConstructSignatureDeclarationWithoutParams(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSConstructSignatureDeclarationTypeParameters(
+        ancestor::TSConstructSignatureDeclarationWithoutTypeParameters(node, PhantomData),
     ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationParams);
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
@@ -4848,13 +4855,6 @@ pub(crate) unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a
     {
         ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
-    }
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
     ctx.set_current_scope_id(previous_scope_id);
@@ -5229,12 +5229,19 @@ pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_function_type(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSFunctionTypeThisParam(
-        ancestor::TSFunctionTypeWithoutThisParam(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSFunctionTypeTypeParameters(
+        ancestor::TSFunctionTypeWithoutTypeParameters(node, PhantomData),
     ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
         as *mut Option<Box<TSThisParameter>>)
     {
+        ctx.retag_stack(AncestorType::TSFunctionTypeThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSFunctionTypeParams);
@@ -5251,13 +5258,6 @@ pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
             as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::TSFunctionTypeTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
-    }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_function_type(&mut *node, ctx);
 }
@@ -5268,9 +5268,16 @@ pub(crate) unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_constructor_type(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSConstructorTypeParams(
-        ancestor::TSConstructorTypeWithoutParams(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSConstructorTypeTypeParameters(
+        ancestor::TSConstructorTypeWithoutTypeParameters(node, PhantomData),
     ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSConstructorTypeParams);
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
@@ -5284,13 +5291,6 @@ pub(crate) unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
             as *mut Box<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::TSConstructorTypeTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
-    }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_constructor_type(&mut *node, ctx);
 }

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -247,7 +247,7 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["M"]
 rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch for "AbstractClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "ConcreteClass":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
@@ -258,7 +258,7 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["M"]
 rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch for "AbstractClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "ConcreteClass":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -5131,7 +5131,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch for "DEFAULT_TABS_TAG":
-after transform: SymbolId(2): [ReferenceId(11), ReferenceId(17)]
+after transform: SymbolId(2): [ReferenceId(11), ReferenceId(15)]
 rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "TabGroup":
 after transform: SymbolId(10) "TabGroup"
@@ -5148,7 +5148,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch for "DEFAULT_TABS_TAG":
-after transform: SymbolId(6): [ReferenceId(17), ReferenceId(23)]
+after transform: SymbolId(6): [ReferenceId(17), ReferenceId(21)]
 rebuilt        : SymbolId(0): []
 Reference symbol mismatch for "TabGroup":
 after transform: SymbolId(14) "TabGroup"
@@ -9023,13 +9023,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(13)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(11)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(10)]
+after transform: SymbolId(2): [ReferenceId(8)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
@@ -21454,7 +21454,7 @@ Bindings mismatch:
 after transform: ScopeId(7): ["S"]
 rebuilt        : ScopeId(3): []
 Symbol reference IDs mismatch for "Table":
-after transform: SymbolId(4): [ReferenceId(14), ReferenceId(16), ReferenceId(21), ReferenceId(25)]
+after transform: SymbolId(4): [ReferenceId(14), ReferenceId(17), ReferenceId(22), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Unresolved references mismatch:
 after transform: ["Array", "Pick", "Record"]
@@ -24652,7 +24652,7 @@ Bindings mismatch:
 after transform: ScopeId(7): ["T"]
 rebuilt        : ScopeId(5): []
 Symbol reference IDs mismatch for "FeatureRunner":
-after transform: SymbolId(3): [ReferenceId(0)]
+after transform: SymbolId(3): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Promise", "const"]
@@ -55502,7 +55502,7 @@ Bindings mismatch:
 after transform: ScopeId(4): ["T", "a", "x"]
 rebuilt        : ScopeId(3): ["a", "x"]
 Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(24)]
+after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(24)]
 rebuilt        : [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
@@ -55519,7 +55519,7 @@ Bindings mismatch:
 after transform: ScopeId(9): ["T", "U", "a", "x", "y"]
 rebuilt        : ScopeId(8): ["a", "x", "y"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(27), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(36), ReferenceId(37), ReferenceId(39), ReferenceId(40), ReferenceId(49), ReferenceId(50)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40), ReferenceId(49), ReferenceId(50)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(12), ReferenceId(15), ReferenceId(17), ReferenceId(22), ReferenceId(42)]
@@ -55539,7 +55539,7 @@ Bindings mismatch:
 after transform: ScopeId(9): ["T", "U", "a", "x"]
 rebuilt        : ScopeId(8): ["a", "x"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(27), ReferenceId(32), ReferenceId(39)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30), ReferenceId(39)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(23), ReferenceId(36), ReferenceId(38), ReferenceId(46)]
@@ -55822,10 +55822,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(41), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(80), ReferenceId(88), ReferenceId(90), ReferenceId(95), ReferenceId(97), ReferenceId(108)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(40), ReferenceId(56), ReferenceId(61), ReferenceId(67), ReferenceId(75), ReferenceId(85), ReferenceId(90), ReferenceId(92), ReferenceId(99), ReferenceId(107)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(60), ReferenceId(66), ReferenceId(74), ReferenceId(81), ReferenceId(84), ReferenceId(93), ReferenceId(101)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(57), ReferenceId(62), ReferenceId(68), ReferenceId(76), ReferenceId(82), ReferenceId(95), ReferenceId(97)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(28)]
@@ -55842,13 +55842,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(34), ReferenceId(40), ReferenceId(46), ReferenceId(61), ReferenceId(66)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(58), ReferenceId(66)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(13), ReferenceId(30), ReferenceId(37), ReferenceId(62)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(59)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(43)]
+after transform: SymbolId(2): [ReferenceId(41)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
@@ -55859,10 +55859,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(53), ReferenceId(58), ReferenceId(64), ReferenceId(72), ReferenceId(82), ReferenceId(87), ReferenceId(89), ReferenceId(96)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(57), ReferenceId(63), ReferenceId(71), ReferenceId(78), ReferenceId(81), ReferenceId(90), ReferenceId(98)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(54), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(79), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(28)]
@@ -55879,10 +55879,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(18)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(41), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(80), ReferenceId(88), ReferenceId(90), ReferenceId(95), ReferenceId(97), ReferenceId(108)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(40), ReferenceId(56), ReferenceId(61), ReferenceId(67), ReferenceId(75), ReferenceId(85), ReferenceId(90), ReferenceId(92), ReferenceId(99), ReferenceId(107)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(60), ReferenceId(66), ReferenceId(74), ReferenceId(81), ReferenceId(84), ReferenceId(93), ReferenceId(101)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(57), ReferenceId(62), ReferenceId(68), ReferenceId(76), ReferenceId(82), ReferenceId(95), ReferenceId(97)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(28)]
@@ -55899,13 +55899,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(18)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(29), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(53), ReferenceId(71), ReferenceId(76), ReferenceId(85), ReferenceId(87), ReferenceId(91), ReferenceId(94)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(27), ReferenceId(35), ReferenceId(41), ReferenceId(48), ReferenceId(51), ReferenceId(68), ReferenceId(76), ReferenceId(83), ReferenceId(86), ReferenceId(88), ReferenceId(92)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(13), ReferenceId(32), ReferenceId(34), ReferenceId(40), ReferenceId(47), ReferenceId(72)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(30), ReferenceId(33), ReferenceId(37), ReferenceId(45), ReferenceId(69)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(56)]
+after transform: SymbolId(2): [ReferenceId(54)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
@@ -55916,10 +55916,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(53), ReferenceId(58), ReferenceId(64), ReferenceId(72), ReferenceId(82), ReferenceId(87), ReferenceId(89), ReferenceId(96)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(57), ReferenceId(63), ReferenceId(71), ReferenceId(78), ReferenceId(81), ReferenceId(90), ReferenceId(98)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(54), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(79), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(28)]
@@ -56475,10 +56475,10 @@ Bindings mismatch:
 after transform: ScopeId(78): ["T", "x"]
 rebuilt        : ScopeId(42): ["x"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(34), ReferenceId(37), ReferenceId(44), ReferenceId(56), ReferenceId(103), ReferenceId(108), ReferenceId(110), ReferenceId(117), ReferenceId(123), ReferenceId(125), ReferenceId(133), ReferenceId(141), ReferenceId(143), ReferenceId(145), ReferenceId(153), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(183), ReferenceId(187), ReferenceId(195), ReferenceId(197), ReferenceId(202), ReferenceId(216), ReferenceId(220), ReferenceId(245)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(34), ReferenceId(37), ReferenceId(44), ReferenceId(55), ReferenceId(103), ReferenceId(108), ReferenceId(110), ReferenceId(117), ReferenceId(123), ReferenceId(125), ReferenceId(133), ReferenceId(141), ReferenceId(143), ReferenceId(145), ReferenceId(153), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(183), ReferenceId(187), ReferenceId(195), ReferenceId(197), ReferenceId(202), ReferenceId(216), ReferenceId(220), ReferenceId(245)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(32), ReferenceId(41), ReferenceId(46), ReferenceId(48), ReferenceId(54), ReferenceId(104), ReferenceId(109), ReferenceId(118), ReferenceId(124), ReferenceId(126), ReferenceId(134), ReferenceId(142), ReferenceId(144), ReferenceId(146), ReferenceId(154), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(172), ReferenceId(175), ReferenceId(176), ReferenceId(200), ReferenceId(206), ReferenceId(214), ReferenceId(222), ReferenceId(224)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(32), ReferenceId(41), ReferenceId(46), ReferenceId(48), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(118), ReferenceId(124), ReferenceId(126), ReferenceId(134), ReferenceId(142), ReferenceId(144), ReferenceId(146), ReferenceId(154), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(172), ReferenceId(175), ReferenceId(176), ReferenceId(200), ReferenceId(206), ReferenceId(214), ReferenceId(222), ReferenceId(224)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(39), ReferenceId(204)]
@@ -56560,13 +56560,13 @@ Bindings mismatch:
 after transform: ScopeId(54): ["T", "x"]
 rebuilt        : ScopeId(32): ["x"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(35), ReferenceId(41), ReferenceId(50), ReferenceId(57), ReferenceId(59), ReferenceId(67), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(89), ReferenceId(90), ReferenceId(101), ReferenceId(109), ReferenceId(117), ReferenceId(119), ReferenceId(136)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(33), ReferenceId(39), ReferenceId(50), ReferenceId(57), ReferenceId(59), ReferenceId(67), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(89), ReferenceId(90), ReferenceId(101), ReferenceId(109), ReferenceId(117), ReferenceId(119), ReferenceId(136)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(32), ReferenceId(51), ReferenceId(58), ReferenceId(68), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(86), ReferenceId(97), ReferenceId(113)]
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(30), ReferenceId(51), ReferenceId(58), ReferenceId(68), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(86), ReferenceId(97), ReferenceId(113)]
 rebuilt        : SymbolId(3): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
+after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
 rebuilt        : SymbolId(4): []
 Unresolved references mismatch:
 after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
@@ -56637,13 +56637,13 @@ Bindings mismatch:
 after transform: ScopeId(46): ["T", "x"]
 rebuilt        : ScopeId(24): ["x"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(34), ReferenceId(40), ReferenceId(46), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(13), ReferenceId(30), ReferenceId(37), ReferenceId(97), ReferenceId(103)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(43)]
+after transform: SymbolId(2): [ReferenceId(41)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures.ts
@@ -56672,10 +56672,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(36), ScopeId(37), ScopeId(40), ScopeId(41), ScopeId(44), ScopeId(45), ScopeId(52)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(34), ReferenceId(37), ReferenceId(44), ReferenceId(56), ReferenceId(106), ReferenceId(108), ReferenceId(110), ReferenceId(121), ReferenceId(123), ReferenceId(125), ReferenceId(139), ReferenceId(141), ReferenceId(143), ReferenceId(145), ReferenceId(158), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(186), ReferenceId(187), ReferenceId(195), ReferenceId(200), ReferenceId(202), ReferenceId(214), ReferenceId(220), ReferenceId(246)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(34), ReferenceId(37), ReferenceId(44), ReferenceId(55), ReferenceId(103), ReferenceId(108), ReferenceId(110), ReferenceId(117), ReferenceId(123), ReferenceId(125), ReferenceId(133), ReferenceId(141), ReferenceId(143), ReferenceId(145), ReferenceId(153), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(183), ReferenceId(187), ReferenceId(195), ReferenceId(197), ReferenceId(202), ReferenceId(216), ReferenceId(220), ReferenceId(245)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(32), ReferenceId(41), ReferenceId(46), ReferenceId(48), ReferenceId(54), ReferenceId(107), ReferenceId(109), ReferenceId(122), ReferenceId(124), ReferenceId(126), ReferenceId(140), ReferenceId(142), ReferenceId(144), ReferenceId(146), ReferenceId(159), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(174), ReferenceId(175), ReferenceId(176), ReferenceId(198), ReferenceId(206), ReferenceId(218), ReferenceId(222), ReferenceId(224)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(13), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(32), ReferenceId(41), ReferenceId(46), ReferenceId(48), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(118), ReferenceId(124), ReferenceId(126), ReferenceId(134), ReferenceId(142), ReferenceId(144), ReferenceId(146), ReferenceId(154), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(172), ReferenceId(175), ReferenceId(176), ReferenceId(200), ReferenceId(206), ReferenceId(214), ReferenceId(222), ReferenceId(224)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(39), ReferenceId(204)]
@@ -56715,13 +56715,13 @@ Scope children mismatch:
 after transform: ScopeId(36): [ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40)]
 rebuilt        : ScopeId(6): []
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(35), ReferenceId(41), ReferenceId(55), ReferenceId(58), ReferenceId(60), ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(90), ReferenceId(91), ReferenceId(102), ReferenceId(110), ReferenceId(116), ReferenceId(118), ReferenceId(139)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(33), ReferenceId(39), ReferenceId(51), ReferenceId(58), ReferenceId(60), ReferenceId(68), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(90), ReferenceId(91), ReferenceId(102), ReferenceId(110), ReferenceId(118), ReferenceId(120), ReferenceId(137)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(59), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(89), ReferenceId(101), ReferenceId(114)]
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(30), ReferenceId(52), ReferenceId(59), ReferenceId(69), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(87), ReferenceId(98), ReferenceId(114)]
 rebuilt        : SymbolId(3): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(57), ReferenceId(61), ReferenceId(112), ReferenceId(121)]
+after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(53), ReferenceId(61), ReferenceId(112), ReferenceId(116)]
 rebuilt        : SymbolId(4): []
 Unresolved references mismatch:
 after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
@@ -56735,13 +56735,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(26), ScopeId(27), ScopeId(34)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(34), ReferenceId(40), ReferenceId(46), ReferenceId(99), ReferenceId(104), ReferenceId(114), ReferenceId(118), ReferenceId(140), ReferenceId(144)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(13), ReferenceId(30), ReferenceId(37), ReferenceId(100), ReferenceId(102)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(43)]
+after transform: SymbolId(2): [ReferenceId(41)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
@@ -56752,10 +56752,10 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(53), ReferenceId(58), ReferenceId(64), ReferenceId(72), ReferenceId(82), ReferenceId(87), ReferenceId(89), ReferenceId(96)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(57), ReferenceId(63), ReferenceId(71), ReferenceId(78), ReferenceId(81), ReferenceId(90), ReferenceId(98)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(30), ReferenceId(34), ReferenceId(36), ReferenceId(54), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(79), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(28)]
@@ -57264,7 +57264,7 @@ Bindings mismatch:
 after transform: ScopeId(20): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(11): ["x", "y"]
 Symbol reference IDs mismatch for "One":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(31)]
+after transform: SymbolId(0): [ReferenceId(5), ReferenceId(29)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Two":
 after transform: SymbolId(1): [ReferenceId(9), ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104)]
@@ -57646,7 +57646,7 @@ Bindings mismatch:
 after transform: ScopeId(18): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(9): ["x", "y"]
 Symbol reference IDs mismatch for "One":
-after transform: SymbolId(0): [ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(25)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Two":
 after transform: SymbolId(1): [ReferenceId(5), ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84)]
@@ -58331,13 +58331,13 @@ Bindings mismatch:
 after transform: ScopeId(17): ["T", "U", "x"]
 rebuilt        : ScopeId(17): ["x"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(22), ReferenceId(29), ReferenceId(56), ReferenceId(61), ReferenceId(90), ReferenceId(118), ReferenceId(121), ReferenceId(124)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(22), ReferenceId(29), ReferenceId(56), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(13), ReferenceId(18), ReferenceId(23), ReferenceId(30), ReferenceId(39), ReferenceId(47), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(91), ReferenceId(103), ReferenceId(111), ReferenceId(114), ReferenceId(119), ReferenceId(122), ReferenceId(125)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(13), ReferenceId(18), ReferenceId(23), ReferenceId(30), ReferenceId(39), ReferenceId(47), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(43), ReferenceId(48), ReferenceId(53), ReferenceId(107), ReferenceId(112), ReferenceId(115)]
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(43), ReferenceId(48), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments3.ts
@@ -58662,13 +58662,13 @@ Scope children mismatch:
 after transform: ScopeId(9): [ScopeId(10), ScopeId(12)]
 rebuilt        : ScopeId(9): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(8), ReferenceId(18), ReferenceId(19), ReferenceId(40), ReferenceId(50), ReferenceId(56)]
+after transform: SymbolId(0): [ReferenceId(8), ReferenceId(18), ReferenceId(19), ReferenceId(40), ReferenceId(50), ReferenceId(51)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(1): [ReferenceId(10), ReferenceId(27), ReferenceId(42), ReferenceId(58)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "X":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(20), ReferenceId(22), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(41), ReferenceId(51), ReferenceId(53)]
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(20), ReferenceId(22), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(41), ReferenceId(52), ReferenceId(54)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(18), ReferenceId(19)]
 Symbol reference IDs mismatch for "G":
 after transform: SymbolId(5): [ReferenceId(11)]

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -2296,7 +2296,7 @@ Bindings mismatch:
 after transform: ScopeId(1): ["M"]
 rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch for "AbstractClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "ConcreteClass":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]


### PR DESCRIPTION
Our convention is that AST type fields are ordered in order they appear in source. Move `type_parameters` fields in TS function declaration types to before `this_param` and formal parameters.