### PR TITLE
feat(coverage): add `ContentEq` test for regular_expression

### DIFF
--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -2,10 +2,24 @@ commit: d62fa93c
 
 parser_test262 Summary:
 AST Parsed     : 43776/43776 (100.00%)
-Positive Passed: 43776/43776 (100.00%)
+Positive Passed: 43772/43776 (99.99%)
 Negative Passed: 4237/4239 (99.95%)
 Expect Syntax Error: tasks/coverage/test262/test/language/import/import-attributes/json-invalid.js
 Expect Syntax Error: tasks/coverage/test262/test/language/import/import-attributes/json-named-bindings.js
+Expect to Parse: tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T1.js
+
+  × Regular Expression content mismatch for `/[^]a/m`: `[]a` == `[]a`
+Expect to Parse: tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T2.js
+
+  × Regular Expression content mismatch for `/a[^]/`: `a[]` == `a[]`
+Expect to Parse: tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T8.js
+
+  × Regular Expression content mismatch for `/[^]/`: `[]` == `[]`
+Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/separator-regexp.js
+
+  × Regular Expression content mismatch for `/[^]/`: `[]` == `[]`
+
+  × Regular Expression content mismatch for `/\cY/`: `\c` == `\c`
 
   × '0'-prefixed octal literals and octal escape sequences are deprecated
     ╭─[test262/test/annexB/language/expressions/template-literal/legacy-octal-escape-sequence-strict.js:19:4]

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: d62fa93c
 
 semantic_test262 Summary:
 AST Parsed     : 43776/43776 (100.00%)
-Positive Passed: 43576/43776 (99.54%)
+Positive Passed: 43572/43776 (99.53%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(3): ScopeId(4294967294)
@@ -1118,6 +1118,19 @@ tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
 rebuilt        : SymbolId(0): ScopeId(4294967294)
+
+tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T1.js
+semantic error: Regular Expression content mismatch for `/[^]a/m`: `[]a` == `[]a`
+
+tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T2.js
+semantic error: Regular Expression content mismatch for `/a[^]/`: `a[]` == `a[]`
+
+tasks/coverage/test262/test/built-ins/RegExp/S15.10.2.13_A2_T8.js
+semantic error: Regular Expression content mismatch for `/[^]/`: `[]` == `[]`
+
+tasks/coverage/test262/test/built-ins/String/prototype/split/separator-regexp.js
+semantic error: Regular Expression content mismatch for `/[^]/`: `[]` == `[]`
+Regular Expression content mismatch for `/\cY/`: `\c` == `\c`
 
 tasks/coverage/test262/test/language/module-code/eval-rqstd-once.js
 semantic error: Bindings mismatch:

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -11,7 +11,7 @@ use oxc::{
     parser::{ParseOptions, ParserReturn},
     regular_expression::{Parser, ParserOptions},
     semantic::{Semantic, SemanticBuilderReturn},
-    span::{SourceType, Span},
+    span::{cmp::ContentEq, SourceType, Span},
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
 };
@@ -163,27 +163,29 @@ impl Driver {
             };
             let printed1 = pattern.to_string();
             let flags = literal.regex.flags.to_string();
-            let printed2 = match Parser::new(
-                &allocator,
-                &printed1,
-                ParserOptions::default().with_flags(&flags),
-            )
-            .parse()
-            {
-                Ok(pattern) => pattern.to_string(),
+            let options = ParserOptions::default().with_flags(&flags);
+            match Parser::new(&allocator, &printed1, options).parse() {
+                Ok(pattern2) => {
+                    let printed2 = pattern2.to_string();
+                    if !pattern2.content_eq(pattern) {
+                        self.errors.push(OxcDiagnostic::error(format!(
+                        "Regular Expression content mismatch for `{}`: `{pattern}` == `{pattern2}`",
+                        literal.span.source_text(semantic.source_text())
+                        )));
+                    }
+                    if printed1 != printed2 {
+                        self.errors.push(OxcDiagnostic::error(format!(
+                            "Regular Expression mismatch: {printed1} {printed2}"
+                        )));
+                    }
+                }
                 Err(error) => {
                     self.errors.push(OxcDiagnostic::error(format!(
                         "Failed to re-parse `{}`, printed as `/{printed1}/{flags}`, {error}",
                         literal.span.source_text(semantic.source_text()),
                     )));
-                    continue;
                 }
             };
-            if printed1 != printed2 {
-                self.errors.push(OxcDiagnostic::error(format!(
-                    "Regular Expression mismatch: {printed1} {printed2}"
-                )));
-            }
         }
     }
 }


### PR DESCRIPTION
closes #6409

Marking as good first issue if anyone wants to pick this up and fix the failing test.