### PR TITLE
test(minifier): add all test cases for `collapse_variable_declarations`

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
@@ -129,4 +129,145 @@ mod test {
     ",
         );
     }
+
+    #[test]
+    #[ignore]
+    fn test_collapsing() {
+        // Basic collapsing
+        test("var a;var b;", "var a,b;");
+
+        // With initial values
+        test("var a = 1;var b = 1;", "var a=1,b=1;");
+
+        // Already collapsed
+        test_same("var a, b;");
+
+        // Already collapsed with values
+        test_same("var a = 1, b = 1;");
+
+        // Some already collapsed
+        test("var a;var b, c;var d;", "var a,b,c,d;");
+
+        // Some already collapsed with values
+        test("var a = 1;var b = 2, c = 3;var d = 4;", "var a=1,b=2,c=3,d=4;");
+
+        test(
+            "var x = 2; foo(x); x = 3; x = 1; var y = 2; var z = 4; x = 5",
+            "var x = 2; foo(x); x = 3; x = 1; var y = 2, z = 4; x = 5",
+        );
+    }
+
+    #[test]
+    fn test_issue820() {
+        // Don't redeclare function parameters, this is incompatible with
+        // strict mode.
+        test_same("function f(a){ var b=1; a=2; var c; }");
+    }
+
+    #[test]
+    fn test_if_else_var_declarations() {
+        test_same("if (x) var a = 1; else var b = 2;");
+    }
+
+    #[test]
+    fn test_aggressive_redeclaration_in_for() {
+        test_same("for(var x = 1; x = 2; x = 3) {x = 4}");
+        test_same("for(var x = 1; y = 2; z = 3) {var a = 4}");
+        test_same("var x; for(x = 1; x = 2; z = 3) {x = 4}");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_issue397() {
+        test_same("var x; x = 5; var z = 7;");
+        test("var x; var y = 3; x = 5;", "var x, y = 3; x = 5;");
+        test("var a = 1; var x; var y = 3; x = 5;", "var a = 1, x, y = 3; x = 5;");
+        test("var x; var y = 3; x = 5; var z = 7;", "var x, y = 3; x = 5; var z = 7;");
+    }
+
+    #[test]
+    fn test_arguments_assignment() {
+        test_same("function f() {arguments = 1;}");
+    }
+
+    // ES6 Tests
+    #[test]
+    #[ignore]
+    fn test_collapsing_let_const() {
+        // Basic collapsing
+        test("let a;let b;", "let a,b;");
+
+        // With initial values
+        test("const a = 1;const b = 1;", "const a=1,b=1;");
+
+        // Already collapsed
+        test_same("let a, b;");
+
+        // Already collapsed with values
+        test_same("let a = 1, b = 1;");
+
+        // Some already collapsed
+        test("let a;let b, c;let d;", "let a,b,c,d;");
+
+        // Some already collapsed with values
+        test("let a = 1;let b = 2, c = 3;let d = 4;", "let a=1,b=2,c=3,d=4;");
+
+        // Different variable types
+        test_same("let a = 1; const b = 2;");
+    }
+
+    #[test]
+    fn test_if_else_var_declarations_let() {
+        test_same("if (x) { let a = 1; } else { let b = 2; }");
+    }
+
+    #[test]
+    fn test_aggressive_redeclaration_of_let_in_for() {
+        test_same("for(let x = 1; x = 2; x = 3) {x = 4}");
+        test_same("for(let x = 1; y = 2; z = 3) {let a = 4}");
+        test_same("let x; for(x = 1; x = 2; z = 3) {x = 4}");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_redeclaration_let_in_function() {
+        test(
+            "function f() { let x = 1; let y = 2; let z = 3; x + y + z; }",
+            "function f() { let x = 1, y = 2, z = 3; x + y + z; } ",
+        );
+
+        // recognize local scope version of x
+        test(
+            "var x = 1; function f() { let x = 1; let y = 2; x + y; }",
+            "var x = 1; function f() { let x = 1, y = 2; x + y } ",
+        );
+
+        // do not redeclare function parameters
+        // incompatible with strict mode
+        test_same("function f(x) { let y = 3; x = 4; x + y; }");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_arrow_function() {
+        test("() => {let x = 1; let y = 2; x + y; }", "() => {let x = 1, y = 2; x + y; }");
+
+        // do not redeclare function parameters
+        // incompatible with strict mode
+        test_same("(x) => {x = 4; let y = 2; x + y; }");
+    }
+
+    #[test]
+    fn test_uncollapsable_declarations() {
+        test_same("let x = 1; var y = 2; const z = 3");
+        test_same("let x = 1; var y = 2; let z = 3;");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_mixed_declaration_types() {
+        // lets, vars, const declarations consecutive
+        test("let x = 1; let z = 3; var y = 2;", "let x = 1, z = 3; var y = 2;");
+        test("let x = 1; let y = 2; var z = 3; var a = 4;", "let x = 1, y = 2; var z = 3, a = 4");
+    }
 }


### PR DESCRIPTION
closes #6227

I noticed that the implementation of `collapse-variable-declarations` seems incomplete and appears quite simple. Therefore, I would like to quickly add all the test cases to work on this. 

Previously, I saw that `DonIsaac` had also submitted a related PR, but he might have been too busy to respond for a long time. I want to apologize for closing his PR.