### PR TITLE
refactor(codegen): only print necessary parentheses in TSAsExpression

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2092,13 +2092,13 @@ impl<'a> GenExpr for NewExpression<'a> {
 
 impl<'a> GenExpr for TSAsExpression<'a> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        p.print_char(b'(');
-        p.print_char(b'(');
-        self.expression.print_expr(p, precedence, Context::default());
-        p.print_char(b')');
-        p.print_str(" as ");
-        self.type_annotation.print(p, ctx);
-        p.print_char(b')');
+        let wrap = precedence >= Precedence::Shift;
+
+        p.wrap(wrap, |p| {
+            self.expression.print_expr(p, Precedence::Exponentiation, ctx);
+            p.print_str(" as ");
+            self.type_annotation.print(p, ctx);
+        });
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -159,7 +159,7 @@ a = x!;
 ########## 25
 b = (x as y);
 ----------
-b = ((x) as y);
+b = x as y;
 
 ########## 26
 c = foo<string>;
@@ -210,3 +210,18 @@ export type Component<
 	E extends EmitsOptions | Record<string, any[]> = {},
 	S extends Record<string, any> = any
 > = ConcreteComponent<Props, RawBindings, D, C, M, E, S> | ComponentPublicInstanceConstructor<Props>;
+
+########## 32
+(a || b) as any
+----------
+(a || b) as any;
+
+########## 33
+(a ** b) as any
+----------
+(a ** b) as any;
+
+########## 34
+(function g() {}) as any
+----------
+(function g() {}) as any;

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -50,7 +50,10 @@ export type Component<
 > =
   | ConcreteComponent<Props, RawBindings, D, C, M, E, S>
   | ComponentPublicInstanceConstructor<Props>
-"
+",
+"(a || b) as any",
+"(a ** b) as any",
+"(function g() {}) as any",
     ];
 
     snapshot("ts", &cases);


### PR DESCRIPTION
Part of fixing #6385 