### PR TITLE
fix(codegen): invalid codegen when `in` inside bin expr in or loop

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1737,7 +1737,7 @@ impl<'a> GenExpr for LogicalExpression<'a> {
             precedence,
             ctx,
             left_precedence: Precedence::Lowest,
-            left_ctx: Context::empty(),
+            left_ctx: ctx,
             operator: BinaryishOperator::Logical(self.operator),
             wrap: false,
             right_precedence: Precedence::Lowest,

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -279,4 +279,9 @@ fn in_expr_in_sequence_in_for_loop_init() {
         "for (l = ('foo' in bar), i; i < 10; i += 1) {}",
         "for (l = (\"foo\" in bar), i; i < 10; i += 1) {}\n",
     );
+
+    test(
+        "for (('hidden' in a) && (m = a.hidden), r = 0; s > r; r++) {}",
+        "for ((\"hidden\" in a) && (m = a.hidden), r = 0; s > r; r++) {}\n",
+    );
 }


### PR DESCRIPTION
https://github.com/oxc-project/monitor-oxc/actions/runs/11278829870 ??