### PR TITLE
refactor(linter): move module cache logic out of Runtime

### DIFF
--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -11,7 +11,6 @@ use rayon::{iter::ParallelBridge, prelude::ParallelIterator};
 
 use crate::Linter;
 
-use module_cache::{CacheState, CacheStateEntry, ModuleMap, ModuleState};
 use runtime::Runtime;
 
 pub struct LintServiceOptions {
@@ -86,7 +85,7 @@ impl LintService {
     }
 
     pub fn number_of_dependencies(&self) -> usize {
-        self.runtime.module_map.len() - self.runtime.paths.len()
+        self.runtime.modules.len() - self.runtime.paths.len()
     }
 
     /// # Panics

--- a/crates/oxc_linter/src/service/module_cache.rs
+++ b/crates/oxc_linter/src/service/module_cache.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Condvar, Mutex},
 };
 
-use dashmap::DashMap;
+use dashmap::{mapref::one::Ref, DashMap};
 use oxc_semantic::ModuleRecord;
 use rustc_hash::FxHashMap;
 
@@ -16,19 +16,106 @@ use rustc_hash::FxHashMap;
 ///
 /// See the "problem section" in <https://medium.com/@polyglot_factotum/rust-concurrency-patterns-condvars-and-locks-e278f18db74f>
 /// and the solution is copied here to fix the issue.
-pub(super) type CacheState = Mutex<FxHashMap<Box<Path>, Arc<(Mutex<CacheStateEntry>, Condvar)>>>;
+type CacheState = Mutex<FxHashMap<Box<Path>, Arc<(Mutex<CacheStateEntry>, Condvar)>>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum CacheStateEntry {
+enum CacheStateEntry {
     ReadyToConstruct,
     PendingStore(usize),
 }
 
 /// Keyed by canonicalized path
-pub(super) type ModuleMap = DashMap<Box<Path>, ModuleState>;
+type ModuleMap = DashMap<Box<Path>, ModuleState>;
 
 #[derive(Clone)]
 pub(super) enum ModuleState {
     Resolved(Arc<ModuleRecord>),
     Ignored,
+}
+
+#[derive(Default)]
+pub(super) struct ModuleCache {
+    cache_state: Arc<CacheState>,
+    modules: ModuleMap,
+}
+
+impl ModuleCache {
+    #[inline]
+    pub fn get(&self, path: &Path) -> Option<Ref<'_, Box<Path>, ModuleState>> {
+        self.modules.get(path)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.modules.len()
+    }
+
+    pub(super) fn init_cache_state(&self, path: &Path) -> bool {
+        let (lock, cvar) = {
+            let mut state_map = self.cache_state.lock().expect("Failed to lock cache state");
+            &*Arc::clone(state_map.entry(path.to_path_buf().into_boxed_path()).or_insert_with(
+                || Arc::new((Mutex::new(CacheStateEntry::ReadyToConstruct), Condvar::new())),
+            ))
+        };
+        let mut state = cvar
+            .wait_while(lock.lock().expect("Failed lock inner cache state"), |state| {
+                matches!(*state, CacheStateEntry::PendingStore(_))
+            })
+            .unwrap();
+
+        let cache_hit = if self.modules.contains_key(path) {
+            true
+        } else {
+            let i = if let CacheStateEntry::PendingStore(i) = *state { i } else { 0 };
+            *state = CacheStateEntry::PendingStore(i + 1);
+            false
+        };
+
+        if *state == CacheStateEntry::ReadyToConstruct {
+            cvar.notify_one();
+        }
+
+        drop(state);
+        cache_hit
+    }
+
+    /// # Panics
+    /// If a cache entry for `path` does not exist. You must call `init_cache_state` first.
+    pub(super) fn add_resolved_module(&self, path: &Path, module_record: Arc<ModuleRecord>) {
+        self.modules
+            .insert(path.to_path_buf().into_boxed_path(), ModuleState::Resolved(module_record));
+
+        self.update_cache_state(path);
+    }
+
+    /// # Panics
+    /// If a cache entry for `path` does not exist. You must call `init_cache_state` first.
+    pub(super) fn ignore_path(&self, path: &Path) {
+        self.modules.insert(path.to_path_buf().into_boxed_path(), ModuleState::Ignored);
+        self.update_cache_state(path);
+    }
+
+    /// # Panics
+    /// If a cache entry for `path` does not exist. You must call `init_cache_state` first.
+    fn update_cache_state(&self, path: &Path) {
+        let (lock, cvar) = {
+            let mut state_map = self.cache_state.lock().expect("Failed to lock cache state");
+            &*Arc::clone(
+                state_map
+                    .get_mut(path)
+                    .expect("Entry in http-cache state to have been previously inserted"),
+            )
+        };
+        let mut state = lock.lock().expect("Failed lock inner cache state");
+        if let CacheStateEntry::PendingStore(i) = *state {
+            let new = i - 1;
+            if new == 0 {
+                *state = CacheStateEntry::ReadyToConstruct;
+                // Notify the next thread waiting in line, if there is any.
+                cvar.notify_one();
+            } else {
+                *state = CacheStateEntry::PendingStore(new);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Pure refactor. Makes `Runtime` easier to reason about.