### PR TITLE
refactor(linter): make Runtime's members private

### DIFF
--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -85,14 +85,13 @@ impl LintService {
     }
 
     pub fn number_of_dependencies(&self) -> usize {
-        self.runtime.modules.len() - self.runtime.paths.len()
+        self.runtime.number_of_dependencies()
     }
 
     /// # Panics
     pub fn run(&self, tx_error: &DiagnosticSender) {
         self.runtime
-            .paths
-            .iter()
+            .iter_paths()
             .par_bridge()
             .for_each_with(&self.runtime, |runtime, path| runtime.process_path(path, tx_error));
         tx_error.send(None).unwrap();
@@ -108,8 +107,7 @@ impl LintService {
         tx_error: &DiagnosticSender,
     ) -> Vec<crate::Message<'a>> {
         self.runtime
-            .paths
-            .iter()
+            .iter_paths()
             .flat_map(|path| {
                 let source_type = oxc_span::SourceType::from_path(path).unwrap();
                 self.runtime.init_cache_state(path);

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -28,12 +28,12 @@ use super::{
 };
 
 pub struct Runtime {
-    pub(super) cwd: Box<Path>,
+    cwd: Box<Path>,
     /// All paths to lint
-    pub(super) paths: FxHashSet<Box<Path>>,
+    paths: FxHashSet<Box<Path>>,
     pub(super) linter: Linter,
-    pub(super) resolver: Option<Resolver>,
-    pub(super) modules: ModuleCache,
+    resolver: Option<Resolver>,
+    modules: ModuleCache,
 }
 
 impl Runtime {
@@ -300,7 +300,16 @@ impl Runtime {
 
         self.modules.init_cache_state(path)
     }
+
     fn ignore_path(&self, path: &Path) {
         self.resolver.is_some().then(|| self.modules.ignore_path(path));
+    }
+
+    pub(super) fn number_of_dependencies(&self) -> usize {
+        self.modules.len() - self.paths.len()
+    }
+
+    pub(super) fn iter_paths(&self) -> impl Iterator<Item = &Box<Path>> + '_ {
+        self.paths.iter()
     }
 }


### PR DESCRIPTION
Protecting `Runtime`'s API in preparation of multli-config support.