### PR TITLE
fix(parser): do not parse `as` and `satisfies` expression in javascript

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -951,12 +951,13 @@ impl<'a> ParserImpl<'a> {
         // Pratt Parsing Algorithm
         // <https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html>
         let mut lhs = lhs;
+        let is_ts = self.ts_enabled();
         loop {
             // re-lex for `>=` `>>` `>>>`
             // This is need for jsx `<div>=</div>` case
             let kind = self.re_lex_right_angle();
 
-            let Some(left_precedence) = kind_to_precedence(kind) else { break };
+            let Some(left_precedence) = kind_to_precedence(kind, is_ts) else { break };
 
             let stop = if left_precedence.is_right_associative() {
                 left_precedence < min_precedence

--- a/crates/oxc_parser/src/js/operator.rs
+++ b/crates/oxc_parser/src/js/operator.rs
@@ -7,7 +7,7 @@ use oxc_syntax::{
 
 use crate::lexer::Kind;
 
-pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
+pub fn kind_to_precedence(kind: Kind, is_typescript: bool) -> Option<Precedence> {
     match kind {
         Kind::Question2 => Some(Precedence::NullishCoalescing),
         Kind::Pipe2 => Some(Precedence::LogicalOr),
@@ -16,18 +16,14 @@ pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
         Kind::Caret => Some(Precedence::BitwiseXor),
         Kind::Amp => Some(Precedence::BitwiseAnd),
         Kind::Eq2 | Kind::Eq3 | Kind::Neq | Kind::Neq2 => Some(Precedence::Equals),
-        Kind::LAngle
-        | Kind::RAngle
-        | Kind::LtEq
-        | Kind::GtEq
-        | Kind::Instanceof
-        | Kind::In
-        | Kind::As
-        | Kind::Satisfies => Some(Precedence::Compare),
+        Kind::LAngle | Kind::RAngle | Kind::LtEq | Kind::GtEq | Kind::Instanceof | Kind::In => {
+            Some(Precedence::Compare)
+        }
         Kind::ShiftLeft | Kind::ShiftRight | Kind::ShiftRight3 => Some(Precedence::Shift),
         Kind::Plus | Kind::Minus => Some(Precedence::Add),
         Kind::Star | Kind::Slash | Kind::Percent => Some(Precedence::Multiply),
         Kind::Star2 => Some(Precedence::Exponentiation),
+        Kind::As | Kind::Satisfies if is_typescript => Some(Precedence::Compare),
         _ => None,
     }
 }

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -159,9 +159,9 @@ Negative Passed: 20/20 (100.00%)
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[misc/fail/oxc-4111-1.js:1:35]
+   ╭─[misc/fail/oxc-4111-1.js:1:18]
  1 │ funtransientction as longciiConÞr>ol(cde) {
-   ·                                  ▲
+   ·                  ▲
    ╰────
   help: Try insert a semicolon here
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: a709f989
 parser_typescript Summary:
 AST Parsed     : 6470/6479 (99.86%)
 Positive Passed: 6459/6479 (99.69%)
-Negative Passed: 1235/5715 (21.61%)
+Negative Passed: 1236/5715 (21.63%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration10.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration11.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration13.ts
@@ -3130,7 +3130,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressio
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfactionWithDefaultExport.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_optionalMemberConformance.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propNameConstraining.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyNameFulfillment.ts
@@ -8491,11 +8490,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ Foo<number>(1);
    ╰────
 
-  × Expected `<` but found `EOF`
-   ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:2:27]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:1:2]
  1 │ 0 as number;
+   ·  ▲
  2 │ var v = <string>undefined;
    ╰────
+  help: Try insert a semicolon here
 
   × Expected `,` but found `:`
    ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeOfParameter.ts:1:13]
@@ -18678,6 +18679,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/conformance/expressions/typeGuards/typePredicateOnVariableDeclaration02.ts:1:9]
  1 │ var y: z is number;
    ·         ▲
+   ╰────
+  help: Try insert a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts:1:18]
+ 1 │ var v = undefined satisfies 1;
+   ·                  ▲
    ╰────
   help: Try insert a semicolon here
 


### PR DESCRIPTION
closes #6427