### PR TITLE
feat(ast): implement Display for NumericLiteral and BigIntLiteral

### DIFF
--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
 };
-
+use std::fmt::Debug;
 use oxc_allocator::CloneIn;
 use oxc_regular_expression::ast::Pattern;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, Span};
@@ -295,5 +295,20 @@ impl<'a> fmt::Display for StringLiteral<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for NumericLiteral<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // To tell apart from CodeGen, this is the scenario when concat with string.
+        self.value.fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for BigIntLiteral<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.raw.fmt(f)
     }
 }

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -3,16 +3,16 @@
 // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
 #![allow(non_snake_case)]
 
+use oxc_allocator::CloneIn;
+use oxc_regular_expression::ast::Pattern;
+use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, Span};
+use oxc_syntax::number::NumberBase;
+use std::fmt::Debug;
 use std::{
     borrow::Cow,
     fmt,
     hash::{Hash, Hasher},
 };
-use std::fmt::Debug;
-use oxc_allocator::CloneIn;
-use oxc_regular_expression::ast::Pattern;
-use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, Span};
-use oxc_syntax::number::NumberBase;
 
 use crate::ast::*;
 


### PR DESCRIPTION
Used in this scenario:

```js
`a${2}`
```

The minifier should handle it to `"a2"`.

Using the `Display` trait with `ToString` is more elegant I think.