### PR TITLE
refactor(linter): `no_global_assign` rule: reduce name lookups

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -59,19 +59,17 @@ impl Rule for NoGlobalAssign {
 
     fn run_once(&self, ctx: &LintContext) {
         let symbol_table = ctx.symbols();
-        for reference_id_list in ctx.scopes().root_unresolved_references_ids() {
-            for reference_id in reference_id_list {
+        for (name, reference_id_list) in ctx.scopes().root_unresolved_references() {
+            for &reference_id in reference_id_list {
                 let reference = symbol_table.get_reference(reference_id);
-                if reference.is_write() {
-                    let name = ctx.semantic().reference_name(reference);
-                    if !self.excludes.contains(&CompactStr::from(name))
-                        && ctx.env_contains_var(name)
-                    {
-                        ctx.diagnostic(no_global_assign_diagnostic(
-                            name,
-                            ctx.semantic().reference_span(reference),
-                        ));
-                    }
+                if reference.is_write()
+                    && !self.excludes.contains(name)
+                    && ctx.env_contains_var(name)
+                {
+                    ctx.diagnostic(no_global_assign_diagnostic(
+                        name,
+                        ctx.semantic().reference_span(reference),
+                    ));
                 }
             }
         }


### PR DESCRIPTION
2 small optimizations to this lint rule:

1. Get the name for the symbol only once, rather than on each turn of the inner loop (every reference to a symbol has the same name by definition).
2. Avoid creating temporary `CompactStr`s, which causes an allocation if the string is longer than 24 bytes.