### PR TITLE
refactor(linter): make advertised fix kinds consistent

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -78,7 +78,7 @@ declare_oxc_lint!(
     /// ```
     ForDirection,
     correctness,
-    dangerous_fix
+    fix_dangerous
 );
 
 impl Rule for ForDirection {

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     /// ```
     NoCompareNegZero,
     correctness,
-    conditional_suggestion_fix
+    conditional_fix_suggestion
 );
 
 impl Rule for NoCompareNegZero {


### PR DESCRIPTION
- fix_dangerous is already used by `eslint/no-eq-null` and `eslint/no-unexpected-multiline`
- conditional_fix_suggestion is already used by `eslint/func-names`

You can see the doubles here: https://github.com/oxc-project/eslint-plugin-oxlint/blob/main/src/rules-by-category.ts#L477-L495