### PR TITLE
fix(linter): error fixer of `switch-case-braces`

### DIFF
--- a/crates/oxc_linter/src/snapshots/switch_case_braces.snap
+++ b/crates/oxc_linter/src/snapshots/switch_case_braces.snap
@@ -2,6 +2,13 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-unicorn(switch-case-braces):  Empty switch case shouldn't have braces and not-empty case should have braces around it.
+   ╭─[switch_case_braces.tsx:1:18]
+ 1 │ switch(s){case'':/]/}
+   ·                  ───
+   ╰────
+  help: There is less visual clutter for empty cases and proper scope for non-empty cases.
+
+  ⚠ eslint-plugin-unicorn(switch-case-braces):  Empty switch case shouldn't have braces and not-empty case should have braces around it.
    ╭─[switch_case_braces.tsx:1:29]
  1 │ switch(something) { case 1: {} case 2: {console.log('something'); break;}}
    ·                             ──


### PR DESCRIPTION
Related to #6466 

This PR does not fundamentally solve the problem, we need to implement `raw` or `value` for `RegExpLiteral`.

https://github.com/oxc-project/oxc/blob/1ba2a247e1e91f1e0e8685bcad0ad132a70c0603/crates/oxc_codegen/src/gen.rs#L1194-L1198

https://github.com/oxc-project/oxc/blob/1ba2a247e1e91f1e0e8685bcad0ad132a70c0603/crates/oxc_ast/src/ast/literal.rs#L94-L101