### PR TITLE
feat(parser): better errors for reserved words used as identifier names

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -283,6 +283,14 @@ pub fn identifier_generator(x0: &str, span1: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn identifier_reserved_word(span: Span, reserved: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!(
+        "Identifier expected. '{reserved}' is a reserved word that cannot be used here."
+    ))
+    .with_label(span)
+}
+
+#[cold]
 pub fn constructor_generator(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Constructor can't be a generator").with_label(span)
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -72,8 +72,14 @@ impl<'a> ParserImpl<'a> {
 
     /// `BindingIdentifier` : Identifier
     pub(crate) fn parse_binding_identifier(&mut self) -> Result<BindingIdentifier<'a>> {
-        if !self.cur_kind().is_binding_identifier() {
-            return Err(self.unexpected());
+        let cur = self.cur_kind();
+        if !cur.is_binding_identifier() {
+            let err = if cur.is_reserved_keyword() {
+                diagnostics::identifier_reserved_word(self.cur_token().span(), cur.to_str())
+            } else {
+                self.unexpected()
+            };
+            return Err(err);
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.check_identifier(span, &name);

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1316,7 +1316,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ──
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/382/input.js:1:5]
  1 │ var if = 42
    ·     ──
@@ -1411,25 +1411,25 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ───────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/397/input.js:1:12]
  1 │ function t(if) { }
    ·            ──
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'true' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/398/input.js:1:12]
  1 │ function t(true) { }
    ·            ────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'false' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/399/input.js:1:12]
  1 │ function t(false) { }
    ·            ─────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'null' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/400/input.js:1:12]
  1 │ function t(null) { }
    ·            ────
@@ -2192,7 +2192,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: for octal literals use the '0o' prefix instead
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/523/input.js:1:5]
  1 │ var this = 10;
    ·     ────
@@ -2669,14 +2669,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement
 
-  × Unexpected token
+  × Identifier expected. 'const' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/identifiers/invalid-escape-seq-const/input.js:1:5]
  1 │ var co\u{6e}st = 123;
    ·     ──────────
  2 │ 
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/identifiers/invalid-escape-seq-export/input.js:1:5]
  1 │ var expor\u{74} = 123;
    ·     ───────────
@@ -2689,7 +2689,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    · ────────────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'import' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/identifiers/invalid-escape-seq-import/input.js:1:5]
  1 │ var \u{69}\u{6d}\u{70}\u{6f}\u{72}\u{74} = 123;
    ·     ────────────────────────────────────
@@ -3331,13 +3331,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │     return `<div class="bar">Hola</div>`;
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword/input.js:1:10]
  1 │ import { debugger } from "foo";
    ·          ────────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'typeof' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/modules/import-invalid-keyword-typeof/input.js:1:10]
  1 │ import { typeof } from "foo";
    ·          ──────
@@ -3734,25 +3734,25 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                                   ╰── `t` has already been declared here
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'super' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/229/input.js:1:5]
  1 │ var super
    ·     ─────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/230/input.js:1:5]
  1 │ var default
    ·     ───────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/231/input.js:1:5]
  1 │ let default
    ·     ───────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/232/input.js:1:7]
  1 │ const default = 2
    ·       ───────
@@ -4244,13 +4244,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/370/input.js:1:7]
  1 │ const enum = foo();
    ·       ────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/371/input.js:1:7]
  1 │ const enum = foo();
    ·       ────
@@ -8378,7 +8378,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ──
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0064/input.js:1:5]
  1 │ var if = 42
    ·     ──
@@ -9636,7 +9636,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0277/input.js:1:12]
  1 │ class A {a(enum){}}
    ·            ────
@@ -10812,7 +10812,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/export-invalid-type-only-keyword/input.ts:1:7]
  1 │ const if = {};
    ·       ──
@@ -10831,19 +10831,19 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·          ─────────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-invalid-named-type-as-keyword/input.ts:1:18]
  1 │ import { type as if } from "mod";
    ·                  ──
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-invalid-type-named-keywords/input.ts:1:15]
  1 │ import { type if } from "./mod.js";
    ·               ──
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-invalid-type-only-as-as-keyword/input.ts:1:21]
  1 │ import { type as as if } from "mod";
    ·                     ──

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -18310,42 +18310,42 @@ Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/se
  24 │ }
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'class' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/class.js:21:5]
  20 │ 
  21 │ var class = 1;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'const' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/const.js:21:5]
  20 │ 
  21 │ var const = 1;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/debugger.js:21:5]
  20 │ 
  21 │ var debugger = 1;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/enum.js:21:5]
  20 │ 
  21 │ var enum = 1;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/export.js:21:5]
  20 │ 
  21 │ var export = 1;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'extends' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/extends.js:21:5]
  20 │ 
  21 │ var extends = 1;
@@ -18366,7 +18366,7 @@ Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/se
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'import' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/import.js:21:5]
  20 │ 
  21 │ var import = 1;
@@ -18471,7 +18471,7 @@ Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/se
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'super' is a reserved word that cannot be used here.
     ╭─[test262/test/language/future-reserved-words/super.js:21:5]
  20 │ 
  21 │ var super = 1;
@@ -18631,756 +18631,756 @@ Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/se
     ·             ─
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'break' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-break-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{62}\u{72}\u{65}\u{61}\u{6b} = 123;;
     ·     ──────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'break' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-break-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0062\u0072\u0065\u0061\u006b = 123;;
     ·     ──────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'break' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-break.js:16:5]
  15 │ 
  16 │ var break = 123;;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'case' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-case-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{63}ase = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'case' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-case-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0063ase = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'case' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-case.js:16:5]
  15 │ 
  16 │ var case = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'catch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-catch-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{63}atch = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'catch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-catch-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0063atch = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'catch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-catch.js:16:5]
  15 │ 
  16 │ var catch = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'class' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-class-via-escape-hex.js:17:5]
  16 │ 
  17 │ var cla\u{73}s = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'class' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-class-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var cla\u0073s = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'class' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-class.js:16:5]
  15 │ 
  16 │ var class = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'const' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-const-via-escape-hex.js:17:5]
  16 │ 
  17 │ var co\u{6e}st = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'const' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-const-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var co\u006est = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'const' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-const.js:16:5]
  15 │ 
  16 │ var const = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'continue' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-continue-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{63}ontinue = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'continue' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-continue-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0063ontinue = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'continue' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-continue.js:16:5]
  15 │ 
  16 │ var continue = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-debugger-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{64}ebugger = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-debugger-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0064ebugger = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-debugger.js:16:5]
  15 │ 
  16 │ var debugger = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-default-via-escape-hex.js:17:5]
  16 │ 
  17 │ var def\u{61}ult = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-default-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var def\u0061ult = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-default.js:16:5]
  15 │ 
  16 │ var default = 123;
     ·     ───────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'delete' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-delete-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{64}elete = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'delete' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-delete-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0064elete = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'delete' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-delete.js:16:5]
  15 │ 
  16 │ var delete = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'do' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-do-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{64}\u{6f} = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'do' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-do-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0064\u006f = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'do' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-do.js:16:5]
  15 │ 
  16 │ var do = 123;
     ·     ──
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'else' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-else-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{65}lse = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'else' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-else-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0065lse = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'else' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-else.js:16:5]
  15 │ 
  16 │ var else = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-enum-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{65}\u{6e}\u{75}\u{6d} = 123;
     ·     ────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-enum-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0065\u006e\u0075\u006d = 123;
     ·     ────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-enum.js:16:5]
  15 │ 
  16 │ var enum = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-export-via-escape-hex.js:17:5]
  16 │ 
  17 │ var expor\u{74} = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-export-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var expor\u0074 = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-export.js:16:5]
  15 │ 
  16 │ var export = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'extends' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-extends-via-escape-hex.js:17:5]
  16 │ 
  17 │ var extend\u{73} = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'extends' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-extends-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var extend\u0073 = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'extends' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-extends.js:16:5]
  15 │ 
  16 │ var extends = 123;
     ·     ───────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'false' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-false-via-escape-hex.js:17:5]
  16 │ 
  17 │ var fals\u{65} = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'false' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-false-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var fals\u0065 = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'false' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-false.js:16:5]
  15 │ 
  16 │ var false = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'finally' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-finally-via-escape-hex.js:17:5]
  16 │ 
  17 │ var fina\u{6c}ly = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'finally' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-finally-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var fina\u006cly = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'finally' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-finally.js:16:5]
  15 │ 
  16 │ var finally = 123;
     ·     ───────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'for' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-for-via-escape-hex.js:17:5]
  16 │ 
  17 │ var f\u{6f}r = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'for' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-for-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var f\u006fr = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'for' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-for.js:16:5]
  15 │ 
  16 │ var for = 123;
     ·     ───
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'function' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-function-via-escape-hex.js:17:5]
  16 │ 
  17 │ var func\u{74}ion = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'function' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-function-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var func\u0074ion = 123;
     ·     ─────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'function' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-function.js:16:5]
  15 │ 
  16 │ var function = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-if-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{69}\u{66} = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-if-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0069\u0066 = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'if' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-if.js:16:5]
  15 │ 
  16 │ var if = 123;
     ·     ──
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'import' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-import-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{69}\u{6d}\u{70}\u{6f}\u{72}\u{74} = 123;
     ·     ────────────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'import' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-import-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0069\u006d\u0070\u006f\u0072\u0074 = 123;
     ·     ────────────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'import' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-import.js:16:5]
  15 │ 
  16 │ var import = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'in' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-in-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{69}\u{6e} = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'in' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-in-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0069\u006e = 123;
     ·     ────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'in' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-in.js:16:5]
  15 │ 
  16 │ var in = 123;
     ·     ──
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'instanceof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-instanceof-via-escape-hex.js:17:5]
  16 │ 
  17 │ var insta\u{6e}ceof = 123;
     ·     ───────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'instanceof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-instanceof-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var insta\u006eceof = 123;
     ·     ───────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'instanceof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-instanceof.js:16:5]
  15 │ 
  16 │ var instanceof = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'new' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-new-via-escape-hex.js:17:5]
  16 │ 
  17 │ var n\u{65}w = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'new' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-new-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var n\u0065w = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'new' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-new.js:16:5]
  15 │ 
  16 │ var new = 123;
     ·     ───
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'null' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-null-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{6e}ull = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'null' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-null-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u006eull = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'null' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-null.js:16:5]
  15 │ 
  16 │ var null = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'return' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-return-via-escape-hex.js:17:5]
  16 │ 
  17 │ var retur\u{6e} = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'return' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-return-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var retur\u006e = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'return' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-return.js:16:5]
  15 │ 
  16 │ var return = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'super' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-super-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{73}uper = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'super' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-super-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0073uper = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'super' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-super.js:16:5]
  15 │ 
  16 │ var super = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'switch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-switch-via-escape-hex.js:17:5]
  16 │ 
  17 │ var switc\u{68} = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'switch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-switch-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var switc\u0068 = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'switch' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-switch.js:16:5]
  15 │ 
  16 │ var switch = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-this-via-escape-hex.js:17:5]
  16 │ 
  17 │ var thi\u{73} = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-this-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var thi\u0073 = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-this.js:16:5]
  15 │ 
  16 │ var this = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'throw' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-throw-via-escape-hex.js:17:5]
  16 │ 
  17 │ var thro\u{77} = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'throw' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-throw-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var thro\u0077 = 123;
     ·     ──────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'throw' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-throw.js:16:5]
  15 │ 
  16 │ var throw = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'true' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-true-via-escape-hex.js:17:5]
  16 │ 
  17 │ var tr\u{75}e = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'true' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-true-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var tr\u0075e = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'true' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-true.js:16:5]
  15 │ 
  16 │ var true = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'try' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-try-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{74}\u{72}\u{79} = 123;
     ·     ──────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'try' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-try-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0074\u0072\u0079 = 123;
     ·     ──────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'try' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-try.js:16:5]
  15 │ 
  16 │ var try = 123;
     ·     ───
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'typeof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-typeof-via-escape-hex.js:17:5]
  16 │ 
  17 │ var typeo\u{66} = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'typeof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-typeof-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var typeo\u0066 = 123;
     ·     ───────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'typeof' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-typeof.js:16:5]
  15 │ 
  16 │ var typeof = 123;
     ·     ──────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'var' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-var-via-escape-hex.js:17:5]
  16 │ 
  17 │ var va\u{72} = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'var' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-var-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var va\u0072 = 123;
     ·     ────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'var' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-var.js:16:5]
  15 │ 
  16 │ var var = 123;
     ·     ───
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'void' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-void-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{76}\u{6f}\u{69}\u{64} = 123;
     ·     ────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'void' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-void-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0076\u006f\u0069\u0064 = 123;
     ·     ────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'void' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-void.js:16:5]
  15 │ 
  16 │ var void = 123;
     ·     ────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'while' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-while-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{77}\u{68}\u{69}\u{6c}\u{65} = 123;
     ·     ──────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'while' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-while-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0077\u0068\u0069\u006c\u0065 = 123;
     ·     ──────────────────────────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'while' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-while.js:16:5]
  15 │ 
  16 │ var while = 123;
     ·     ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'with' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-with-via-escape-hex.js:17:5]
  16 │ 
  17 │ var \u{77}ith = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'with' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-with-via-escape-hex4.js:17:5]
  16 │ 
  17 │ var \u0077ith = 123;
     ·     ─────────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'with' is a reserved word that cannot be used here.
     ╭─[test262/test/language/identifiers/val-with.js:16:5]
  15 │ 
  16 │ var with = 123;
@@ -37268,7 +37268,7 @@ Expect to Parse: tasks/coverage/test262/test/built-ins/String/prototype/split/se
     · ─────
     ╰────
 
-  × Unexpected token
+  × Identifier expected. 'null' is a reserved word that cannot be used here.
     ╭─[test262/test/language/types/null/S8.2_A2.js:16:5]
  15 │ 
  16 │ var null;

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6629,7 +6629,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │     }
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/compiler/constructorArgsErrors5.ts:2:18]
  1 │ class foo {
  2 │     constructor (export a: number) {
@@ -7565,7 +7565,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ function foo() {}
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'default' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/compiler/es6ImportNamedImportIdentifiersParsing.ts:2:10]
  1 │ import { yield } from "somemodule"; // Allowed
  2 │ import { default } from "somemodule"; // Error - as this is keyword that is not allowed as identifier
@@ -11191,7 +11191,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ import * as  while from "foo"
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'enum' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/compiler/reservedWords3.ts:1:13]
  1 │ function f1(enum) {}
    ·             ────
@@ -13072,7 +13072,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ 
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/ambient/ambientModuleDeclarationWithReservedIdentifierInDottedPath.ts:3:23]
  2 │ 
  3 │ declare module chrome.debugger {
@@ -13080,7 +13080,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │     declare var tabId: number;
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'debugger' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/ambient/ambientModuleDeclarationWithReservedIdentifierInDottedPath2.ts:1:26]
  1 │ declare namespace chrome.debugger {
    ·                          ────────
@@ -15191,7 +15191,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  6 │   }
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts:4:17]
  3 │ class C {
  4 │     method(@dec this: C) {}
@@ -15232,7 +15232,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ }
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts:5:22]
  4 │ 
  5 │ function direct(@dec this: C) { return this.n; }
@@ -15905,7 +15905,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·             ╰── `:` expected
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'while' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers02.ts:1:14]
  1 │ var { while: while } = { while: 1 }
    ·              ─────
@@ -15918,7 +15918,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·               ╰── `:` expected
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'while' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers04.ts:1:16]
  1 │ var { "while": while } = { while: 1 }
    ·                ─────
@@ -20027,7 +20027,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'void' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration4.ts:1:6]
  1 │ enum void {
    ·      ────
@@ -20426,14 +20426,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·          ─
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'return' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserErrorRecovery_VariableList1.ts:2:1]
  1 │ var a,
  2 │ return;
    · ──────
    ╰────
 
-  × Unexpected token
+  × Identifier expected. 'export' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts:1:5]
  1 │ var export;
    ·     ──────
@@ -21730,7 +21730,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: This iterator's type will be inferred from the iterable. You can safely remove the type annotation.
 
-  × Unexpected token
+  × Identifier expected. 'in' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement2.ts:1:10]
  1 │ for (var in X) {
    ·          ──
@@ -24545,7 +24545,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  165 │ function notFirst(a: number, this: C): number { return this.n; }
      ╰────
 
-  × Unexpected token
+  × Identifier expected. 'this' is a reserved word that cannot be used here.
      ╭─[typescript/tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts:165:30]
  164 │ var thisConstructorType: new (this: number) => number;
  165 │ function notFirst(a: number, this: C): number { return this.n; }
@@ -24618,7 +24618,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
   help: Remove the duplicate modifier.
 
-  × Unexpected token
+  × Identifier expected. 'in' is a reserved word that cannot be used here.
    ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts:1:12]
  1 │ type T1<in in> = T1 // Error: circularly references 
    ·            ──


### PR DESCRIPTION
## What This PR Does
Provide better error messages when a reserved word is used as a `BindingIdentifier`
```ts
var const = 1;
export enum const {}
const if = 1;
```