### PR TITLE
feat(oxc_language_server):  add related code for `lsp_types::Diagnostic#source`

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -107,7 +107,8 @@ impl ErrorWithPosition {
                 ret_range
             },
         );
-
+        let source =
+            self.miette_err.code().map(|code| format!("oxc:{code}")).unwrap_or("oxc".to_string());
         let message = self.miette_err.help().map_or_else(
             || self.miette_err.to_string(),
             |help| format!("{}\nhelp: {}", self.miette_err, help),
@@ -118,7 +119,7 @@ impl ErrorWithPosition {
             severity,
             code: None,
             message,
-            source: Some("oxc".into()),
+            source: Some(source),
             code_description: None,
             related_information,
             tags: None,
@@ -176,7 +177,6 @@ impl IsolatedLintHandler {
                     let Some(ref related_info) = d.diagnostic.related_information else {
                         continue;
                     };
-
                     let related_information = Some(vec![DiagnosticRelatedInformation {
                         location: lsp_types::Location {
                             uri: lsp_types::Url::from_file_path(path).unwrap(),
@@ -194,7 +194,7 @@ impl IsolatedLintHandler {
                                 severity: Some(DiagnosticSeverity::HINT),
                                 code: None,
                                 message: r.message.clone(),
-                                source: Some("oxc".into()),
+                                source: d.diagnostic.source.clone(),
                                 code_description: None,
                                 related_information: related_information.clone(),
                                 tags: None,

--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -107,8 +107,7 @@ impl ErrorWithPosition {
                 ret_range
             },
         );
-        let source =
-            self.miette_err.code().map(|code| format!("oxc:{code}")).unwrap_or("oxc".to_string());
+        let source = self.miette_err.code().map_or("oxc".to_string(), |code| format!("oxc:{code}"));
         let message = self.miette_err.help().map_or_else(
             || self.miette_err.to_string(),
             |help| format!("{}\nhelp: {}", self.miette_err, help),


### PR DESCRIPTION
Closed #6477
# Before
# After
![image](https://github.com/user-attachments/assets/20377c2f-ba94-4fb5-a21c-fbd269f40385)
![image](https://github.com/user-attachments/assets/fae901b3-9753-4610-8b36-61974781f770)

Compare to eslint: 
![image](https://github.com/user-attachments/assets/0037b265-0a84-4eae-8bc9-4cbb66197485)

we could polish in the feature and link to `lsp_types::Diagnostic#source`
