### PR TITLE
feat(linter): promote `no_unsafe_optional_chaining` to correctness

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
     /// const { bar } = obj?.foo;  // TypeError
     /// ```
     NoUnsafeOptionalChaining,
-    restriction // TypeScript checks optional chaining
+    correctness
 );
 
 impl Rule for NoUnsafeOptionalChaining {


### PR DESCRIPTION
It's in the eslint recommended list https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining