### PR TITLE
perf(codegen): check last char with byte methods

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -87,7 +87,7 @@ impl<'a> Codegen<'a> {
 
         if comments.first().is_some_and(|c| c.preceded_by_newline) {
             // Skip printing newline if this comment is already on a newline.
-            if self.peek_nth_back(0).is_some_and(|c| c != '\n' && c != '\t') {
+            if self.last_byte().is_some_and(|b| b != b'\n' && b != b'\t') {
                 self.print_hard_newline();
                 self.print_indent();
             }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1194,11 +1194,11 @@ impl<'a> Gen for BigIntLiteral<'a> {
 impl<'a> Gen for RegExpLiteral<'a> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span.start);
-        let last = p.peek_nth_back(0);
+        let last = p.last_byte();
         let pattern_text = self.regex.pattern.source_text(p.source_text);
         // Avoid forming a single-line comment or "</script" sequence
-        if Some('/') == last
-            || (Some('<') == last && pattern_text.cow_to_lowercase().starts_with("script"))
+        if last == Some(b'/')
+            || (last == Some(b'<') && pattern_text.cow_to_lowercase().starts_with("script"))
         {
             p.print_hard_space();
         }


### PR DESCRIPTION
When checking what last char in buffer is, avoid calculating a `char` when only comparing to an ASCII char (byte) anyway.