### PR TITLE
refactor(codegen)!: rename `print_char` method to `print_ascii_byte`

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -155,7 +155,7 @@ impl<'a> BinaryExpressionVisitor<'a> {
                 && self.ctx.intersects(Context::FORBID_IN));
 
         if self.wrap {
-            p.print_char(b'(');
+            p.print_ascii_byte(b'(');
             self.ctx &= Context::FORBID_IN.not();
         }
 
@@ -200,7 +200,7 @@ impl<'a> BinaryExpressionVisitor<'a> {
         p.print_soft_space();
         self.e.right().gen_expr(p, self.right_precedence, self.ctx & Context::FORBID_IN);
         if self.wrap {
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
         }
     }
 }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -64,7 +64,7 @@ impl<'a> Gen for Directive<'a> {
         p.wrap_quote(|p, _| {
             p.print_str(self.directive.as_str());
         });
-        p.print_char(b';');
+        p.print_ascii_byte(b';');
         p.print_soft_newline();
     }
 }
@@ -168,9 +168,9 @@ impl<'a> Gen for IfStatement<'a> {
 fn print_if(if_stmt: &IfStatement<'_>, p: &mut Codegen, ctx: Context) {
     p.print_str("if");
     p.print_soft_space();
-    p.print_char(b'(');
+    p.print_ascii_byte(b'(');
     p.print_expression(&if_stmt.test);
-    p.print_char(b')');
+    p.print_ascii_byte(b')');
 
     match &if_stmt.consequent {
         Statement::BlockStatement(block) => {
@@ -252,7 +252,7 @@ impl<'a> Gen for ForStatement<'a> {
         p.print_indent();
         p.print_str("for");
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
 
         if let Some(init) = &self.init {
             init.print(p, Context::FORBID_IN);
@@ -272,7 +272,7 @@ impl<'a> Gen for ForStatement<'a> {
             p.print_expression(update);
         }
 
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_body(&self.body, false, ctx);
     }
 }
@@ -283,14 +283,14 @@ impl<'a> Gen for ForInStatement<'a> {
         p.print_indent();
         p.print_str("for");
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         self.left.print(p, Context::empty().and_forbid_in(false));
         p.print_soft_space();
         p.print_space_before_identifier();
         p.print_str("in");
         p.print_hard_space();
         p.print_expression(&self.right);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_body(&self.body, false, ctx);
     }
 }
@@ -304,13 +304,13 @@ impl<'a> Gen for ForOfStatement<'a> {
             p.print_str(" await");
         }
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         self.left.print(p, ctx);
         p.print_soft_space();
         p.print_space_before_identifier();
         p.print_str("of ");
         self.right.print_expr(p, Precedence::Comma, Context::empty());
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_body(&self.body, false, ctx);
     }
 }
@@ -347,9 +347,9 @@ impl<'a> Gen for WhileStatement<'a> {
         p.print_indent();
         p.print_str("while");
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         p.print_expression(&self.test);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_body(&self.body, false, ctx);
     }
 }
@@ -372,9 +372,9 @@ impl<'a> Gen for DoWhileStatement<'a> {
         }
         p.print_str("while");
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         p.print_expression(&self.test);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_semicolon_after_statement();
     }
 }
@@ -420,9 +420,9 @@ impl<'a> Gen for SwitchStatement<'a> {
         p.print_indent();
         p.print_str("switch");
         p.print_soft_space();
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         p.print_expression(&self.discriminant);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_soft_space();
         p.print_curly_braces(self.span, self.cases.is_empty(), |p| {
             for case in &self.cases {
@@ -535,9 +535,9 @@ impl<'a> Gen for WithStatement<'a> {
         p.add_source_mapping(self.span.start);
         p.print_indent();
         p.print_str("with");
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         p.print_expression(&self.object);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_body(&self.body, false, ctx);
     }
 }
@@ -585,7 +585,7 @@ impl<'a> Gen for VariableDeclarator<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.id.kind.print(p, ctx);
         if self.definite {
-            p.print_char(b'!');
+            p.print_ascii_byte(b'!');
         }
         if self.id.optional {
             p.print_str("?");
@@ -621,7 +621,7 @@ impl<'a> Gen for Function<'a> {
             }
             p.print_str("function");
             if self.generator {
-                p.print_char(b'*');
+                p.print_ascii_byte(b'*');
                 p.print_soft_space();
             }
             if let Some(id) = &self.id {
@@ -631,7 +631,7 @@ impl<'a> Gen for Function<'a> {
             if let Some(type_parameters) = &self.type_parameters {
                 type_parameters.print(p, ctx);
             }
-            p.print_char(b'(');
+            p.print_ascii_byte(b'(');
             if let Some(this_param) = &self.this_param {
                 this_param.print(p, ctx);
                 if !self.params.is_empty() || self.params.rest.is_some() {
@@ -640,7 +640,7 @@ impl<'a> Gen for Function<'a> {
                 p.print_soft_space();
             }
             self.params.print(p, ctx);
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
             if let Some(return_type) = &self.return_type {
                 p.print_str(": ");
                 return_type.print(p, ctx);
@@ -714,9 +714,9 @@ impl<'a> Gen for ImportDeclaration<'a> {
                 p.print_soft_space();
                 p.print_str("from");
                 p.print_soft_space();
-                p.print_char(b'"');
+                p.print_ascii_byte(b'"');
                 p.print_str(self.source.value.as_str());
-                p.print_char(b'"');
+                p.print_ascii_byte(b'"');
                 if let Some(with_clause) = &self.with_clause {
                     p.print_hard_space();
                     with_clause.print(p, ctx);
@@ -761,7 +761,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
                                 p.print_soft_space();
                             }
                             in_block = true;
-                            p.print_char(b'{');
+                            p.print_ascii_byte(b'{');
                             p.print_soft_space();
                         }
 
@@ -781,7 +781,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
             }
             if in_block {
                 p.print_soft_space();
-                p.print_char(b'}');
+                p.print_ascii_byte(b'}');
             }
             p.print_str(" from ");
         }
@@ -871,13 +871,13 @@ impl<'a> Gen for ExportNamedDeclaration<'a> {
                 }
             }
             None => {
-                p.print_char(b'{');
+                p.print_ascii_byte(b'{');
                 if !self.specifiers.is_empty() {
                     p.print_soft_space();
                     p.print_list(&self.specifiers, ctx);
                     p.print_soft_space();
                 }
-                p.print_char(b'}');
+                p.print_ascii_byte(b'}');
                 if let Some(source) = &self.source {
                     p.print_soft_space();
                     p.print_str("from");
@@ -954,7 +954,7 @@ impl<'a> Gen for ExportAllDeclaration<'a> {
         if self.export_kind.is_type() {
             p.print_str("type ");
         }
-        p.print_char(b'*');
+        p.print_ascii_byte(b'*');
 
         if let Some(exported) = &self.exported {
             p.print_str(" as ");
@@ -1202,9 +1202,9 @@ impl<'a> Gen for RegExpLiteral<'a> {
         {
             p.print_hard_space();
         }
-        p.print_char(b'/');
+        p.print_ascii_byte(b'/');
         p.print_str(pattern_text.as_ref());
-        p.print_char(b'/');
+        p.print_ascii_byte(b'/');
         p.print_str(self.regex.flags.to_string().as_str());
         p.prev_reg_exp_end = p.code().len();
     }
@@ -1330,9 +1330,9 @@ impl<'a> GenExpr for ComputedMemberExpression<'a> {
         if self.optional {
             p.print_str("?.");
         }
-        p.print_char(b'[');
+        p.print_ascii_byte(b'[');
         self.expression.print_expr(p, Precedence::Lowest, Context::empty());
-        p.print_char(b']');
+        p.print_ascii_byte(b']');
     }
 }
 
@@ -1340,12 +1340,12 @@ impl<'a> GenExpr for StaticMemberExpression<'a> {
     fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
         self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
         if self.optional {
-            p.print_char(b'?');
+            p.print_ascii_byte(b'?');
         } else if p.need_space_before_dot == p.code_len() {
             // `0.toExponential()` is invalid, add a space before the dot, `0 .toExponential()` is valid
             p.print_hard_space();
         }
-        p.print_char(b'.');
+        p.print_ascii_byte(b'.');
         self.property.print(p, ctx);
     }
 }
@@ -1356,7 +1356,7 @@ impl<'a> GenExpr for PrivateFieldExpression<'a> {
         if self.optional {
             p.print_str("?");
         }
-        p.print_char(b'.');
+        p.print_ascii_byte(b'.');
         self.field.print(p, ctx);
     }
 }
@@ -1382,7 +1382,7 @@ impl<'a> GenExpr for CallExpression<'a> {
             if let Some(type_parameters) = &self.type_parameters {
                 type_parameters.print(p, ctx);
             }
-            p.print_char(b'(');
+            p.print_ascii_byte(b'(');
             let has_comment = (self.span.end > 0 && p.has_comment(self.span.end - 1))
                 || self.arguments.iter().any(|item| p.has_comment(item.span().start));
             if has_comment {
@@ -1396,7 +1396,7 @@ impl<'a> GenExpr for CallExpression<'a> {
             } else {
                 p.print_list(&self.arguments, ctx);
             }
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
             p.add_source_mapping(self.span.end);
         });
     }
@@ -1437,7 +1437,7 @@ impl<'a> Gen for ArrayExpression<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.elements.len() > 2;
         p.add_source_mapping(self.span.start);
-        p.print_char(b'[');
+        p.print_ascii_byte(b'[');
         if is_multi_line {
             p.indent();
         }
@@ -1462,7 +1462,7 @@ impl<'a> Gen for ArrayExpression<'a> {
             p.print_indent();
         }
         p.add_source_mapping(self.span.end);
-        p.print_char(b']');
+        p.print_ascii_byte(b']');
     }
 }
 
@@ -1474,7 +1474,7 @@ impl<'a> GenExpr for ObjectExpression<'a> {
         let wrap = p.start_of_stmt == n || p.start_of_arrow_expr == n;
         p.wrap(wrap, |p| {
             p.add_source_mapping(self.span.start);
-            p.print_char(b'{');
+            p.print_ascii_byte(b'{');
             if is_multi_line {
                 p.indent();
             }
@@ -1498,7 +1498,7 @@ impl<'a> GenExpr for ObjectExpression<'a> {
                 p.print_soft_space();
             }
             p.add_source_mapping(self.span.end);
-            p.print_char(b'}');
+            p.print_ascii_byte(b'}');
         });
     }
 }
@@ -1537,18 +1537,18 @@ impl<'a> Gen for ObjectProperty<'a> {
                     p.print_str("*");
                 }
                 if self.computed {
-                    p.print_char(b'[');
+                    p.print_ascii_byte(b'[');
                 }
                 self.key.print(p, ctx);
                 if self.computed {
-                    p.print_char(b']');
+                    p.print_ascii_byte(b']');
                 }
                 if let Some(type_parameters) = &func.type_parameters {
                     type_parameters.print(p, ctx);
                 }
-                p.print_char(b'(');
+                p.print_ascii_byte(b'(');
                 func.params.print(p, ctx);
-                p.print_char(b')');
+                p.print_ascii_byte(b')');
                 if let Some(body) = &func.body {
                     p.print_soft_space();
                     body.print(p, ctx);
@@ -1567,13 +1567,13 @@ impl<'a> Gen for ObjectProperty<'a> {
         }
 
         if self.computed {
-            p.print_char(b'[');
+            p.print_ascii_byte(b'[');
         }
         if !shorthand {
             self.key.print(p, ctx);
         }
         if self.computed {
-            p.print_char(b']');
+            p.print_ascii_byte(b']');
         }
         if !shorthand {
             p.print_colon();
@@ -1612,9 +1612,9 @@ impl<'a> GenExpr for ArrowFunctionExpression<'a> {
                 type_parameters.print(p, ctx);
             }
             p.add_source_mapping(self.span.start);
-            p.print_char(b'(');
+            p.print_ascii_byte(b'(');
             self.params.print(p, ctx);
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
             if let Some(return_type) = &self.return_type {
                 p.print_str(":");
                 p.print_soft_space();
@@ -1642,7 +1642,7 @@ impl<'a> GenExpr for YieldExpression<'a> {
             p.print_space_before_identifier();
             p.print_str("yield");
             if self.delegate {
-                p.print_char(b'*');
+                p.print_ascii_byte(b'*');
                 p.print_soft_space();
             }
             if let Some(argument) = self.argument.as_ref() {
@@ -1756,7 +1756,7 @@ impl<'a> GenExpr for ConditionalExpression<'a> {
         p.wrap(wrap, |p| {
             self.test.print_expr(p, Precedence::Conditional, ctx & Context::FORBID_IN);
             p.print_soft_space();
-            p.print_char(b'?');
+            p.print_ascii_byte(b'?');
             p.print_soft_space();
             self.consequent.print_expr(p, Precedence::Yield, Context::empty());
             p.print_soft_space();
@@ -1828,7 +1828,7 @@ impl<'a> Gen for AssignmentTargetPattern<'a> {
 impl<'a> Gen for ArrayAssignmentTarget<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
-        p.print_char(b'[');
+        p.print_ascii_byte(b'[');
         for (index, item) in self.elements.iter().enumerate() {
             if index != 0 {
                 p.print_comma();
@@ -1848,7 +1848,7 @@ impl<'a> Gen for ArrayAssignmentTarget<'a> {
         if self.trailing_comma.is_some() {
             p.print_comma();
         }
-        p.print_char(b']');
+        p.print_ascii_byte(b']');
         p.add_source_mapping(self.span.end);
     }
 }
@@ -1856,7 +1856,7 @@ impl<'a> Gen for ArrayAssignmentTarget<'a> {
 impl<'a> Gen for ObjectAssignmentTarget<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
-        p.print_char(b'{');
+        p.print_ascii_byte(b'{');
         p.print_list(&self.properties, ctx);
         if let Some(target) = &self.rest {
             if !self.properties.is_empty() {
@@ -1865,7 +1865,7 @@ impl<'a> Gen for ObjectAssignmentTarget<'a> {
             p.add_source_mapping(self.span.start);
             target.print(p, ctx);
         }
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
         p.add_source_mapping(self.span.end);
     }
 }
@@ -1929,9 +1929,9 @@ impl<'a> Gen for AssignmentTargetPropertyProperty<'a> {
                 ident.print(p, ctx);
             }
             key @ match_expression!(PropertyKey) => {
-                p.print_char(b'[');
+                p.print_ascii_byte(b'[');
                 key.to_expression().print_expr(p, Precedence::Comma, Context::empty());
-                p.print_char(b']');
+                p.print_ascii_byte(b']');
             }
         }
         p.print_colon();
@@ -1992,14 +1992,14 @@ impl<'a> GenExpr for ImportExpression<'a> {
                 }
                 p.dedent();
             }
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
         });
     }
 }
 
 impl<'a> Gen for TemplateLiteral<'a> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
-        p.print_char(b'`');
+        p.print_ascii_byte(b'`');
         let mut expressions = self.expressions.iter();
 
         for quasi in &self.quasis {
@@ -2009,11 +2009,11 @@ impl<'a> Gen for TemplateLiteral<'a> {
             if let Some(expr) = expressions.next() {
                 p.print_str("${");
                 p.print_expression(expr);
-                p.print_char(b'}');
+                p.print_ascii_byte(b'}');
             }
         }
 
-        p.print_char(b'`');
+        p.print_ascii_byte(b'`');
     }
 }
 
@@ -2068,7 +2068,7 @@ impl<'a> GenExpr for NewExpression<'a> {
             p.add_source_mapping(self.span.start);
             p.print_str("new ");
             self.callee.print_expr(p, Precedence::New, Context::FORBID_CALL);
-            p.print_char(b'(');
+            p.print_ascii_byte(b'(');
             let has_comment = p.has_comment(self.span.end - 1)
                 || self.arguments.iter().any(|item| p.has_comment(item.span().start));
             if has_comment {
@@ -2082,7 +2082,7 @@ impl<'a> GenExpr for NewExpression<'a> {
             } else {
                 p.print_list(&self.arguments, ctx);
             }
-            p.print_char(b')');
+            p.print_ascii_byte(b')');
         });
     }
 }
@@ -2101,13 +2101,13 @@ impl<'a> GenExpr for TSAsExpression<'a> {
 
 impl<'a> GenExpr for TSSatisfiesExpression<'a> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        p.print_char(b'(');
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
+        p.print_ascii_byte(b'(');
         self.expression.print_expr(p, precedence, Context::default());
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         p.print_str(" satisfies ");
         self.type_annotation.print(p, ctx);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
     }
 }
 
@@ -2116,7 +2116,7 @@ impl<'a> GenExpr for TSNonNullExpression<'a> {
         p.wrap(matches!(self.expression, Expression::ParenthesizedExpression(_)), |p| {
             self.expression.print_expr(p, precedence, ctx);
         });
-        p.print_char(b'!');
+        p.print_ascii_byte(b'!');
         if p.options.minify {
             p.print_hard_space();
         }
@@ -2153,7 +2153,7 @@ impl<'a> Gen for MetaProperty<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
         self.meta.print(p, ctx);
-        p.print_char(b'.');
+        p.print_ascii_byte(b'.');
         self.property.print(p, ctx);
     }
 }
@@ -2264,7 +2264,7 @@ impl<'a> Gen for JSXMemberExpressionObject<'a> {
 impl<'a> Gen for JSXMemberExpression<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.object.print(p, ctx);
-        p.print_char(b'.');
+        p.print_ascii_byte(b'.');
         self.property.print(p, ctx);
     }
 }
@@ -2323,9 +2323,9 @@ impl<'a> Gen for JSXExpression<'a> {
 
 impl<'a> Gen for JSXExpressionContainer<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
-        p.print_char(b'{');
+        p.print_ascii_byte(b'{');
         self.expression.print(p, ctx);
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
     }
 }
 
@@ -2336,9 +2336,9 @@ impl<'a> Gen for JSXAttributeValue<'a> {
             Self::Element(el) => el.print(p, ctx),
             Self::StringLiteral(lit) => {
                 let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
-                p.print_char(quote);
+                p.print_ascii_byte(quote);
                 p.print_str(&lit.value);
-                p.print_char(quote);
+                p.print_ascii_byte(quote);
             }
             Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
         }
@@ -2349,7 +2349,7 @@ impl<'a> Gen for JSXSpreadAttribute<'a> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_str("{...");
         self.argument.print_expr(p, Precedence::Comma, Context::empty());
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
     }
 }
 
@@ -2365,7 +2365,7 @@ impl<'a> Gen for JSXAttributeItem<'a> {
 impl<'a> Gen for JSXOpeningElement<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
-        p.print_char(b'<');
+        p.print_ascii_byte(b'<');
         self.name.print(p, ctx);
         for attr in &self.attributes {
             match attr {
@@ -2382,7 +2382,7 @@ impl<'a> Gen for JSXOpeningElement<'a> {
             p.print_soft_space();
             p.print_str("/");
         }
-        p.print_char(b'>');
+        p.print_ascii_byte(b'>');
     }
 }
 
@@ -2391,7 +2391,7 @@ impl<'a> Gen for JSXClosingElement<'a> {
         p.add_source_mapping(self.span.start);
         p.print_str("</");
         self.name.print(p, ctx);
-        p.print_char(b'>');
+        p.print_ascii_byte(b'>');
     }
 }
 
@@ -2510,21 +2510,21 @@ impl<'a> Gen for MethodDefinition<'a> {
         }
 
         if self.computed {
-            p.print_char(b'[');
+            p.print_ascii_byte(b'[');
         }
         self.key.print(p, ctx);
         if self.computed {
-            p.print_char(b']');
+            p.print_ascii_byte(b']');
         }
         if self.optional {
-            p.print_char(b'?');
+            p.print_ascii_byte(b'?');
         }
         if let Some(type_parameters) = self.value.type_parameters.as_ref() {
             type_parameters.print(p, ctx);
         }
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         self.value.params.print(p, ctx);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
         if let Some(return_type) = &self.value.return_type {
             p.print_colon();
             p.print_soft_space();
@@ -2563,11 +2563,11 @@ impl<'a> Gen for PropertyDefinition<'a> {
             p.print_str("readonly ");
         }
         if self.computed {
-            p.print_char(b'[');
+            p.print_ascii_byte(b'[');
         }
         self.key.print(p, ctx);
         if self.computed {
-            p.print_char(b']');
+            p.print_ascii_byte(b']');
         }
         if self.optional {
             p.print_str("?");
@@ -2606,13 +2606,13 @@ impl<'a> Gen for AccessorProperty<'a> {
         p.print_str("accessor");
         if self.computed {
             p.print_soft_space();
-            p.print_char(b'[');
+            p.print_ascii_byte(b'[');
         } else {
             p.print_hard_space();
         }
         self.key.print(p, ctx);
         if self.computed {
-            p.print_char(b']');
+            p.print_ascii_byte(b']');
         }
         if let Some(type_annotation) = &self.type_annotation {
             p.print_colon();
@@ -2631,7 +2631,7 @@ impl<'a> Gen for AccessorProperty<'a> {
 impl<'a> Gen for PrivateIdentifier<'a> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping_for_name(self.span, &self.name);
-        p.print_char(b'#');
+        p.print_ascii_byte(b'#');
         p.print_str(self.name.as_str());
     }
 }
@@ -2664,7 +2664,7 @@ impl<'a> Gen for BindingPatternKind<'a> {
 impl<'a> Gen for ObjectPattern<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
-        p.print_char(b'{');
+        p.print_ascii_byte(b'{');
         if !self.is_empty() {
             p.print_soft_space();
         }
@@ -2678,7 +2678,7 @@ impl<'a> Gen for ObjectPattern<'a> {
         if !self.is_empty() {
             p.print_soft_space();
         }
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
         p.add_source_mapping(self.span.end);
     }
 }
@@ -2687,7 +2687,7 @@ impl<'a> Gen for BindingProperty<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
         if self.computed {
-            p.print_char(b'[');
+            p.print_ascii_byte(b'[');
         }
 
         let mut shorthand = false;
@@ -2715,7 +2715,7 @@ impl<'a> Gen for BindingProperty<'a> {
             self.key.print(p, ctx);
         }
         if self.computed {
-            p.print_char(b']');
+            p.print_ascii_byte(b']');
         }
         if !shorthand {
             p.print_colon();
@@ -2736,7 +2736,7 @@ impl<'a> Gen for BindingRestElement<'a> {
 impl<'a> Gen for ArrayPattern<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span.start);
-        p.print_char(b'[');
+        p.print_ascii_byte(b'[');
         for (index, item) in self.elements.iter().enumerate() {
             if index != 0 {
                 p.print_comma();
@@ -2753,7 +2753,7 @@ impl<'a> Gen for ArrayPattern<'a> {
             p.print_soft_space();
             rest.print(p, ctx);
         }
-        p.print_char(b']');
+        p.print_ascii_byte(b']');
         p.add_source_mapping(self.span.end);
     }
 }
@@ -2787,7 +2787,7 @@ impl<'a> Gen for Decorator<'a> {
         }
 
         p.add_source_mapping(self.span.start);
-        p.print_char(b'@');
+        p.print_ascii_byte(b'@');
         let wrap = need_wrap(&self.expression);
         p.wrap(wrap, |p| {
             self.expression.print_expr(p, Precedence::Lowest, Context::empty());
@@ -2807,7 +2807,7 @@ impl<'a> Gen for TSClassImplements<'a> {
 impl<'a> Gen for TSTypeParameterDeclaration<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.params.len() >= 2;
-        p.print_char(b'<');
+        p.print_ascii_byte(b'<');
         if is_multi_line {
             p.indent();
         }
@@ -2828,7 +2828,7 @@ impl<'a> Gen for TSTypeParameterDeclaration<'a> {
             p.dedent();
             p.print_indent();
         }
-        p.print_char(b'>');
+        p.print_ascii_byte(b'>');
     }
 }
 
@@ -2917,9 +2917,9 @@ impl<'a> Gen for TSUnionType<'a> {
 
 impl<'a> Gen for TSParenthesizedType<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
-        p.print_char(b'(');
+        p.print_ascii_byte(b'(');
         self.type_annotation.print(p, ctx);
-        p.print_char(b')');
+        p.print_ascii_byte(b')');
     }
 }
 
@@ -3227,9 +3227,9 @@ impl<'a> Gen for TSSignature<'a> {
                     p.print_str("readonly ");
                 }
                 if signature.computed {
-                    p.print_char(b'[');
+                    p.print_ascii_byte(b'[');
                     signature.key.print(p, ctx);
-                    p.print_char(b']');
+                    p.print_ascii_byte(b']');
                 } else {
                     match &signature.key {
                         PropertyKey::StaticIdentifier(key) => {
@@ -3293,9 +3293,9 @@ impl<'a> Gen for TSSignature<'a> {
                     TSMethodSignatureKind::Set => p.print_str("set "),
                 }
                 if signature.computed {
-                    p.print_char(b'[');
+                    p.print_ascii_byte(b'[');
                     signature.key.print(p, ctx);
-                    p.print_char(b']');
+                    p.print_ascii_byte(b']');
                 } else {
                     match &signature.key {
                         PropertyKey::StaticIdentifier(key) => {
@@ -3367,7 +3367,7 @@ impl<'a> Gen for TSImportType<'a> {
         }
         p.print_str(")");
         if let Some(qualifier) = &self.qualifier {
-            p.print_char(b'.');
+            p.print_ascii_byte(b'.');
             qualifier.print(p, ctx);
         }
         if let Some(type_parameters) = &self.type_parameters {
@@ -3378,18 +3378,18 @@ impl<'a> Gen for TSImportType<'a> {
 
 impl<'a> Gen for TSImportAttributes<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
-        p.print_char(b'{');
+        p.print_ascii_byte(b'{');
         p.print_soft_space();
         self.attributes_keyword.print(p, ctx);
         p.print_str(":");
         p.print_soft_space();
-        p.print_char(b'{');
+        p.print_ascii_byte(b'{');
         p.print_soft_space();
         p.print_list(&self.elements, ctx);
         p.print_soft_space();
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
         p.print_soft_space();
-        p.print_char(b'}');
+        p.print_ascii_byte(b'}');
     }
 }
 
@@ -3485,7 +3485,7 @@ impl<'a> Gen for TSModuleDeclaration<'a> {
             loop {
                 match body {
                     TSModuleDeclarationBody::TSModuleDeclaration(b) => {
-                        p.print_char(b'.');
+                        p.print_ascii_byte(b'.');
                         b.id.print(p, ctx);
                         if let Some(b) = &b.body {
                             body = b;

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -225,10 +225,13 @@ impl<'a> Codegen<'a> {
         self.code.take_source_text()
     }
 
-    /// Push a single character into the buffer
+    /// Push a single ASCII byte into the buffer.
+    ///
+    /// # Panics
+    /// Panics if `byte` is not an ASCII byte (`0 - 0x7F`).
     #[inline]
-    pub fn print_char(&mut self, ch: u8) {
-        self.code.print_ascii_byte(ch);
+    pub fn print_ascii_byte(&mut self, byte: u8) {
+        self.code.print_ascii_byte(byte);
     }
 
     /// Push str into the buffer
@@ -256,35 +259,35 @@ impl<'a> Codegen<'a> {
     #[inline]
     fn print_soft_space(&mut self) {
         if !self.options.minify {
-            self.code.print_ascii_byte(b' ');
+            self.print_ascii_byte(b' ');
         }
     }
 
     #[inline]
     fn print_hard_space(&mut self) {
-        self.print_char(b' ');
+        self.print_ascii_byte(b' ');
     }
 
     #[inline]
     fn print_soft_newline(&mut self) {
         if !self.options.minify {
-            self.print_char(b'\n');
+            self.print_ascii_byte(b'\n');
         }
     }
 
     #[inline]
     fn print_hard_newline(&mut self) {
-        self.print_char(b'\n');
+        self.print_ascii_byte(b'\n');
     }
 
     #[inline]
     fn print_semicolon(&mut self) {
-        self.print_char(b';');
+        self.print_ascii_byte(b';');
     }
 
     #[inline]
     fn print_comma(&mut self) {
-        self.print_char(b',');
+        self.print_ascii_byte(b',');
     }
 
     #[inline]
@@ -356,12 +359,12 @@ impl<'a> Codegen<'a> {
 
     #[inline]
     fn print_colon(&mut self) {
-        self.print_char(b':');
+        self.print_ascii_byte(b':');
     }
 
     #[inline]
     fn print_equal(&mut self) {
-        self.print_char(b'=');
+        self.print_ascii_byte(b'=');
     }
 
     fn print_sequence<T: Gen>(&mut self, items: &[T], ctx: Context) {
@@ -373,7 +376,7 @@ impl<'a> Codegen<'a> {
 
     fn print_curly_braces<F: FnOnce(&mut Self)>(&mut self, span: Span, single_line: bool, op: F) {
         self.add_source_mapping(span.start);
-        self.print_char(b'{');
+        self.print_ascii_byte(b'{');
         if !single_line {
             self.print_soft_newline();
             self.indent();
@@ -384,12 +387,12 @@ impl<'a> Codegen<'a> {
             self.print_indent();
         }
         self.add_source_mapping(span.end);
-        self.print_char(b'}');
+        self.print_ascii_byte(b'}');
     }
 
     fn print_block_start(&mut self, position: u32) {
         self.add_source_mapping(position);
-        self.print_char(b'{');
+        self.print_ascii_byte(b'{');
         self.print_soft_newline();
         self.indent();
     }
@@ -398,7 +401,7 @@ impl<'a> Codegen<'a> {
         self.dedent();
         self.print_indent();
         self.add_source_mapping(position);
-        self.print_char(b'}');
+        self.print_ascii_byte(b'}');
     }
 
     fn print_body(&mut self, stmt: &Statement<'_>, need_space: bool, ctx: Context) {
@@ -539,19 +542,19 @@ impl<'a> Codegen<'a> {
     #[inline]
     fn wrap<F: FnMut(&mut Self)>(&mut self, wrap: bool, mut f: F) {
         if wrap {
-            self.print_char(b'(');
+            self.print_ascii_byte(b'(');
         }
         f(self);
         if wrap {
-            self.print_char(b')');
+            self.print_ascii_byte(b')');
         }
     }
 
     #[inline]
     fn wrap_quote<F: FnMut(&mut Self, u8)>(&mut self, mut f: F) {
-        self.print_char(self.quote);
+        self.print_ascii_byte(self.quote);
         f(self, self.quote);
-        self.print_char(self.quote);
+        self.print_ascii_byte(self.quote);
     }
 
     fn add_source_mapping(&mut self, position: u32) {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -83,15 +83,15 @@ impl NoUnsafeNegation {
             // modify `!a instance of B` to `!(a instanceof B)`
             let modified_code = {
                 let mut codegen = fixer.codegen();
-                codegen.print_char(b'!');
+                codegen.print_ascii_byte(b'!');
                 let Expression::UnaryExpression(left) = &expr.left else { unreachable!() };
-                codegen.print_char(b'(');
+                codegen.print_ascii_byte(b'(');
                 codegen.print_expression(&left.argument);
-                codegen.print_char(b' ');
+                codegen.print_ascii_byte(b' ');
                 codegen.print_str(expr.operator.as_str());
-                codegen.print_char(b' ');
+                codegen.print_ascii_byte(b' ');
                 codegen.print_expression(&expr.right);
-                codegen.print_char(b')');
+                codegen.print_ascii_byte(b')');
                 codegen.into_source_text()
             };
             fixer.replace(expr.span, modified_code)

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -183,10 +183,10 @@ impl PreferComparisonMatcher {
     ) -> String {
         let mut content = fixer.codegen();
         content.print_str(local_name);
-        content.print_char(b'(');
+        content.print_ascii_byte(b'(');
         content.print_expression(&binary_expr.left);
         content.print_str(call_span_end);
-        content.print_char(b'.');
+        content.print_ascii_byte(b'.');
         for modifier in modifiers {
             let Some(modifier_name) = modifier.name() else {
                 continue;
@@ -194,11 +194,11 @@ impl PreferComparisonMatcher {
 
             if !modifier_name.eq("not") {
                 content.print_str(&modifier_name);
-                content.print_char(b'.');
+                content.print_ascii_byte(b'.');
             }
         }
         content.print_str(prefer_matcher_name);
-        content.print_char(b'(');
+        content.print_ascii_byte(b'(');
         content.print_expression(&binary_expr.right);
         content.print_str(arg_span_end);
         content.into_source_text()

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -137,9 +137,9 @@ impl PreferExpectResolves {
         );
 
         formatter.print_str("await");
-        formatter.print_char(b' ');
+        formatter.print_ascii_byte(b' ');
         formatter.print_str(&jest_expect_fn_call.local);
-        formatter.print_char(b'(');
+        formatter.print_ascii_byte(b'(');
         formatter.print_str(fixer.source_range(arg_span));
         formatter.print_str(".resolves");
         fixer.replace(call_expr.span, formatter)

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -170,7 +170,7 @@ impl PreferMockPromiseShorthand {
     ) -> String {
         let mut content = fixer.codegen();
         content.print_str(prefer_name);
-        content.print_char(b'(');
+        content.print_ascii_byte(b'(');
         if call_expr.arguments.is_empty() {
             content.print_str("undefined");
         } else {

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -145,21 +145,21 @@ impl PreferSpyOn {
         match left_assign {
             MemberExpression::ComputedMemberExpression(cmp_mem_expr) => {
                 formatter.print_expression(&cmp_mem_expr.object);
-                formatter.print_char(b',');
-                formatter.print_char(b' ');
+                formatter.print_ascii_byte(b',');
+                formatter.print_ascii_byte(b' ');
                 formatter.print_expression(&cmp_mem_expr.expression);
             }
             MemberExpression::StaticMemberExpression(static_mem_expr) => {
                 let name = &static_mem_expr.property.name;
                 formatter.print_expression(&static_mem_expr.object);
-                formatter.print_char(b',');
-                formatter.print_char(b' ');
+                formatter.print_ascii_byte(b',');
+                formatter.print_ascii_byte(b' ');
                 formatter.print_str(format!("\'{name}\'").as_str());
             }
             MemberExpression::PrivateFieldExpression(_) => (),
         }
 
-        formatter.print_char(b')');
+        formatter.print_ascii_byte(b')');
 
         if has_mock_implementation {
             return formatter.into_source_text();
@@ -171,7 +171,7 @@ impl PreferSpyOn {
             formatter.print_expression(expr);
         }
 
-        formatter.print_char(b')');
+        formatter.print_ascii_byte(b')');
         formatter.into_source_text()
     }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -163,17 +163,17 @@ fn build_code<'a>(fixer: RuleFixer<'_, 'a>, expr: &CallExpression<'a>) -> RuleFi
 
     if let Argument::StringLiteral(ident) = &expr.arguments[0] {
         // Todo: this punctuation should read from the config
-        formatter.print_char(b'\'');
+        formatter.print_ascii_byte(b'\'');
         formatter.print_str(ident.value.as_str());
-        formatter.print_char(b'\'');
-        formatter.print_char(b')');
+        formatter.print_ascii_byte(b'\'');
+        formatter.print_ascii_byte(b')');
     } else if let Argument::TemplateLiteral(temp) = &expr.arguments[0] {
-        formatter.print_char(b'`');
+        formatter.print_ascii_byte(b'`');
         for q in &temp.quasis {
             formatter.print_str(q.value.raw.as_str());
         }
-        formatter.print_char(b'`');
-        formatter.print_char(b')');
+        formatter.print_ascii_byte(b'`');
+        formatter.print_ascii_byte(b')');
     }
 
     fixer.replace(expr.span, formatter)

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -94,9 +94,9 @@ impl Rule for DoubleComparisons {
                 let modified_code = {
                     let mut codegen = fixer.codegen();
                     codegen.print_expression(llhs);
-                    codegen.print_char(b' ');
+                    codegen.print_ascii_byte(b' ');
                     codegen.print_str(new_op);
-                    codegen.print_char(b' ');
+                    codegen.print_ascii_byte(b' ');
                     codegen.print_expression(lrhs);
                     codegen.into_source_text()
                 };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -268,18 +268,18 @@ fn diagnose_array_in_array_spread<'a>(
             // [ ...[a, b, c], ...[d, e, f] ] -> [a, b, c, d, e, f]
             ctx.diagnostic_with_fix(diagnostic, |fixer| {
                 let mut codegen = fixer.codegen();
-                codegen.print_char(b'[');
+                codegen.print_ascii_byte(b'[');
                 let elements =
                     spreads.iter().flat_map(|arr| arr.elements.iter()).collect::<Vec<_>>();
                 let n = elements.len();
                 for (i, el) in elements.into_iter().enumerate() {
                     codegen.print_expression(el.to_expression());
                     if i < n - 1 {
-                        codegen.print_char(b',');
-                        codegen.print_char(b' ');
+                        codegen.print_ascii_byte(b',');
+                        codegen.print_ascii_byte(b' ');
                     }
                 }
-                codegen.print_char(b']');
+                codegen.print_ascii_byte(b']');
                 fixer.replace(outer_array.span, codegen)
             });
         }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -85,16 +85,16 @@ impl Rule for SwitchCaseBraces {
                                         formatter.print_str("default");
                                     }
 
-                                    formatter.print_char(b':');
-                                    formatter.print_char(b' ');
-                                    formatter.print_char(b'{');
+                                    formatter.print_ascii_byte(b':');
+                                    formatter.print_ascii_byte(b' ');
+                                    formatter.print_ascii_byte(b'{');
 
                                     let source_text = ctx.source_text();
                                     for x in &case.consequent {
                                         formatter.print_str(x.span().source_text(source_text));
                                     }
 
-                                    formatter.print_char(b'}');
+                                    formatter.print_ascii_byte(b'}');
 
                                     formatter.into_source_text()
                                 };


### PR DESCRIPTION
`print_ascii_byte` is more descriptive of what this method does, and makes clear the invariant that `byte` must be ASCII.