### PR TITLE
refactor(linter): improve recursive argument handling and diagnostics creation

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -225,20 +225,14 @@ fn is_function_maybe_reassigned<'a>(
     function_id: &'a BindingIdentifier,
     ctx: &'a LintContext<'_>,
 ) -> bool {
-    let mut is_maybe_reassigned = false;
-
-    for reference in ctx
-        .semantic()
+    ctx.semantic()
         .symbol_references(function_id.symbol_id.get().expect("`symbol_id` should be set"))
-    {
-        if let Some(AstKind::SimpleAssignmentTarget(_)) =
-            ctx.nodes().parent_kind(reference.node_id())
-        {
-            is_maybe_reassigned = true;
-        }
-    }
-
-    is_maybe_reassigned
+        .any(|reference| {
+            matches!(
+                ctx.nodes().parent_kind(reference.node_id()),
+                Some(AstKind::SimpleAssignmentTarget(_))
+            )
+        })
 }
 
 // skipping whitespace, commas, finds the next character (exclusive)


### PR DESCRIPTION
### Overview
This PR refactors `only-used-in-recursion` codebase to make the implementation of #5530 easier.

The diff isn't displaying cleanly, so it might be better to review it commit by commit when looking at the changes.

### Key changes
1. Extracted diagnostic logic into `craete_diagnostic` function: 3bf00152e9359d26dccc75bc7ae9fb03970fc409
2. Removed redundant check in `is_function_maybe_reassigned`: a133ec63d12562bbcd4030fd5e4e7245380e5ced
3. Simplified `is_argument_only_used_in_recursion` by removing nesting: 6e6bd0495374528ec20458cb95247a8f88b1b260