### PR TITLE
perf(codegen): optimize `CodeBuffer::print_ascii_byte`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
 name = "oxc_codegen"
 version = "0.31.0"
 dependencies = [
+ "assert-unchecked",
  "base64",
  "bitflags 2.6.0",
  "cow-utils",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -28,6 +28,7 @@ oxc_sourcemap = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
+assert-unchecked = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
 daachorse = { workspace = true }


### PR DESCRIPTION
Optimize `CodeBuffer`'s `print_byte_unchecked` and `print_ascii_byte` methods by making a fast path for when the buffer has sufficient capacity to be pushed to without growing.

As discussed in https://github.com/oxc-project/oxc/pull/6148#issuecomment-2381635390