### PR TITLE
chore(repo): add note to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,3 +4,9 @@ about: Create a report to help us improve.
 title: ''
 labels: C-bug
 ---
+
+<!--
+!!IMPORTANT!! If you are reporting a bug for Oxlint or the Oxc VSCode extension,
+please use the "Linter bug report" template instead. You can find it here:
+https://github.com/oxc-project/oxc/issues/new?assignees=DonIsaac&labels=C-bug,A-linter&projects=&template=linter_bug_report.yaml&title=linter:+
+-->


### PR DESCRIPTION
I'm seeing lots of bug reports for oxlint & the VSCode extension that are not using the "linter bug report" template. This PR adds a notice to our default bug report template that redirects people to the correct place.