### PR TITLE
fix(data_structures): fix compilation failure on older Rust versions

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_null.rs
+++ b/crates/oxc_data_structures/src/stack/non_null.rs
@@ -14,8 +14,9 @@ use std::{cmp::Ordering, ptr::NonNull as NativeNonNull};
 #[derive(Debug)]
 pub struct NonNull<T>(NativeNonNull<T>);
 
-#[expect(dead_code, clippy::incompatible_msrv)]
-unsafe fn non_null_add_is_not_stable(ptr: NativeNonNull<u8>) -> NativeNonNull<u8> {
+#[cfg(clippy)]
+#[expect(clippy::incompatible_msrv)]
+unsafe fn _non_null_add_is_not_stable(ptr: NativeNonNull<u8>) -> NativeNonNull<u8> {
     ptr.add(1)
 }
 


### PR DESCRIPTION
I thought I was being clever, but too clever = stupid.

The dummy code designed to flag when our MSRV is bumped and supports `NonNull::add` would fail to compile on Rust versions below 1.80.0. Precisely because of the condition this code is testing - it's not supported!

Fix this by skipping compilation unless running clippy.