### PR TITLE
fix(linter/no-control-regex): allow capture group references

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_control_regex@capture-group-indexing.snap
+++ b/crates/oxc_linter/src/snapshots/no_control_regex@capture-group-indexing.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-control-regex): Unexpected control character(s)
+   ╭─[no_control_regex.tsx:1:11]
+ 1 │ const r = /\0/;
+   ·           ────
+   ╰────
+  help: Unexpected control character(s) in regular expression: "\0"
+
+  ⚠ eslint(no-control-regex): Unexpected control character(s)
+   ╭─[no_control_regex.tsx:1:11]
+ 1 │ const r = /[a-z]\1/;
+   ·           ─────────
+   ╰────
+  help: Unexpected control character(s) in regular expression: "\1"
+
+  ⚠ eslint(no-control-regex): Unexpected control character(s)
+   ╭─[no_control_regex.tsx:1:11]
+ 1 │ const r = /([a-z])\2/;
+   ·           ───────────
+   ╰────
+  help: Unexpected control character(s) in regular expression: "\2"
+
+  ⚠ eslint(no-control-regex): Unexpected control character(s)
+   ╭─[no_control_regex.tsx:1:11]
+ 1 │ const r = /([a-z])\0/;
+   ·           ───────────
+   ╰────
+  help: Unexpected control character(s) in regular expression: "\0"


### PR DESCRIPTION
Closes #6525.

Allows `\1`, `\2`, etc. when referencing a capturing group.

Examples of now-allowed patterns:
```js
// both of these have a capture group with an index of 1
const r = /([a-z]+)\1/; 
const r = /\1([a-z]+)/;
```

Examples of still-banned patterns:
```js
/([a-z])\0/; //out of range: capture groups are 1-indexed
/([a-z])\2/; // there's only one capture group here
```