### PR TITLE
fix(linter/no-control-regex): false negative for flags in template literals

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -287,11 +287,15 @@ pub fn extract_regex_flags<'a>(
     if args.len() <= 1 {
         return None;
     }
-    let Argument::StringLiteral(flag_arg) = &args[1] else {
-        return None;
+    let flag_arg = match &args[1] {
+        Argument::StringLiteral(flag_arg) => flag_arg.value.clone(),
+        Argument::TemplateLiteral(template) if template.is_no_substitution_template() => {
+            template.quasi().expect("no-substitution templates always have a quasi")
+        }
+        _ => return None,
     };
     let mut flags = RegExpFlags::empty();
-    for ch in flag_arg.value.chars() {
+    for ch in flag_arg.chars() {
         let flag = RegExpFlags::try_from(ch).ok()?;
         flags |= flag;
     }

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -278,6 +278,8 @@ mod tests {
             ],
             vec![
                 r"let r = /\u{0}/u",
+                r"let r = new RegExp('\\u{0}', 'u');",
+                r"let r = new RegExp('\\u{0}', `u`);",
                 r"let r = /\u{c}/u",
                 r"let r = /\u{1F}/u",
                 r"let r = new RegExp('\\u{1F}', 'u');", // flags are known & contain u


### PR DESCRIPTION
Updates regex flag extraction logic to handle no-substitution template literals, allowing cases like this to be correctly reported:
```js
let r = new RegExp('\\u{0}', `u`);
```