### PR TITLE
perf(linter/jsx-no-comment-textnodes): remove regex for checking comment patterns

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -1,9 +1,7 @@
-use lazy_static::lazy_static;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use regex::Regex;
 
 use crate::{
     context::{ContextHost, LintContext},
@@ -60,7 +58,7 @@ impl Rule for JsxNoCommentTextnodes {
             return;
         };
 
-        if control_patterns(&jsx_text.value) {
+        if has_comment_pattern(&jsx_text.value) {
             ctx.diagnostic(jsx_no_comment_textnodes_diagnostic(jsx_text.span));
         }
     }
@@ -70,11 +68,12 @@ impl Rule for JsxNoCommentTextnodes {
     }
 }
 
-fn control_patterns(pattern: &str) -> bool {
-    lazy_static! {
-        static ref CTL_PAT: Regex = Regex::new(r"(?m)^\s*/(/|\*)",).unwrap();
-    }
-    CTL_PAT.is_match(pattern)
+/// Returns true if the given text contains a comment pattern such as `//` or `/*`.
+fn has_comment_pattern(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.trim();
+        line.starts_with("//") || line.starts_with("/*")
+    })
 }
 
 #[test]


### PR DESCRIPTION
Improves performance of this rule by replacing `Regex` with simpler string methods. On the `RadixUIAdoptionSection.jsx` file alone, this improves performance by ~5%:

```
hyperfine --warmup 100 --shell=none --runs 3000 './oxlint-main -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx' './oxlint-jsx-no-comment-textnodes-no-regex -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx'
Benchmark 1: ./oxlint-main -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx
  Time (mean ± σ):       4.4 ms ±   0.1 ms    [User: 1.7 ms, System: 1.9 ms]
  Range (min … max):     4.1 ms …   5.3 ms    3000 runs

Benchmark 2: ./oxlint-jsx-no-comment-textnodes-no-regex -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx
  Time (mean ± σ):       4.2 ms ±   0.1 ms    [User: 1.5 ms, System: 1.8 ms]
  Range (min … max):     3.9 ms …   5.0 ms    3000 runs

Summary
  ./oxlint-jsx-no-comment-textnodes-no-regex -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx ran
    1.06 ± 0.05 times faster than ./oxlint-main -W jsx-no-comment-textnodes --silent ./RadixUIAdoptionSection.jsx
```