### PR TITLE
docs(codegen): fix example for `CodeBuffer::print_ascii_bytes`

### DIFF
--- a/crates/oxc_codegen/src/code_buffer.rs
+++ b/crates/oxc_codegen/src/code_buffer.rs
@@ -320,7 +320,7 @@ impl CodeBuffer {
     /// use oxc_codegen::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
-    /// code.print_ascii([b'f', b'o', b'o'].into_iter());
+    /// code.print_ascii_bytes([b'f', b'o', b'o']);
     /// assert_eq!(String::from(code), "foo");
     /// ```
     pub fn print_ascii_bytes<I>(&mut self, bytes: I)
@@ -491,6 +491,17 @@ mod test {
             code.print_byte_unchecked(b'o');
             code.print_byte_unchecked(b'o');
         }
+
+        assert_eq!(code.len(), 3);
+        assert_eq!(code.as_bytes(), &[b'f', b'o', b'o']);
+        assert_eq!(String::from(code), "foo");
+    }
+
+    #[test]
+    #[allow(clippy::byte_char_slices)]
+    fn print_ascii_bytes() {
+        let mut code = CodeBuffer::new();
+        code.print_ascii_bytes([b'f', b'o', b'o']);
 
         assert_eq!(code.len(), 3);
         assert_eq!(code.as_bytes(), &[b'f', b'o', b'o']);


### PR DESCRIPTION
Fix example and add a test.