### PR TITLE
perf(codegen): use `AsciiChar` for statically unknowable characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "once_cell",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_data_structures",
  "oxc_index",
  "oxc_mangler",
  "oxc_parser",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_data_structures = { workspace = true }
 oxc_index = { workspace = true }
 oxc_mangler = { workspace = true }
 oxc_sourcemap = { workspace = true }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3,6 +3,7 @@ use std::ops::Not;
 use cow_utils::CowUtils;
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
+use oxc_data_structures::AsciiChar;
 use oxc_span::GetSpan;
 use oxc_syntax::{
     identifier::{LS, PS},
@@ -1210,7 +1211,7 @@ impl<'a> Gen for RegExpLiteral<'a> {
     }
 }
 
-fn print_unquoted_str(s: &str, quote: u8, p: &mut Codegen) {
+fn print_unquoted_str(s: &str, quote: AsciiChar, p: &mut Codegen) {
     let mut chars = s.chars().peekable();
 
     while let Some(c) = chars.next() {
@@ -1250,21 +1251,21 @@ fn print_unquoted_str(s: &str, quote: u8, p: &mut Codegen) {
                 p.print_str("\\\\");
             }
             '\'' => {
-                if quote == b'\'' {
+                if quote == AsciiChar::SingleQuote {
                     p.print_str("\\'");
                 } else {
                     p.print_str("'");
                 }
             }
             '\"' => {
-                if quote == b'"' {
+                if quote == AsciiChar::DoubleQuote {
                     p.print_str("\\\"");
                 } else {
                     p.print_str("\"");
                 }
             }
             '`' => {
-                if quote == b'`' {
+                if quote == AsciiChar::GraveAccent {
                     p.print_str("\\`");
                 } else {
                     p.print_str("`");
@@ -2335,10 +2336,14 @@ impl<'a> Gen for JSXAttributeValue<'a> {
             Self::Fragment(fragment) => fragment.print(p, ctx),
             Self::Element(el) => el.print(p, ctx),
             Self::StringLiteral(lit) => {
-                let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
-                p.print_ascii_byte(quote);
+                let quote = if lit.value.contains('"') {
+                    AsciiChar::SingleQuote
+                } else {
+                    AsciiChar::DoubleQuote
+                };
+                p.print_ascii_char(quote);
                 p.print_str(&lit.value);
-                p.print_ascii_byte(quote);
+                p.print_ascii_char(quote);
             }
             Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
         }


### PR DESCRIPTION
Small optimization. Use `AsciiChar` (introduced in #6537) for pushing bytes to buffer where the byte values are not statically known.

This also allows removing some unsafe code.