### PR TITLE
chore(benchmark): Add small JSX file to linter benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -152,6 +152,7 @@ jobs:
         fixture:
           - 0
           - 1
+          - 2
 
     steps:
       - name: Checkout Branch


### PR DESCRIPTION
We don't currently have any good representation for small files in the linter benchmarks. We already have benchmarks for lexer, parser, semantic, etc. for `RadixUIAdoptionSection.tsx`, so I think it makes sense to enable it for `linter` as well.

This will help us measure any fixed costs that we pay for some lint rules, such as initializing data structures, etc.