### PR TITLE
chore(transformer): turns off async_to_generator plugin in `enable_all`

### DIFF
--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -89,7 +89,10 @@ impl TransformOptions {
             },
             es2016: ES2016Options { exponentiation_operator: true },
             es2018: ES2018Options { object_rest_spread: Some(ObjectRestSpreadOptions::default()) },
-            es2017: ES2017Options { async_to_generator: true },
+            es2017: ES2017Options {
+                // Turned off because it is not ready.
+                async_to_generator: false,
+            },
             es2019: ES2019Options { optional_catch_binding: true },
             es2020: ES2020Options { nullish_coalescing_operator: true },
             es2021: ES2021Options { logical_assignment_operators: true },

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -37,8 +37,10 @@ fn bench_transformer(criterion: &mut Criterion) {
                     .into_symbol_table_and_scope_tree();
 
                 // `enable_all` enables all transforms except arrow functions transform
+                // and async-to-generator
                 let mut options = TransformOptions::enable_all();
                 options.es2015.arrow_function = Some(ArrowFunctionsOptions { spec: true });
+                options.es2017.async_to_generator = true;
 
                 runner.run(|| {
                     let ret = Transformer::new(&allocator, Path::new(&file.file_name), options)


### PR DESCRIPTION
The plugin is not ready to test
