### PR TITLE
test(linter/no-unused-vars): enable now-passing tests

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
@@ -13,8 +13,6 @@ use crate::{tester::Tester, RuleMeta as _};
 #[test]
 fn fixme() {
     let pass = vec![
-        // ESLint says this one should pass, but I disagree. foox could be
-        // safely removed here.
         ("function foo(cb) { cb = function(a) { return cb(1 + a); }(); } foo();", None),
         ("function foo(cb) { cb = (0, function(a) { cb(1 + a); }); } foo();", None),
         (
@@ -34,8 +32,8 @@ fn test() {
             "var foo = 5;
 			
 			label: while (true) {
-			  console.log(foo);
-			  break label;
+			    console.log(foo);
+			    break label;
 			}",
             None,
         ),
@@ -43,21 +41,19 @@ fn test() {
             "var foo = 5;
 			
 			while (true) {
-			  console.log(foo);
-			  break;
+			    console.log(foo);
+			    break;
 			}",
             None,
         ),
         (
-            "for (let prop in box) {
-			        box[prop] = parseInt(box[prop]);
-			}",
+            "for (let prop in box) { box[prop] = parseInt(box[prop]); }",
             None,
         ), // { "ecmaVersion": 6 },
         (
             "var box = {a: 2};
-			    for (var prop in box) {
-			        box[prop] = parseInt(box[prop]);
+            for (var prop in box) {
+                box[prop] = parseInt(box[prop]);
 			}",
             None,
         ),
@@ -223,44 +219,44 @@ fn test() {
         ), // { "ecmaVersion": 6 },
         (
             "
-			            let _a, b;
-			            foo.forEach(item => {
-			                [_a, b] = item;
-			                doSomething(b);
-			            });
-			            ",
+            let _a, b;
+            foo.forEach(item => {
+                [_a, b] = item;
+                doSomething(b);
+            });
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			            // doesn't report _x
-			            let _x, y;
-			            _x = 1;
-			            [_x, y] = foo;
-			            y;
+            // doesn't report _x
+            let _x, y;
+            _x = 1;
+            [_x, y] = foo;
+            y;
 
-			            // doesn't report _a
-			            let _a, b;
-			            [_a, b] = foo;
-			            _a = 1;
-			            b;
-			            ",
+            // doesn't report _a
+            let _a, b;
+            [_a, b] = foo;
+            _a = 1;
+            b;
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2018 },
         (
             "
-			            // doesn't report _x
-			            let _x, y;
-			            _x = 1;
-			            [_x, y] = foo;
-			            y;
-	
-			            // doesn't report _a
-			            let _a, b;
-			            _a = 1;
-			            ({_a, ...b } = foo);
-			            b;
-			            ",
+            // doesn't report _x
+            let _x, y;
+            _x = 1;
+            [_x, y] = foo;
+            y;
+
+            // doesn't report _a
+            let _a, b;
+            _a = 1;
+            ({_a, ...b } = foo);
+            b;
+            ",
             Some(
                 serde_json::json!([{ "destructuredArrayIgnorePattern": "^_", "ignoreRestSiblings": true }]),
             ),
@@ -508,18 +504,8 @@ fn test() {
             Some(serde_json::json!([{}])),
         ),
         (r#"import x from "y";"#, None), // { "ecmaVersion": 6, "sourceType": "module" },
-        (
-            "export function fn2({ x, y }) {
-			 console.log(x); 
-			};",
-            None,
-        ), // { "ecmaVersion": 6, "sourceType": "module" },
-        (
-            "export function fn2( x, y ) {
-			 console.log(x); 
-			};",
-            None,
-        ), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export function fn2({ x, y }) { console.log(x); };", None), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export function fn2( x, y ) { console.log(x); };", None), // { "ecmaVersion": 6, "sourceType": "module" },
         ("/*exported max*/ var max = 1, min = {min: 1}", None),
         ("/*exported x*/ var { x, y } = z", None), // { "ecmaVersion": 6 },
         ("var _a; var b;", Some(serde_json::json!([{ "vars": "all", "varsIgnorePattern": "^_" }]))),
@@ -545,56 +531,56 @@ fn test() {
         ), // { "ecmaVersion": 6 },
         (
             "
-			            const array = ['a', 'b', 'c'];
-			            const [a, _b, c] = array;
-			            const newArray = [a, c];
-			            ",
+            const array = ['a', 'b', 'c'];
+            const [a, _b, c] = array;
+            const newArray = [a, c];
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2020 },
         (
             "
-			            const array = ['a', 'b', 'c', 'd', 'e'];
-			            const [a, _b, c] = array;
-			            ",
+            const array = ['a', 'b', 'c', 'd', 'e'];
+            const [a, _b, c] = array;
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2020 },
         (
             "
-			            const array = ['a', 'b', 'c'];
-			            const [a, _b, c] = array;
-			            const fooArray = ['foo'];
-			            const barArray = ['bar'];
-			            const ignoreArray = ['ignore'];
-			            ",
+            const array = ['a', 'b', 'c'];
+            const [a, _b, c] = array;
+            const fooArray = ['foo'];
+            const barArray = ['bar'];
+            const ignoreArray = ['ignore'];
+            ",
             Some(
                 serde_json::json!([{ "destructuredArrayIgnorePattern": "^_", "varsIgnorePattern": "ignore" }]),
             ),
         ), // { "ecmaVersion": 2020 },
         (
             "
-			            const array = [obj];
-			            const [{_a, foo}] = array;
-			            console.log(foo);
-			            ",
+            const array = [obj];
+            const [{_a, foo}] = array;
+            console.log(foo);
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2020 },
         (
             "
-			            function foo([{_a, bar}]) {
-			                bar;
-			            }
-			            foo();
-			            ",
+            function foo([{_a, bar}]) {
+                bar;
+            }
+            foo();
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2020 },
         (
             "
-			            let _a, b;
-			
-			            foo.forEach(item => {
-			                [a, b] = item;
-			            });
-			            ",
+            let _a, b;
+
+            foo.forEach(item => {
+                [a, b] = item;
+            });
+            ",
             Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
         ), // { "ecmaVersion": 2020 },
         ("(function(obj) { var name; for ( name in obj ) { i(); return; } })({});", None),
@@ -722,7 +708,7 @@ fn test() {
         (
             "try{}catch(err){};",
             Some(
-                serde_json::json!([                {                    "vars": "all",                    "args": "all",                    "caughtErrors": "all",                    "argsIgnorePattern": "^er"                }            ]),
+                serde_json::json!([{ "vars": "all", "args": "all", "caughtErrors": "all","argsIgnorePattern": "^er" }]),
             ),
         ),
         ("var a = 0; a = a + 1;", None),
@@ -801,9 +787,9 @@ fn test() {
         ("let x = 0; 0, x = x+1;", None),                  // { "ecmaVersion": 2020 },
         ("let x = 0; x = x+1, 0;", None),                  // { "ecmaVersion": 2020 },
         // https://github.com/oxc-project/oxc/issues/4437
-        // ("let x = 0; foo = ((0, x = x + 1), 0);", None),   // { "ecmaVersion": 2020 },
-        // ("let x = 0; foo = (x = x+1, 0);", None),          // { "ecmaVersion": 2020 },
-        ("let x = 0; 0, (1, x=x+1);", None), // { "ecmaVersion": 2020 },
+        ("let x = 0; foo = ((0, x = x + 1), 0);", None), // { "ecmaVersion": 2020 },
+        ("let x = 0; foo = (x = x+1, 0);", None),        // { "ecmaVersion": 2020 },
+        ("let x = 0; 0, (1, x=x+1);", None),             // { "ecmaVersion": 2020 },
         ("(function ({ a, b }, { c } ) { return b; })();", None), // { "ecmaVersion": 2015 },
         ("(function ([ a ], b ) { return b; })();", None), // { "ecmaVersion": 2015 },
         ("(function ([ a ], [ b, c ] ) { return b; })();", None), // { "ecmaVersion": 2015 },
@@ -834,41 +820,38 @@ fn test() {
         // ), // { "ecmaVersion": 2015 },
         (
             "let a = 'a';
-			            a = 10;
-			            function foo(){
-			                a = 11;
-			                a = () => {
-			                    a = 13
-			                }
-			            }",
+            a = 10;
+            function foo(){
+                a = 11;
+                a = () => {
+                    a = 13
+                }
+            }",
             None,
         ), // { "ecmaVersion": 2020 },
         (
             "let foo;
-			            init();
-			            foo = foo + 2;
-			            function init() {
-			                foo = 1;
-			            }",
+            init();
+            foo = foo + 2;
+            function init() {
+                foo = 1;
+            }",
             None,
         ), // { "ecmaVersion": 2020 },
         (
             "function foo(n) {
-			                if (n < 2) return 1;
-			                return n * foo(n - 1);
-			            }",
+                if (n < 2) return 1;
+                return n * foo(n - 1);
+            }",
             None,
         ), // { "ecmaVersion": 2020 },
         (
             "let c = 'c'
 			c = 10
 			function foo1() {
-			  c = 11
-			  c = () => {
-			    c = 13
-			  }
+			    c = 11
+			    c = () => { c = 13 }
 			}
-			
 			c = foo1",
             None,
         ), // { "ecmaVersion": 2020 },
@@ -972,7 +955,7 @@ fn test() {
 			}
 			            ",
             Some(
-                serde_json::json!([{                "caughtErrorsIgnorePattern": "ignored",                "varsIgnorePattern": "_"            }]),
+                serde_json::json!([{ "caughtErrorsIgnorePattern": "ignored", "varsIgnorePattern": "_" }]),
             ),
         ),
         (
@@ -987,9 +970,7 @@ fn test() {
             "
 			_ => { _ = _ + 1 };
 			            ",
-            Some(
-                serde_json::json!([{                "argsIgnorePattern": "ignored",                "varsIgnorePattern": "_"            }]),
-            ),
+            Some(serde_json::json!([{ "argsIgnorePattern": "ignored", "varsIgnorePattern": "_" }])),
         ), // { "ecmaVersion": 2015 }
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -119,6 +119,12 @@ fn test_vars_simple() {
         // vars with references get renamed
         ("let x = 1; x = 2;", "let _x = 1; _x = 2;", None, FixKind::DangerousFix),
         (
+            "let a = 1; a = 2; a = 3;",
+            "let _a = 1; _a = 2; _a = 3;",
+            Some(json!([{ "varsIgnorePattern": "^_" }])),
+            FixKind::DangerousFix,
+        ),
+        (
             "let x = 1; x = 2;",
             "let x = 1; x = 2;",
             Some(json!( [{ "varsIgnorePattern": "^tooCompli[cated]" }] )),
@@ -126,8 +132,6 @@ fn test_vars_simple() {
         ),
         // type annotations do not get clobbered
         ("let x: number = 1; x = 2;", "let _x: number = 1; _x = 2;", None, FixKind::DangerousFix),
-        ("const { a } = obj;", "", None, FixKind::DangerousSuggestion),
-        ("let [f,\u{a0}a]=p", "let [,a]=p", None, FixKind::DangerousSuggestion),
     ];
 
     Tester::new(NoUnusedVars::NAME, pass, fail)
@@ -355,6 +359,7 @@ fn test_vars_destructure() {
             None,
             FixKind::DangerousSuggestion,
         ),
+        ("let [f,\u{a0}a]=p", "let [,a]=p", None, FixKind::DangerousSuggestion),
         (
             "const [a, b, c, d, e] = arr; f(a, e)",
             "const [a, ,,,e] = arr; f(a, e)",
@@ -382,13 +387,6 @@ fn test_vars_destructure() {
         ),
         // TODO: destructures in VariableDeclarations with more than one declarator
         (r#"const l="",{e}=r"#, r"const {e}=r", None, FixKind::All),
-        // renaming
-        // (
-        //     "let a = 1; a = 2;",
-        //     "let _a = 1; _a = 2;",
-        //     Some(json!([{ "varsIgnorePattern": "^_" }])),
-        //     FixKind::DangerousSuggestion,
-        // ),
     ];
 
     Tester::new(NoUnusedVars::NAME, pass, fail)

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
@@ -270,19 +270,17 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used.
    ╭─[no_unused_vars.tsx:1:26]
- 1 │ export function fn2({ x, y }) {
+ 1 │ export function fn2({ x, y }) { console.log(x); };
    ·                          ┬
    ·                          ╰── 'y' is declared here
- 2 │              console.log(x); 
    ╰────
   help: Consider removing this parameter.
 
   ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used.
    ╭─[no_unused_vars.tsx:1:25]
- 1 │ export function fn2( x, y ) {
+ 1 │ export function fn2( x, y ) { console.log(x); };
    ·                         ┬
    ·                         ╰── 'y' is declared here
- 2 │              console.log(x); 
    ╰────
   help: Consider removing this parameter.
 
@@ -367,117 +365,117 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'newArray' is declared but never used.
-   ╭─[no_unused_vars.tsx:4:22]
- 3 │                         const [a, _b, c] = array;
- 4 │                         const newArray = [a, c];
-   ·                               ────┬───
-   ·                                   ╰── 'newArray' is declared here
- 5 │                         
+   ╭─[no_unused_vars.tsx:4:19]
+ 3 │             const [a, _b, c] = array;
+ 4 │             const newArray = [a, c];
+   ·                   ────┬───
+   ·                       ╰── 'newArray' is declared here
+ 5 │             
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:23]
- 2 │                         const array = ['a', 'b', 'c', 'd', 'e'];
- 3 │                         const [a, _b, c] = array;
-   ·                                ┬
-   ·                                ╰── 'a' is declared here
- 4 │                         
+   ╭─[no_unused_vars.tsx:3:20]
+ 2 │             const array = ['a', 'b', 'c', 'd', 'e'];
+ 3 │             const [a, _b, c] = array;
+   ·                    ┬
+   ·                    ╰── 'a' is declared here
+ 4 │             
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:30]
- 2 │                         const array = ['a', 'b', 'c', 'd', 'e'];
- 3 │                         const [a, _b, c] = array;
-   ·                                       ┬
-   ·                                       ╰── 'c' is declared here
- 4 │                         
+   ╭─[no_unused_vars.tsx:3:27]
+ 2 │             const array = ['a', 'b', 'c', 'd', 'e'];
+ 3 │             const [a, _b, c] = array;
+   ·                           ┬
+   ·                           ╰── 'c' is declared here
+ 4 │             
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:23]
- 2 │                         const array = ['a', 'b', 'c'];
- 3 │                         const [a, _b, c] = array;
-   ·                                ┬
-   ·                                ╰── 'a' is declared here
- 4 │                         const fooArray = ['foo'];
+   ╭─[no_unused_vars.tsx:3:20]
+ 2 │             const array = ['a', 'b', 'c'];
+ 3 │             const [a, _b, c] = array;
+   ·                    ┬
+   ·                    ╰── 'a' is declared here
+ 4 │             const fooArray = ['foo'];
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:30]
- 2 │                         const array = ['a', 'b', 'c'];
- 3 │                         const [a, _b, c] = array;
-   ·                                       ┬
-   ·                                       ╰── 'c' is declared here
- 4 │                         const fooArray = ['foo'];
+   ╭─[no_unused_vars.tsx:3:27]
+ 2 │             const array = ['a', 'b', 'c'];
+ 3 │             const [a, _b, c] = array;
+   ·                           ┬
+   ·                           ╰── 'c' is declared here
+ 4 │             const fooArray = ['foo'];
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'fooArray' is declared but never used.
-   ╭─[no_unused_vars.tsx:4:22]
- 3 │                         const [a, _b, c] = array;
- 4 │                         const fooArray = ['foo'];
-   ·                               ────┬───
-   ·                                   ╰── 'fooArray' is declared here
- 5 │                         const barArray = ['bar'];
+   ╭─[no_unused_vars.tsx:4:19]
+ 3 │             const [a, _b, c] = array;
+ 4 │             const fooArray = ['foo'];
+   ·                   ────┬───
+   ·                       ╰── 'fooArray' is declared here
+ 5 │             const barArray = ['bar'];
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'barArray' is declared but never used.
-   ╭─[no_unused_vars.tsx:5:22]
- 4 │                         const fooArray = ['foo'];
- 5 │                         const barArray = ['bar'];
-   ·                               ────┬───
-   ·                                   ╰── 'barArray' is declared here
- 6 │                         const ignoreArray = ['ignore'];
+   ╭─[no_unused_vars.tsx:5:19]
+ 4 │             const fooArray = ['foo'];
+ 5 │             const barArray = ['bar'];
+   ·                   ────┬───
+   ·                       ╰── 'barArray' is declared here
+ 6 │             const ignoreArray = ['ignore'];
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:24]
- 2 │                         const array = [obj];
- 3 │                         const [{_a, foo}] = array;
-   ·                                 ─┬
-   ·                                  ╰── '_a' is declared here
- 4 │                         console.log(foo);
+   ╭─[no_unused_vars.tsx:3:21]
+ 2 │             const array = [obj];
+ 3 │             const [{_a, foo}] = array;
+   ·                     ─┬
+   ·                      ╰── '_a' is declared here
+ 4 │             console.log(foo);
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Parameter '_a' is declared but never used.
-   ╭─[no_unused_vars.tsx:2:31]
+   ╭─[no_unused_vars.tsx:2:28]
  1 │ 
- 2 │                         function foo([{_a, bar}]) {
-   ·                                        ─┬
-   ·                                         ╰── '_a' is declared here
- 3 │                             bar;
+ 2 │             function foo([{_a, bar}]) {
+   ·                            ─┬
+   ·                             ╰── '_a' is declared here
+ 3 │                 bar;
    ╰────
   help: Consider removing this parameter.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is declared but never used.
-   ╭─[no_unused_vars.tsx:2:20]
+   ╭─[no_unused_vars.tsx:2:17]
  1 │ 
- 2 │                         let _a, b;
-   ·                             ─┬
-   ·                              ╰── '_a' is declared here
- 3 │             
+ 2 │             let _a, b;
+   ·                 ─┬
+   ·                  ╰── '_a' is declared here
+ 3 │ 
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'b' is assigned a value but never used.
-   ╭─[no_unused_vars.tsx:2:24]
+   ╭─[no_unused_vars.tsx:2:21]
  1 │ 
- 2 │                         let _a, b;
-   ·                                 ┬
-   ·                                 ╰── 'b' is declared here
- 3 │             
- 4 │                         foo.forEach(item => {
- 5 │                             [a, b] = item;
-   ·                                 ┬
-   ·                                 ╰── it was last assigned here
- 6 │                         });
+ 2 │             let _a, b;
+   ·                     ┬
+   ·                     ╰── 'b' is declared here
+ 3 │ 
+ 4 │             foo.forEach(item => {
+ 5 │                 [a, b] = item;
+   ·                     ┬
+   ·                     ╰── it was last assigned here
+ 6 │             });
    ╰────
   help: Did you mean to use this variable?
 
@@ -1109,6 +1107,24 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
    ╭─[no_unused_vars.tsx:1:5]
+ 1 │ let x = 0; foo = ((0, x = x + 1), 0);
+   ·     ┬                 ┬
+   ·     │                 ╰── it was last assigned here
+   ·     ╰── 'x' is declared here
+   ╰────
+  help: Did you mean to use this variable?
+
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+   ╭─[no_unused_vars.tsx:1:5]
+ 1 │ let x = 0; foo = (x = x+1, 0);
+   ·     ┬             ┬
+   ·     │             ╰── it was last assigned here
+   ·     ╰── 'x' is declared here
+   ╰────
+  help: Did you mean to use this variable?
+
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+   ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, (1, x=x+1);
    ·     ┬             ┬
    ·     │             ╰── it was last assigned here
@@ -1245,24 +1261,24 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let a = 'a';
    ·     ┬
    ·     ╰── 'a' is declared here
- 2 │                         a = 10;
+ 2 │             a = 10;
    ╰────
-   ╭─[no_unused_vars.tsx:6:24]
- 5 │                             a = () => {
- 6 │                                 a = 13
-   ·                                 ┬
-   ·                                 ╰── it was last assigned here
- 7 │                             }
+   ╭─[no_unused_vars.tsx:6:21]
+ 5 │                 a = () => {
+ 6 │                     a = 13
+   ·                     ┬
+   ·                     ╰── it was last assigned here
+ 7 │                 }
    ╰────
   help: Did you mean to use this variable?
 
   ⚠ eslint(no-unused-vars): Function 'foo' is declared but never used.
-   ╭─[no_unused_vars.tsx:3:25]
- 2 │                         a = 10;
- 3 │                         function foo(){
-   ·                                  ─┬─
-   ·                                   ╰── 'foo' is declared here
- 4 │                             a = 11;
+   ╭─[no_unused_vars.tsx:3:22]
+ 2 │             a = 10;
+ 3 │             function foo(){
+   ·                      ─┬─
+   ·                       ╰── 'foo' is declared here
+ 4 │                 a = 11;
    ╰────
   help: Consider removing this declaration.
 
@@ -1271,14 +1287,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let foo;
    ·     ─┬─
    ·      ╰── 'foo' is declared here
- 2 │                         init();
+ 2 │             init();
    ╰────
-   ╭─[no_unused_vars.tsx:5:20]
- 4 │                         function init() {
- 5 │                             foo = 1;
-   ·                             ─┬─
-   ·                              ╰── it was last assigned here
- 6 │                         }
+   ╭─[no_unused_vars.tsx:5:17]
+ 4 │             function init() {
+ 5 │                 foo = 1;
+   ·                 ─┬─
+   ·                  ╰── it was last assigned here
+ 6 │             }
    ╰────
   help: Did you mean to use this variable?
 
@@ -1287,7 +1303,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(n) {
    ·          ─┬─
    ·           ╰── 'foo' is declared here
- 2 │                             if (n < 2) return 1;
+ 2 │                 if (n < 2) return 1;
    ╰────
   help: Consider removing this declaration.
 
@@ -1298,12 +1314,12 @@ source: crates/oxc_linter/src/tester.rs
    ·     ╰── 'c' is declared here
  2 │             c = 10
    ╰────
-    ╭─[no_unused_vars.tsx:10:4]
-  9 │             
- 10 │             c = foo1
-    ·             ┬
-    ·             ╰── it was last assigned here
-    ╰────
+   ╭─[no_unused_vars.tsx:7:4]
+ 6 │             }
+ 7 │             c = foo1
+   ·             ┬
+   ·             ╰── it was last assigned here
+   ╰────
   help: Did you mean to use this variable?
 
   ⚠ eslint(no-unused-vars): Class 'Foo' is declared but never used.


### PR DESCRIPTION
Un-comment tests that are now passing. This PR does not change rule behavior; these have been passing for a while now, but were not getting run.