### PR TITLE
refactor(transformer): `ImportKind` use `BoundIdentifier`

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -150,11 +150,7 @@ impl<'a, 'ctx> HelperLoader<'a, 'ctx> {
     fn add_imports(&self) {
         self.ctx.helper_loader.loaded_helpers.borrow_mut().drain().for_each(
             |(_, (source, import))| {
-                self.ctx.module_imports.add_import(
-                    source,
-                    ImportKind::new_default(import.name, import.symbol_id),
-                    false,
-                );
+                self.ctx.module_imports.add_import(source, ImportKind::new_default(import), false);
             },
         );
     }

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -198,7 +198,7 @@ impl<'a, 'ctx> AutomaticScriptBindings<'a, 'ctx> {
     ) -> BoundIdentifier<'a> {
         let binding =
             ctx.generate_uid_in_root_scope(variable_name, SymbolFlags::FunctionScopedVariable);
-        let import = ImportKind::new_default(binding.name.clone(), binding.symbol_id);
+        let import = ImportKind::new_default(binding.clone());
         self.ctx.module_imports.add_import(source, import, front);
         binding
     }
@@ -297,8 +297,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_root_scope(name, SymbolFlags::Import);
-        let import =
-            ImportKind::new_named(Atom::from(name), binding.name.clone(), binding.symbol_id);
+        let import = ImportKind::new_named(Atom::from(name), binding.clone());
         self.ctx.module_imports.add_import(source, import, false);
         binding
     }


### PR DESCRIPTION
Follow-on after #6434.

Store `BoundIdentifier` in `ImportKind`, rather than storing `name` and `symbol_id` separately. Pure refactor - just allows shortening some code.