### PR TITLE
refactor(transformer): add more specific methods to `ModuleImportsStore`

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -73,7 +73,6 @@ use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
-use super::module_imports::ImportKind;
 use crate::TransformCtx;
 
 /// Defines the mode for loading helper functions.
@@ -150,7 +149,7 @@ impl<'a, 'ctx> HelperLoader<'a, 'ctx> {
     fn add_imports(&self) {
         self.ctx.helper_loader.loaded_helpers.borrow_mut().drain().for_each(
             |(_, (source, import))| {
-                self.ctx.module_imports.add_import(source, ImportKind::new_default(import), false);
+                self.ctx.module_imports.add_default_import(source, import, false);
             },
         );
     }

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -100,7 +100,7 @@ use oxc_syntax::{
 };
 use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
 
-use crate::{common::module_imports::ImportKind, TransformCtx};
+use crate::TransformCtx;
 
 use super::diagnostics;
 pub use super::{
@@ -198,8 +198,7 @@ impl<'a, 'ctx> AutomaticScriptBindings<'a, 'ctx> {
     ) -> BoundIdentifier<'a> {
         let binding =
             ctx.generate_uid_in_root_scope(variable_name, SymbolFlags::FunctionScopedVariable);
-        let import = ImportKind::new_default(binding.clone());
-        self.ctx.module_imports.add_import(source, import, front);
+        self.ctx.module_imports.add_default_import(source, binding.clone(), front);
         binding
     }
 }
@@ -297,8 +296,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_root_scope(name, SymbolFlags::Import);
-        let import = ImportKind::new_named(Atom::from(name), binding.clone());
-        self.ctx.module_imports.add_import(source, import, false);
+        self.ctx.module_imports.add_named_import(source, Atom::from(name), binding.clone(), false);
         binding
     }
 }


### PR DESCRIPTION
Make `ImportKind` private implementation detail of `ModuleImports` common transform. Provide `add_default_import` and `add_named_import` methods instead.