### PR TITLE
refactor(transformer): re-order fields of `Common` and `TransformCtx`

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -17,19 +17,19 @@ use top_level_statements::TopLevelStatements;
 use var_declarations::VarDeclarations;
 
 pub struct Common<'a, 'ctx> {
+    helper_loader: HelperLoader<'a, 'ctx>,
     module_imports: ModuleImports<'a, 'ctx>,
     var_declarations: VarDeclarations<'a, 'ctx>,
     top_level_statements: TopLevelStatements<'a, 'ctx>,
-    helper_loader: HelperLoader<'a, 'ctx>,
 }
 
 impl<'a, 'ctx> Common<'a, 'ctx> {
     pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
+            helper_loader: HelperLoader::new(ctx),
             module_imports: ModuleImports::new(ctx),
             var_declarations: VarDeclarations::new(ctx),
             top_level_statements: TopLevelStatements::new(ctx),
-            helper_loader: HelperLoader::new(ctx),
         }
     }
 }

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -29,14 +29,14 @@ pub struct TransformCtx<'a> {
     pub source_text: &'a str,
 
     // Helpers
+    /// Manage helper loading
+    pub helper_loader: HelperLoaderStore<'a>,
     /// Manage import statement globally
     pub module_imports: ModuleImportsStore<'a>,
     /// Manage inserting `var` statements globally
     pub var_declarations: VarDeclarationsStore<'a>,
     /// Manage inserting statements at top of program globally
     pub top_level_statements: TopLevelStatementsStore<'a>,
-    /// Manage helper loading
-    pub helper_loader: HelperLoaderStore<'a>,
 }
 
 impl<'a> TransformCtx<'a> {
@@ -55,10 +55,10 @@ impl<'a> TransformCtx<'a> {
             source_path,
             source_type: SourceType::default(),
             source_text: "",
+            helper_loader: HelperLoaderStore::new(&options.helper_loader),
             module_imports: ModuleImportsStore::new(),
             var_declarations: VarDeclarationsStore::new(),
             top_level_statements: TopLevelStatementsStore::new(),
-            helper_loader: HelperLoaderStore::new(&options.helper_loader),
         }
     }
 


### PR DESCRIPTION
Follow-on after #6162.

Tiny refactor. Put `HelperLoader` first, so order of fields is same order the common transforms run in.