### PR TITLE
refactor(transformer): reorder imports

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -59,15 +59,17 @@
 //! ```
 //!
 //! Based on [@babel/helper](https://github.com/babel/babel/tree/main/packages/babel-helpers).
+
 use std::{borrow::Cow, cell::RefCell};
+
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::{Argument, CallExpression, Expression, Program, TSTypeParameterInstantiation};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::{Atom, SPAN};
 use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
-use rustc_hash::FxHashMap;
-use serde::Deserialize;
 
 use crate::TransformCtx;
 

--- a/crates/oxc_transformer/src/env/data/mod.rs
+++ b/crates/oxc_transformer/src/env/data/mod.rs
@@ -1,3 +1,3 @@
 mod babel;
 
-pub use self::babel::can_enable_plugin;
+pub use babel::can_enable_plugin;

--- a/crates/oxc_transformer/src/env/mod.rs
+++ b/crates/oxc_transformer/src/env/mod.rs
@@ -2,8 +2,6 @@ mod data;
 mod options;
 mod targets;
 
-pub use self::{
-    data::can_enable_plugin,
-    options::EnvOptions,
-    targets::{Targets, Versions},
-};
+pub use data::can_enable_plugin;
+pub use options::EnvOptions;
+pub use targets::{Targets, Versions};

--- a/crates/oxc_transformer/src/env/options.rs
+++ b/crates/oxc_transformer/src/env/options.rs
@@ -1,6 +1,7 @@
-use oxc_diagnostics::Error;
 use serde::Deserialize;
 use serde_json::Value;
+
+use oxc_diagnostics::Error;
 
 use super::targets::{query::Targets, Versions};
 

--- a/crates/oxc_transformer/src/env/targets/mod.rs
+++ b/crates/oxc_transformer/src/env/targets/mod.rs
@@ -10,10 +10,10 @@ use std::ops::{Deref, DerefMut};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
-pub use self::query::Targets;
-use self::version::Version;
 pub mod query;
 pub mod version;
+pub use query::Targets;
+use version::Version;
 
 /// A map of browser names to data for feature support in browser.
 ///

--- a/crates/oxc_transformer/src/env/targets/query.rs
+++ b/crates/oxc_transformer/src/env/targets/query.rs
@@ -5,9 +5,10 @@
 use std::sync::OnceLock;
 
 use dashmap::DashMap;
-use oxc_diagnostics::{Error, OxcDiagnostic};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+
+use oxc_diagnostics::{Error, OxcDiagnostic};
 
 use super::{version::Version, Versions};
 

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -124,6 +124,8 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-arrow-functions>
 //! * Arrow function specification: <https://tc39.es/ecma262/#sec-arrow-function-definitions>
 
+use serde::Deserialize;
+
 use oxc_allocator::Vec;
 use oxc_ast::{ast::*, NONE};
 use oxc_data_structures::stack::SparseStack;
@@ -133,8 +135,6 @@ use oxc_syntax::{
     symbol::SymbolFlags,
 };
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, TraverseCtx};
-
-use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct ArrowFunctionsOptions {

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -1,10 +1,11 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
 mod arrow_functions;
 mod options;
 
 pub use arrow_functions::{ArrowFunctions, ArrowFunctionsOptions};
 pub use options::ES2015Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
 
 pub struct ES2015<'a> {
     options: ES2015Options,

--- a/crates/oxc_transformer/src/es2015/options.rs
+++ b/crates/oxc_transformer/src/es2015/options.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 
-use super::ArrowFunctionsOptions;
 use crate::env::{can_enable_plugin, Versions};
+
+use super::ArrowFunctionsOptions;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/oxc_transformer/src/es2016/mod.rs
+++ b/crates/oxc_transformer/src/es2016/mod.rs
@@ -1,12 +1,13 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
 mod exponentiation_operator;
 mod options;
 
 pub use exponentiation_operator::ExponentiationOperator;
 pub use options::ES2016Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
-
-use crate::TransformCtx;
 
 pub struct ES2016<'a, 'ctx> {
     options: ES2016Options,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -42,13 +42,15 @@
 //! * Async / Await TC39 proposal: <https://github.com/tc39/proposal-async-await>
 //!
 
-use oxc_ast::ast::{
-    ArrowFunctionExpression, Expression, Function, FunctionType, Statement, VariableDeclarationKind,
+use oxc_ast::{
+    ast::{
+        ArrowFunctionExpression, Expression, Function, FunctionType, Statement,
+        VariableDeclarationKind,
+    },
+    NONE,
 };
-use oxc_ast::NONE;
 use oxc_span::{Atom, SPAN};
-use oxc_syntax::reference::ReferenceFlags;
-use oxc_syntax::symbol::SymbolId;
+use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
 
 pub struct AsyncToGenerator;

--- a/crates/oxc_transformer/src/es2017/mod.rs
+++ b/crates/oxc_transformer/src/es2017/mod.rs
@@ -1,10 +1,11 @@
-mod async_to_generator;
-pub mod options;
+use oxc_ast::ast::{ArrowFunctionExpression, Expression, Statement};
+use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::es2017::async_to_generator::AsyncToGenerator;
 use crate::es2017::options::ES2017Options;
-use oxc_ast::ast::{ArrowFunctionExpression, Expression, Statement};
-use oxc_traverse::{Traverse, TraverseCtx};
+
+mod async_to_generator;
+pub mod options;
 
 #[allow(dead_code)]
 pub struct ES2017 {

--- a/crates/oxc_transformer/src/es2017/options.rs
+++ b/crates/oxc_transformer/src/es2017/options.rs
@@ -1,5 +1,6 @@
-use crate::env::{can_enable_plugin, Versions};
 use serde::Deserialize;
+
+use crate::env::{can_enable_plugin, Versions};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/oxc_transformer/src/es2018/mod.rs
+++ b/crates/oxc_transformer/src/es2018/mod.rs
@@ -1,12 +1,13 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::context::TransformCtx;
+
 mod object_rest_spread;
 mod options;
 
 pub use object_rest_spread::{ObjectRestSpread, ObjectRestSpreadOptions};
 pub use options::ES2018Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
-
-use crate::context::TransformCtx;
 
 pub struct ES2018<'a, 'ctx> {
     options: ES2018Options,

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/mod.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/mod.rs
@@ -26,16 +26,17 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
-use object_rest::ObjectRest;
-use object_spread::ObjectSpread;
+use serde::Deserialize;
+
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
-use serde::Deserialize;
 
 use crate::context::TransformCtx;
 
 mod object_rest;
 mod object_spread;
+use object_rest::ObjectRest;
+use object_spread::ObjectSpread;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/crates/oxc_transformer/src/es2018/options.rs
+++ b/crates/oxc_transformer/src/es2018/options.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 
-use super::ObjectRestSpreadOptions;
 use crate::env::{can_enable_plugin, Versions};
+
+use super::ObjectRestSpreadOptions;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/oxc_transformer/src/es2019/mod.rs
+++ b/crates/oxc_transformer/src/es2019/mod.rs
@@ -1,10 +1,11 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
 mod optional_catch_binding;
 mod options;
 
 pub use optional_catch_binding::OptionalCatchBinding;
 pub use options::ES2019Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
 
 pub struct ES2019 {
     options: ES2019Options,

--- a/crates/oxc_transformer/src/es2020/mod.rs
+++ b/crates/oxc_transformer/src/es2020/mod.rs
@@ -1,12 +1,13 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
 mod nullish_coalescing_operator;
 mod options;
 
 pub use nullish_coalescing_operator::NullishCoalescingOperator;
 pub use options::ES2020Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
-
-use crate::TransformCtx;
 
 pub struct ES2020<'a, 'ctx> {
     options: ES2020Options,

--- a/crates/oxc_transformer/src/es2021/mod.rs
+++ b/crates/oxc_transformer/src/es2021/mod.rs
@@ -1,12 +1,13 @@
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
 mod logical_assignment_operators;
 mod options;
 
 pub use logical_assignment_operators::LogicalAssignmentOperators;
 pub use options::ES2021Options;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
-
-use crate::TransformCtx;
 
 pub struct ES2021<'a, 'ctx> {
     options: ES2021Options,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -8,7 +8,14 @@
 //! * <https://babel.dev/docs/presets>
 //! * <https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformer.ts>
 
-use oxc_ast::AstBuilder;
+use std::path::Path;
+
+use oxc_allocator::{Allocator, Vec};
+use oxc_ast::{ast::*, AstBuilder};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::{ScopeTree, SymbolTable};
+use oxc_span::SPAN;
+use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 
 // Core
 mod common;
@@ -30,22 +37,18 @@ mod typescript;
 
 mod plugins;
 
-use std::path::Path;
-
 use common::Common;
+use context::TransformCtx;
+use es2015::ES2015;
 use es2016::ES2016;
 use es2017::ES2017;
 use es2018::ES2018;
 use es2019::ES2019;
 use es2020::ES2020;
 use es2021::ES2021;
-use oxc_allocator::{Allocator, Vec};
-use oxc_ast::ast::*;
-use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::{ScopeTree, SymbolTable};
-use oxc_span::SPAN;
-use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
+use react::React;
 use regexp::RegExp;
+use typescript::TypeScript;
 
 pub use crate::{
     compiler_assumptions::CompilerAssumptions,
@@ -56,7 +59,6 @@ pub use crate::{
     react::{JsxOptions, JsxRuntime, ReactRefreshOptions},
     typescript::{RewriteExtensionsMode, TypeScriptOptions},
 };
-use crate::{context::TransformCtx, es2015::ES2015, react::React, typescript::TypeScript};
 
 pub struct TransformerReturn {
     pub errors: std::vec::Vec<OxcDiagnostic>,

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -1,4 +1,5 @@
 mod babel;
 mod transformer;
 
-pub use self::{babel::BabelOptions, transformer::TransformOptions};
+pub use babel::BabelOptions;
+pub use transformer::TransformOptions;

--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-use oxc_diagnostics::{Error, OxcDiagnostic};
 use serde_json::{from_value, json, Value};
+
+use oxc_diagnostics::{Error, OxcDiagnostic};
 
 use crate::{
     common::helper_loader::{HelperLoaderMode, HelperLoaderOptions},

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -103,6 +103,7 @@ use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
 use crate::TransformCtx;
 
 use super::diagnostics;
+
 pub use super::{
     jsx_self::ReactJsxSelf,
     jsx_source::ReactJsxSource,

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -33,12 +33,13 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
+use ropey::Rope;
+
 use oxc_ast::{ast::*, NONE};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};
 use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
-use ropey::Rope;
 
 use crate::TransformCtx;
 

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -1,3 +1,9 @@
+use oxc_allocator::Vec;
+use oxc_ast::{ast::*, AstBuilder};
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
 mod comments;
 mod diagnostics;
 mod display_name;
@@ -7,18 +13,11 @@ mod jsx_source;
 mod options;
 mod refresh;
 mod utils;
-
-use oxc_allocator::Vec;
-use oxc_ast::{ast::*, AstBuilder};
-use oxc_traverse::{Traverse, TraverseCtx};
 use refresh::ReactRefresh;
 
-pub use self::{
-    display_name::ReactDisplayName,
-    jsx::ReactJsx,
-    options::{JsxOptions, JsxRuntime, ReactRefreshOptions},
-};
-use crate::TransformCtx;
+pub use display_name::ReactDisplayName;
+pub use jsx::ReactJsx;
+pub use options::{JsxOptions, JsxRuntime, ReactRefreshOptions};
 
 pub(crate) use comments::update_options_with_comments;
 

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -1,17 +1,19 @@
 use std::iter::once;
 
 use base64::prelude::{Engine, BASE64_STANDARD};
+use rustc_hash::FxHashMap;
+use sha1::{Digest, Sha1};
+
 use oxc_allocator::CloneIn;
 use oxc_ast::{ast::*, match_expression, AstBuilder, NONE};
 use oxc_semantic::{Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{Atom, GetSpan, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
-use rustc_hash::FxHashMap;
-use sha1::{Digest, Sha1};
+
+use crate::TransformCtx;
 
 use super::options::ReactRefreshOptions;
-use crate::TransformCtx;
 
 /// Parse a string into a `RefreshIdentifierResolver` and convert it into an `Expression`
 #[derive(Debug)]

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -58,6 +58,7 @@ use oxc_traverse::{Traverse, TraverseCtx};
 use crate::TransformCtx;
 
 mod options;
+
 pub use options::RegExpOptions;
 
 pub struct RegExp<'a, 'ctx> {

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -2,6 +2,8 @@
 
 use std::cell::Cell;
 
+use rustc_hash::FxHashSet;
+
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
@@ -14,7 +16,6 @@ use oxc_syntax::{
     symbol::SymbolId,
 };
 use oxc_traverse::{Traverse, TraverseCtx};
-use rustc_hash::FxHashSet;
 
 use crate::{TransformCtx, TypeScriptOptions};
 

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -1,3 +1,9 @@
+use oxc_allocator::Vec;
+use oxc_ast::ast::*;
+use oxc_traverse::{Traverse, TraverseCtx};
+
+use crate::TransformCtx;
+
 mod annotations;
 mod diagnostics;
 mod r#enum;
@@ -6,16 +12,13 @@ mod namespace;
 mod options;
 mod rewrite_extensions;
 
+use annotations::TypeScriptAnnotations;
 use module::TypeScriptModule;
 use namespace::TypeScriptNamespace;
-use oxc_allocator::Vec;
-use oxc_ast::ast::*;
-use oxc_traverse::{Traverse, TraverseCtx};
+use r#enum::TypeScriptEnum;
 use rewrite_extensions::TypeScriptRewriteExtensions;
 
-pub use self::options::{RewriteExtensionsMode, TypeScriptOptions};
-use self::{annotations::TypeScriptAnnotations, r#enum::TypeScriptEnum};
-use crate::TransformCtx;
+pub use options::{RewriteExtensionsMode, TypeScriptOptions};
 
 /// [Preset TypeScript](https://babeljs.io/docs/babel-preset-typescript)
 ///

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashSet;
+
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{ast::*, NONE};
 use oxc_ecmascript::BoundNames;
@@ -9,13 +11,12 @@ use oxc_syntax::{
 };
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use rustc_hash::FxHashSet;
+use crate::TransformCtx;
 
 use super::{
     diagnostics::{ambient_module_nested, namespace_exporting_non_const, namespace_not_supported},
     TypeScriptOptions,
 };
-use crate::TransformCtx;
 
 pub struct TypeScriptNamespace<'a, 'ctx> {
     ctx: &'ctx TransformCtx<'a>,


### PR DESCRIPTION
Re-order `use` statements in order:

1. `std`
2. External crates
3. `oxc_*` crates
4. Current crate `use crate::...`
5. Super `use super::...`
6. Local modules

This order is from "furthest away" to "closest". This makes it clearer to see what is coming from where.