### PR TITLE
perf(linter/no-unused-vars): do not construct `Regex` for default ignore pattern

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -4,10 +4,12 @@ use oxc_ast::{
 };
 use oxc_semantic::{AstNode, NodeId};
 use oxc_span::CompactStr;
-use regex::Regex;
 
 use super::{count_whitespace_or_commas, BindingInfo, NoUnusedVars, Symbol};
-use crate::fixer::{RuleFix, RuleFixer};
+use crate::{
+    fixer::{RuleFix, RuleFixer},
+    rules::eslint::no_unused_vars::options::IgnorePattern,
+};
 
 impl NoUnusedVars {
     /// Delete a variable declaration or rename it to match `varsIgnorePattern`.
@@ -115,11 +117,14 @@ impl NoUnusedVars {
     }
 
     fn get_unused_var_name(&self, symbol: &Symbol<'_, '_>) -> Option<CompactStr> {
-        let pat = self.vars_ignore_pattern.as_ref().map(Regex::as_str)?;
-
-        let ignored_name: String = match pat {
+        let ignored_name: String = match self.vars_ignore_pattern.as_ref() {
             // TODO: support more patterns
-            "^_" => format!("_{}", symbol.name()),
+            IgnorePattern::Default => {
+                format!("_{}", symbol.name())
+            }
+            IgnorePattern::Some(re) if re.as_str() == "^_" => {
+                format!("_{}", symbol.name())
+            }
             _ => return None,
         };
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
 };
 use regex::Regex;
 
-use super::{NoUnusedVars, Symbol};
+use super::{options::IgnorePattern, NoUnusedVars, Symbol};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(super) enum FoundStatus {
@@ -336,8 +336,12 @@ impl NoUnusedVars {
     }
 
     #[inline]
-    fn is_none_or_match(re: Option<&Regex>, haystack: &str) -> bool {
-        re.map_or(false, |pat| pat.is_match(haystack))
+    fn is_none_or_match(re: IgnorePattern<&Regex>, haystack: &str) -> bool {
+        match re {
+            IgnorePattern::None => false,
+            IgnorePattern::Some(re) => re.is_match(haystack),
+            IgnorePattern::Default => haystack.starts_with('_'),
+        }
     }
 }
 


### PR DESCRIPTION
Profiling shows that constructing the `Regex` for `no-unused-vars` takes up a good chunk of time for small files. Since the default pattern for ignored variables is just `^_`, we can more simply implement this with `.starts_with('_')`.

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/7a4abb8c-2c0e-4252-8df4-e5b1880e8209">


I decided to create a new `Option`-like enum that has three states: `Some` and `None` which are like the typical `Option` states, and another `Default` state which is a special case. The `Default` state represents that matching code should use the default pattern (if applicable). I decided not to keep using `Option`, because I didn't want to overload the `None` state by confusing whether or not it was the default state, or the user explicitly overrided it as `None`.

The theory here is that most users are not going to pass a custom ignore pattern, so we can avoid needing to create a `Regex` in most cases, which greatly speeds up the initialization for this rule.