### PR TITLE
fix(codegen): panic occurred when printing the comment of the right parenthesis

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1383,13 +1383,15 @@ impl<'a> GenExpr for CallExpression<'a> {
                 type_parameters.print(p, ctx);
             }
             p.print_ascii_byte(b'(');
-            let has_comment = (self.span.end > 0 && p.has_comment(self.span.end - 1))
+            let has_comment_before_right_paren =
+                self.span.end > 0 && p.has_comment(self.span.end - 1);
+            let has_comment = has_comment_before_right_paren
                 || self.arguments.iter().any(|item| p.has_comment(item.span().start));
             if has_comment {
                 p.indent();
                 p.print_list_with_comments(&self.arguments, ctx);
                 // Handle `/* comment */);`
-                if !p.print_expr_comments(self.span.end - 1) {
+                if !has_comment_before_right_paren || !p.print_expr_comments(self.span.end - 1) {
                     p.print_soft_newline();
                 }
                 p.dedent();
@@ -1958,7 +1960,8 @@ impl<'a> GenExpr for SequenceExpression<'a> {
 impl<'a> GenExpr for ImportExpression<'a> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
-        let has_comment = (self.span.end > 0 && p.has_comment(self.span.end - 1))
+        let has_comment_before_right_paren = self.span.end > 0 && p.has_comment(self.span.end - 1);
+        let has_comment = has_comment_before_right_paren
             || p.has_comment(self.source.span().start)
             || self.arguments.first().is_some_and(|argument| p.has_comment(argument.span().start));
 


### PR DESCRIPTION
fix: https://github.com/oxc-project/monitor-oxc/actions/runs/11349185798/job/31564783192

It's hard to add a test for this because I haven't figured out caused by which plugin