### PR TITLE
refactor(transformer): `HelperLoader` common transform: `Helper` enum

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -1,6 +1,5 @@
 //! Utility transforms which are in common between other transforms.
 
-use helper_loader::HelperLoader;
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -12,6 +11,7 @@ pub mod module_imports;
 pub mod top_level_statements;
 pub mod var_declarations;
 
+use helper_loader::HelperLoader;
 use module_imports::ModuleImports;
 use top_level_statements::TopLevelStatements;
 use var_declarations::VarDeclarations;

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
@@ -31,7 +31,7 @@ use oxc_semantic::{ReferenceFlags, SymbolId};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use crate::context::TransformCtx;
+use crate::{common::helper_loader::Helper, TransformCtx};
 
 use super::ObjectRestSpreadOptions;
 
@@ -132,6 +132,6 @@ impl<'a, 'ctx> ObjectSpread<'a, 'ctx> {
     }
 
     fn babel_external_helper(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-        self.ctx.helper_loader.load(Atom::from("objectSpread2"), ctx)
+        self.ctx.helper_loader.load(Helper::ObjectSpread2, ctx)
     }
 }


### PR DESCRIPTION
`HelperLoaderStore::load` take a `Helper` instead of a string.

`Helper` has 2 purposes:

1. Constrain what helpers you can add to a fixed list (prevent typos).
2. Makes the hashmap lookup cheaper - hashing a single-byte `enum` (`u8`) is cheaper than hashing a string.