### PR TITLE
refactor(transformer): `HelperLoader`: add import immediately

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -11,13 +11,11 @@ pub mod module_imports;
 pub mod top_level_statements;
 pub mod var_declarations;
 
-use helper_loader::HelperLoader;
 use module_imports::ModuleImports;
 use top_level_statements::TopLevelStatements;
 use var_declarations::VarDeclarations;
 
 pub struct Common<'a, 'ctx> {
-    helper_loader: HelperLoader<'a, 'ctx>,
     module_imports: ModuleImports<'a, 'ctx>,
     var_declarations: VarDeclarations<'a, 'ctx>,
     top_level_statements: TopLevelStatements<'a, 'ctx>,
@@ -26,7 +24,6 @@ pub struct Common<'a, 'ctx> {
 impl<'a, 'ctx> Common<'a, 'ctx> {
     pub fn new(ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
-            helper_loader: HelperLoader::new(ctx),
             module_imports: ModuleImports::new(ctx),
             var_declarations: VarDeclarations::new(ctx),
             top_level_statements: TopLevelStatements::new(ctx),
@@ -36,7 +33,6 @@ impl<'a, 'ctx> Common<'a, 'ctx> {
 
 impl<'a, 'ctx> Traverse<'a> for Common<'a, 'ctx> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.helper_loader.exit_program(program, ctx);
         self.module_imports.exit_program(program, ctx);
         self.var_declarations.exit_program(program, ctx);
         self.top_level_statements.exit_program(program, ctx);

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
@@ -132,6 +132,6 @@ impl<'a, 'ctx> ObjectSpread<'a, 'ctx> {
     }
 
     fn babel_external_helper(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-        self.ctx.helper_loader.load(Helper::ObjectSpread2, ctx)
+        self.ctx.helper_load(Helper::ObjectSpread2, ctx)
     }
 }


### PR DESCRIPTION
Helper loader does not need to store details for import statements and then add them in an `exit_program` visitor. It can add them immediately.

That means `HelperLoader` transform can be removed, and its public methods are implemented directly on `TransformCtx`.