### PR TITLE
fix(website/linter): better md rendering for primitive arrays

### DIFF
--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -62,9 +62,7 @@ Rules enabled or disabled this way will be overwritten by individual rules in th
 
 
 
-
 ### categories.nursery
-
 
 
 
@@ -76,9 +74,7 @@ Rules enabled or disabled this way will be overwritten by individual rules in th
 
 
 
-
 ### categories.perf
-
 
 
 
@@ -90,17 +86,13 @@ Rules enabled or disabled this way will be overwritten by individual rules in th
 
 
 
-
 ### categories.style
 
 
 
 
 
-
 ### categories.suspicious
-
-
 
 
 
@@ -113,7 +105,6 @@ type: `object`
 Predefine global variables.
 
 Environments specify what global variables are predefined. See [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments) for what environments are available and what each one provides.
-
 
 
 ## globals
@@ -140,19 +131,9 @@ Globals can be disabled by setting their value to `"off"`. For example, in an en
 You may also use `"readable"` or `false` to represent `"readonly"`, and `"writeable"` or `true` to represent `"writable"`.
 
 
-
 ## plugins
 
-type: `array`
-
-
-
-
-### plugins[n]
-
-type: `string`
-
-
+type: `string[]`
 
 
 
@@ -162,7 +143,6 @@ type: `string`
 type: `object`
 
 See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
-
 
 
 ## settings
@@ -186,13 +166,11 @@ type: `boolean`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-
 #### settings.jsdoc.exemptDestructuredRootsFromChecks
 
 type: `boolean`
 
 Only for `require-param-type` and `require-param-description` rule
-
 
 
 #### settings.jsdoc.ignoreInternal
@@ -202,13 +180,11 @@ type: `boolean`
 For all rules but NOT apply to `empty-tags` rule
 
 
-
 #### settings.jsdoc.ignorePrivate
 
 type: `boolean`
 
 For all rules but NOT apply to `check-access` and `empty-tags` rule
-
 
 
 #### settings.jsdoc.ignoreReplacesDocs
@@ -218,13 +194,11 @@ type: `boolean`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-
 #### settings.jsdoc.implementsReplacesDocs
 
 type: `boolean`
 
 Only for `require-(yields|returns|description|example|param|throws)` rule
-
 
 
 #### settings.jsdoc.overrideReplacesDocs
@@ -234,12 +208,9 @@ type: `boolean`
 Only for `require-(yields|returns|description|example|param|throws)` rule
 
 
-
 #### settings.jsdoc.tagNamePreference
 
 type: `object`
-
-
 
 
 
@@ -258,15 +229,12 @@ type: `object`
 
 
 
-
 #### settings.jsx-a11y.polymorphicPropName
 
 type: `[
   string,
   null
 ]`
-
-
 
 
 
@@ -279,8 +247,6 @@ type: `object`
 
 
 #### settings.next.rootDir
-
-
 
 
 
@@ -301,8 +267,6 @@ type: `array`
 
 
 ##### settings.react.formComponents[n]
-
-
 
 
 


### PR DESCRIPTION
Improves how config docs are rendered for the website. If a config property is an array of primitive values, we now skip subsection rendering and render a better type, e.g. `string[]` instead of `array`.