### PR TITLE
chore(parser): enable lint warnings on missing docs

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -65,6 +65,7 @@
 //! See [full linter example](https://github.com/Boshen/oxc/blob/ab2ef4f89ba3ca50c68abb2ca43e36b7793f3673/crates/oxc_linter/examples/linter.rs#L38-L39)
 
 #![allow(clippy::wildcard_imports)] // allow for use `oxc_ast::ast::*`
+#![warn(missing_docs)]
 
 mod context;
 mod cursor;


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/130