### PR TITLE
docs(data-structures): enable lint warnings on missing docs, and add missing doc comments

### DIFF
--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -1,1 +1,3 @@
+//! Data structures used across other oxc crates.
+#![warn(missing_docs)]
 pub mod stack;

--- a/crates/oxc_data_structures/src/stack/mod.rs
+++ b/crates/oxc_data_structures/src/stack/mod.rs
@@ -1,3 +1,8 @@
+//! Contains the following FILO data structures:
+//! - [`Stack`]: A growable stack
+//! - [`SparseStack`]: A stack that can have empty entries
+//! - [`NonEmptyStack`]: A growable stack that can never be empty, allowing for more efficient
+//!  operations
 mod capacity;
 mod common;
 mod non_empty;

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -1,7 +1,6 @@
 //! Source positions and related helper functions.
 //!
 //! <https://doc.rust-lang.org/beta/nightly-rustc/rustc_span>
-#![warn(missing_docs)]
 
 mod atom;
 mod compact_str;


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/130