### PR TITLE
docs(allocator): enable lint warnings on missing docs, and add missing doc comments

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -167,6 +167,7 @@ impl<'alloc, T: Hash> Hash for Box<'alloc, T> {
 pub struct Address(usize);
 
 impl<'a, T> Box<'a, T> {
+    /// Get the memory address of a value allocated in the arena.
     #[inline]
     pub fn address(&self) -> Address {
         Address(ptr::addr_of!(**self) as usize)

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -20,8 +20,13 @@ use crate::{Allocator, Box, Vec};
 /// However, it **isn't** guaranteed.
 ///
 pub trait CloneIn<'new_alloc>: Sized {
+    /// The type of the cloned object.
+    ///
+    /// This should always be `Self` with a different lifetime.
     type Cloned;
 
+    /// Clone `self` into the given `allocator`. `allocator` may be the same one
+    /// that `self` is already in.
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned;
 }
 

--- a/crates/oxc_allocator/src/convert.rs
+++ b/crates/oxc_allocator/src/convert.rs
@@ -2,17 +2,19 @@
 
 use crate::{Allocator, Box};
 
-/// This trait works similarly to the standard library `From` trait, It comes with a similar
-/// implementation containing blanket implementation for `IntoIn`, reflective implementation and a
+/// This trait works similarly to the standard library [`From`] trait, It comes with a similar
+/// implementation containing blanket implementation for [`IntoIn`], reflective implementation and a
 /// bunch of primitive conversions from Rust types to their arena equivalent.
 pub trait FromIn<'a, T>: Sized {
+    /// Converts to this type from the input type within the given `allocator`.
     fn from_in(value: T, allocator: &'a Allocator) -> Self;
 }
 
-/// This trait works similarly to the standard library `Into` trait.
-/// It is similar to `FromIn` is reflective, A `FromIn` implementation also implicitly implements
-/// `IntoIn` for the opposite type.
+/// This trait works similarly to the standard library [`Into`] trait.
+/// It is similar to [`FromIn`] is reflective, A [`FromIn`] implementation also implicitly implements
+/// [`IntoIn`] for the opposite type.
 pub trait IntoIn<'a, T>: Sized {
+    /// Converts this type into the (usually inferred) input type within the given `allocator`.
     fn into_in(self, allocator: &'a Allocator) -> T;
 }
 

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -38,7 +38,7 @@
 //! let parsed = Parser::new(&allocator, "let x = 1;", SourceType::default());
 //! assert!(parsed.errors.is_empty());
 //! ```
-
+#![warn(missing_docs)]
 use std::{
     convert::From,
     ops::{Deref, DerefMut},

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -93,6 +93,10 @@ impl<'alloc, T> Vec<'alloc, T> {
         Self(vec::Vec::with_capacity_in(capacity, allocator))
     }
 
+    /// Create a new [`Vec`] whose elements are taken from an iterator and
+    /// allocated in the given `allocator`.
+    ///
+    /// This is behaviorially identical to [`FromIterator::from_iter`].
     #[inline]
     pub fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, allocator: &'alloc Allocator) -> Self {
         let iter = iter.into_iter();


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/130