### PR TITLE
ci: skip coverage/benchmarks on more unrelated files

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,11 @@ on:
     types: [opened, synchronize]
     paths:
       - "**/*.rs"
+      - "!apps/**"
+      - "!tasks/website/**"
+      - "!tasks/ast_tools/**"
+      - "!tasks/coverage/**"
+      - "!crates/oxc_language_server/**"
       - "napi/parser/**/*.js"
       - "napi/parser/**/*.mjs"
       - "Cargo.lock"
@@ -30,6 +35,11 @@ on:
       - main
     paths:
       - "**/*.rs"
+      - "!apps/**"
+      - "!tasks/website/**"
+      - "!tasks/ast_tools/**"
+      - "!tasks/coverage/**"
+      - "!crates/oxc_language_server/**"
       - "napi/parser/**/*.js"
       - "napi/parser/**/*.mjs"
       - "Cargo.lock"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,18 @@ jobs:
         with:
           filters: |
             src:
+              - '!.github/**'
+              - '!.vscode/**'
+              - '!apps/**'
+              - '!editors/**'
+              - '!napi/**'
+              - '!npm/**'
+              - '!wasm/**'
               - '!crates/oxc_linter/**'
               - '!crates/oxc_wasm/**'
               - '!crates/oxc_language_server/**'
+              - '!tasks/**'
+              - 'tasks/conformance/**'
 
       - uses: ./.github/actions/clone-submodules
         if: steps.filter.outputs.src == 'true'


### PR DESCRIPTION
Enhance file filters that trigger coverage and benchmark jobs by adding more ignored globs.