### PR TITLE
docs(span): enable lint warnings on missing docs

### DIFF
--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! <https://doc.rust-lang.org/beta/nightly-rustc/rustc_span>
 
+#![warn(missing_docs)]
+
 mod atom;
 mod compact_str;
 mod source_type;


### PR DESCRIPTION
This attribute was added in #6610, but then removed again in #6612. I assume removing it was an accident.