### PR TITLE
docs(allocator): clarify docs for `Box`

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -16,10 +16,16 @@ use serde::{Serialize, Serializer};
 
 use crate::Allocator;
 
-/// A Box without [`Drop`].
+/// A `Box` without [`Drop`], which stores its data in the arena allocator.
 ///
-/// This is used for over coming self-referential structs.
-/// It is a memory leak if the boxed value has a [`Drop`] implementation.
+/// Should only be used for storing AST types.
+///
+/// Must NOT be used to store types which have a [`Drop`] implementation.
+/// `T::drop` will NOT be called on the `Box`'s contents when the `Box` is dropped.
+/// If `T` owns memory outside of the arena, this will be a memory leak.
+///
+/// Note: This is not a soundness issue, as Rust does not support relying on `drop`
+/// being called to guarantee soundness.
 pub struct Box<'alloc, T: ?Sized>(NonNull<T>, PhantomData<(&'alloc (), T)>);
 
 impl<'alloc, T> Box<'alloc, T> {


### PR DESCRIPTION
Clarify the consequences of storing `Drop` types in `oxc_allocator::Box`.