### PR TITLE
fix(allocator): prevent putting drop types into arena

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -7,6 +7,7 @@ use std::{
     fmt::{self, Debug, Formatter},
     hash::{Hash, Hasher},
     marker::PhantomData,
+    mem::needs_drop,
     ops::{self, Deref},
     ptr::{self, NonNull},
 };
@@ -62,6 +63,7 @@ impl<'alloc, T> Box<'alloc, T> {
     /// let in_arena: Box<i32> = Box::new_in(5, &arena);
     /// ```
     pub fn new_in(value: T, allocator: &Allocator) -> Self {
+        const { assert!(!needs_drop::<T>()) };
         Self(NonNull::from(allocator.alloc(value)), PhantomData)
     }
 
@@ -91,6 +93,7 @@ impl<'alloc, T: ?Sized> Box<'alloc, T> {
     /// `ptr` must have been created from a `*mut T` or `&mut T` (not a `*const T` / `&T`).
     #[inline]
     pub(crate) const unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
+        const { assert!(!needs_drop::<T>()) };
         Self(ptr, PhantomData)
     }
 }

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -6,7 +6,7 @@ use std::{
     self,
     fmt::{self, Debug},
     hash::{Hash, Hasher},
-    mem::ManuallyDrop,
+    mem::{needs_drop, ManuallyDrop},
     ops,
     ptr::NonNull,
 };
@@ -48,6 +48,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// ```
     #[inline]
     pub fn new_in(allocator: &'alloc Allocator) -> Self {
+        const { assert!(!needs_drop::<T>()) };
         Self(ManuallyDrop::new(vec::Vec::new_in(allocator)))
     }
 
@@ -100,6 +101,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// ```
     #[inline]
     pub fn with_capacity_in(capacity: usize, allocator: &'alloc Allocator) -> Self {
+        const { assert!(!needs_drop::<T>()) };
         Self(ManuallyDrop::new(vec::Vec::with_capacity_in(capacity, allocator)))
     }
 
@@ -109,6 +111,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// This is behaviorially identical to [`FromIterator::from_iter`].
     #[inline]
     pub fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, allocator: &'alloc Allocator) -> Self {
+        const { assert!(!needs_drop::<T>()) };
         let iter = iter.into_iter();
         let hint = iter.size_hint();
         let capacity = hint.1.unwrap_or(hint.0);


### PR DESCRIPTION
Should not be merged.

Is a quick and dirty check that we do not put any drop types into either `oxc_allocator::Box` or `oxc_allocator::Vec`.

Unfortunately, this is probably not reliable enough to use. From [`needs_drop`'s docs](https://doc.rust-lang.org/std/mem/fn.needs_drop.html):

> May be implemented conservatively: it may return `true` for types that don’t actually need to be dropped. As such always returning `true` would be a valid implementation of this function. However if this function actually returns `false`, then you can be certain dropping `T` has no side effect.

So the fact that tests and conformance pass on this PR does prove that no code path that they exercise attempts to put `Drop` types into `Box` or `Vec`. So this demonstrates that #6623 does not introduce any memory leaks. Good!

However, as the docs say, we cannot rely on `needs_drop` not producing false positives, so this could start producing erroneous compilation errors in a future version of Rust.