### PR TITLE
chore(transform_conformance): do not extend plugins if current options has plugins

### DIFF
--- a/crates/oxc_transformer/src/options/babel.rs
+++ b/crates/oxc_transformer/src/options/babel.rs
@@ -74,7 +74,9 @@ impl BabelOptions {
                         existing_json.throws = Some(throws);
                     }
                 }
-                existing_json.plugins.extend(new_json.plugins);
+                if existing_json.plugins.is_empty() {
+                    existing_json.plugins = new_json.plugins;
+                }
             } else {
                 options_json = Some(new_json);
             }

--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -1,5 +1,5 @@
 commit: 3bcfee23
 
 codegen_babel Summary:
-AST Parsed     : 2101/2101 (100.00%)
-Positive Passed: 2101/2101 (100.00%)
+AST Parsed     : 2129/2129 (100.00%)
+Positive Passed: 2129/2129 (100.00%)

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -1,5 +1,5 @@
 commit: 3bcfee23
 
 minifier_babel Summary:
-AST Parsed     : 1637/1637 (100.00%)
-Positive Passed: 1637/1637 (100.00%)
+AST Parsed     : 1654/1654 (100.00%)
+Positive Passed: 1654/1654 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,9 +1,9 @@
 commit: 3bcfee23
 
 parser_babel Summary:
-AST Parsed     : 2093/2101 (99.62%)
-Positive Passed: 2083/2101 (99.14%)
-Negative Passed: 1382/1493 (92.57%)
+AST Parsed     : 2119/2129 (99.53%)
+Positive Passed: 2109/2129 (99.06%)
+Negative Passed: 1385/1498 (92.46%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -31,6 +31,8 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0101/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0276/input.js
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/satisfies-const-error/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-type-assertion-and-assign/input.ts
@@ -132,6 +134,18 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/o
    ·                 ──────────
    ╰────
   help: new.target is only allowed in constructors and functions invoked using thew `new` operator
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
+
+  × Expected `<` but found `EOF`
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js:2:1]
+ 1 │ <div>() => {}
+   ╰────
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
+
+  × Expected `<` but found `EOF`
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js:2:1]
+ 1 │ <div>() => {}
+   ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
 
   × Expected `<` but found `EOF`
@@ -9682,6 +9696,33 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/statement-variable/complex-pattern-requires-init/input.js:1:5]
  1 │ var []
    ·     ──
+   ╰────
+
+  × A 'set' accessor must have exactly one parameter.
+   ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/getter-setter/input.ts:3:9]
+ 2 │ ({ get x() { return 1 } });
+ 3 │ ({ set x() {} });
+   ·         ──
+ 4 │ ({ get x(x) {} });
+   ╰────
+
+  × A 'get' accessor must not have any formal parameters.
+   ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/getter-setter/input.ts:4:9]
+ 3 │ ({ set x() {} });
+ 4 │ ({ get x(x) {} });
+   ·         ───
+   ╰────
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type-named/input.js:2:13]
+ 1 │ var Foo;
+ 2 │ export type { Foo };
+   ·             ─
+   ╰────
+
+  × Expected `<` but found `EOF`
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/unclosed-jsx-element/input.js:2:1]
+ 1 │ <div>() => {}
    ╰────
 
   × Bad escape sequence in untagged template literal

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1,8 +1,8 @@
 commit: 3bcfee23
 
 semantic_babel Summary:
-AST Parsed     : 2101/2101 (100.00%)
-Positive Passed: 1739/2101 (82.77%)
+AST Parsed     : 2129/2129 (100.00%)
+Positive Passed: 1756/2129 (82.48%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
@@ -140,6 +140,74 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/statement-if/mi
 semantic error: Symbol scope ID mismatch for "a":
 after transform: SymbolId(0): ScopeId(4294967294)
 rebuilt        : SymbolId(0): ScopeId(4294967294)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.js
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Array", "foo"]
+rebuilt        : ["foo"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/enum/input.js
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "a", "r"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Y", "foo"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-require/input.js
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/literals/input.js
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "Foo2", "Foo3", "Foo4", "Foo5", "Foo6", "Foo7"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["true"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property/input.js
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AssertsFoo", "Foo"]
+rebuilt        : ScopeId(0): ["AssertsFoo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/loc-index-property-babel-7/input.js
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["AssertsFoo", "Foo"]
+rebuilt        : ScopeId(0): ["AssertsFoo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/optional-chaining/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["T", "foo"]
+rebuilt        : ["foo"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
+semantic error: Expected `<` but found `EOF`
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
+semantic error: Expected `<` but found `EOF`
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
 semantic error: Unresolved references mismatch:

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -1,5 +1,5 @@
 commit: 3bcfee23
 
 transformer_babel Summary:
-AST Parsed     : 2101/2101 (100.00%)
-Positive Passed: 2101/2101 (100.00%)
+AST Parsed     : 2129/2129 (100.00%)
+Positive Passed: 2129/2129 (100.00%)

--- a/tasks/coverage/src/babel/mod.rs
+++ b/tasks/coverage/src/babel/mod.rs
@@ -167,12 +167,15 @@ impl Case for BabelCase {
     fn skip_test_case(&self) -> bool {
         let not_supported_plugins =
             ["async-do-expression", "flow", "placeholders", "decorators-legacy", "recordAndTuple"];
-        let has_not_supported_plugins = self
-            .options
-            .plugins
-            .iter()
-            .filter_map(Value::as_str)
-            .any(|p| not_supported_plugins.contains(&p));
+        let has_not_supported_plugins = self.options.plugins.iter().any(|p| {
+            let plugin_name = match p {
+                Value::String(plugin_name) => Some(plugin_name.as_str()),
+                Value::Array(a) => a.first().and_then(|plugin_name| plugin_name.as_str()),
+                _ => None,
+            };
+            let plugin_name = plugin_name.expect("Failed to parse plugins config");
+            not_supported_plugins.contains(&plugin_name)
+        });
         has_not_supported_plugins
             || self.options.allow_await_outside_function
             || self.options.allow_undeclared_exports

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 339/1039
+Passed: 341/1051
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1628,7 +1628,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-async-to-generator (1/17)
+# babel-plugin-transform-async-to-generator (1/24)
 * assumption-ignoreFunctionLength-true/basic/input.mjs
 x Output mismatch
 
@@ -1636,6 +1636,27 @@ x Output mismatch
 x Output mismatch
 
 * assumption-noNewArrows-false/basic/input.js
+x Output mismatch
+
+* async-to-generator/async-iife-with-regenerator/input.js
+x Output mismatch
+
+* async-to-generator/async-iife-with-regenerator-spec/input.js
+x Output mismatch
+
+* async-to-generator/function-arity/input.js
+x Output mismatch
+
+* async-to-generator/object-method-with-super/input.js
+x Output mismatch
+
+* async-to-generator/shadowed-promise/input.js
+x Output mismatch
+
+* async-to-generator/shadowed-promise-import/input.mjs
+x Output mismatch
+
+* async-to-generator/shadowed-promise-nested/input.js
 x Output mismatch
 
 * bluebird-coroutines/arrow-function/input.js
@@ -1683,7 +1704,16 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-arrow-functions (1/6)
+# babel-plugin-transform-arrow-functions (3/11)
+* arrow-functions/implicit-var-arguments/input.js
+x Output mismatch
+
+* arrow-functions/self-referential/input.js
+x Output mismatch
+
+* arrow-functions/spec/input.js
+x Output mismatch
+
 * assumption-newableArrowFunctions-false/basic/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -1,13 +1,12 @@
 commit: 3bcfee23
 
-Passed: 34/60
+Passed: 35/62
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-exponentiation-operator
-* babel-plugin-transform-arrow-functions
 
 
 # babel-preset-env (7/11)
@@ -85,6 +84,11 @@ exec failed
 exec failed
 
 * regression/test262-fn-length/exec.js
+exec failed
+
+
+# babel-plugin-transform-arrow-functions (2/3)
+* arrow-functions/implicit-var-arguments/exec.js
 exec failed
 
 


### PR DESCRIPTION
I saw many tests were ignored even if they don't contain any unsupported plugins
