### PR TITLE
fix(editor): misaligned command prefixes

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -19,13 +19,14 @@ const languageClientId = 'oxc-vscode';
 const languageClientName = 'oxc';
 const outputChannelName = 'oxc_language_server';
 const traceOutputChannelName = 'oxc_language_server.trace';
+const commandPrefix = 'oxc';
 
 const enum OxcCommands {
-  RestartServer = 'oxc.restartServer',
-  ApplyAllFixes = 'oxc.applyAllFixes',
-  ShowOutputChannel = 'oxc.showOutputChannel',
-  ShowTraceOutputChannel = 'oxc.showTraceOutputChannel',
-  ToggleEnable = 'oxc.toggleEnable',
+  RestartServer = `${commandPrefix}.restartServer`,
+  ApplyAllFixes = `${commandPrefix}.applyAllFixes`,
+  ShowOutputChannel = `${commandPrefix}.showOutputChannel`,
+  ShowTraceOutputChannel = `${commandPrefix}.showTraceOutputChannel`,
+  ToggleEnable = `${commandPrefix}.toggleEnable`,
 }
 
 let client: LanguageClient;

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -64,7 +64,7 @@
       "type": "object",
       "title": "oxc",
       "properties": {
-        "oxc_language_server.run": {
+        "oxc.lint.run": {
           "scope": "resource",
           "type": "string",
           "enum": [
@@ -74,12 +74,12 @@
           "default": "onType",
           "description": "Run the linter on save (onSave) or on type (onType)"
         },
-        "oxc_language_server.enable": {
+        "oxc.enable": {
           "type": "boolean",
           "default": true,
           "description": "enable oxc language server"
         },
-        "oxc_language_server.trace.server": {
+        "oxc.trace.server": {
           "type": "string",
           "scope": "window",
           "enum": [
@@ -95,7 +95,7 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "oxc_language_server.configPath": {
+        "oxc.configPath": {
           "type": "string",
           "scope": "window",
           "default": ".eslintrc",


### PR DESCRIPTION
In the client code, we were registering commands under the `oxc` prefix, but in our `package.json` we were advertising a `oxc_language_server` prefix.