### PR TITLE
fix(editor): use human-readable output channel names

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -17,8 +17,8 @@ import { join } from 'node:path';
 
 const languageClientId = 'oxc-vscode';
 const languageClientName = 'oxc';
-const outputChannelName = 'oxc_language_server';
-const traceOutputChannelName = 'oxc_language_server.trace';
+const outputChannelName = 'Oxc';
+const traceOutputChannelName = 'Oxc (Trace)';
 const commandPrefix = 'oxc';
 
 const enum OxcCommands {


### PR DESCRIPTION
Changes the names of output channels our editor uses to make them friendlier.