### PR TITLE
test(traverse): add an api to get the index of the current node in Vec<'a, Statements<'a>>.

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -354,6 +354,7 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        println!("index {:?}", ctx.ancestor_index(stmt));
         self.x0_typescript.enter_statement(stmt, ctx);
     }
 

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -156,6 +156,12 @@ impl<'a> TraverseCtx<'a> {
         self.ancestry.ancestor(level)
     }
 
+    /// Get the index of the current node in `Vec<'a, Statements<'a>>`.
+    #[inline]
+    pub fn ancestor_index<'t>(&'t self, statement: &Statement<'a>) -> Option<usize> {
+        self.ancestry.ancestor_index(statement)
+    }
+
     /// Get iterator over ancestors, starting with parent and working up.
     ///
     /// Last `Ancestor` returned will be `Program`. `Ancestor::None` is not included in iteration.


### PR DESCRIPTION
Try to get the index of the current node in `Vec<'a, Statements<'a>>`.

