### PR TITLE
chore(semantic, wasm): re-order dependencies in `Cargo.toml` files

### DIFF
--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -33,8 +33,8 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
-serde = { workspace = true, features = ["derive"], optional = true }
 
+serde = { workspace = true, features = ["derive"], optional = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 

--- a/crates/oxc_wasm/Cargo.toml
+++ b/crates/oxc_wasm/Cargo.toml
@@ -24,9 +24,9 @@ oxc = { workspace = true, features = ["codegen", "minifier", "semantic", "serial
 oxc_index = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_prettier = { workspace = true }
-serde = { workspace = true }
 
 console_error_panic_hook = { workspace = true }
+serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 tsify = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/wasm/parser/Cargo.toml
+++ b/wasm/parser/Cargo.toml
@@ -22,8 +22,8 @@ doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["serialize"] }
-serde = { workspace = true, features = ["derive"] }
 
+serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = { workspace = true }
 tsify = { workspace = true }
 wasm-bindgen = { workspace = true }


### PR DESCRIPTION
Nit. Move `serde` dependency into more natural place in the list.