### PR TITLE
style(transformer): re-order dependencies

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -21,10 +21,6 @@ test = true
 doctest = false
 
 [dependencies]
-base64 = { workspace = true }
-cow-utils = { workspace = true }
-dashmap = { workspace = true }
-indexmap = { workspace = true }
 oxc-browserslist = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
@@ -37,6 +33,11 @@ oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 oxc_traverse = { workspace = true }
+
+base64 = { workspace = true }
+cow-utils = { workspace = true }
+dashmap = { workspace = true }
+indexmap = { workspace = true }
 ropey = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Nit. Move `oxc_*` dependencies to first in list.