### PR TITLE
fix(linter/no-cond-assign): false positive when assignment is in body statement

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_cond_assign.snap
+++ b/crates/oxc_linter/src/snapshots/no_cond_assign.snap
@@ -65,13 +65,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider wrapping the assignment in additional parentheses
 
   ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
-   ╭─[no_cond_assign.tsx:1:39]
- 1 │ for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }
-   ·                                       ─
-   ╰────
-  help: Consider wrapping the assignment in additional parentheses
-
-  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:7]
  1 │ if (x = 0) { }
    ·       ─


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/6656

rather than reporting any assignment inside of `if`, `while`, etc. when the `always` option is enabled, we only check if the assignment resides in specific areas that assignment should not be. for example, inside the test of an `if`, or the test of a `for` loop.

incidentally, this also fixes an issue (seen in snapshot file) where the same assignment was reported twice.