### PR TITLE
refactor(linter): add missing `should_run` implementations

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -39,9 +39,6 @@ declare_oxc_lint!(
 
 impl Rule for NoUnusedLabels {
     fn run_once(&self, ctx: &LintContext) {
-        if ctx.file_path().extension().is_some_and(|ext| ext == "svelte") {
-            return;
-        }
         for id in ctx.semantic().unused_labels() {
             let node = ctx.semantic().nodes().get_node(*id);
             let AstKind::LabeledStatement(stmt) = node.kind() else {
@@ -52,6 +49,10 @@ impl Rule for NoUnusedLabels {
                 |fixer| fixer.replace_with(stmt, &stmt.body),
             );
         }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_path().extension().is_some_and(|ext| ext != "svelte")
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -93,13 +93,13 @@ declare_oxc_lint!(
 
 impl Rule for NoUntypedMockFactory {
     fn run_once(&self, ctx: &LintContext<'_>) {
-        if !ctx.source_type().is_typescript() {
-            return;
-        }
-
         for possible_jest_node in &collect_possible_jest_call_node(ctx) {
             Self::run(possible_jest_node, ctx);
         }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -83,10 +83,6 @@ impl Rule for NoNamespace {
             return;
         }
 
-        if self.allow_definition_files && ctx.source_type().is_typescript_definition() {
-            return;
-        }
-
         let declaration_code = declaration.span.source_text(ctx.source_text());
 
         let span = match declaration.kind {
@@ -104,6 +100,9 @@ impl Rule for NoNamespace {
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
+        if self.allow_definition_files && ctx.source_type().is_typescript_definition() {
+            return false;
+        }
         ctx.source_type().is_typescript()
     }
 }


### PR DESCRIPTION
Added some `should_run` implementations that probably should exist but didn't previously.