### PR TITLE
fix(tasks/lint_rules): sync vitest compatible rules with jest rules

### DIFF
--- a/tasks/lint_rules/src/main.cjs
+++ b/tasks/lint_rules/src/main.cjs
@@ -9,6 +9,7 @@ const {
   updateNotSupportedStatus,
   updateImplementedStatus,
   overrideTypeScriptPluginStatusWithEslintPluginStatus: syncTypeScriptPluginStatusWithEslintPluginStatus,
+  syncVitestPluginStatusWithJestPluginStatus,
 } = require('./oxlint-rules.cjs');
 const { renderMarkdown } = require('./markdown-renderer.cjs');
 const { updateGitHubIssue } = require('./result-reporter.cjs');
@@ -61,6 +62,7 @@ Plugins: ${Array.from(ALL_TARGET_PLUGINS.keys()).join(', ')}
   await updateImplementedStatus(ruleEntries);
   updateNotSupportedStatus(ruleEntries);
   syncTypeScriptPluginStatusWithEslintPluginStatus(ruleEntries);
+  await syncVitestPluginStatusWithJestPluginStatus(ruleEntries);
 
   //
   // Render list and update if necessary

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -127,3 +127,55 @@ exports.overrideTypeScriptPluginStatusWithEslintPluginStatus = (
     rule.isNotSupported = eslintRule.isNotSupported;
   }
 };
+
+/**
+ * Some Jest rules are written to be compatible with Vitest, so we should
+ * override the status of the Vitest rules to match the Jest rules.
+ * @param {RuleEntries} ruleEntries
+ */
+exports.syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
+  const vitestCompatibleRulesFile = await readFile(
+    "crates/oxc_linter/src/utils/mod.rs",
+    "utf8"
+  );
+
+  // Find the start of the list of vitest-compatible rules
+  // ```
+  // const VITEST_COMPATIBLE_JEST_RULES: phf::Set<&'static str> = phf::phf_set! {
+  //   "consistent-test-it",
+  //   "expect-expect",
+  //   ...
+  // };
+  // ```
+  const vitestCompatibleRules = vitestCompatibleRulesFile.match(
+    /const VITEST_COMPATIBLE_JEST_RULES.+phf_set! {([^}]+)/s
+  )?.[1];
+  if (!vitestCompatibleRules) {
+    throw new Error("Failed to find the list of vitest-compatible rules");
+  }
+
+  const rules = new Set(
+    vitestCompatibleRules
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("//"))
+      .map((line) =>
+        line
+          .replace(/"/g, "")
+          .split(",")
+          .filter((s) => s !== "")
+      )
+      .flat()
+  );
+
+  for (const rule of rules) {
+    const vitestRuleEntry = ruleEntries.get(`vitest/${rule}`);
+    const jestRuleEntry = ruleEntries.get(`jest/${rule}`);
+    if (vitestRuleEntry && jestRuleEntry) {
+      ruleEntries.set(`vitest/${rule}`, {
+        ...vitestRuleEntry,
+        isImplemented: jestRuleEntry.isImplemented,
+      });
+    }
+  }
+};

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -135,8 +135,8 @@ exports.overrideTypeScriptPluginStatusWithEslintPluginStatus = (
  */
 exports.syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
   const vitestCompatibleRulesFile = await readFile(
-    "crates/oxc_linter/src/utils/mod.rs",
-    "utf8"
+    'crates/oxc_linter/src/utils/mod.rs',
+    'utf8',
   );
 
   // Find the start of the list of vitest-compatible rules
@@ -148,24 +148,24 @@ exports.syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
   // };
   // ```
   const vitestCompatibleRules = vitestCompatibleRulesFile.match(
-    /const VITEST_COMPATIBLE_JEST_RULES.+phf_set! {([^}]+)/s
+    /const VITEST_COMPATIBLE_JEST_RULES.+phf_set! {([^}]+)/s,
   )?.[1];
   if (!vitestCompatibleRules) {
-    throw new Error("Failed to find the list of vitest-compatible rules");
+    throw new Error('Failed to find the list of vitest-compatible rules');
   }
 
   const rules = new Set(
     vitestCompatibleRules
-      .split("\n")
+      .split('\n')
       .map((line) => line.trim())
-      .filter((line) => line && !line.startsWith("//"))
+      .filter((line) => line && !line.startsWith('//'))
       .map((line) =>
         line
-          .replace(/"/g, "")
-          .split(",")
-          .filter((s) => s !== "")
+          .replace(/"/g, '')
+          .split(',')
+          .filter((s) => s !== '')
       )
-      .flat()
+      .flat(),
   );
 
   for (const rule of rules) {


### PR DESCRIPTION
Ensures that Jest rules which are compatible with Vitest are properly reflected in the tracking issue.

Here is a preview of what the updated markdown looks like:

---

---

> [!WARNING]
> This comment is maintained by CI. Do not edit this comment directly.
> To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules

This is tracking issue for `eslint-plugin-vitest`.


There are 51(+ 1 deprecated) rules.

- 1/8 recommended rules are remaining as TODO
- 30/43 not recommended rules are remaining as TODO


To get started, run the following command:

```sh
just new-vitest-rule <RULE_NAME>
```

Then register the rule in `crates/oxc_linter/src/rules.rs` and also `declare_all_lint_rules` at the bottom.


## Recommended rules

<details open>
<summary>
  ✨: 7, 🚫: 0 / total: 8
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
| ✨ | vitest/no-identical-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md |
| ✨ | vitest/expect-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/expect-expect.md |
| ✨ | vitest/no-commented-out-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md |
| ✨ | vitest/no-import-node-test | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-import-node-test.md |
|  | vitest/valid-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md |
| ✨ | vitest/valid-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-expect.md |
| ✨ | vitest/require-local-test-context-for-concurrent-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-local-test-context-for-concurrent-snapshots.md |
| ✨ | vitest/valid-describe-callback | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-describe-callback.md |

✨ = Implemented, 🚫 = Not supported

</details>


## Not recommended rules

<details open>
<summary>
  ✨: 13, 🚫: 0 / total: 43
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | vitest/prefer-lowercase-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-lowercase-title.md |
|  | vitest/max-nested-describe | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md |
| ✨ | vitest/no-focused-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md |
| ✨ | vitest/no-conditional-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-tests.md |
| ✨ | vitest/consistent-test-it | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md |
|  | vitest/prefer-to-be | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be.md |
|  | vitest/no-hooks | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md |
|  | vitest/no-restricted-vi-methods | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md |
|  | vitest/consistent-test-filename | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md |
|  | vitest/max-expects | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md |
| ✨ | vitest/no-alias-methods | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-alias-methods.md |
| ✨ | vitest/no-conditional-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md |
| ✨ | vitest/no-conditional-in-test | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md |
| ✨ | vitest/no-disabled-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md |
|  | vitest/no-duplicate-hooks | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md |
|  | vitest/no-large-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-large-snapshots.md |
|  | vitest/no-interpolation-in-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md |
|  | vitest/no-mocks-import | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md |
|  | vitest/no-restricted-matchers | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md |
|  | vitest/no-standalone-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md |
| ✨ | vitest/no-test-prefixes | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md |
|  | vitest/no-test-return-statement | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-test-return-statement.md |
|  | vitest/prefer-called-with | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md |
| ✨ | vitest/prefer-to-be-falsy | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-falsy.md |
| ✨ | vitest/prefer-to-be-object | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-object.md |
| ✨ | vitest/prefer-to-be-truthy | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-truthy.md |
|  | vitest/prefer-to-have-length | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md |
|  | vitest/prefer-equality-matcher | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md |
|  | vitest/prefer-strict-equal | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-equal.md |
|  | vitest/prefer-expect-resolves | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md |
| ✨ | vitest/prefer-each | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md |
|  | vitest/prefer-hooks-on-top | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md |
| ✨ | vitest/prefer-hooks-in-order | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md |
|  | vitest/prefer-mock-promise-shorthand | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md |
|  | vitest/prefer-snapshot-hint | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-snapshot-hint.md |
|  | vitest/require-top-level-describe | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md |
|  | vitest/require-to-throw-message | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md |
|  | vitest/require-hook | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-hook.md |
|  | vitest/prefer-todo | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md |
|  | vitest/prefer-spy-on | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-spy-on.md |
|  | vitest/prefer-comparison-matcher | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-comparison-matcher.md |
|  | vitest/prefer-to-contain | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-contain.md |
|  | vitest/prefer-expect-assertions | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md |

✨ = Implemented, 🚫 = Not supported

</details>


## Deprecated rules

<details >
<summary>
  ✨: 0, 🚫: 0 / total: 1
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | vitest/no-done-callback | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md |

✨ = Implemented, 🚫 = Not supported

</details>