### PR TITLE
style(regular_expression): re-order dependencies in `Cargo.toml`

### DIFF
--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -28,9 +28,9 @@ oxc_span = { workspace = true }
 
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
-serde = { workspace = true, optional = true }
 unicode-id-start = { workspace = true }
 
+serde = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [features]


### PR DESCRIPTION
Follow-on after #6404. Nit. Group optional dependencies together.