### PR TITLE
refactor(ast_tools): add line breaks to generated code for `ESTree` derive

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -26,6 +26,7 @@ impl Serialize for BooleanLiteral {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type BooleanLiteral = ({\n\ttype: 'BooleanLiteral';\n\tvalue: boolean;\n}) & Span;";
@@ -38,6 +39,7 @@ impl Serialize for NullLiteral {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type NullLiteral = ({\n\ttype: 'NullLiteral';\n}) & Span;";
@@ -52,6 +54,7 @@ impl<'a> Serialize for NumericLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type NumericLiteral = ({\n\ttype: 'NumericLiteral';\n\tvalue: number;\n\traw: string;\n}) & Span;";
 
@@ -64,6 +67,7 @@ impl<'a> Serialize for BigIntLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type BigIntLiteral = ({\n\ttype: 'BigIntLiteral';\n\traw: string;\n}) & Span;";
@@ -78,6 +82,7 @@ impl<'a> Serialize for RegExpLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type RegExpLiteral = ({\n\ttype: 'RegExpLiteral';\n\tvalue: EmptyObject;\n\tregex: RegExp;\n}) & Span;";
 
@@ -89,6 +94,7 @@ impl<'a> Serialize for RegExp<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type RegExp = ({\n\tpattern: RegExpPattern;\n\tflags: RegExpFlags;\n});";
@@ -102,6 +108,7 @@ impl<'a> Serialize for RegExpPattern<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type RegExpPattern = string | string | Pattern;";
 
@@ -111,6 +118,7 @@ impl Serialize for EmptyObject {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type EmptyObject = ({\n});";
 
@@ -123,6 +131,7 @@ impl<'a> Serialize for StringLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type StringLiteral = ({\n\ttype: 'StringLiteral';\n\tvalue: string;\n}) & Span;";
@@ -139,6 +148,7 @@ impl<'a> Serialize for Program<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Program = ({\n\ttype: 'Program';\n\tsourceType: SourceType;\n\thashbang: (Hashbang) | null;\n\tdirectives: Array<Directive>;\n\tbody: Array<Statement>;\n}) & Span;";
 
@@ -190,6 +200,7 @@ impl<'a> Serialize for Expression<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Expression = BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -202,6 +213,7 @@ impl<'a> Serialize for IdentifierName<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type IdentifierName = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
@@ -215,6 +227,7 @@ impl<'a> Serialize for IdentifierReference<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type IdentifierReference = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
@@ -228,6 +241,7 @@ impl<'a> Serialize for BindingIdentifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type BindingIdentifier = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
@@ -241,6 +255,7 @@ impl<'a> Serialize for LabelIdentifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type LabelIdentifier = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
@@ -253,6 +268,7 @@ impl Serialize for ThisExpression {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ThisExpression = ({\n\ttype: 'ThisExpression';\n}) & Span;";
@@ -266,6 +282,7 @@ impl<'a> Serialize for ArrayExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ArrayExpression = ({\n\ttype: 'ArrayExpression';\n\telements: Array<SpreadElement | Expression | null>;\n}) & Span;";
 
@@ -333,6 +350,7 @@ impl<'a> Serialize for ArrayExpressionElement<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ArrayExpressionElement = SpreadElement | Elision | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -345,6 +363,7 @@ impl<'a> Serialize for ObjectExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ObjectExpression = ({\n\ttype: 'ObjectExpression';\n\tproperties: Array<ObjectPropertyKind>;\n}) & Span;";
 
@@ -356,6 +375,7 @@ impl<'a> Serialize for ObjectPropertyKind<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ObjectPropertyKind = ObjectProperty | SpreadElement;";
@@ -375,6 +395,7 @@ impl<'a> Serialize for ObjectProperty<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ObjectProperty = ({\n\ttype: 'ObjectProperty';\n\tkind: PropertyKind;\n\tkey: PropertyKey;\n\tvalue: Expression;\n\tinit: (Expression) | null;\n\tmethod: boolean;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
 
@@ -428,6 +449,7 @@ impl<'a> Serialize for PropertyKey<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type PropertyKey = IdentifierName | PrivateIdentifier | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -440,6 +462,7 @@ impl Serialize for PropertyKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type PropertyKind = 'init' | 'get' | 'set';";
 
@@ -453,6 +476,7 @@ impl<'a> Serialize for TemplateLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TemplateLiteral = ({\n\ttype: 'TemplateLiteral';\n\tquasis: Array<TemplateElement>;\n\texpressions: Array<Expression>;\n}) & Span;";
 
@@ -467,6 +491,7 @@ impl<'a> Serialize for TaggedTemplateExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TaggedTemplateExpression = ({\n\ttype: 'TaggedTemplateExpression';\n\ttag: Expression;\n\tquasi: TemplateLiteral;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -480,6 +505,7 @@ impl<'a> Serialize for TemplateElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TemplateElement = ({\n\ttype: 'TemplateElement';\n\ttail: boolean;\n\tvalue: TemplateElementValue;\n}) & Span;";
 
@@ -491,6 +517,7 @@ impl<'a> Serialize for TemplateElementValue<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TemplateElementValue = ({\n\traw: string;\n\tcooked: (string) | null;\n});";
@@ -504,6 +531,7 @@ impl<'a> Serialize for MemberExpression<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type MemberExpression = ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -518,6 +546,7 @@ impl<'a> Serialize for ComputedMemberExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ComputedMemberExpression = ({\n\ttype: 'ComputedMemberExpression';\n\tobject: Expression;\n\texpression: Expression;\n\toptional: boolean;\n}) & Span;";
 
@@ -532,6 +561,7 @@ impl<'a> Serialize for StaticMemberExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type StaticMemberExpression = ({\n\ttype: 'StaticMemberExpression';\n\tobject: Expression;\n\tproperty: IdentifierName;\n\toptional: boolean;\n}) & Span;";
 
@@ -546,6 +576,7 @@ impl<'a> Serialize for PrivateFieldExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type PrivateFieldExpression = ({\n\ttype: 'PrivateFieldExpression';\n\tobject: Expression;\n\tfield: PrivateIdentifier;\n\toptional: boolean;\n}) & Span;";
 
@@ -561,6 +592,7 @@ impl<'a> Serialize for CallExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CallExpression = ({\n\ttype: 'CallExpression';\n\tcallee: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n\targuments: Array<Argument>;\n\toptional: boolean;\n}) & Span;";
 
@@ -575,6 +607,7 @@ impl<'a> Serialize for NewExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type NewExpression = ({\n\ttype: 'NewExpression';\n\tcallee: Expression;\n\targuments: Array<Argument>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -588,6 +621,7 @@ impl<'a> Serialize for MetaProperty<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type MetaProperty = ({\n\ttype: 'MetaProperty';\n\tmeta: IdentifierName;\n\tproperty: IdentifierName;\n}) & Span;";
 
@@ -600,6 +634,7 @@ impl<'a> Serialize for SpreadElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type SpreadElement = ({\n\ttype: 'SpreadElement';\n\targument: Expression;\n}) & Span;";
@@ -653,6 +688,7 @@ impl<'a> Serialize for Argument<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Argument = SpreadElement | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -667,6 +703,7 @@ impl<'a> Serialize for UpdateExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type UpdateExpression = ({\n\ttype: 'UpdateExpression';\n\toperator: UpdateOperator;\n\tprefix: boolean;\n\targument: SimpleAssignmentTarget;\n}) & Span;";
 
@@ -680,6 +717,7 @@ impl<'a> Serialize for UnaryExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type UnaryExpression = ({\n\ttype: 'UnaryExpression';\n\toperator: UnaryOperator;\n\targument: Expression;\n}) & Span;";
 
@@ -694,6 +732,7 @@ impl<'a> Serialize for BinaryExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BinaryExpression = ({\n\ttype: 'BinaryExpression';\n\tleft: Expression;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
 
@@ -708,6 +747,7 @@ impl<'a> Serialize for PrivateInExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type PrivateInExpression = ({\n\ttype: 'PrivateInExpression';\n\tleft: PrivateIdentifier;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
 
@@ -722,6 +762,7 @@ impl<'a> Serialize for LogicalExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LogicalExpression = ({\n\ttype: 'LogicalExpression';\n\tleft: Expression;\n\toperator: LogicalOperator;\n\tright: Expression;\n}) & Span;";
 
@@ -736,6 +777,7 @@ impl<'a> Serialize for ConditionalExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ConditionalExpression = ({\n\ttype: 'ConditionalExpression';\n\ttest: Expression;\n\tconsequent: Expression;\n\talternate: Expression;\n}) & Span;";
 
@@ -750,6 +792,7 @@ impl<'a> Serialize for AssignmentExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentExpression = ({\n\ttype: 'AssignmentExpression';\n\toperator: AssignmentOperator;\n\tleft: AssignmentTarget;\n\tright: Expression;\n}) & Span;";
 
@@ -770,6 +813,7 @@ impl<'a> Serialize for AssignmentTarget<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTarget = IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression | ArrayAssignmentTarget | ObjectAssignmentTarget;";
 
@@ -798,6 +842,7 @@ impl<'a> Serialize for SimpleAssignmentTarget<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type SimpleAssignmentTarget = IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -813,6 +858,7 @@ impl<'a> Serialize for AssignmentTargetPattern<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTarget;";
@@ -832,6 +878,7 @@ impl<'a> Serialize for AssignmentTargetRest<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetRest = ({\n\ttype: 'RestElement';\n\targument: AssignmentTarget;\n}) & Span;";
 
@@ -873,6 +920,7 @@ impl<'a> Serialize for AssignmentTargetMaybeDefault<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression | ArrayAssignmentTarget | ObjectAssignmentTarget;";
 
@@ -886,6 +934,7 @@ impl<'a> Serialize for AssignmentTargetWithDefault<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetWithDefault = ({\n\ttype: 'AssignmentTargetWithDefault';\n\tbinding: AssignmentTarget;\n\tinit: Expression;\n}) & Span;";
 
@@ -901,6 +950,7 @@ impl<'a> Serialize for AssignmentTargetProperty<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty;";
 
@@ -914,6 +964,7 @@ impl<'a> Serialize for AssignmentTargetPropertyIdentifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyIdentifier = ({\n\ttype: 'AssignmentTargetPropertyIdentifier';\n\tbinding: IdentifierReference;\n\tinit: (Expression) | null;\n}) & Span;";
 
@@ -927,6 +978,7 @@ impl<'a> Serialize for AssignmentTargetPropertyProperty<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyProperty = ({\n\ttype: 'AssignmentTargetPropertyProperty';\n\tname: PropertyKey;\n\tbinding: AssignmentTargetMaybeDefault;\n}) & Span;";
 
@@ -939,6 +991,7 @@ impl<'a> Serialize for SequenceExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type SequenceExpression = ({\n\ttype: 'SequenceExpression';\n\texpressions: Array<Expression>;\n}) & Span;";
 
@@ -950,6 +1003,7 @@ impl Serialize for Super {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Super = ({\n\ttype: 'Super';\n}) & Span;";
 
@@ -962,6 +1016,7 @@ impl<'a> Serialize for AwaitExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AwaitExpression = ({\n\ttype: 'AwaitExpression';\n\targument: Expression;\n}) & Span;";
 
@@ -974,6 +1029,7 @@ impl<'a> Serialize for ChainExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ChainExpression = ({\n\ttype: 'ChainExpression';\n\texpression: ChainElement;\n}) & Span;";
 
@@ -987,6 +1043,7 @@ impl<'a> Serialize for ChainElement<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ChainElement = CallExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -999,6 +1056,7 @@ impl<'a> Serialize for ParenthesizedExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ParenthesizedExpression = ({\n\ttype: 'ParenthesizedExpression';\n\texpression: Expression;\n}) & Span;";
 
@@ -1040,6 +1098,7 @@ impl<'a> Serialize for Statement<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Statement = BlockStatement | BreakStatement | ContinueStatement | DebuggerStatement | DoWhileStatement | EmptyStatement | ExpressionStatement | ForInStatement | ForOfStatement | ForStatement | IfStatement | LabeledStatement | ReturnStatement | SwitchStatement | ThrowStatement | TryStatement | WhileStatement | WithStatement | VariableDeclaration | Function | Class | TSTypeAliasDeclaration | TSInterfaceDeclaration | TSEnumDeclaration | TSModuleDeclaration | TSImportEqualsDeclaration | ImportDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | TSExportAssignment | TSNamespaceExportDeclaration;";
 
@@ -1053,6 +1112,7 @@ impl<'a> Serialize for Directive<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Directive = ({\n\ttype: 'Directive';\n\texpression: StringLiteral;\n\tdirective: string;\n}) & Span;";
 
@@ -1065,6 +1125,7 @@ impl<'a> Serialize for Hashbang<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Hashbang = ({\n\ttype: 'Hashbang';\n\tvalue: string;\n}) & Span;";
@@ -1078,6 +1139,7 @@ impl<'a> Serialize for BlockStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BlockStatement = ({\n\ttype: 'BlockStatement';\n\tbody: Array<Statement>;\n}) & Span;";
 
@@ -1095,6 +1157,7 @@ impl<'a> Serialize for Declaration<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Declaration = VariableDeclaration | Function | Class | TSTypeAliasDeclaration | TSInterfaceDeclaration | TSEnumDeclaration | TSModuleDeclaration | TSImportEqualsDeclaration;";
 
@@ -1109,6 +1172,7 @@ impl<'a> Serialize for VariableDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type VariableDeclaration = ({\n\ttype: 'VariableDeclaration';\n\tkind: VariableDeclarationKind;\n\tdeclarations: Array<VariableDeclarator>;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -1133,6 +1197,7 @@ impl Serialize for VariableDeclarationKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type VariableDeclarationKind = 'var' | 'const' | 'let' | 'using' | 'await using';";
@@ -1148,6 +1213,7 @@ impl<'a> Serialize for VariableDeclarator<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type VariableDeclarator = ({\n\ttype: 'VariableDeclarator';\n\tid: BindingPattern;\n\tinit: (Expression) | null;\n\tdefinite: boolean;\n}) & Span;";
 
@@ -1159,6 +1225,7 @@ impl Serialize for EmptyStatement {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type EmptyStatement = ({\n\ttype: 'EmptyStatement';\n}) & Span;";
@@ -1172,6 +1239,7 @@ impl<'a> Serialize for ExpressionStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExpressionStatement = ({\n\ttype: 'ExpressionStatement';\n\texpression: Expression;\n}) & Span;";
 
@@ -1186,6 +1254,7 @@ impl<'a> Serialize for IfStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type IfStatement = ({\n\ttype: 'IfStatement';\n\ttest: Expression;\n\tconsequent: Statement;\n\talternate: (Statement) | null;\n}) & Span;";
 
@@ -1199,6 +1268,7 @@ impl<'a> Serialize for DoWhileStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type DoWhileStatement = ({\n\ttype: 'DoWhileStatement';\n\tbody: Statement;\n\ttest: Expression;\n}) & Span;";
 
@@ -1212,6 +1282,7 @@ impl<'a> Serialize for WhileStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type WhileStatement = ({\n\ttype: 'WhileStatement';\n\ttest: Expression;\n\tbody: Statement;\n}) & Span;";
 
@@ -1227,6 +1298,7 @@ impl<'a> Serialize for ForStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ForStatement = ({\n\ttype: 'ForStatement';\n\tinit: (ForStatementInit) | null;\n\ttest: (Expression) | null;\n\tupdate: (Expression) | null;\n\tbody: Statement;\n}) & Span;";
 
@@ -1279,6 +1351,7 @@ impl<'a> Serialize for ForStatementInit<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ForStatementInit = VariableDeclaration | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -1293,6 +1366,7 @@ impl<'a> Serialize for ForInStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ForInStatement = ({\n\ttype: 'ForInStatement';\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
 
@@ -1314,6 +1388,7 @@ impl<'a> Serialize for ForStatementLeft<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ForStatementLeft = VariableDeclaration | IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression | ArrayAssignmentTarget | ObjectAssignmentTarget;";
 
@@ -1329,6 +1404,7 @@ impl<'a> Serialize for ForOfStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ForOfStatement = ({\n\ttype: 'ForOfStatement';\n\tawait: boolean;\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
 
@@ -1341,6 +1417,7 @@ impl<'a> Serialize for ContinueStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ContinueStatement = ({\n\ttype: 'ContinueStatement';\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
 
@@ -1353,6 +1430,7 @@ impl<'a> Serialize for BreakStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BreakStatement = ({\n\ttype: 'BreakStatement';\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
 
@@ -1365,6 +1443,7 @@ impl<'a> Serialize for ReturnStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ReturnStatement = ({\n\ttype: 'ReturnStatement';\n\targument: (Expression) | null;\n}) & Span;";
 
@@ -1378,6 +1457,7 @@ impl<'a> Serialize for WithStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type WithStatement = ({\n\ttype: 'WithStatement';\n\tobject: Expression;\n\tbody: Statement;\n}) & Span;";
 
@@ -1391,6 +1471,7 @@ impl<'a> Serialize for SwitchStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type SwitchStatement = ({\n\ttype: 'SwitchStatement';\n\tdiscriminant: Expression;\n\tcases: Array<SwitchCase>;\n}) & Span;";
 
@@ -1404,6 +1485,7 @@ impl<'a> Serialize for SwitchCase<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type SwitchCase = ({\n\ttype: 'SwitchCase';\n\ttest: (Expression) | null;\n\tconsequent: Array<Statement>;\n}) & Span;";
 
@@ -1417,6 +1499,7 @@ impl<'a> Serialize for LabeledStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LabeledStatement = ({\n\ttype: 'LabeledStatement';\n\tlabel: LabelIdentifier;\n\tbody: Statement;\n}) & Span;";
 
@@ -1429,6 +1512,7 @@ impl<'a> Serialize for ThrowStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ThrowStatement = ({\n\ttype: 'ThrowStatement';\n\targument: Expression;\n}) & Span;";
 
@@ -1443,6 +1527,7 @@ impl<'a> Serialize for TryStatement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TryStatement = ({\n\ttype: 'TryStatement';\n\tblock: BlockStatement;\n\thandler: (CatchClause) | null;\n\tfinalizer: (BlockStatement) | null;\n}) & Span;";
 
@@ -1456,6 +1541,7 @@ impl<'a> Serialize for CatchClause<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CatchClause = ({\n\ttype: 'CatchClause';\n\tparam: (CatchParameter) | null;\n\tbody: BlockStatement;\n}) & Span;";
 
@@ -1468,6 +1554,7 @@ impl<'a> Serialize for CatchParameter<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CatchParameter = ({\n\ttype: 'CatchParameter';\n\tpattern: BindingPattern;\n}) & Span;";
 
@@ -1479,6 +1566,7 @@ impl Serialize for DebuggerStatement {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type DebuggerStatement = ({\n\ttype: 'DebuggerStatement';\n}) & Span;";
@@ -1492,6 +1580,7 @@ impl<'a> Serialize for BindingPattern<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BindingPattern = ({\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n\toptional: boolean;\n}) & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);";
 
@@ -1505,6 +1594,7 @@ impl<'a> Serialize for BindingPatternKind<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BindingPatternKind = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;";
 
@@ -1518,6 +1608,7 @@ impl<'a> Serialize for AssignmentPattern<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentPattern = ({\n\ttype: 'AssignmentPattern';\n\tleft: BindingPattern;\n\tright: Expression;\n}) & Span;";
 
@@ -1536,6 +1627,7 @@ impl<'a> Serialize for BindingProperty<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BindingProperty = ({\n\ttype: 'BindingProperty';\n\tkey: PropertyKey;\n\tvalue: BindingPattern;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
 
@@ -1551,6 +1643,7 @@ impl<'a> Serialize for BindingRestElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BindingRestElement = ({\n\ttype: 'RestElement';\n\targument: BindingPattern;\n}) & Span;";
 
@@ -1571,6 +1664,7 @@ impl<'a> Serialize for Function<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Function = ({\n\ttype: FunctionType;\n\tid: (BindingIdentifier) | null;\n\tgenerator: boolean;\n\tasync: boolean;\n\tdeclare: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n\tbody: (FunctionBody) | null;\n}) & Span;";
 
@@ -1594,6 +1688,7 @@ impl Serialize for FunctionType {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type FunctionType = 'FunctionDeclaration' | 'FunctionExpression' | 'TSDeclareFunction' | 'TSEmptyBodyFunctionExpression';";
 
@@ -1613,6 +1708,7 @@ impl<'a> Serialize for FormalParameter<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type FormalParameter = ({\n\ttype: 'FormalParameter';\n\tdecorators: Array<Decorator>;\n\tpattern: BindingPattern;\n\taccessibility: (TSAccessibility) | null;\n\treadonly: boolean;\n\toverride: boolean;\n}) & Span;";
 
@@ -1638,6 +1734,7 @@ impl Serialize for FormalParameterKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type FormalParameterKind = 'FormalParameter' | 'UniqueFormalParameters' | 'ArrowFormalParameters' | 'Signature';";
 
@@ -1651,6 +1748,7 @@ impl<'a> Serialize for FunctionBody<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type FunctionBody = ({\n\ttype: 'FunctionBody';\n\tdirectives: Array<Directive>;\n\tstatements: Array<Statement>;\n}) & Span;";
 
@@ -1668,6 +1766,7 @@ impl<'a> Serialize for ArrowFunctionExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ArrowFunctionExpression = ({\n\ttype: 'ArrowFunctionExpression';\n\texpression: boolean;\n\tasync: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n\tbody: FunctionBody;\n}) & Span;";
 
@@ -1681,6 +1780,7 @@ impl<'a> Serialize for YieldExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type YieldExpression = ({\n\ttype: 'YieldExpression';\n\tdelegate: boolean;\n\targument: (Expression) | null;\n}) & Span;";
 
@@ -1701,6 +1801,7 @@ impl<'a> Serialize for Class<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Class = ({\n\ttype: ClassType;\n\tdecorators: Array<Decorator>;\n\tid: (BindingIdentifier) | null;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tsuperClass: (Expression) | null;\n\tsuperTypeParameters: (TSTypeParameterInstantiation) | null;\n\timplements: (Array<TSClassImplements>) | null;\n\tbody: ClassBody;\n\tabstract: boolean;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -1716,6 +1817,7 @@ impl Serialize for ClassType {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ClassType = 'ClassDeclaration' | 'ClassExpression';";
@@ -1729,6 +1831,7 @@ impl<'a> Serialize for ClassBody<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ClassBody = ({\n\ttype: 'ClassBody';\n\tbody: Array<ClassElement>;\n}) & Span;";
@@ -1744,6 +1847,7 @@ impl<'a> Serialize for ClassElement<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition | AccessorProperty | TSIndexSignature;";
 
@@ -1764,6 +1868,7 @@ impl<'a> Serialize for MethodDefinition<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type MethodDefinition = ({\n\ttype: MethodDefinitionType;\n\tdecorators: Array<Decorator>;\n\tkey: PropertyKey;\n\tvalue: Function;\n\tkind: MethodDefinitionKind;\n\tcomputed: boolean;\n\tstatic: boolean;\n\toverride: boolean;\n\toptional: boolean;\n\taccessibility: (TSAccessibility) | null;\n}) & Span;";
 
@@ -1781,6 +1886,7 @@ impl Serialize for MethodDefinitionType {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinition';";
@@ -1805,6 +1911,7 @@ impl<'a> Serialize for PropertyDefinition<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type PropertyDefinition = ({\n\ttype: PropertyDefinitionType;\n\tdecorators: Array<Decorator>;\n\tkey: PropertyKey;\n\tvalue: (Expression) | null;\n\tcomputed: boolean;\n\tstatic: boolean;\n\tdeclare: boolean;\n\toverride: boolean;\n\toptional: boolean;\n\tdefinite: boolean;\n\treadonly: boolean;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n\taccessibility: (TSAccessibility) | null;\n}) & Span;";
 
@@ -1825,6 +1932,7 @@ impl Serialize for PropertyDefinitionType {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type PropertyDefinitionType = 'PropertyDefinition' | 'TSAbstractPropertyDefinition';";
@@ -1847,6 +1955,7 @@ impl Serialize for MethodDefinitionKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type MethodDefinitionKind = 'constructor' | 'method' | 'get' | 'set';";
@@ -1860,6 +1969,7 @@ impl<'a> Serialize for PrivateIdentifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type PrivateIdentifier = ({\n\ttype: 'PrivateIdentifier';\n\tname: string;\n}) & Span;";
@@ -1873,6 +1983,7 @@ impl<'a> Serialize for StaticBlock<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type StaticBlock = ({\n\ttype: 'StaticBlock';\n\tbody: Array<Statement>;\n}) & Span;";
@@ -1891,6 +2002,7 @@ impl<'a> Serialize for ModuleDeclaration<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ModuleDeclaration = ImportDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | TSExportAssignment | TSNamespaceExportDeclaration;";
 
@@ -1908,6 +2020,7 @@ impl Serialize for AccessorPropertyType {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type AccessorPropertyType = 'AccessorProperty' | 'TSAbstractAccessorProperty';";
@@ -1928,6 +2041,7 @@ impl<'a> Serialize for AccessorProperty<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AccessorProperty = ({\n\ttype: AccessorPropertyType;\n\tdecorators: Array<Decorator>;\n\tkey: PropertyKey;\n\tvalue: (Expression) | null;\n\tcomputed: boolean;\n\tstatic: boolean;\n\tdefinite: boolean;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n\taccessibility: (TSAccessibility) | null;\n}) & Span;";
 
@@ -1941,6 +2055,7 @@ impl<'a> Serialize for ImportExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportExpression = ({\n\ttype: 'ImportExpression';\n\tsource: Expression;\n\targuments: Array<Expression>;\n}) & Span;";
 
@@ -1956,6 +2071,7 @@ impl<'a> Serialize for ImportDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportDeclaration = ({\n\ttype: 'ImportDeclaration';\n\tspecifiers: (Array<ImportDeclarationSpecifier>) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
@@ -1972,6 +2088,7 @@ impl<'a> Serialize for ImportDeclarationSpecifier<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportDeclarationSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier;";
 
@@ -1986,6 +2103,7 @@ impl<'a> Serialize for ImportSpecifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportSpecifier = ({\n\ttype: 'ImportSpecifier';\n\timported: ModuleExportName;\n\tlocal: BindingIdentifier;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
@@ -1998,6 +2116,7 @@ impl<'a> Serialize for ImportDefaultSpecifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportDefaultSpecifier = ({\n\ttype: 'ImportDefaultSpecifier';\n\tlocal: BindingIdentifier;\n}) & Span;";
 
@@ -2010,6 +2129,7 @@ impl<'a> Serialize for ImportNamespaceSpecifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportNamespaceSpecifier = ({\n\ttype: 'ImportNamespaceSpecifier';\n\tlocal: BindingIdentifier;\n}) & Span;";
 
@@ -2023,6 +2143,7 @@ impl<'a> Serialize for WithClause<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type WithClause = ({\n\ttype: 'WithClause';\n\tattributesKeyword: IdentifierName;\n\twithEntries: Array<ImportAttribute>;\n}) & Span;";
 
@@ -2036,6 +2157,7 @@ impl<'a> Serialize for ImportAttribute<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportAttribute = ({\n\ttype: 'ImportAttribute';\n\tkey: ImportAttributeKey;\n\tvalue: StringLiteral;\n}) & Span;";
 
@@ -2047,6 +2169,7 @@ impl<'a> Serialize for ImportAttributeKey<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ImportAttributeKey = IdentifierName | StringLiteral;";
@@ -2064,6 +2187,7 @@ impl<'a> Serialize for ExportNamedDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExportNamedDeclaration = ({\n\ttype: 'ExportNamedDeclaration';\n\tdeclaration: (Declaration) | null;\n\tspecifiers: Array<ExportSpecifier>;\n\tsource: (StringLiteral) | null;\n\texportKind: ImportOrExportKind;\n\twithClause: (WithClause) | null;\n}) & Span;";
 
@@ -2077,6 +2201,7 @@ impl<'a> Serialize for ExportDefaultDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExportDefaultDeclaration = ({\n\ttype: 'ExportDefaultDeclaration';\n\tdeclaration: ExportDefaultDeclarationKind;\n\texported: ModuleExportName;\n}) & Span;";
 
@@ -2092,6 +2217,7 @@ impl<'a> Serialize for ExportAllDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExportAllDeclaration = ({\n\ttype: 'ExportAllDeclaration';\n\texported: (ModuleExportName) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\texportKind: ImportOrExportKind;\n}) & Span;";
 
@@ -2106,6 +2232,7 @@ impl<'a> Serialize for ExportSpecifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExportSpecifier = ({\n\ttype: 'ExportSpecifier';\n\tlocal: ModuleExportName;\n\texported: ModuleExportName;\n\texportKind: ImportOrExportKind;\n}) & Span;";
 
@@ -2204,6 +2331,7 @@ impl<'a> Serialize for ExportDefaultDeclarationKind<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ExportDefaultDeclarationKind = Function | Class | TSInterfaceDeclaration | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -2216,6 +2344,7 @@ impl<'a> Serialize for ModuleExportName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ModuleExportName = IdentifierName | IdentifierReference | StringLiteral;";
@@ -2230,6 +2359,7 @@ impl<'a> Serialize for TSThisParameter<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSThisParameter = ({\n\ttype: 'TSThisParameter';\n\tthisSpan: Span;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -2245,6 +2375,7 @@ impl<'a> Serialize for TSEnumDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSEnumDeclaration = ({\n\ttype: 'TSEnumDeclaration';\n\tid: BindingIdentifier;\n\tmembers: Array<TSEnumMember>;\n\tconst: boolean;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -2258,6 +2389,7 @@ impl<'a> Serialize for TSEnumMember<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSEnumMember = ({\n\ttype: 'TSEnumMember';\n\tid: TSEnumMemberName;\n\tinitializer: (Expression) | null;\n}) & Span;";
 
@@ -2313,6 +2445,7 @@ impl<'a> Serialize for TSEnumMemberName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral | NumericLiteral | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -2325,6 +2458,7 @@ impl<'a> Serialize for TSTypeAnnotation<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeAnnotation = ({\n\ttype: 'TSTypeAnnotation';\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -2337,6 +2471,7 @@ impl<'a> Serialize for TSLiteralType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSLiteralType = ({\n\ttype: 'TSLiteralType';\n\tliteral: TSLiteral;\n}) & Span;";
@@ -2355,6 +2490,7 @@ impl<'a> Serialize for TSLiteral<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSLiteral = BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | UnaryExpression;";
 
@@ -2402,6 +2538,7 @@ impl<'a> Serialize for TSType<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSType = TSAnyKeyword | TSBigIntKeyword | TSBooleanKeyword | TSIntrinsicKeyword | TSNeverKeyword | TSNullKeyword | TSNumberKeyword | TSObjectKeyword | TSStringKeyword | TSSymbolKeyword | TSUndefinedKeyword | TSUnknownKeyword | TSVoidKeyword | TSArrayType | TSConditionalType | TSConstructorType | TSFunctionType | TSImportType | TSIndexedAccessType | TSInferType | TSIntersectionType | TSLiteralType | TSMappedType | TSNamedTupleMember | TSQualifiedName | TSTemplateLiteralType | TSThisType | TSTupleType | TSTypeLiteral | TSTypeOperator | TSTypePredicate | TSTypeQuery | TSTypeReference | TSUnionType | TSParenthesizedType | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType;";
 
@@ -2417,6 +2554,7 @@ impl<'a> Serialize for TSConditionalType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSConditionalType = ({\n\ttype: 'TSConditionalType';\n\tcheckType: TSType;\n\textendsType: TSType;\n\ttrueType: TSType;\n\tfalseType: TSType;\n}) & Span;";
 
@@ -2429,6 +2567,7 @@ impl<'a> Serialize for TSUnionType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSUnionType = ({\n\ttype: 'TSUnionType';\n\ttypes: Array<TSType>;\n}) & Span;";
@@ -2442,6 +2581,7 @@ impl<'a> Serialize for TSIntersectionType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSIntersectionType = ({\n\ttype: 'TSIntersectionType';\n\ttypes: Array<TSType>;\n}) & Span;";
 
@@ -2454,6 +2594,7 @@ impl<'a> Serialize for TSParenthesizedType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSParenthesizedType = ({\n\ttype: 'TSParenthesizedType';\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -2467,6 +2608,7 @@ impl<'a> Serialize for TSTypeOperator<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeOperator = ({\n\ttype: 'TSTypeOperator';\n\toperator: TSTypeOperatorOperator;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -2485,6 +2627,7 @@ impl Serialize for TSTypeOperatorOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSTypeOperatorOperator = 'keyof' | 'unique' | 'readonly';";
@@ -2498,6 +2641,7 @@ impl<'a> Serialize for TSArrayType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSArrayType = ({\n\ttype: 'TSArrayType';\n\telementType: TSType;\n}) & Span;";
@@ -2512,6 +2656,7 @@ impl<'a> Serialize for TSIndexedAccessType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSIndexedAccessType = ({\n\ttype: 'TSIndexedAccessType';\n\tobjectType: TSType;\n\tindexType: TSType;\n}) & Span;";
 
@@ -2524,6 +2669,7 @@ impl<'a> Serialize for TSTupleType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTupleType = ({\n\ttype: 'TSTupleType';\n\telementTypes: Array<TSTupleElement>;\n}) & Span;";
 
@@ -2538,6 +2684,7 @@ impl<'a> Serialize for TSNamedTupleMember<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSNamedTupleMember = ({\n\ttype: 'TSNamedTupleMember';\n\telementType: TSTupleElement;\n\tlabel: IdentifierName;\n\toptional: boolean;\n}) & Span;";
 
@@ -2550,6 +2697,7 @@ impl<'a> Serialize for TSOptionalType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSOptionalType = ({\n\ttype: 'TSOptionalType';\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -2562,6 +2710,7 @@ impl<'a> Serialize for TSRestType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSRestType = ({\n\ttype: 'TSRestType';\n\ttypeAnnotation: TSType;\n}) & Span;";
@@ -2612,6 +2761,7 @@ impl<'a> Serialize for TSTupleElement<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTupleElement = TSOptionalType | TSRestType | TSAnyKeyword | TSBigIntKeyword | TSBooleanKeyword | TSIntrinsicKeyword | TSNeverKeyword | TSNullKeyword | TSNumberKeyword | TSObjectKeyword | TSStringKeyword | TSSymbolKeyword | TSUndefinedKeyword | TSUnknownKeyword | TSVoidKeyword | TSArrayType | TSConditionalType | TSConstructorType | TSFunctionType | TSImportType | TSIndexedAccessType | TSInferType | TSIntersectionType | TSLiteralType | TSMappedType | TSNamedTupleMember | TSQualifiedName | TSTemplateLiteralType | TSThisType | TSTupleType | TSTypeLiteral | TSTypeOperator | TSTypePredicate | TSTypeQuery | TSTypeReference | TSUnionType | TSParenthesizedType | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType;";
 
@@ -2623,6 +2773,7 @@ impl Serialize for TSAnyKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSAnyKeyword = ({\n\ttype: 'TSAnyKeyword';\n}) & Span;";
@@ -2635,6 +2786,7 @@ impl Serialize for TSStringKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSStringKeyword = ({\n\ttype: 'TSStringKeyword';\n}) & Span;";
@@ -2647,6 +2799,7 @@ impl Serialize for TSBooleanKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSBooleanKeyword = ({\n\ttype: 'TSBooleanKeyword';\n}) & Span;";
@@ -2659,6 +2812,7 @@ impl Serialize for TSNumberKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSNumberKeyword = ({\n\ttype: 'TSNumberKeyword';\n}) & Span;";
@@ -2671,6 +2825,7 @@ impl Serialize for TSNeverKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSNeverKeyword = ({\n\ttype: 'TSNeverKeyword';\n}) & Span;";
@@ -2683,6 +2838,7 @@ impl Serialize for TSIntrinsicKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSIntrinsicKeyword = ({\n\ttype: 'TSIntrinsicKeyword';\n}) & Span;";
@@ -2695,6 +2851,7 @@ impl Serialize for TSUnknownKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSUnknownKeyword = ({\n\ttype: 'TSUnknownKeyword';\n}) & Span;";
@@ -2707,6 +2864,7 @@ impl Serialize for TSNullKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSNullKeyword = ({\n\ttype: 'TSNullKeyword';\n}) & Span;";
@@ -2719,6 +2877,7 @@ impl Serialize for TSUndefinedKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSUndefinedKeyword = ({\n\ttype: 'TSUndefinedKeyword';\n}) & Span;";
@@ -2731,6 +2890,7 @@ impl Serialize for TSVoidKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSVoidKeyword = ({\n\ttype: 'TSVoidKeyword';\n}) & Span;";
@@ -2743,6 +2903,7 @@ impl Serialize for TSSymbolKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSSymbolKeyword = ({\n\ttype: 'TSSymbolKeyword';\n}) & Span;";
@@ -2755,6 +2916,7 @@ impl Serialize for TSThisType {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSThisType = ({\n\ttype: 'TSThisType';\n}) & Span;";
@@ -2767,6 +2929,7 @@ impl Serialize for TSObjectKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSObjectKeyword = ({\n\ttype: 'TSObjectKeyword';\n}) & Span;";
@@ -2779,6 +2942,7 @@ impl Serialize for TSBigIntKeyword {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSBigIntKeyword = ({\n\ttype: 'TSBigIntKeyword';\n}) & Span;";
@@ -2793,6 +2957,7 @@ impl<'a> Serialize for TSTypeReference<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeReference = ({\n\ttype: 'TSTypeReference';\n\ttypeName: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -2804,6 +2969,7 @@ impl<'a> Serialize for TSTypeName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSTypeName = IdentifierReference | TSQualifiedName;";
@@ -2818,6 +2984,7 @@ impl<'a> Serialize for TSQualifiedName<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSQualifiedName = ({\n\ttype: 'TSQualifiedName';\n\tleft: TSTypeName;\n\tright: IdentifierName;\n}) & Span;";
 
@@ -2830,6 +2997,7 @@ impl<'a> Serialize for TSTypeParameterInstantiation<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterInstantiation = ({\n\ttype: 'TSTypeParameterInstantiation';\n\tparams: Array<TSType>;\n}) & Span;";
 
@@ -2847,6 +3015,7 @@ impl<'a> Serialize for TSTypeParameter<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameter = ({\n\ttype: 'TSTypeParameter';\n\tname: BindingIdentifier;\n\tconstraint: (TSType) | null;\n\tdefault: (TSType) | null;\n\tin: boolean;\n\tout: boolean;\n\tconst: boolean;\n}) & Span;";
 
@@ -2859,6 +3028,7 @@ impl<'a> Serialize for TSTypeParameterDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterDeclaration = ({\n\ttype: 'TSTypeParameterDeclaration';\n\tparams: Array<TSTypeParameter>;\n}) & Span;";
 
@@ -2874,6 +3044,7 @@ impl<'a> Serialize for TSTypeAliasDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeAliasDeclaration = ({\n\ttype: 'TSTypeAliasDeclaration';\n\tid: BindingIdentifier;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\ttypeAnnotation: TSType;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -2892,6 +3063,7 @@ impl Serialize for TSAccessibility {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSAccessibility = 'private' | 'protected' | 'public';";
@@ -2906,6 +3078,7 @@ impl<'a> Serialize for TSClassImplements<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSClassImplements = ({\n\ttype: 'TSClassImplements';\n\texpression: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -2922,6 +3095,7 @@ impl<'a> Serialize for TSInterfaceDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceDeclaration = ({\n\ttype: 'TSInterfaceDeclaration';\n\tid: BindingIdentifier;\n\textends: (Array<TSInterfaceHeritage>) | null;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tbody: TSInterfaceBody;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -2934,6 +3108,7 @@ impl<'a> Serialize for TSInterfaceBody<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceBody = ({\n\ttype: 'TSInterfaceBody';\n\tbody: Array<TSSignature>;\n}) & Span;";
 
@@ -2950,6 +3125,7 @@ impl<'a> Serialize for TSPropertySignature<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSPropertySignature = ({\n\ttype: 'TSPropertySignature';\n\tcomputed: boolean;\n\toptional: boolean;\n\treadonly: boolean;\n\tkey: PropertyKey;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -2964,6 +3140,7 @@ impl<'a> Serialize for TSSignature<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSSignature = TSIndexSignature | TSPropertySignature | TSCallSignatureDeclaration | TSConstructSignatureDeclaration | TSMethodSignature;";
 
@@ -2978,6 +3155,7 @@ impl<'a> Serialize for TSIndexSignature<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignature = ({\n\ttype: 'TSIndexSignature';\n\tparameters: Array<TSIndexSignatureName>;\n\ttypeAnnotation: TSTypeAnnotation;\n\treadonly: boolean;\n}) & Span;";
 
@@ -2993,6 +3171,7 @@ impl<'a> Serialize for TSCallSignatureDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSCallSignatureDeclaration = ({\n\ttype: 'TSCallSignatureDeclaration';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -3011,6 +3190,7 @@ impl Serialize for TSMethodSignatureKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSMethodSignatureKind = 'method' | 'get' | 'set';";
@@ -3031,6 +3211,7 @@ impl<'a> Serialize for TSMethodSignature<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSMethodSignature = ({\n\ttype: 'TSMethodSignature';\n\tkey: PropertyKey;\n\tcomputed: boolean;\n\toptional: boolean;\n\tkind: TSMethodSignatureKind;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -3045,6 +3226,7 @@ impl<'a> Serialize for TSConstructSignatureDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSConstructSignatureDeclaration = ({\n\ttype: 'TSConstructSignatureDeclaration';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -3058,6 +3240,7 @@ impl<'a> Serialize for TSIndexSignatureName<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignatureName = ({\n\ttype: 'Identifier';\n\tname: string;\n\ttypeAnnotation: TSTypeAnnotation;\n}) & Span;";
 
@@ -3071,6 +3254,7 @@ impl<'a> Serialize for TSInterfaceHeritage<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceHeritage = ({\n\ttype: 'TSInterfaceHeritage';\n\texpression: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -3085,6 +3269,7 @@ impl<'a> Serialize for TSTypePredicate<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypePredicate = ({\n\ttype: 'TSTypePredicate';\n\tparameterName: TSTypePredicateName;\n\tasserts: boolean;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
@@ -3096,6 +3281,7 @@ impl<'a> Serialize for TSTypePredicateName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSTypePredicateName = IdentifierName | TSThisType;";
@@ -3112,6 +3298,7 @@ impl<'a> Serialize for TSModuleDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSModuleDeclaration = ({\n\ttype: 'TSModuleDeclaration';\n\tid: TSModuleDeclarationName;\n\tbody: (TSModuleDeclarationBody) | null;\n\tkind: TSModuleDeclarationKind;\n\tdeclare: boolean;\n}) & Span;";
 
@@ -3130,6 +3317,7 @@ impl Serialize for TSModuleDeclarationKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSModuleDeclarationKind = 'global' | 'module' | 'namespace';";
@@ -3142,6 +3330,7 @@ impl<'a> Serialize for TSModuleDeclarationName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSModuleDeclarationName = BindingIdentifier | StringLiteral;";
@@ -3154,6 +3343,7 @@ impl<'a> Serialize for TSModuleDeclarationBody<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSModuleDeclarationBody = TSModuleDeclaration | TSModuleBlock;";
@@ -3170,6 +3360,7 @@ impl<'a> Serialize for TSTypeLiteral<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeLiteral = ({\n\ttype: 'TSTypeLiteral';\n\tmembers: Array<TSSignature>;\n}) & Span;";
 
@@ -3182,6 +3373,7 @@ impl<'a> Serialize for TSInferType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSInferType = ({\n\ttype: 'TSInferType';\n\ttypeParameter: TSTypeParameter;\n}) & Span;";
 
@@ -3195,6 +3387,7 @@ impl<'a> Serialize for TSTypeQuery<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeQuery = ({\n\ttype: 'TSTypeQuery';\n\texprName: TSTypeQueryExprName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -3207,6 +3400,7 @@ impl<'a> Serialize for TSTypeQueryExprName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSTypeQueryExprName = TSImportType | IdentifierReference | TSQualifiedName;";
@@ -3224,6 +3418,7 @@ impl<'a> Serialize for TSImportType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSImportType = ({\n\ttype: 'TSImportType';\n\tisTypeOf: boolean;\n\tparameter: TSType;\n\tqualifier: (TSTypeName) | null;\n\tattributes: (TSImportAttributes) | null;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -3237,6 +3432,7 @@ impl<'a> Serialize for TSImportAttributes<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSImportAttributes = ({\n\ttype: 'TSImportAttributes';\n\tattributesKeyword: IdentifierName;\n\telements: Array<TSImportAttribute>;\n}) & Span;";
 
@@ -3250,6 +3446,7 @@ impl<'a> Serialize for TSImportAttribute<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSImportAttribute = ({\n\ttype: 'TSImportAttribute';\n\tname: TSImportAttributeName;\n\tvalue: Expression;\n}) & Span;";
 
@@ -3261,6 +3458,7 @@ impl<'a> Serialize for TSImportAttributeName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSImportAttributeName = IdentifierName | StringLiteral;";
@@ -3277,6 +3475,7 @@ impl<'a> Serialize for TSFunctionType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSFunctionType = ({\n\ttype: 'TSFunctionType';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
 
@@ -3292,6 +3491,7 @@ impl<'a> Serialize for TSConstructorType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSConstructorType = ({\n\ttype: 'TSConstructorType';\n\tabstract: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
 
@@ -3308,6 +3508,7 @@ impl<'a> Serialize for TSMappedType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSMappedType = ({\n\ttype: 'TSMappedType';\n\ttypeParameter: TSTypeParameter;\n\tnameType: (TSType) | null;\n\ttypeAnnotation: (TSType) | null;\n\toptional: TSMappedTypeModifierOperator;\n\treadonly: TSMappedTypeModifierOperator;\n}) & Span;";
 
@@ -3329,6 +3530,7 @@ impl Serialize for TSMappedTypeModifierOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type TSMappedTypeModifierOperator = 'true' | '+' | '-' | 'none';";
@@ -3343,6 +3545,7 @@ impl<'a> Serialize for TSTemplateLiteralType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTemplateLiteralType = ({\n\ttype: 'TSTemplateLiteralType';\n\tquasis: Array<TemplateElement>;\n\ttypes: Array<TSType>;\n}) & Span;";
 
@@ -3356,6 +3559,7 @@ impl<'a> Serialize for TSAsExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSAsExpression = ({\n\ttype: 'TSAsExpression';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -3369,6 +3573,7 @@ impl<'a> Serialize for TSSatisfiesExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSSatisfiesExpression = ({\n\ttype: 'TSSatisfiesExpression';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -3382,6 +3587,7 @@ impl<'a> Serialize for TSTypeAssertion<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSTypeAssertion = ({\n\ttype: 'TSTypeAssertion';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
@@ -3396,6 +3602,7 @@ impl<'a> Serialize for TSImportEqualsDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSImportEqualsDeclaration = ({\n\ttype: 'TSImportEqualsDeclaration';\n\tid: BindingIdentifier;\n\tmoduleReference: TSModuleReference;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
@@ -3408,6 +3615,7 @@ impl<'a> Serialize for TSModuleReference<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSModuleReference = TSExternalModuleReference | IdentifierReference | TSQualifiedName;";
 
@@ -3420,6 +3628,7 @@ impl<'a> Serialize for TSExternalModuleReference<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSExternalModuleReference = ({\n\ttype: 'TSExternalModuleReference';\n\texpression: StringLiteral;\n}) & Span;";
 
@@ -3432,6 +3641,7 @@ impl<'a> Serialize for TSNonNullExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSNonNullExpression = ({\n\ttype: 'TSNonNullExpression';\n\texpression: Expression;\n}) & Span;";
 
@@ -3444,6 +3654,7 @@ impl<'a> Serialize for Decorator<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Decorator = ({\n\ttype: 'Decorator';\n\texpression: Expression;\n}) & Span;";
@@ -3457,6 +3668,7 @@ impl<'a> Serialize for TSExportAssignment<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSExportAssignment = ({\n\ttype: 'TSExportAssignment';\n\texpression: Expression;\n}) & Span;";
 
@@ -3469,6 +3681,7 @@ impl<'a> Serialize for TSNamespaceExportDeclaration<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSNamespaceExportDeclaration = ({\n\ttype: 'TSNamespaceExportDeclaration';\n\tid: IdentifierName;\n}) & Span;";
 
@@ -3482,6 +3695,7 @@ impl<'a> Serialize for TSInstantiationExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type TSInstantiationExpression = ({\n\ttype: 'TSInstantiationExpression';\n\texpression: Expression;\n\ttypeParameters: TSTypeParameterInstantiation;\n}) & Span;";
 
@@ -3497,6 +3711,7 @@ impl Serialize for ImportOrExportKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ImportOrExportKind = 'value' | 'type';";
 
@@ -3510,6 +3725,7 @@ impl<'a> Serialize for JSDocNullableType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSDocNullableType = ({\n\ttype: 'JSDocNullableType';\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
 
@@ -3523,6 +3739,7 @@ impl<'a> Serialize for JSDocNonNullableType<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSDocNonNullableType = ({\n\ttype: 'JSDocNonNullableType';\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
 
@@ -3534,6 +3751,7 @@ impl Serialize for JSDocUnknownType {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSDocUnknownType = ({\n\ttype: 'JSDocUnknownType';\n}) & Span;";
@@ -3549,6 +3767,7 @@ impl<'a> Serialize for JSXElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXElement = ({\n\ttype: 'JSXElement';\n\topeningElement: JSXOpeningElement;\n\tclosingElement: (JSXClosingElement) | null;\n\tchildren: Array<JSXChild>;\n}) & Span;";
 
@@ -3564,6 +3783,7 @@ impl<'a> Serialize for JSXOpeningElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXOpeningElement = ({\n\ttype: 'JSXOpeningElement';\n\tselfClosing: boolean;\n\tname: JSXElementName;\n\tattributes: Array<JSXAttributeItem>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
@@ -3576,6 +3796,7 @@ impl<'a> Serialize for JSXClosingElement<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXClosingElement = ({\n\ttype: 'JSXClosingElement';\n\tname: JSXElementName;\n}) & Span;";
 
@@ -3590,6 +3811,7 @@ impl<'a> Serialize for JSXFragment<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXFragment = ({\n\ttype: 'JSXFragment';\n\topeningFragment: JSXOpeningFragment;\n\tclosingFragment: JSXClosingFragment;\n\tchildren: Array<JSXChild>;\n}) & Span;";
 
@@ -3601,6 +3823,7 @@ impl Serialize for JSXOpeningFragment {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXOpeningFragment = ({\n\ttype: 'JSXOpeningFragment';\n}) & Span;";
@@ -3613,6 +3836,7 @@ impl Serialize for JSXClosingFragment {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXClosingFragment = ({\n\ttype: 'JSXClosingFragment';\n}) & Span;";
@@ -3627,6 +3851,7 @@ impl<'a> Serialize for JSXNamespacedName<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXNamespacedName = ({\n\ttype: 'JSXNamespacedName';\n\tnamespace: JSXIdentifier;\n\tproperty: JSXIdentifier;\n}) & Span;";
 
@@ -3640,6 +3865,7 @@ impl<'a> Serialize for JSXMemberExpression<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXMemberExpression = ({\n\ttype: 'JSXMemberExpression';\n\tobject: JSXMemberExpressionObject;\n\tproperty: JSXIdentifier;\n}) & Span;";
 
@@ -3652,6 +3878,7 @@ impl<'a> Serialize for JSXExpressionContainer<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXExpressionContainer = ({\n\ttype: 'JSXExpressionContainer';\n\texpression: JSXExpression;\n}) & Span;";
 
@@ -3704,6 +3931,7 @@ impl<'a> Serialize for JSXExpression<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXExpression = JSXEmptyExpression | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
 
@@ -3715,6 +3943,7 @@ impl Serialize for JSXEmptyExpression {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXEmptyExpression = ({\n\ttype: 'JSXEmptyExpression';\n}) & Span;";
@@ -3727,6 +3956,7 @@ impl<'a> Serialize for JSXAttributeItem<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;";
@@ -3741,6 +3971,7 @@ impl<'a> Serialize for JSXAttribute<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXAttribute = ({\n\ttype: 'JSXAttribute';\n\tname: JSXAttributeName;\n\tvalue: (JSXAttributeValue) | null;\n}) & Span;";
 
@@ -3753,6 +3984,7 @@ impl<'a> Serialize for JSXSpreadAttribute<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadAttribute = ({\n\ttype: 'JSXSpreadAttribute';\n\targument: Expression;\n}) & Span;";
 
@@ -3764,6 +3996,7 @@ impl<'a> Serialize for JSXAttributeName<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXAttributeName = JSXIdentifier | JSXNamespacedName;";
@@ -3778,6 +4011,7 @@ impl<'a> Serialize for JSXAttributeValue<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;";
 
@@ -3790,6 +4024,7 @@ impl<'a> Serialize for JSXIdentifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXIdentifier = ({\n\ttype: 'JSXIdentifier';\n\tname: string;\n}) & Span;";
@@ -3805,6 +4040,7 @@ impl<'a> Serialize for JSXChild<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;";
 
@@ -3817,6 +4053,7 @@ impl<'a> Serialize for JSXSpreadChild<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadChild = ({\n\ttype: 'JSXSpreadChild';\n\texpression: Expression;\n}) & Span;";
 
@@ -3829,6 +4066,7 @@ impl<'a> Serialize for JSXText<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type JSXText = ({\n\ttype: 'JSXText';\n\tvalue: string;\n}) & Span;";

--- a/crates/oxc_regular_expression/src/generated/derive_estree.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_estree.rs
@@ -17,6 +17,7 @@ impl<'a> Serialize for Pattern<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Pattern = ({\n\ttype: 'Pattern';\n\tbody: Disjunction;\n}) & Span;";
@@ -30,6 +31,7 @@ impl<'a> Serialize for Disjunction<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Disjunction = ({\n\ttype: 'Disjunction';\n\tbody: Array<Alternative>;\n}) & Span;";
@@ -43,6 +45,7 @@ impl<'a> Serialize for Alternative<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Alternative = ({\n\ttype: 'Alternative';\n\tbody: Array<Term>;\n}) & Span;";
@@ -65,6 +68,7 @@ impl<'a> Serialize for Term<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Term = BoundaryAssertion | LookAroundAssertion | Quantifier | Character | Dot | CharacterClassEscape | UnicodePropertyEscape | CharacterClass | CapturingGroup | IgnoreGroup | IndexedReference | NamedReference;";
 
@@ -77,6 +81,7 @@ impl Serialize for BoundaryAssertion {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BoundaryAssertion = ({\n\ttype: 'BoundaryAssertion';\n\tspan: Span;\n\tkind: BoundaryAssertionKind;\n});";
 
@@ -98,6 +103,7 @@ impl Serialize for BoundaryAssertionKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type BoundaryAssertionKind = 'start' | 'end' | 'boundary' | 'negativeBoundary';";
@@ -112,6 +118,7 @@ impl<'a> Serialize for LookAroundAssertion<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertion = ({\n\ttype: 'LookAroundAssertion';\n\tkind: LookAroundAssertionKind;\n\tbody: Disjunction;\n}) & Span;";
 
@@ -137,6 +144,7 @@ impl Serialize for LookAroundAssertionKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertionKind = 'lookahead' | 'negativeLookahead' | 'lookbehind' | 'negativeLookbehind';";
 
@@ -152,6 +160,7 @@ impl<'a> Serialize for Quantifier<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Quantifier = ({\n\ttype: 'Quantifier';\n\tmin: number;\n\tmax: (number) | null;\n\tgreedy: boolean;\n\tbody: Term;\n}) & Span;";
 
@@ -165,6 +174,7 @@ impl Serialize for Character {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Character = ({\n\ttype: 'Character';\n\tkind: CharacterKind;\n\tvalue: number;\n}) & Span;";
 
@@ -202,6 +212,7 @@ impl Serialize for CharacterKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterKind = 'controlLetter' | 'hexadecimalEscape' | 'identifier' | 'null' | 'octal1' | 'octal2' | 'octal3' | 'singleEscape' | 'symbol' | 'unicodeEscape';";
 
@@ -214,6 +225,7 @@ impl Serialize for CharacterClassEscape {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscape = ({\n\ttype: 'CharacterClassEscape';\n\tkind: CharacterClassEscapeKind;\n}) & Span;";
 
@@ -241,6 +253,7 @@ impl Serialize for CharacterClassEscapeKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscapeKind = 'd' | 'negativeD' | 's' | 'negativeS' | 'w' | 'negativeW';";
 
@@ -256,6 +269,7 @@ impl<'a> Serialize for UnicodePropertyEscape<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type UnicodePropertyEscape = ({\n\ttype: 'UnicodePropertyEscape';\n\tnegative: boolean;\n\tstrings: boolean;\n\tname: string;\n\tvalue: (string) | null;\n}) & Span;";
 
@@ -267,6 +281,7 @@ impl Serialize for Dot {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Dot = ({\n\ttype: 'Dot';\n}) & Span;";
 
@@ -282,6 +297,7 @@ impl<'a> Serialize for CharacterClass<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterClass = ({\n\ttype: 'CharacterClass';\n\tnegative: boolean;\n\tstrings: boolean;\n\tkind: CharacterClassContentsKind;\n\tbody: Array<CharacterClassContents>;\n}) & Span;";
 
@@ -302,6 +318,7 @@ impl Serialize for CharacterClassContentsKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type CharacterClassContentsKind = 'union' | 'intersection' | 'subtraction';";
@@ -320,6 +337,7 @@ impl<'a> Serialize for CharacterClassContents<'a> {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterClassContents = CharacterClassRange | CharacterClassEscape | UnicodePropertyEscape | Character | CharacterClass | ClassStringDisjunction;";
 
@@ -333,6 +351,7 @@ impl Serialize for CharacterClassRange {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CharacterClassRange = ({\n\ttype: 'CharacterClassRange';\n\tmin: Character;\n\tmax: Character;\n}) & Span;";
 
@@ -346,6 +365,7 @@ impl<'a> Serialize for ClassStringDisjunction<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ClassStringDisjunction = ({\n\ttype: 'ClassStringDisjunction';\n\tstrings: boolean;\n\tbody: Array<ClassString>;\n}) & Span;";
 
@@ -359,6 +379,7 @@ impl<'a> Serialize for ClassString<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type ClassString = ({\n\ttype: 'ClassString';\n\tstrings: boolean;\n\tbody: Array<Character>;\n}) & Span;";
 
@@ -372,6 +393,7 @@ impl<'a> Serialize for CapturingGroup<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type CapturingGroup = ({\n\ttype: 'CapturingGroup';\n\tname: (string) | null;\n\tbody: Disjunction;\n}) & Span;";
 
@@ -385,6 +407,7 @@ impl<'a> Serialize for IgnoreGroup<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type IgnoreGroup = ({\n\ttype: 'IgnoreGroup';\n\tmodifiers: (Modifiers) | null;\n\tbody: Disjunction;\n}) & Span;";
 
@@ -398,6 +421,7 @@ impl Serialize for Modifiers {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Modifiers = ({\n\ttype: 'Modifiers';\n\tenabling: (Modifier) | null;\n\tdisabling: (Modifier) | null;\n}) & Span;";
 
@@ -411,6 +435,7 @@ impl Serialize for Modifier {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type Modifier = ({\n\ttype: 'Modifier';\n\tignoreCase: boolean;\n\tmultiline: boolean;\n\tsticky: boolean;\n});";
 
@@ -423,6 +448,7 @@ impl Serialize for IndexedReference {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type IndexedReference = ({\n\ttype: 'IndexedReference';\n\tindex: number;\n}) & Span;";
@@ -436,6 +462,7 @@ impl<'a> Serialize for NamedReference<'a> {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type NamedReference = ({\n\ttype: 'NamedReference';\n\tname: string;\n}) & Span;";

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -19,6 +19,7 @@ impl Serialize for Span {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Span = ({\n\tstart: number;\n\tend: number;\n});";
@@ -32,6 +33,7 @@ impl Serialize for SourceType {
         map.end()
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type SourceType = ({\n\tlanguage: Language;\n\tmoduleKind: ModuleKind;\n\tvariant: LanguageVariant;\n});";
 
@@ -50,6 +52,7 @@ impl Serialize for Language {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type Language = 'javascript' | 'typescript' | 'typescriptDefinition';";
@@ -65,6 +68,7 @@ impl Serialize for ModuleKind {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type ModuleKind = 'script' | 'module' | 'unambiguous';";
@@ -81,5 +85,6 @@ impl Serialize for LanguageVariant {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LanguageVariant = 'standard' | 'jsx';";

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -62,6 +62,7 @@ impl Serialize for AssignmentOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type AssignmentOperator = '=' | '+=' | '-=' | '*=' | '/=' | '%=' | '<<=' | '>>=' | '>>>=' | '|=' | '^=' | '&=' | '&&=' | '||=' | '??=' | '**=';";
 
@@ -135,6 +136,7 @@ impl Serialize for BinaryOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type BinaryOperator = '==' | '!=' | '===' | '!==' | '<' | '<=' | '>' | '>=' | '<<' | '>>' | '>>>' | '+' | '-' | '*' | '/' | '%' | '|' | '^' | '&' | 'in' | 'instanceof' | '**';";
 
@@ -151,6 +153,7 @@ impl Serialize for LogicalOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type LogicalOperator = '||' | '&&' | '??';";
 
@@ -179,6 +182,7 @@ impl Serialize for UnaryOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
     "export type UnaryOperator = '-' | '+' | '!' | '~' | 'typeof' | 'void' | 'delete';";
@@ -195,5 +199,6 @@ impl Serialize for UpdateOperator {
         }
     }
 }
+
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = "export type UpdateOperator = '++' | '--';";

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -55,6 +55,8 @@ impl Derive for DeriveESTree {
                     #body
                 }
             }
+
+            ///@@line_break
             #ts_type_def
         }
     }


### PR DESCRIPTION
Follow-on after #6404. Style nit. Add line breaks to generated code, to make it easier to read.