### PR TITLE
refactor(ast_tools): use double quotes in TS type defs

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -29,7 +29,7 @@ impl Serialize for BooleanLiteral {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type BooleanLiteral = ({\n\ttype: 'BooleanLiteral';\n\tvalue: boolean;\n}) & Span;";
+    "export type BooleanLiteral = ({\n\ttype: \"BooleanLiteral\";\n\tvalue: boolean;\n}) & Span;";
 
 impl Serialize for NullLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -42,7 +42,7 @@ impl Serialize for NullLiteral {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type NullLiteral = ({\n\ttype: 'NullLiteral';\n}) & Span;";
+    "export type NullLiteral = ({\n\ttype: \"NullLiteral\";\n}) & Span;";
 
 impl<'a> Serialize for NumericLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -56,7 +56,7 @@ impl<'a> Serialize for NumericLiteral<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type NumericLiteral = ({\n\ttype: 'NumericLiteral';\n\tvalue: number;\n\traw: string;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type NumericLiteral = ({\n\ttype: \"NumericLiteral\";\n\tvalue: number;\n\traw: string;\n}) & Span;";
 
 impl<'a> Serialize for BigIntLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -70,7 +70,7 @@ impl<'a> Serialize for BigIntLiteral<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type BigIntLiteral = ({\n\ttype: 'BigIntLiteral';\n\traw: string;\n}) & Span;";
+    "export type BigIntLiteral = ({\n\ttype: \"BigIntLiteral\";\n\traw: string;\n}) & Span;";
 
 impl<'a> Serialize for RegExpLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -84,7 +84,7 @@ impl<'a> Serialize for RegExpLiteral<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type RegExpLiteral = ({\n\ttype: 'RegExpLiteral';\n\tvalue: EmptyObject;\n\tregex: RegExp;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type RegExpLiteral = ({\n\ttype: \"RegExpLiteral\";\n\tvalue: EmptyObject;\n\tregex: RegExp;\n}) & Span;";
 
 impl<'a> Serialize for RegExp<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -134,7 +134,7 @@ impl<'a> Serialize for StringLiteral<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type StringLiteral = ({\n\ttype: 'StringLiteral';\n\tvalue: string;\n}) & Span;";
+    "export type StringLiteral = ({\n\ttype: \"StringLiteral\";\n\tvalue: string;\n}) & Span;";
 
 impl<'a> Serialize for Program<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -150,7 +150,7 @@ impl<'a> Serialize for Program<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Program = ({\n\ttype: 'Program';\n\tsourceType: SourceType;\n\thashbang: (Hashbang) | null;\n\tdirectives: Array<Directive>;\n\tbody: Array<Statement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Program = ({\n\ttype: \"Program\";\n\tsourceType: SourceType;\n\thashbang: (Hashbang) | null;\n\tdirectives: Array<Directive>;\n\tbody: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for Expression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -216,7 +216,7 @@ impl<'a> Serialize for IdentifierName<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type IdentifierName = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
+    "export type IdentifierName = ({\n\ttype: \"Identifier\";\n\tname: string;\n}) & Span;";
 
 impl<'a> Serialize for IdentifierReference<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -230,7 +230,7 @@ impl<'a> Serialize for IdentifierReference<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type IdentifierReference = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
+    "export type IdentifierReference = ({\n\ttype: \"Identifier\";\n\tname: string;\n}) & Span;";
 
 impl<'a> Serialize for BindingIdentifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -244,7 +244,7 @@ impl<'a> Serialize for BindingIdentifier<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type BindingIdentifier = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
+    "export type BindingIdentifier = ({\n\ttype: \"Identifier\";\n\tname: string;\n}) & Span;";
 
 impl<'a> Serialize for LabelIdentifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -258,7 +258,7 @@ impl<'a> Serialize for LabelIdentifier<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type LabelIdentifier = ({\n\ttype: 'Identifier';\n\tname: string;\n}) & Span;";
+    "export type LabelIdentifier = ({\n\ttype: \"Identifier\";\n\tname: string;\n}) & Span;";
 
 impl Serialize for ThisExpression {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -271,7 +271,7 @@ impl Serialize for ThisExpression {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type ThisExpression = ({\n\ttype: 'ThisExpression';\n}) & Span;";
+    "export type ThisExpression = ({\n\ttype: \"ThisExpression\";\n}) & Span;";
 
 impl<'a> Serialize for ArrayExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -284,7 +284,7 @@ impl<'a> Serialize for ArrayExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ArrayExpression = ({\n\ttype: 'ArrayExpression';\n\telements: Array<SpreadElement | Expression | null>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ArrayExpression = ({\n\ttype: \"ArrayExpression\";\n\telements: Array<SpreadElement | Expression | null>;\n}) & Span;";
 
 impl<'a> Serialize for ArrayExpressionElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -365,7 +365,7 @@ impl<'a> Serialize for ObjectExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ObjectExpression = ({\n\ttype: 'ObjectExpression';\n\tproperties: Array<ObjectPropertyKind>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ObjectExpression = ({\n\ttype: \"ObjectExpression\";\n\tproperties: Array<ObjectPropertyKind>;\n}) & Span;";
 
 impl<'a> Serialize for ObjectPropertyKind<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -397,7 +397,7 @@ impl<'a> Serialize for ObjectProperty<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ObjectProperty = ({\n\ttype: 'ObjectProperty';\n\tkind: PropertyKind;\n\tkey: PropertyKey;\n\tvalue: Expression;\n\tinit: (Expression) | null;\n\tmethod: boolean;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ObjectProperty = ({\n\ttype: \"ObjectProperty\";\n\tkind: PropertyKind;\n\tkey: PropertyKey;\n\tvalue: Expression;\n\tinit: (Expression) | null;\n\tmethod: boolean;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
 
 impl<'a> Serialize for PropertyKey<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -464,7 +464,7 @@ impl Serialize for PropertyKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type PropertyKind = 'init' | 'get' | 'set';";
+const TS_APPEND_CONTENT: &'static str = "export type PropertyKind = \"init\" | \"get\" | \"set\";";
 
 impl<'a> Serialize for TemplateLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -478,7 +478,7 @@ impl<'a> Serialize for TemplateLiteral<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TemplateLiteral = ({\n\ttype: 'TemplateLiteral';\n\tquasis: Array<TemplateElement>;\n\texpressions: Array<Expression>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TemplateLiteral = ({\n\ttype: \"TemplateLiteral\";\n\tquasis: Array<TemplateElement>;\n\texpressions: Array<Expression>;\n}) & Span;";
 
 impl<'a> Serialize for TaggedTemplateExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -493,7 +493,7 @@ impl<'a> Serialize for TaggedTemplateExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TaggedTemplateExpression = ({\n\ttype: 'TaggedTemplateExpression';\n\ttag: Expression;\n\tquasi: TemplateLiteral;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TaggedTemplateExpression = ({\n\ttype: \"TaggedTemplateExpression\";\n\ttag: Expression;\n\tquasi: TemplateLiteral;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TemplateElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -507,7 +507,7 @@ impl<'a> Serialize for TemplateElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TemplateElement = ({\n\ttype: 'TemplateElement';\n\ttail: boolean;\n\tvalue: TemplateElementValue;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TemplateElement = ({\n\ttype: \"TemplateElement\";\n\ttail: boolean;\n\tvalue: TemplateElementValue;\n}) & Span;";
 
 impl<'a> Serialize for TemplateElementValue<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -548,7 +548,7 @@ impl<'a> Serialize for ComputedMemberExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ComputedMemberExpression = ({\n\ttype: 'ComputedMemberExpression';\n\tobject: Expression;\n\texpression: Expression;\n\toptional: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ComputedMemberExpression = ({\n\ttype: \"ComputedMemberExpression\";\n\tobject: Expression;\n\texpression: Expression;\n\toptional: boolean;\n}) & Span;";
 
 impl<'a> Serialize for StaticMemberExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -563,7 +563,7 @@ impl<'a> Serialize for StaticMemberExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type StaticMemberExpression = ({\n\ttype: 'StaticMemberExpression';\n\tobject: Expression;\n\tproperty: IdentifierName;\n\toptional: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type StaticMemberExpression = ({\n\ttype: \"StaticMemberExpression\";\n\tobject: Expression;\n\tproperty: IdentifierName;\n\toptional: boolean;\n}) & Span;";
 
 impl<'a> Serialize for PrivateFieldExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -578,7 +578,7 @@ impl<'a> Serialize for PrivateFieldExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type PrivateFieldExpression = ({\n\ttype: 'PrivateFieldExpression';\n\tobject: Expression;\n\tfield: PrivateIdentifier;\n\toptional: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type PrivateFieldExpression = ({\n\ttype: \"PrivateFieldExpression\";\n\tobject: Expression;\n\tfield: PrivateIdentifier;\n\toptional: boolean;\n}) & Span;";
 
 impl<'a> Serialize for CallExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -594,7 +594,7 @@ impl<'a> Serialize for CallExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CallExpression = ({\n\ttype: 'CallExpression';\n\tcallee: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n\targuments: Array<Argument>;\n\toptional: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CallExpression = ({\n\ttype: \"CallExpression\";\n\tcallee: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n\targuments: Array<Argument>;\n\toptional: boolean;\n}) & Span;";
 
 impl<'a> Serialize for NewExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -609,7 +609,7 @@ impl<'a> Serialize for NewExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type NewExpression = ({\n\ttype: 'NewExpression';\n\tcallee: Expression;\n\targuments: Array<Argument>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type NewExpression = ({\n\ttype: \"NewExpression\";\n\tcallee: Expression;\n\targuments: Array<Argument>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for MetaProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -623,7 +623,7 @@ impl<'a> Serialize for MetaProperty<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type MetaProperty = ({\n\ttype: 'MetaProperty';\n\tmeta: IdentifierName;\n\tproperty: IdentifierName;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type MetaProperty = ({\n\ttype: \"MetaProperty\";\n\tmeta: IdentifierName;\n\tproperty: IdentifierName;\n}) & Span;";
 
 impl<'a> Serialize for SpreadElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -636,8 +636,7 @@ impl<'a> Serialize for SpreadElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type SpreadElement = ({\n\ttype: 'SpreadElement';\n\targument: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type SpreadElement = ({\n\ttype: \"SpreadElement\";\n\targument: Expression;\n}) & Span;";
 
 impl<'a> Serialize for Argument<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -705,7 +704,7 @@ impl<'a> Serialize for UpdateExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type UpdateExpression = ({\n\ttype: 'UpdateExpression';\n\toperator: UpdateOperator;\n\tprefix: boolean;\n\targument: SimpleAssignmentTarget;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type UpdateExpression = ({\n\ttype: \"UpdateExpression\";\n\toperator: UpdateOperator;\n\tprefix: boolean;\n\targument: SimpleAssignmentTarget;\n}) & Span;";
 
 impl<'a> Serialize for UnaryExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -719,7 +718,7 @@ impl<'a> Serialize for UnaryExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type UnaryExpression = ({\n\ttype: 'UnaryExpression';\n\toperator: UnaryOperator;\n\targument: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type UnaryExpression = ({\n\ttype: \"UnaryExpression\";\n\toperator: UnaryOperator;\n\targument: Expression;\n}) & Span;";
 
 impl<'a> Serialize for BinaryExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -734,7 +733,7 @@ impl<'a> Serialize for BinaryExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BinaryExpression = ({\n\ttype: 'BinaryExpression';\n\tleft: Expression;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type BinaryExpression = ({\n\ttype: \"BinaryExpression\";\n\tleft: Expression;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
 
 impl<'a> Serialize for PrivateInExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -749,7 +748,7 @@ impl<'a> Serialize for PrivateInExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type PrivateInExpression = ({\n\ttype: 'PrivateInExpression';\n\tleft: PrivateIdentifier;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type PrivateInExpression = ({\n\ttype: \"PrivateInExpression\";\n\tleft: PrivateIdentifier;\n\toperator: BinaryOperator;\n\tright: Expression;\n}) & Span;";
 
 impl<'a> Serialize for LogicalExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -764,7 +763,7 @@ impl<'a> Serialize for LogicalExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LogicalExpression = ({\n\ttype: 'LogicalExpression';\n\tleft: Expression;\n\toperator: LogicalOperator;\n\tright: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type LogicalExpression = ({\n\ttype: \"LogicalExpression\";\n\tleft: Expression;\n\toperator: LogicalOperator;\n\tright: Expression;\n}) & Span;";
 
 impl<'a> Serialize for ConditionalExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -779,7 +778,7 @@ impl<'a> Serialize for ConditionalExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ConditionalExpression = ({\n\ttype: 'ConditionalExpression';\n\ttest: Expression;\n\tconsequent: Expression;\n\talternate: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ConditionalExpression = ({\n\ttype: \"ConditionalExpression\";\n\ttest: Expression;\n\tconsequent: Expression;\n\talternate: Expression;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -794,7 +793,7 @@ impl<'a> Serialize for AssignmentExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentExpression = ({\n\ttype: 'AssignmentExpression';\n\toperator: AssignmentOperator;\n\tleft: AssignmentTarget;\n\tright: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentExpression = ({\n\ttype: \"AssignmentExpression\";\n\toperator: AssignmentOperator;\n\tleft: AssignmentTarget;\n\tright: Expression;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentTarget<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -864,10 +863,10 @@ const TS_APPEND_CONTENT: &'static str =
     "export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTarget;";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ArrayAssignmentTarget = ({\n\ttype: 'ArrayAssignmentTarget';\n\telements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ArrayAssignmentTarget = ({\n\ttype: \"ArrayAssignmentTarget\";\n\telements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;\n}) & Span;";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ObjectAssignmentTarget = ({\n\ttype: 'ObjectAssignmentTarget';\n\tproperties: Array<AssignmentTargetProperty | AssignmentTargetRest>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ObjectAssignmentTarget = ({\n\ttype: \"ObjectAssignmentTarget\";\n\tproperties: Array<AssignmentTargetProperty | AssignmentTargetRest>;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentTargetRest<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -880,7 +879,7 @@ impl<'a> Serialize for AssignmentTargetRest<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetRest = ({\n\ttype: 'RestElement';\n\targument: AssignmentTarget;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetRest = ({\n\ttype: \"RestElement\";\n\targument: AssignmentTarget;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentTargetMaybeDefault<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -936,7 +935,7 @@ impl<'a> Serialize for AssignmentTargetWithDefault<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetWithDefault = ({\n\ttype: 'AssignmentTargetWithDefault';\n\tbinding: AssignmentTarget;\n\tinit: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetWithDefault = ({\n\ttype: \"AssignmentTargetWithDefault\";\n\tbinding: AssignmentTarget;\n\tinit: Expression;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentTargetProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -966,7 +965,7 @@ impl<'a> Serialize for AssignmentTargetPropertyIdentifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyIdentifier = ({\n\ttype: 'AssignmentTargetPropertyIdentifier';\n\tbinding: IdentifierReference;\n\tinit: (Expression) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyIdentifier = ({\n\ttype: \"AssignmentTargetPropertyIdentifier\";\n\tbinding: IdentifierReference;\n\tinit: (Expression) | null;\n}) & Span;";
 
 impl<'a> Serialize for AssignmentTargetPropertyProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -980,7 +979,7 @@ impl<'a> Serialize for AssignmentTargetPropertyProperty<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyProperty = ({\n\ttype: 'AssignmentTargetPropertyProperty';\n\tname: PropertyKey;\n\tbinding: AssignmentTargetMaybeDefault;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentTargetPropertyProperty = ({\n\ttype: \"AssignmentTargetPropertyProperty\";\n\tname: PropertyKey;\n\tbinding: AssignmentTargetMaybeDefault;\n}) & Span;";
 
 impl<'a> Serialize for SequenceExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -993,7 +992,7 @@ impl<'a> Serialize for SequenceExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type SequenceExpression = ({\n\ttype: 'SequenceExpression';\n\texpressions: Array<Expression>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type SequenceExpression = ({\n\ttype: \"SequenceExpression\";\n\texpressions: Array<Expression>;\n}) & Span;";
 
 impl Serialize for Super {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1005,7 +1004,7 @@ impl Serialize for Super {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Super = ({\n\ttype: 'Super';\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Super = ({\n\ttype: \"Super\";\n}) & Span;";
 
 impl<'a> Serialize for AwaitExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1018,7 +1017,7 @@ impl<'a> Serialize for AwaitExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AwaitExpression = ({\n\ttype: 'AwaitExpression';\n\targument: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AwaitExpression = ({\n\ttype: \"AwaitExpression\";\n\targument: Expression;\n}) & Span;";
 
 impl<'a> Serialize for ChainExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1031,7 +1030,7 @@ impl<'a> Serialize for ChainExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ChainExpression = ({\n\ttype: 'ChainExpression';\n\texpression: ChainElement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ChainExpression = ({\n\ttype: \"ChainExpression\";\n\texpression: ChainElement;\n}) & Span;";
 
 impl<'a> Serialize for ChainElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1058,7 +1057,7 @@ impl<'a> Serialize for ParenthesizedExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ParenthesizedExpression = ({\n\ttype: 'ParenthesizedExpression';\n\texpression: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ParenthesizedExpression = ({\n\ttype: \"ParenthesizedExpression\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for Statement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1114,7 +1113,7 @@ impl<'a> Serialize for Directive<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Directive = ({\n\ttype: 'Directive';\n\texpression: StringLiteral;\n\tdirective: string;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Directive = ({\n\ttype: \"Directive\";\n\texpression: StringLiteral;\n\tdirective: string;\n}) & Span;";
 
 impl<'a> Serialize for Hashbang<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1128,7 +1127,7 @@ impl<'a> Serialize for Hashbang<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type Hashbang = ({\n\ttype: 'Hashbang';\n\tvalue: string;\n}) & Span;";
+    "export type Hashbang = ({\n\ttype: \"Hashbang\";\n\tvalue: string;\n}) & Span;";
 
 impl<'a> Serialize for BlockStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1141,7 +1140,7 @@ impl<'a> Serialize for BlockStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BlockStatement = ({\n\ttype: 'BlockStatement';\n\tbody: Array<Statement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type BlockStatement = ({\n\ttype: \"BlockStatement\";\n\tbody: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for Declaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1174,7 +1173,7 @@ impl<'a> Serialize for VariableDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type VariableDeclaration = ({\n\ttype: 'VariableDeclaration';\n\tkind: VariableDeclarationKind;\n\tdeclarations: Array<VariableDeclarator>;\n\tdeclare: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type VariableDeclaration = ({\n\ttype: \"VariableDeclaration\";\n\tkind: VariableDeclarationKind;\n\tdeclarations: Array<VariableDeclarator>;\n\tdeclare: boolean;\n}) & Span;";
 
 impl Serialize for VariableDeclarationKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1199,8 +1198,7 @@ impl Serialize for VariableDeclarationKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type VariableDeclarationKind = 'var' | 'const' | 'let' | 'using' | 'await using';";
+const TS_APPEND_CONTENT: &'static str = "export type VariableDeclarationKind = \"var\" | \"const\" | \"let\" | \"using\" | \"await using\";";
 
 impl<'a> Serialize for VariableDeclarator<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1215,7 +1213,7 @@ impl<'a> Serialize for VariableDeclarator<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type VariableDeclarator = ({\n\ttype: 'VariableDeclarator';\n\tid: BindingPattern;\n\tinit: (Expression) | null;\n\tdefinite: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type VariableDeclarator = ({\n\ttype: \"VariableDeclarator\";\n\tid: BindingPattern;\n\tinit: (Expression) | null;\n\tdefinite: boolean;\n}) & Span;";
 
 impl Serialize for EmptyStatement {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1228,7 +1226,7 @@ impl Serialize for EmptyStatement {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type EmptyStatement = ({\n\ttype: 'EmptyStatement';\n}) & Span;";
+    "export type EmptyStatement = ({\n\ttype: \"EmptyStatement\";\n}) & Span;";
 
 impl<'a> Serialize for ExpressionStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1241,7 +1239,7 @@ impl<'a> Serialize for ExpressionStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ExpressionStatement = ({\n\ttype: 'ExpressionStatement';\n\texpression: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ExpressionStatement = ({\n\ttype: \"ExpressionStatement\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for IfStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1256,7 +1254,7 @@ impl<'a> Serialize for IfStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type IfStatement = ({\n\ttype: 'IfStatement';\n\ttest: Expression;\n\tconsequent: Statement;\n\talternate: (Statement) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type IfStatement = ({\n\ttype: \"IfStatement\";\n\ttest: Expression;\n\tconsequent: Statement;\n\talternate: (Statement) | null;\n}) & Span;";
 
 impl<'a> Serialize for DoWhileStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1270,7 +1268,7 @@ impl<'a> Serialize for DoWhileStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type DoWhileStatement = ({\n\ttype: 'DoWhileStatement';\n\tbody: Statement;\n\ttest: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type DoWhileStatement = ({\n\ttype: \"DoWhileStatement\";\n\tbody: Statement;\n\ttest: Expression;\n}) & Span;";
 
 impl<'a> Serialize for WhileStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1284,7 +1282,7 @@ impl<'a> Serialize for WhileStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type WhileStatement = ({\n\ttype: 'WhileStatement';\n\ttest: Expression;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type WhileStatement = ({\n\ttype: \"WhileStatement\";\n\ttest: Expression;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for ForStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1300,7 +1298,7 @@ impl<'a> Serialize for ForStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ForStatement = ({\n\ttype: 'ForStatement';\n\tinit: (ForStatementInit) | null;\n\ttest: (Expression) | null;\n\tupdate: (Expression) | null;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ForStatement = ({\n\ttype: \"ForStatement\";\n\tinit: (ForStatementInit) | null;\n\ttest: (Expression) | null;\n\tupdate: (Expression) | null;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for ForStatementInit<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1368,7 +1366,7 @@ impl<'a> Serialize for ForInStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ForInStatement = ({\n\ttype: 'ForInStatement';\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ForInStatement = ({\n\ttype: \"ForInStatement\";\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for ForStatementLeft<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1406,7 +1404,7 @@ impl<'a> Serialize for ForOfStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ForOfStatement = ({\n\ttype: 'ForOfStatement';\n\tawait: boolean;\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ForOfStatement = ({\n\ttype: \"ForOfStatement\";\n\tawait: boolean;\n\tleft: ForStatementLeft;\n\tright: Expression;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for ContinueStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1419,7 +1417,7 @@ impl<'a> Serialize for ContinueStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ContinueStatement = ({\n\ttype: 'ContinueStatement';\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ContinueStatement = ({\n\ttype: \"ContinueStatement\";\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
 
 impl<'a> Serialize for BreakStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1432,7 +1430,7 @@ impl<'a> Serialize for BreakStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BreakStatement = ({\n\ttype: 'BreakStatement';\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type BreakStatement = ({\n\ttype: \"BreakStatement\";\n\tlabel: (LabelIdentifier) | null;\n}) & Span;";
 
 impl<'a> Serialize for ReturnStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1445,7 +1443,7 @@ impl<'a> Serialize for ReturnStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ReturnStatement = ({\n\ttype: 'ReturnStatement';\n\targument: (Expression) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ReturnStatement = ({\n\ttype: \"ReturnStatement\";\n\targument: (Expression) | null;\n}) & Span;";
 
 impl<'a> Serialize for WithStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1459,7 +1457,7 @@ impl<'a> Serialize for WithStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type WithStatement = ({\n\ttype: 'WithStatement';\n\tobject: Expression;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type WithStatement = ({\n\ttype: \"WithStatement\";\n\tobject: Expression;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for SwitchStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1473,7 +1471,7 @@ impl<'a> Serialize for SwitchStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type SwitchStatement = ({\n\ttype: 'SwitchStatement';\n\tdiscriminant: Expression;\n\tcases: Array<SwitchCase>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type SwitchStatement = ({\n\ttype: \"SwitchStatement\";\n\tdiscriminant: Expression;\n\tcases: Array<SwitchCase>;\n}) & Span;";
 
 impl<'a> Serialize for SwitchCase<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1487,7 +1485,7 @@ impl<'a> Serialize for SwitchCase<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type SwitchCase = ({\n\ttype: 'SwitchCase';\n\ttest: (Expression) | null;\n\tconsequent: Array<Statement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type SwitchCase = ({\n\ttype: \"SwitchCase\";\n\ttest: (Expression) | null;\n\tconsequent: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for LabeledStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1501,7 +1499,7 @@ impl<'a> Serialize for LabeledStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LabeledStatement = ({\n\ttype: 'LabeledStatement';\n\tlabel: LabelIdentifier;\n\tbody: Statement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type LabeledStatement = ({\n\ttype: \"LabeledStatement\";\n\tlabel: LabelIdentifier;\n\tbody: Statement;\n}) & Span;";
 
 impl<'a> Serialize for ThrowStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1514,7 +1512,7 @@ impl<'a> Serialize for ThrowStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ThrowStatement = ({\n\ttype: 'ThrowStatement';\n\targument: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ThrowStatement = ({\n\ttype: \"ThrowStatement\";\n\targument: Expression;\n}) & Span;";
 
 impl<'a> Serialize for TryStatement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1529,7 +1527,7 @@ impl<'a> Serialize for TryStatement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TryStatement = ({\n\ttype: 'TryStatement';\n\tblock: BlockStatement;\n\thandler: (CatchClause) | null;\n\tfinalizer: (BlockStatement) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TryStatement = ({\n\ttype: \"TryStatement\";\n\tblock: BlockStatement;\n\thandler: (CatchClause) | null;\n\tfinalizer: (BlockStatement) | null;\n}) & Span;";
 
 impl<'a> Serialize for CatchClause<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1543,7 +1541,7 @@ impl<'a> Serialize for CatchClause<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CatchClause = ({\n\ttype: 'CatchClause';\n\tparam: (CatchParameter) | null;\n\tbody: BlockStatement;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CatchClause = ({\n\ttype: \"CatchClause\";\n\tparam: (CatchParameter) | null;\n\tbody: BlockStatement;\n}) & Span;";
 
 impl<'a> Serialize for CatchParameter<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1556,7 +1554,7 @@ impl<'a> Serialize for CatchParameter<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CatchParameter = ({\n\ttype: 'CatchParameter';\n\tpattern: BindingPattern;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CatchParameter = ({\n\ttype: \"CatchParameter\";\n\tpattern: BindingPattern;\n}) & Span;";
 
 impl Serialize for DebuggerStatement {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1569,7 +1567,7 @@ impl Serialize for DebuggerStatement {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type DebuggerStatement = ({\n\ttype: 'DebuggerStatement';\n}) & Span;";
+    "export type DebuggerStatement = ({\n\ttype: \"DebuggerStatement\";\n}) & Span;";
 
 impl<'a> Serialize for BindingPattern<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1610,10 +1608,10 @@ impl<'a> Serialize for AssignmentPattern<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentPattern = ({\n\ttype: 'AssignmentPattern';\n\tleft: BindingPattern;\n\tright: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentPattern = ({\n\ttype: \"AssignmentPattern\";\n\tleft: BindingPattern;\n\tright: Expression;\n}) & Span;";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ObjectPattern = ({\n\ttype: 'ObjectPattern';\n\tproperties: Array<BindingProperty | BindingRestElement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ObjectPattern = ({\n\ttype: \"ObjectPattern\";\n\tproperties: Array<BindingProperty | BindingRestElement>;\n}) & Span;";
 
 impl<'a> Serialize for BindingProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1629,10 +1627,10 @@ impl<'a> Serialize for BindingProperty<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BindingProperty = ({\n\ttype: 'BindingProperty';\n\tkey: PropertyKey;\n\tvalue: BindingPattern;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type BindingProperty = ({\n\ttype: \"BindingProperty\";\n\tkey: PropertyKey;\n\tvalue: BindingPattern;\n\tshorthand: boolean;\n\tcomputed: boolean;\n}) & Span;";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ArrayPattern = ({\n\ttype: 'ArrayPattern';\n\telements: Array<BindingPattern | BindingRestElement | null>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ArrayPattern = ({\n\ttype: \"ArrayPattern\";\n\telements: Array<BindingPattern | BindingRestElement | null>;\n}) & Span;";
 
 impl<'a> Serialize for BindingRestElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1645,7 +1643,7 @@ impl<'a> Serialize for BindingRestElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BindingRestElement = ({\n\ttype: 'RestElement';\n\targument: BindingPattern;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type BindingRestElement = ({\n\ttype: \"RestElement\";\n\targument: BindingPattern;\n}) & Span;";
 
 impl<'a> Serialize for Function<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1690,10 +1688,10 @@ impl Serialize for FunctionType {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type FunctionType = 'FunctionDeclaration' | 'FunctionExpression' | 'TSDeclareFunction' | 'TSEmptyBodyFunctionExpression';";
+const TS_APPEND_CONTENT: &'static str = "export type FunctionType = \"FunctionDeclaration\" | \"FunctionExpression\" | \"TSDeclareFunction\" | \"TSEmptyBodyFunctionExpression\";";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type FormalParameters = ({\n\ttype: 'FormalParameters';\n\tkind: FormalParameterKind;\n\titems: Array<FormalParameter | FormalParameterRest>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type FormalParameters = ({\n\ttype: \"FormalParameters\";\n\tkind: FormalParameterKind;\n\titems: Array<FormalParameter | FormalParameterRest>;\n}) & Span;";
 
 impl<'a> Serialize for FormalParameter<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1710,7 +1708,7 @@ impl<'a> Serialize for FormalParameter<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type FormalParameter = ({\n\ttype: 'FormalParameter';\n\tdecorators: Array<Decorator>;\n\tpattern: BindingPattern;\n\taccessibility: (TSAccessibility) | null;\n\treadonly: boolean;\n\toverride: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type FormalParameter = ({\n\ttype: \"FormalParameter\";\n\tdecorators: Array<Decorator>;\n\tpattern: BindingPattern;\n\taccessibility: (TSAccessibility) | null;\n\treadonly: boolean;\n\toverride: boolean;\n}) & Span;";
 
 impl Serialize for FormalParameterKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1736,7 +1734,7 @@ impl Serialize for FormalParameterKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type FormalParameterKind = 'FormalParameter' | 'UniqueFormalParameters' | 'ArrowFormalParameters' | 'Signature';";
+const TS_APPEND_CONTENT: &'static str = "export type FormalParameterKind = \"FormalParameter\" | \"UniqueFormalParameters\" | \"ArrowFormalParameters\" | \"Signature\";";
 
 impl<'a> Serialize for FunctionBody<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1750,7 +1748,7 @@ impl<'a> Serialize for FunctionBody<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type FunctionBody = ({\n\ttype: 'FunctionBody';\n\tdirectives: Array<Directive>;\n\tstatements: Array<Statement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type FunctionBody = ({\n\ttype: \"FunctionBody\";\n\tdirectives: Array<Directive>;\n\tstatements: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for ArrowFunctionExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1768,7 +1766,7 @@ impl<'a> Serialize for ArrowFunctionExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ArrowFunctionExpression = ({\n\ttype: 'ArrowFunctionExpression';\n\texpression: boolean;\n\tasync: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n\tbody: FunctionBody;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ArrowFunctionExpression = ({\n\ttype: \"ArrowFunctionExpression\";\n\texpression: boolean;\n\tasync: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n\tbody: FunctionBody;\n}) & Span;";
 
 impl<'a> Serialize for YieldExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1782,7 +1780,7 @@ impl<'a> Serialize for YieldExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type YieldExpression = ({\n\ttype: 'YieldExpression';\n\tdelegate: boolean;\n\targument: (Expression) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type YieldExpression = ({\n\ttype: \"YieldExpression\";\n\tdelegate: boolean;\n\targument: (Expression) | null;\n}) & Span;";
 
 impl<'a> Serialize for Class<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1820,7 +1818,7 @@ impl Serialize for ClassType {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type ClassType = 'ClassDeclaration' | 'ClassExpression';";
+    "export type ClassType = \"ClassDeclaration\" | \"ClassExpression\";";
 
 impl<'a> Serialize for ClassBody<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1834,7 +1832,7 @@ impl<'a> Serialize for ClassBody<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type ClassBody = ({\n\ttype: 'ClassBody';\n\tbody: Array<ClassElement>;\n}) & Span;";
+    "export type ClassBody = ({\n\ttype: \"ClassBody\";\n\tbody: Array<ClassElement>;\n}) & Span;";
 
 impl<'a> Serialize for ClassElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1889,7 +1887,7 @@ impl Serialize for MethodDefinitionType {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinition';";
+    "export type MethodDefinitionType = \"MethodDefinition\" | \"TSAbstractMethodDefinition\";";
 
 impl<'a> Serialize for PropertyDefinition<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1934,8 +1932,7 @@ impl Serialize for PropertyDefinitionType {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type PropertyDefinitionType = 'PropertyDefinition' | 'TSAbstractPropertyDefinition';";
+const TS_APPEND_CONTENT: &'static str = "export type PropertyDefinitionType = \"PropertyDefinition\" | \"TSAbstractPropertyDefinition\";";
 
 impl Serialize for MethodDefinitionKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1958,7 +1955,7 @@ impl Serialize for MethodDefinitionKind {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type MethodDefinitionKind = 'constructor' | 'method' | 'get' | 'set';";
+    "export type MethodDefinitionKind = \"constructor\" | \"method\" | \"get\" | \"set\";";
 
 impl<'a> Serialize for PrivateIdentifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1971,8 +1968,7 @@ impl<'a> Serialize for PrivateIdentifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type PrivateIdentifier = ({\n\ttype: 'PrivateIdentifier';\n\tname: string;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type PrivateIdentifier = ({\n\ttype: \"PrivateIdentifier\";\n\tname: string;\n}) & Span;";
 
 impl<'a> Serialize for StaticBlock<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1986,7 +1982,7 @@ impl<'a> Serialize for StaticBlock<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type StaticBlock = ({\n\ttype: 'StaticBlock';\n\tbody: Array<Statement>;\n}) & Span;";
+    "export type StaticBlock = ({\n\ttype: \"StaticBlock\";\n\tbody: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for ModuleDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2023,7 +2019,7 @@ impl Serialize for AccessorPropertyType {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type AccessorPropertyType = 'AccessorProperty' | 'TSAbstractAccessorProperty';";
+    "export type AccessorPropertyType = \"AccessorProperty\" | \"TSAbstractAccessorProperty\";";
 
 impl<'a> Serialize for AccessorProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2057,7 +2053,7 @@ impl<'a> Serialize for ImportExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportExpression = ({\n\ttype: 'ImportExpression';\n\tsource: Expression;\n\targuments: Array<Expression>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportExpression = ({\n\ttype: \"ImportExpression\";\n\tsource: Expression;\n\targuments: Array<Expression>;\n}) & Span;";
 
 impl<'a> Serialize for ImportDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2073,7 +2069,7 @@ impl<'a> Serialize for ImportDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportDeclaration = ({\n\ttype: 'ImportDeclaration';\n\tspecifiers: (Array<ImportDeclarationSpecifier>) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\timportKind: ImportOrExportKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportDeclaration = ({\n\ttype: \"ImportDeclaration\";\n\tspecifiers: (Array<ImportDeclarationSpecifier>) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
 impl<'a> Serialize for ImportDeclarationSpecifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2105,7 +2101,7 @@ impl<'a> Serialize for ImportSpecifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportSpecifier = ({\n\ttype: 'ImportSpecifier';\n\timported: ModuleExportName;\n\tlocal: BindingIdentifier;\n\timportKind: ImportOrExportKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportSpecifier = ({\n\ttype: \"ImportSpecifier\";\n\timported: ModuleExportName;\n\tlocal: BindingIdentifier;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
 impl<'a> Serialize for ImportDefaultSpecifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2118,7 +2114,7 @@ impl<'a> Serialize for ImportDefaultSpecifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportDefaultSpecifier = ({\n\ttype: 'ImportDefaultSpecifier';\n\tlocal: BindingIdentifier;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportDefaultSpecifier = ({\n\ttype: \"ImportDefaultSpecifier\";\n\tlocal: BindingIdentifier;\n}) & Span;";
 
 impl<'a> Serialize for ImportNamespaceSpecifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2131,7 +2127,7 @@ impl<'a> Serialize for ImportNamespaceSpecifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportNamespaceSpecifier = ({\n\ttype: 'ImportNamespaceSpecifier';\n\tlocal: BindingIdentifier;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportNamespaceSpecifier = ({\n\ttype: \"ImportNamespaceSpecifier\";\n\tlocal: BindingIdentifier;\n}) & Span;";
 
 impl<'a> Serialize for WithClause<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2145,7 +2141,7 @@ impl<'a> Serialize for WithClause<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type WithClause = ({\n\ttype: 'WithClause';\n\tattributesKeyword: IdentifierName;\n\twithEntries: Array<ImportAttribute>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type WithClause = ({\n\ttype: \"WithClause\";\n\tattributesKeyword: IdentifierName;\n\twithEntries: Array<ImportAttribute>;\n}) & Span;";
 
 impl<'a> Serialize for ImportAttribute<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2159,7 +2155,7 @@ impl<'a> Serialize for ImportAttribute<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportAttribute = ({\n\ttype: 'ImportAttribute';\n\tkey: ImportAttributeKey;\n\tvalue: StringLiteral;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ImportAttribute = ({\n\ttype: \"ImportAttribute\";\n\tkey: ImportAttributeKey;\n\tvalue: StringLiteral;\n}) & Span;";
 
 impl<'a> Serialize for ImportAttributeKey<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2189,7 +2185,7 @@ impl<'a> Serialize for ExportNamedDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ExportNamedDeclaration = ({\n\ttype: 'ExportNamedDeclaration';\n\tdeclaration: (Declaration) | null;\n\tspecifiers: Array<ExportSpecifier>;\n\tsource: (StringLiteral) | null;\n\texportKind: ImportOrExportKind;\n\twithClause: (WithClause) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ExportNamedDeclaration = ({\n\ttype: \"ExportNamedDeclaration\";\n\tdeclaration: (Declaration) | null;\n\tspecifiers: Array<ExportSpecifier>;\n\tsource: (StringLiteral) | null;\n\texportKind: ImportOrExportKind;\n\twithClause: (WithClause) | null;\n}) & Span;";
 
 impl<'a> Serialize for ExportDefaultDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2203,7 +2199,7 @@ impl<'a> Serialize for ExportDefaultDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ExportDefaultDeclaration = ({\n\ttype: 'ExportDefaultDeclaration';\n\tdeclaration: ExportDefaultDeclarationKind;\n\texported: ModuleExportName;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ExportDefaultDeclaration = ({\n\ttype: \"ExportDefaultDeclaration\";\n\tdeclaration: ExportDefaultDeclarationKind;\n\texported: ModuleExportName;\n}) & Span;";
 
 impl<'a> Serialize for ExportAllDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2219,7 +2215,7 @@ impl<'a> Serialize for ExportAllDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ExportAllDeclaration = ({\n\ttype: 'ExportAllDeclaration';\n\texported: (ModuleExportName) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\texportKind: ImportOrExportKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ExportAllDeclaration = ({\n\ttype: \"ExportAllDeclaration\";\n\texported: (ModuleExportName) | null;\n\tsource: StringLiteral;\n\twithClause: (WithClause) | null;\n\texportKind: ImportOrExportKind;\n}) & Span;";
 
 impl<'a> Serialize for ExportSpecifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2234,7 +2230,7 @@ impl<'a> Serialize for ExportSpecifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ExportSpecifier = ({\n\ttype: 'ExportSpecifier';\n\tlocal: ModuleExportName;\n\texported: ModuleExportName;\n\texportKind: ImportOrExportKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ExportSpecifier = ({\n\ttype: \"ExportSpecifier\";\n\tlocal: ModuleExportName;\n\texported: ModuleExportName;\n\texportKind: ImportOrExportKind;\n}) & Span;";
 
 impl<'a> Serialize for ExportDefaultDeclarationKind<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2361,7 +2357,7 @@ impl<'a> Serialize for TSThisParameter<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSThisParameter = ({\n\ttype: 'TSThisParameter';\n\tthisSpan: Span;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSThisParameter = ({\n\ttype: \"TSThisParameter\";\n\tthisSpan: Span;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSEnumDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2377,7 +2373,7 @@ impl<'a> Serialize for TSEnumDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSEnumDeclaration = ({\n\ttype: 'TSEnumDeclaration';\n\tid: BindingIdentifier;\n\tmembers: Array<TSEnumMember>;\n\tconst: boolean;\n\tdeclare: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSEnumDeclaration = ({\n\ttype: \"TSEnumDeclaration\";\n\tid: BindingIdentifier;\n\tmembers: Array<TSEnumMember>;\n\tconst: boolean;\n\tdeclare: boolean;\n}) & Span;";
 
 impl<'a> Serialize for TSEnumMember<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2391,7 +2387,7 @@ impl<'a> Serialize for TSEnumMember<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSEnumMember = ({\n\ttype: 'TSEnumMember';\n\tid: TSEnumMemberName;\n\tinitializer: (Expression) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSEnumMember = ({\n\ttype: \"TSEnumMember\";\n\tid: TSEnumMemberName;\n\tinitializer: (Expression) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSEnumMemberName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2460,7 +2456,7 @@ impl<'a> Serialize for TSTypeAnnotation<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeAnnotation = ({\n\ttype: 'TSTypeAnnotation';\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeAnnotation = ({\n\ttype: \"TSTypeAnnotation\";\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSLiteralType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2474,7 +2470,7 @@ impl<'a> Serialize for TSLiteralType<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSLiteralType = ({\n\ttype: 'TSLiteralType';\n\tliteral: TSLiteral;\n}) & Span;";
+    "export type TSLiteralType = ({\n\ttype: \"TSLiteralType\";\n\tliteral: TSLiteral;\n}) & Span;";
 
 impl<'a> Serialize for TSLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2556,7 +2552,7 @@ impl<'a> Serialize for TSConditionalType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSConditionalType = ({\n\ttype: 'TSConditionalType';\n\tcheckType: TSType;\n\textendsType: TSType;\n\ttrueType: TSType;\n\tfalseType: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSConditionalType = ({\n\ttype: \"TSConditionalType\";\n\tcheckType: TSType;\n\textendsType: TSType;\n\ttrueType: TSType;\n\tfalseType: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSUnionType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2570,7 +2566,7 @@ impl<'a> Serialize for TSUnionType<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSUnionType = ({\n\ttype: 'TSUnionType';\n\ttypes: Array<TSType>;\n}) & Span;";
+    "export type TSUnionType = ({\n\ttype: \"TSUnionType\";\n\ttypes: Array<TSType>;\n}) & Span;";
 
 impl<'a> Serialize for TSIntersectionType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2583,7 +2579,7 @@ impl<'a> Serialize for TSIntersectionType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSIntersectionType = ({\n\ttype: 'TSIntersectionType';\n\ttypes: Array<TSType>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSIntersectionType = ({\n\ttype: \"TSIntersectionType\";\n\ttypes: Array<TSType>;\n}) & Span;";
 
 impl<'a> Serialize for TSParenthesizedType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2596,7 +2592,7 @@ impl<'a> Serialize for TSParenthesizedType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSParenthesizedType = ({\n\ttype: 'TSParenthesizedType';\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSParenthesizedType = ({\n\ttype: \"TSParenthesizedType\";\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeOperator<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2610,7 +2606,7 @@ impl<'a> Serialize for TSTypeOperator<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeOperator = ({\n\ttype: 'TSTypeOperator';\n\toperator: TSTypeOperatorOperator;\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeOperator = ({\n\ttype: \"TSTypeOperator\";\n\toperator: TSTypeOperatorOperator;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl Serialize for TSTypeOperatorOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2630,7 +2626,7 @@ impl Serialize for TSTypeOperatorOperator {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSTypeOperatorOperator = 'keyof' | 'unique' | 'readonly';";
+    "export type TSTypeOperatorOperator = \"keyof\" | \"unique\" | \"readonly\";";
 
 impl<'a> Serialize for TSArrayType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2644,7 +2640,7 @@ impl<'a> Serialize for TSArrayType<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSArrayType = ({\n\ttype: 'TSArrayType';\n\telementType: TSType;\n}) & Span;";
+    "export type TSArrayType = ({\n\ttype: \"TSArrayType\";\n\telementType: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSIndexedAccessType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2658,7 +2654,7 @@ impl<'a> Serialize for TSIndexedAccessType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSIndexedAccessType = ({\n\ttype: 'TSIndexedAccessType';\n\tobjectType: TSType;\n\tindexType: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSIndexedAccessType = ({\n\ttype: \"TSIndexedAccessType\";\n\tobjectType: TSType;\n\tindexType: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSTupleType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2671,7 +2667,7 @@ impl<'a> Serialize for TSTupleType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTupleType = ({\n\ttype: 'TSTupleType';\n\telementTypes: Array<TSTupleElement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTupleType = ({\n\ttype: \"TSTupleType\";\n\telementTypes: Array<TSTupleElement>;\n}) & Span;";
 
 impl<'a> Serialize for TSNamedTupleMember<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2686,7 +2682,7 @@ impl<'a> Serialize for TSNamedTupleMember<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSNamedTupleMember = ({\n\ttype: 'TSNamedTupleMember';\n\telementType: TSTupleElement;\n\tlabel: IdentifierName;\n\toptional: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSNamedTupleMember = ({\n\ttype: \"TSNamedTupleMember\";\n\telementType: TSTupleElement;\n\tlabel: IdentifierName;\n\toptional: boolean;\n}) & Span;";
 
 impl<'a> Serialize for TSOptionalType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2699,7 +2695,7 @@ impl<'a> Serialize for TSOptionalType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSOptionalType = ({\n\ttype: 'TSOptionalType';\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSOptionalType = ({\n\ttype: \"TSOptionalType\";\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSRestType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2713,7 +2709,7 @@ impl<'a> Serialize for TSRestType<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSRestType = ({\n\ttype: 'TSRestType';\n\ttypeAnnotation: TSType;\n}) & Span;";
+    "export type TSRestType = ({\n\ttype: \"TSRestType\";\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSTupleElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2776,7 +2772,7 @@ impl Serialize for TSAnyKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSAnyKeyword = ({\n\ttype: 'TSAnyKeyword';\n}) & Span;";
+    "export type TSAnyKeyword = ({\n\ttype: \"TSAnyKeyword\";\n}) & Span;";
 
 impl Serialize for TSStringKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2789,7 +2785,7 @@ impl Serialize for TSStringKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSStringKeyword = ({\n\ttype: 'TSStringKeyword';\n}) & Span;";
+    "export type TSStringKeyword = ({\n\ttype: \"TSStringKeyword\";\n}) & Span;";
 
 impl Serialize for TSBooleanKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2802,7 +2798,7 @@ impl Serialize for TSBooleanKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSBooleanKeyword = ({\n\ttype: 'TSBooleanKeyword';\n}) & Span;";
+    "export type TSBooleanKeyword = ({\n\ttype: \"TSBooleanKeyword\";\n}) & Span;";
 
 impl Serialize for TSNumberKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2815,7 +2811,7 @@ impl Serialize for TSNumberKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSNumberKeyword = ({\n\ttype: 'TSNumberKeyword';\n}) & Span;";
+    "export type TSNumberKeyword = ({\n\ttype: \"TSNumberKeyword\";\n}) & Span;";
 
 impl Serialize for TSNeverKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2828,7 +2824,7 @@ impl Serialize for TSNeverKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSNeverKeyword = ({\n\ttype: 'TSNeverKeyword';\n}) & Span;";
+    "export type TSNeverKeyword = ({\n\ttype: \"TSNeverKeyword\";\n}) & Span;";
 
 impl Serialize for TSIntrinsicKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2841,7 +2837,7 @@ impl Serialize for TSIntrinsicKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSIntrinsicKeyword = ({\n\ttype: 'TSIntrinsicKeyword';\n}) & Span;";
+    "export type TSIntrinsicKeyword = ({\n\ttype: \"TSIntrinsicKeyword\";\n}) & Span;";
 
 impl Serialize for TSUnknownKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2854,7 +2850,7 @@ impl Serialize for TSUnknownKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSUnknownKeyword = ({\n\ttype: 'TSUnknownKeyword';\n}) & Span;";
+    "export type TSUnknownKeyword = ({\n\ttype: \"TSUnknownKeyword\";\n}) & Span;";
 
 impl Serialize for TSNullKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2867,7 +2863,7 @@ impl Serialize for TSNullKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSNullKeyword = ({\n\ttype: 'TSNullKeyword';\n}) & Span;";
+    "export type TSNullKeyword = ({\n\ttype: \"TSNullKeyword\";\n}) & Span;";
 
 impl Serialize for TSUndefinedKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2880,7 +2876,7 @@ impl Serialize for TSUndefinedKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSUndefinedKeyword = ({\n\ttype: 'TSUndefinedKeyword';\n}) & Span;";
+    "export type TSUndefinedKeyword = ({\n\ttype: \"TSUndefinedKeyword\";\n}) & Span;";
 
 impl Serialize for TSVoidKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2893,7 +2889,7 @@ impl Serialize for TSVoidKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSVoidKeyword = ({\n\ttype: 'TSVoidKeyword';\n}) & Span;";
+    "export type TSVoidKeyword = ({\n\ttype: \"TSVoidKeyword\";\n}) & Span;";
 
 impl Serialize for TSSymbolKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2906,7 +2902,7 @@ impl Serialize for TSSymbolKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSSymbolKeyword = ({\n\ttype: 'TSSymbolKeyword';\n}) & Span;";
+    "export type TSSymbolKeyword = ({\n\ttype: \"TSSymbolKeyword\";\n}) & Span;";
 
 impl Serialize for TSThisType {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2919,7 +2915,7 @@ impl Serialize for TSThisType {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSThisType = ({\n\ttype: 'TSThisType';\n}) & Span;";
+    "export type TSThisType = ({\n\ttype: \"TSThisType\";\n}) & Span;";
 
 impl Serialize for TSObjectKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2932,7 +2928,7 @@ impl Serialize for TSObjectKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSObjectKeyword = ({\n\ttype: 'TSObjectKeyword';\n}) & Span;";
+    "export type TSObjectKeyword = ({\n\ttype: \"TSObjectKeyword\";\n}) & Span;";
 
 impl Serialize for TSBigIntKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2945,7 +2941,7 @@ impl Serialize for TSBigIntKeyword {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSBigIntKeyword = ({\n\ttype: 'TSBigIntKeyword';\n}) & Span;";
+    "export type TSBigIntKeyword = ({\n\ttype: \"TSBigIntKeyword\";\n}) & Span;";
 
 impl<'a> Serialize for TSTypeReference<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2959,7 +2955,7 @@ impl<'a> Serialize for TSTypeReference<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeReference = ({\n\ttype: 'TSTypeReference';\n\ttypeName: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeReference = ({\n\ttype: \"TSTypeReference\";\n\ttypeName: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2986,7 +2982,7 @@ impl<'a> Serialize for TSQualifiedName<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSQualifiedName = ({\n\ttype: 'TSQualifiedName';\n\tleft: TSTypeName;\n\tright: IdentifierName;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSQualifiedName = ({\n\ttype: \"TSQualifiedName\";\n\tleft: TSTypeName;\n\tright: IdentifierName;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeParameterInstantiation<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -2999,7 +2995,7 @@ impl<'a> Serialize for TSTypeParameterInstantiation<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterInstantiation = ({\n\ttype: 'TSTypeParameterInstantiation';\n\tparams: Array<TSType>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterInstantiation = ({\n\ttype: \"TSTypeParameterInstantiation\";\n\tparams: Array<TSType>;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeParameter<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3017,7 +3013,7 @@ impl<'a> Serialize for TSTypeParameter<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameter = ({\n\ttype: 'TSTypeParameter';\n\tname: BindingIdentifier;\n\tconstraint: (TSType) | null;\n\tdefault: (TSType) | null;\n\tin: boolean;\n\tout: boolean;\n\tconst: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameter = ({\n\ttype: \"TSTypeParameter\";\n\tname: BindingIdentifier;\n\tconstraint: (TSType) | null;\n\tdefault: (TSType) | null;\n\tin: boolean;\n\tout: boolean;\n\tconst: boolean;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeParameterDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3030,7 +3026,7 @@ impl<'a> Serialize for TSTypeParameterDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterDeclaration = ({\n\ttype: 'TSTypeParameterDeclaration';\n\tparams: Array<TSTypeParameter>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeParameterDeclaration = ({\n\ttype: \"TSTypeParameterDeclaration\";\n\tparams: Array<TSTypeParameter>;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeAliasDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3046,7 +3042,7 @@ impl<'a> Serialize for TSTypeAliasDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeAliasDeclaration = ({\n\ttype: 'TSTypeAliasDeclaration';\n\tid: BindingIdentifier;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\ttypeAnnotation: TSType;\n\tdeclare: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeAliasDeclaration = ({\n\ttype: \"TSTypeAliasDeclaration\";\n\tid: BindingIdentifier;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\ttypeAnnotation: TSType;\n\tdeclare: boolean;\n}) & Span;";
 
 impl Serialize for TSAccessibility {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3066,7 +3062,7 @@ impl Serialize for TSAccessibility {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSAccessibility = 'private' | 'protected' | 'public';";
+    "export type TSAccessibility = \"private\" | \"protected\" | \"public\";";
 
 impl<'a> Serialize for TSClassImplements<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3080,7 +3076,7 @@ impl<'a> Serialize for TSClassImplements<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSClassImplements = ({\n\ttype: 'TSClassImplements';\n\texpression: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSClassImplements = ({\n\ttype: \"TSClassImplements\";\n\texpression: TSTypeName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSInterfaceDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3097,7 +3093,7 @@ impl<'a> Serialize for TSInterfaceDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceDeclaration = ({\n\ttype: 'TSInterfaceDeclaration';\n\tid: BindingIdentifier;\n\textends: (Array<TSInterfaceHeritage>) | null;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tbody: TSInterfaceBody;\n\tdeclare: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceDeclaration = ({\n\ttype: \"TSInterfaceDeclaration\";\n\tid: BindingIdentifier;\n\textends: (Array<TSInterfaceHeritage>) | null;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tbody: TSInterfaceBody;\n\tdeclare: boolean;\n}) & Span;";
 
 impl<'a> Serialize for TSInterfaceBody<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3110,7 +3106,7 @@ impl<'a> Serialize for TSInterfaceBody<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceBody = ({\n\ttype: 'TSInterfaceBody';\n\tbody: Array<TSSignature>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceBody = ({\n\ttype: \"TSInterfaceBody\";\n\tbody: Array<TSSignature>;\n}) & Span;";
 
 impl<'a> Serialize for TSPropertySignature<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3127,7 +3123,7 @@ impl<'a> Serialize for TSPropertySignature<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSPropertySignature = ({\n\ttype: 'TSPropertySignature';\n\tcomputed: boolean;\n\toptional: boolean;\n\treadonly: boolean;\n\tkey: PropertyKey;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSPropertySignature = ({\n\ttype: \"TSPropertySignature\";\n\tcomputed: boolean;\n\toptional: boolean;\n\treadonly: boolean;\n\tkey: PropertyKey;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSSignature<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3157,7 +3153,7 @@ impl<'a> Serialize for TSIndexSignature<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignature = ({\n\ttype: 'TSIndexSignature';\n\tparameters: Array<TSIndexSignatureName>;\n\ttypeAnnotation: TSTypeAnnotation;\n\treadonly: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignature = ({\n\ttype: \"TSIndexSignature\";\n\tparameters: Array<TSIndexSignatureName>;\n\ttypeAnnotation: TSTypeAnnotation;\n\treadonly: boolean;\n}) & Span;";
 
 impl<'a> Serialize for TSCallSignatureDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3173,7 +3169,7 @@ impl<'a> Serialize for TSCallSignatureDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSCallSignatureDeclaration = ({\n\ttype: 'TSCallSignatureDeclaration';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSCallSignatureDeclaration = ({\n\ttype: \"TSCallSignatureDeclaration\";\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl Serialize for TSMethodSignatureKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3193,7 +3189,7 @@ impl Serialize for TSMethodSignatureKind {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSMethodSignatureKind = 'method' | 'get' | 'set';";
+    "export type TSMethodSignatureKind = \"method\" | \"get\" | \"set\";";
 
 impl<'a> Serialize for TSMethodSignature<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3213,7 +3209,7 @@ impl<'a> Serialize for TSMethodSignature<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSMethodSignature = ({\n\ttype: 'TSMethodSignature';\n\tkey: PropertyKey;\n\tcomputed: boolean;\n\toptional: boolean;\n\tkind: TSMethodSignatureKind;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSMethodSignature = ({\n\ttype: \"TSMethodSignature\";\n\tkey: PropertyKey;\n\tcomputed: boolean;\n\toptional: boolean;\n\tkind: TSMethodSignatureKind;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSConstructSignatureDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3228,7 +3224,7 @@ impl<'a> Serialize for TSConstructSignatureDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSConstructSignatureDeclaration = ({\n\ttype: 'TSConstructSignatureDeclaration';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSConstructSignatureDeclaration = ({\n\ttype: \"TSConstructSignatureDeclaration\";\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSIndexSignatureName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3242,7 +3238,7 @@ impl<'a> Serialize for TSIndexSignatureName<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignatureName = ({\n\ttype: 'Identifier';\n\tname: string;\n\ttypeAnnotation: TSTypeAnnotation;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSIndexSignatureName = ({\n\ttype: \"Identifier\";\n\tname: string;\n\ttypeAnnotation: TSTypeAnnotation;\n}) & Span;";
 
 impl<'a> Serialize for TSInterfaceHeritage<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3256,7 +3252,7 @@ impl<'a> Serialize for TSInterfaceHeritage<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceHeritage = ({\n\ttype: 'TSInterfaceHeritage';\n\texpression: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSInterfaceHeritage = ({\n\ttype: \"TSInterfaceHeritage\";\n\texpression: Expression;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSTypePredicate<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3271,7 +3267,7 @@ impl<'a> Serialize for TSTypePredicate<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypePredicate = ({\n\ttype: 'TSTypePredicate';\n\tparameterName: TSTypePredicateName;\n\tasserts: boolean;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypePredicate = ({\n\ttype: \"TSTypePredicate\";\n\tparameterName: TSTypePredicateName;\n\tasserts: boolean;\n\ttypeAnnotation: (TSTypeAnnotation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSTypePredicateName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3300,7 +3296,7 @@ impl<'a> Serialize for TSModuleDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSModuleDeclaration = ({\n\ttype: 'TSModuleDeclaration';\n\tid: TSModuleDeclarationName;\n\tbody: (TSModuleDeclarationBody) | null;\n\tkind: TSModuleDeclarationKind;\n\tdeclare: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSModuleDeclaration = ({\n\ttype: \"TSModuleDeclaration\";\n\tid: TSModuleDeclarationName;\n\tbody: (TSModuleDeclarationBody) | null;\n\tkind: TSModuleDeclarationKind;\n\tdeclare: boolean;\n}) & Span;";
 
 impl Serialize for TSModuleDeclarationKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3320,7 +3316,7 @@ impl Serialize for TSModuleDeclarationKind {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSModuleDeclarationKind = 'global' | 'module' | 'namespace';";
+    "export type TSModuleDeclarationKind = \"global\" | \"module\" | \"namespace\";";
 
 impl<'a> Serialize for TSModuleDeclarationName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3349,7 +3345,7 @@ const TS_APPEND_CONTENT: &'static str =
     "export type TSModuleDeclarationBody = TSModuleDeclaration | TSModuleBlock;";
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSModuleBlock = ({\n\ttype: 'TSModuleBlock';\n\tbody: Array<Statement>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSModuleBlock = ({\n\ttype: \"TSModuleBlock\";\n\tbody: Array<Statement>;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3362,7 +3358,7 @@ impl<'a> Serialize for TSTypeLiteral<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeLiteral = ({\n\ttype: 'TSTypeLiteral';\n\tmembers: Array<TSSignature>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeLiteral = ({\n\ttype: \"TSTypeLiteral\";\n\tmembers: Array<TSSignature>;\n}) & Span;";
 
 impl<'a> Serialize for TSInferType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3375,7 +3371,7 @@ impl<'a> Serialize for TSInferType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSInferType = ({\n\ttype: 'TSInferType';\n\ttypeParameter: TSTypeParameter;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSInferType = ({\n\ttype: \"TSInferType\";\n\ttypeParameter: TSTypeParameter;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeQuery<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3389,7 +3385,7 @@ impl<'a> Serialize for TSTypeQuery<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeQuery = ({\n\ttype: 'TSTypeQuery';\n\texprName: TSTypeQueryExprName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeQuery = ({\n\ttype: \"TSTypeQuery\";\n\texprName: TSTypeQueryExprName;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeQueryExprName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3420,7 +3416,7 @@ impl<'a> Serialize for TSImportType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSImportType = ({\n\ttype: 'TSImportType';\n\tisTypeOf: boolean;\n\tparameter: TSType;\n\tqualifier: (TSTypeName) | null;\n\tattributes: (TSImportAttributes) | null;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSImportType = ({\n\ttype: \"TSImportType\";\n\tisTypeOf: boolean;\n\tparameter: TSType;\n\tqualifier: (TSTypeName) | null;\n\tattributes: (TSImportAttributes) | null;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for TSImportAttributes<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3434,7 +3430,7 @@ impl<'a> Serialize for TSImportAttributes<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSImportAttributes = ({\n\ttype: 'TSImportAttributes';\n\tattributesKeyword: IdentifierName;\n\telements: Array<TSImportAttribute>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSImportAttributes = ({\n\ttype: \"TSImportAttributes\";\n\tattributesKeyword: IdentifierName;\n\telements: Array<TSImportAttribute>;\n}) & Span;";
 
 impl<'a> Serialize for TSImportAttribute<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3448,7 +3444,7 @@ impl<'a> Serialize for TSImportAttribute<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSImportAttribute = ({\n\ttype: 'TSImportAttribute';\n\tname: TSImportAttributeName;\n\tvalue: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSImportAttribute = ({\n\ttype: \"TSImportAttribute\";\n\tname: TSImportAttributeName;\n\tvalue: Expression;\n}) & Span;";
 
 impl<'a> Serialize for TSImportAttributeName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3477,7 +3473,7 @@ impl<'a> Serialize for TSFunctionType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSFunctionType = ({\n\ttype: 'TSFunctionType';\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSFunctionType = ({\n\ttype: \"TSFunctionType\";\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tthisParam: (TSThisParameter) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
 
 impl<'a> Serialize for TSConstructorType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3493,7 +3489,7 @@ impl<'a> Serialize for TSConstructorType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSConstructorType = ({\n\ttype: 'TSConstructorType';\n\tabstract: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSConstructorType = ({\n\ttype: \"TSConstructorType\";\n\tabstract: boolean;\n\ttypeParameters: (TSTypeParameterDeclaration) | null;\n\tparams: FormalParameters;\n\treturnType: TSTypeAnnotation;\n}) & Span;";
 
 impl<'a> Serialize for TSMappedType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3510,7 +3506,7 @@ impl<'a> Serialize for TSMappedType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSMappedType = ({\n\ttype: 'TSMappedType';\n\ttypeParameter: TSTypeParameter;\n\tnameType: (TSType) | null;\n\ttypeAnnotation: (TSType) | null;\n\toptional: TSMappedTypeModifierOperator;\n\treadonly: TSMappedTypeModifierOperator;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSMappedType = ({\n\ttype: \"TSMappedType\";\n\ttypeParameter: TSTypeParameter;\n\tnameType: (TSType) | null;\n\ttypeAnnotation: (TSType) | null;\n\toptional: TSMappedTypeModifierOperator;\n\treadonly: TSMappedTypeModifierOperator;\n}) & Span;";
 
 impl Serialize for TSMappedTypeModifierOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3533,7 +3529,7 @@ impl Serialize for TSMappedTypeModifierOperator {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type TSMappedTypeModifierOperator = 'true' | '+' | '-' | 'none';";
+    "export type TSMappedTypeModifierOperator = \"true\" | \"+\" | \"-\" | \"none\";";
 
 impl<'a> Serialize for TSTemplateLiteralType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3547,7 +3543,7 @@ impl<'a> Serialize for TSTemplateLiteralType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTemplateLiteralType = ({\n\ttype: 'TSTemplateLiteralType';\n\tquasis: Array<TemplateElement>;\n\ttypes: Array<TSType>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTemplateLiteralType = ({\n\ttype: \"TSTemplateLiteralType\";\n\tquasis: Array<TemplateElement>;\n\ttypes: Array<TSType>;\n}) & Span;";
 
 impl<'a> Serialize for TSAsExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3561,7 +3557,7 @@ impl<'a> Serialize for TSAsExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSAsExpression = ({\n\ttype: 'TSAsExpression';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSAsExpression = ({\n\ttype: \"TSAsExpression\";\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSSatisfiesExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3575,7 +3571,7 @@ impl<'a> Serialize for TSSatisfiesExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSSatisfiesExpression = ({\n\ttype: 'TSSatisfiesExpression';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSSatisfiesExpression = ({\n\ttype: \"TSSatisfiesExpression\";\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSTypeAssertion<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3589,7 +3585,7 @@ impl<'a> Serialize for TSTypeAssertion<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSTypeAssertion = ({\n\ttype: 'TSTypeAssertion';\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSTypeAssertion = ({\n\ttype: \"TSTypeAssertion\";\n\texpression: Expression;\n\ttypeAnnotation: TSType;\n}) & Span;";
 
 impl<'a> Serialize for TSImportEqualsDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3604,7 +3600,7 @@ impl<'a> Serialize for TSImportEqualsDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSImportEqualsDeclaration = ({\n\ttype: 'TSImportEqualsDeclaration';\n\tid: BindingIdentifier;\n\tmoduleReference: TSModuleReference;\n\timportKind: ImportOrExportKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSImportEqualsDeclaration = ({\n\ttype: \"TSImportEqualsDeclaration\";\n\tid: BindingIdentifier;\n\tmoduleReference: TSModuleReference;\n\timportKind: ImportOrExportKind;\n}) & Span;";
 
 impl<'a> Serialize for TSModuleReference<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3630,7 +3626,7 @@ impl<'a> Serialize for TSExternalModuleReference<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSExternalModuleReference = ({\n\ttype: 'TSExternalModuleReference';\n\texpression: StringLiteral;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSExternalModuleReference = ({\n\ttype: \"TSExternalModuleReference\";\n\texpression: StringLiteral;\n}) & Span;";
 
 impl<'a> Serialize for TSNonNullExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3643,7 +3639,7 @@ impl<'a> Serialize for TSNonNullExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSNonNullExpression = ({\n\ttype: 'TSNonNullExpression';\n\texpression: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSNonNullExpression = ({\n\ttype: \"TSNonNullExpression\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for Decorator<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3657,7 +3653,7 @@ impl<'a> Serialize for Decorator<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type Decorator = ({\n\ttype: 'Decorator';\n\texpression: Expression;\n}) & Span;";
+    "export type Decorator = ({\n\ttype: \"Decorator\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for TSExportAssignment<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3670,7 +3666,7 @@ impl<'a> Serialize for TSExportAssignment<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSExportAssignment = ({\n\ttype: 'TSExportAssignment';\n\texpression: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSExportAssignment = ({\n\ttype: \"TSExportAssignment\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for TSNamespaceExportDeclaration<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3683,7 +3679,7 @@ impl<'a> Serialize for TSNamespaceExportDeclaration<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSNamespaceExportDeclaration = ({\n\ttype: 'TSNamespaceExportDeclaration';\n\tid: IdentifierName;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSNamespaceExportDeclaration = ({\n\ttype: \"TSNamespaceExportDeclaration\";\n\tid: IdentifierName;\n}) & Span;";
 
 impl<'a> Serialize for TSInstantiationExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3697,7 +3693,7 @@ impl<'a> Serialize for TSInstantiationExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type TSInstantiationExpression = ({\n\ttype: 'TSInstantiationExpression';\n\texpression: Expression;\n\ttypeParameters: TSTypeParameterInstantiation;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type TSInstantiationExpression = ({\n\ttype: \"TSInstantiationExpression\";\n\texpression: Expression;\n\ttypeParameters: TSTypeParameterInstantiation;\n}) & Span;";
 
 impl Serialize for ImportOrExportKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3713,7 +3709,7 @@ impl Serialize for ImportOrExportKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ImportOrExportKind = 'value' | 'type';";
+const TS_APPEND_CONTENT: &'static str = "export type ImportOrExportKind = \"value\" | \"type\";";
 
 impl<'a> Serialize for JSDocNullableType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3727,7 +3723,7 @@ impl<'a> Serialize for JSDocNullableType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSDocNullableType = ({\n\ttype: 'JSDocNullableType';\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSDocNullableType = ({\n\ttype: \"JSDocNullableType\";\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
 
 impl<'a> Serialize for JSDocNonNullableType<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3741,7 +3737,7 @@ impl<'a> Serialize for JSDocNonNullableType<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSDocNonNullableType = ({\n\ttype: 'JSDocNonNullableType';\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSDocNonNullableType = ({\n\ttype: \"JSDocNonNullableType\";\n\ttypeAnnotation: TSType;\n\tpostfix: boolean;\n}) & Span;";
 
 impl Serialize for JSDocUnknownType {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3754,7 +3750,7 @@ impl Serialize for JSDocUnknownType {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSDocUnknownType = ({\n\ttype: 'JSDocUnknownType';\n}) & Span;";
+    "export type JSDocUnknownType = ({\n\ttype: \"JSDocUnknownType\";\n}) & Span;";
 
 impl<'a> Serialize for JSXElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3769,7 +3765,7 @@ impl<'a> Serialize for JSXElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXElement = ({\n\ttype: 'JSXElement';\n\topeningElement: JSXOpeningElement;\n\tclosingElement: (JSXClosingElement) | null;\n\tchildren: Array<JSXChild>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXElement = ({\n\ttype: \"JSXElement\";\n\topeningElement: JSXOpeningElement;\n\tclosingElement: (JSXClosingElement) | null;\n\tchildren: Array<JSXChild>;\n}) & Span;";
 
 impl<'a> Serialize for JSXOpeningElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3785,7 +3781,7 @@ impl<'a> Serialize for JSXOpeningElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXOpeningElement = ({\n\ttype: 'JSXOpeningElement';\n\tselfClosing: boolean;\n\tname: JSXElementName;\n\tattributes: Array<JSXAttributeItem>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXOpeningElement = ({\n\ttype: \"JSXOpeningElement\";\n\tselfClosing: boolean;\n\tname: JSXElementName;\n\tattributes: Array<JSXAttributeItem>;\n\ttypeParameters: (TSTypeParameterInstantiation) | null;\n}) & Span;";
 
 impl<'a> Serialize for JSXClosingElement<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3798,7 +3794,7 @@ impl<'a> Serialize for JSXClosingElement<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXClosingElement = ({\n\ttype: 'JSXClosingElement';\n\tname: JSXElementName;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXClosingElement = ({\n\ttype: \"JSXClosingElement\";\n\tname: JSXElementName;\n}) & Span;";
 
 impl<'a> Serialize for JSXFragment<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3813,7 +3809,7 @@ impl<'a> Serialize for JSXFragment<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXFragment = ({\n\ttype: 'JSXFragment';\n\topeningFragment: JSXOpeningFragment;\n\tclosingFragment: JSXClosingFragment;\n\tchildren: Array<JSXChild>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXFragment = ({\n\ttype: \"JSXFragment\";\n\topeningFragment: JSXOpeningFragment;\n\tclosingFragment: JSXClosingFragment;\n\tchildren: Array<JSXChild>;\n}) & Span;";
 
 impl Serialize for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3826,7 +3822,7 @@ impl Serialize for JSXOpeningFragment {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSXOpeningFragment = ({\n\ttype: 'JSXOpeningFragment';\n}) & Span;";
+    "export type JSXOpeningFragment = ({\n\ttype: \"JSXOpeningFragment\";\n}) & Span;";
 
 impl Serialize for JSXClosingFragment {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3839,7 +3835,7 @@ impl Serialize for JSXClosingFragment {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSXClosingFragment = ({\n\ttype: 'JSXClosingFragment';\n}) & Span;";
+    "export type JSXClosingFragment = ({\n\ttype: \"JSXClosingFragment\";\n}) & Span;";
 
 impl<'a> Serialize for JSXNamespacedName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3853,7 +3849,7 @@ impl<'a> Serialize for JSXNamespacedName<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXNamespacedName = ({\n\ttype: 'JSXNamespacedName';\n\tnamespace: JSXIdentifier;\n\tproperty: JSXIdentifier;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXNamespacedName = ({\n\ttype: \"JSXNamespacedName\";\n\tnamespace: JSXIdentifier;\n\tproperty: JSXIdentifier;\n}) & Span;";
 
 impl<'a> Serialize for JSXMemberExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3867,7 +3863,7 @@ impl<'a> Serialize for JSXMemberExpression<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXMemberExpression = ({\n\ttype: 'JSXMemberExpression';\n\tobject: JSXMemberExpressionObject;\n\tproperty: JSXIdentifier;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXMemberExpression = ({\n\ttype: \"JSXMemberExpression\";\n\tobject: JSXMemberExpressionObject;\n\tproperty: JSXIdentifier;\n}) & Span;";
 
 impl<'a> Serialize for JSXExpressionContainer<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3880,7 +3876,7 @@ impl<'a> Serialize for JSXExpressionContainer<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXExpressionContainer = ({\n\ttype: 'JSXExpressionContainer';\n\texpression: JSXExpression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXExpressionContainer = ({\n\ttype: \"JSXExpressionContainer\";\n\texpression: JSXExpression;\n}) & Span;";
 
 impl<'a> Serialize for JSXExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3946,7 +3942,7 @@ impl Serialize for JSXEmptyExpression {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSXEmptyExpression = ({\n\ttype: 'JSXEmptyExpression';\n}) & Span;";
+    "export type JSXEmptyExpression = ({\n\ttype: \"JSXEmptyExpression\";\n}) & Span;";
 
 impl<'a> Serialize for JSXAttributeItem<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3973,7 +3969,7 @@ impl<'a> Serialize for JSXAttribute<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXAttribute = ({\n\ttype: 'JSXAttribute';\n\tname: JSXAttributeName;\n\tvalue: (JSXAttributeValue) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXAttribute = ({\n\ttype: \"JSXAttribute\";\n\tname: JSXAttributeName;\n\tvalue: (JSXAttributeValue) | null;\n}) & Span;";
 
 impl<'a> Serialize for JSXSpreadAttribute<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -3986,7 +3982,7 @@ impl<'a> Serialize for JSXSpreadAttribute<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadAttribute = ({\n\ttype: 'JSXSpreadAttribute';\n\targument: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadAttribute = ({\n\ttype: \"JSXSpreadAttribute\";\n\targument: Expression;\n}) & Span;";
 
 impl<'a> Serialize for JSXAttributeName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -4027,7 +4023,7 @@ impl<'a> Serialize for JSXIdentifier<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSXIdentifier = ({\n\ttype: 'JSXIdentifier';\n\tname: string;\n}) & Span;";
+    "export type JSXIdentifier = ({\n\ttype: \"JSXIdentifier\";\n\tname: string;\n}) & Span;";
 
 impl<'a> Serialize for JSXChild<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -4055,7 +4051,7 @@ impl<'a> Serialize for JSXSpreadChild<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadChild = ({\n\ttype: 'JSXSpreadChild';\n\texpression: Expression;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type JSXSpreadChild = ({\n\ttype: \"JSXSpreadChild\";\n\texpression: Expression;\n}) & Span;";
 
 impl<'a> Serialize for JSXText<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -4069,4 +4065,4 @@ impl<'a> Serialize for JSXText<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type JSXText = ({\n\ttype: 'JSXText';\n\tvalue: string;\n}) & Span;";
+    "export type JSXText = ({\n\ttype: \"JSXText\";\n\tvalue: string;\n}) & Span;";

--- a/crates/oxc_regular_expression/src/generated/derive_estree.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_estree.rs
@@ -20,7 +20,7 @@ impl<'a> Serialize for Pattern<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type Pattern = ({\n\ttype: 'Pattern';\n\tbody: Disjunction;\n}) & Span;";
+    "export type Pattern = ({\n\ttype: \"Pattern\";\n\tbody: Disjunction;\n}) & Span;";
 
 impl<'a> Serialize for Disjunction<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -33,8 +33,7 @@ impl<'a> Serialize for Disjunction<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type Disjunction = ({\n\ttype: 'Disjunction';\n\tbody: Array<Alternative>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Disjunction = ({\n\ttype: \"Disjunction\";\n\tbody: Array<Alternative>;\n}) & Span;";
 
 impl<'a> Serialize for Alternative<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -48,7 +47,7 @@ impl<'a> Serialize for Alternative<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type Alternative = ({\n\ttype: 'Alternative';\n\tbody: Array<Term>;\n}) & Span;";
+    "export type Alternative = ({\n\ttype: \"Alternative\";\n\tbody: Array<Term>;\n}) & Span;";
 
 impl<'a> Serialize for Term<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -83,7 +82,7 @@ impl Serialize for BoundaryAssertion {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BoundaryAssertion = ({\n\ttype: 'BoundaryAssertion';\n\tspan: Span;\n\tkind: BoundaryAssertionKind;\n});";
+const TS_APPEND_CONTENT: &'static str = "export type BoundaryAssertion = ({\n\ttype: \"BoundaryAssertion\";\n\tspan: Span;\n\tkind: BoundaryAssertionKind;\n});";
 
 impl Serialize for BoundaryAssertionKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -105,8 +104,7 @@ impl Serialize for BoundaryAssertionKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type BoundaryAssertionKind = 'start' | 'end' | 'boundary' | 'negativeBoundary';";
+const TS_APPEND_CONTENT: &'static str = "export type BoundaryAssertionKind = \"start\" | \"end\" | \"boundary\" | \"negativeBoundary\";";
 
 impl<'a> Serialize for LookAroundAssertion<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -120,7 +118,7 @@ impl<'a> Serialize for LookAroundAssertion<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertion = ({\n\ttype: 'LookAroundAssertion';\n\tkind: LookAroundAssertionKind;\n\tbody: Disjunction;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertion = ({\n\ttype: \"LookAroundAssertion\";\n\tkind: LookAroundAssertionKind;\n\tbody: Disjunction;\n}) & Span;";
 
 impl Serialize for LookAroundAssertionKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -146,7 +144,7 @@ impl Serialize for LookAroundAssertionKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertionKind = 'lookahead' | 'negativeLookahead' | 'lookbehind' | 'negativeLookbehind';";
+const TS_APPEND_CONTENT: &'static str = "export type LookAroundAssertionKind = \"lookahead\" | \"negativeLookahead\" | \"lookbehind\" | \"negativeLookbehind\";";
 
 impl<'a> Serialize for Quantifier<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -162,7 +160,7 @@ impl<'a> Serialize for Quantifier<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Quantifier = ({\n\ttype: 'Quantifier';\n\tmin: number;\n\tmax: (number) | null;\n\tgreedy: boolean;\n\tbody: Term;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Quantifier = ({\n\ttype: \"Quantifier\";\n\tmin: number;\n\tmax: (number) | null;\n\tgreedy: boolean;\n\tbody: Term;\n}) & Span;";
 
 impl Serialize for Character {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -176,7 +174,7 @@ impl Serialize for Character {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Character = ({\n\ttype: 'Character';\n\tkind: CharacterKind;\n\tvalue: number;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Character = ({\n\ttype: \"Character\";\n\tkind: CharacterKind;\n\tvalue: number;\n}) & Span;";
 
 impl Serialize for CharacterKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -214,7 +212,7 @@ impl Serialize for CharacterKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CharacterKind = 'controlLetter' | 'hexadecimalEscape' | 'identifier' | 'null' | 'octal1' | 'octal2' | 'octal3' | 'singleEscape' | 'symbol' | 'unicodeEscape';";
+const TS_APPEND_CONTENT: &'static str = "export type CharacterKind = \"controlLetter\" | \"hexadecimalEscape\" | \"identifier\" | \"null\" | \"octal1\" | \"octal2\" | \"octal3\" | \"singleEscape\" | \"symbol\" | \"unicodeEscape\";";
 
 impl Serialize for CharacterClassEscape {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -227,7 +225,7 @@ impl Serialize for CharacterClassEscape {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscape = ({\n\ttype: 'CharacterClassEscape';\n\tkind: CharacterClassEscapeKind;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscape = ({\n\ttype: \"CharacterClassEscape\";\n\tkind: CharacterClassEscapeKind;\n}) & Span;";
 
 impl Serialize for CharacterClassEscapeKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -255,7 +253,7 @@ impl Serialize for CharacterClassEscapeKind {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscapeKind = 'd' | 'negativeD' | 's' | 'negativeS' | 'w' | 'negativeW';";
+const TS_APPEND_CONTENT: &'static str = "export type CharacterClassEscapeKind = \"d\" | \"negativeD\" | \"s\" | \"negativeS\" | \"w\" | \"negativeW\";";
 
 impl<'a> Serialize for UnicodePropertyEscape<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -271,7 +269,7 @@ impl<'a> Serialize for UnicodePropertyEscape<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type UnicodePropertyEscape = ({\n\ttype: 'UnicodePropertyEscape';\n\tnegative: boolean;\n\tstrings: boolean;\n\tname: string;\n\tvalue: (string) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type UnicodePropertyEscape = ({\n\ttype: \"UnicodePropertyEscape\";\n\tnegative: boolean;\n\tstrings: boolean;\n\tname: string;\n\tvalue: (string) | null;\n}) & Span;";
 
 impl Serialize for Dot {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -283,7 +281,7 @@ impl Serialize for Dot {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Dot = ({\n\ttype: 'Dot';\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Dot = ({\n\ttype: \"Dot\";\n}) & Span;";
 
 impl<'a> Serialize for CharacterClass<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -299,7 +297,7 @@ impl<'a> Serialize for CharacterClass<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CharacterClass = ({\n\ttype: 'CharacterClass';\n\tnegative: boolean;\n\tstrings: boolean;\n\tkind: CharacterClassContentsKind;\n\tbody: Array<CharacterClassContents>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CharacterClass = ({\n\ttype: \"CharacterClass\";\n\tnegative: boolean;\n\tstrings: boolean;\n\tkind: CharacterClassContentsKind;\n\tbody: Array<CharacterClassContents>;\n}) & Span;";
 
 impl Serialize for CharacterClassContentsKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -321,7 +319,7 @@ impl Serialize for CharacterClassContentsKind {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type CharacterClassContentsKind = 'union' | 'intersection' | 'subtraction';";
+    "export type CharacterClassContentsKind = \"union\" | \"intersection\" | \"subtraction\";";
 
 impl<'a> Serialize for CharacterClassContents<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -353,7 +351,7 @@ impl Serialize for CharacterClassRange {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CharacterClassRange = ({\n\ttype: 'CharacterClassRange';\n\tmin: Character;\n\tmax: Character;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CharacterClassRange = ({\n\ttype: \"CharacterClassRange\";\n\tmin: Character;\n\tmax: Character;\n}) & Span;";
 
 impl<'a> Serialize for ClassStringDisjunction<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -367,7 +365,7 @@ impl<'a> Serialize for ClassStringDisjunction<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ClassStringDisjunction = ({\n\ttype: 'ClassStringDisjunction';\n\tstrings: boolean;\n\tbody: Array<ClassString>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ClassStringDisjunction = ({\n\ttype: \"ClassStringDisjunction\";\n\tstrings: boolean;\n\tbody: Array<ClassString>;\n}) & Span;";
 
 impl<'a> Serialize for ClassString<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -381,7 +379,7 @@ impl<'a> Serialize for ClassString<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ClassString = ({\n\ttype: 'ClassString';\n\tstrings: boolean;\n\tbody: Array<Character>;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type ClassString = ({\n\ttype: \"ClassString\";\n\tstrings: boolean;\n\tbody: Array<Character>;\n}) & Span;";
 
 impl<'a> Serialize for CapturingGroup<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -395,7 +393,7 @@ impl<'a> Serialize for CapturingGroup<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type CapturingGroup = ({\n\ttype: 'CapturingGroup';\n\tname: (string) | null;\n\tbody: Disjunction;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type CapturingGroup = ({\n\ttype: \"CapturingGroup\";\n\tname: (string) | null;\n\tbody: Disjunction;\n}) & Span;";
 
 impl<'a> Serialize for IgnoreGroup<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -409,7 +407,7 @@ impl<'a> Serialize for IgnoreGroup<'a> {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type IgnoreGroup = ({\n\ttype: 'IgnoreGroup';\n\tmodifiers: (Modifiers) | null;\n\tbody: Disjunction;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type IgnoreGroup = ({\n\ttype: \"IgnoreGroup\";\n\tmodifiers: (Modifiers) | null;\n\tbody: Disjunction;\n}) & Span;";
 
 impl Serialize for Modifiers {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -423,7 +421,7 @@ impl Serialize for Modifiers {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Modifiers = ({\n\ttype: 'Modifiers';\n\tenabling: (Modifier) | null;\n\tdisabling: (Modifier) | null;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type Modifiers = ({\n\ttype: \"Modifiers\";\n\tenabling: (Modifier) | null;\n\tdisabling: (Modifier) | null;\n}) & Span;";
 
 impl Serialize for Modifier {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -437,7 +435,7 @@ impl Serialize for Modifier {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Modifier = ({\n\ttype: 'Modifier';\n\tignoreCase: boolean;\n\tmultiline: boolean;\n\tsticky: boolean;\n});";
+const TS_APPEND_CONTENT: &'static str = "export type Modifier = ({\n\ttype: \"Modifier\";\n\tignoreCase: boolean;\n\tmultiline: boolean;\n\tsticky: boolean;\n});";
 
 impl Serialize for IndexedReference {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -450,8 +448,7 @@ impl Serialize for IndexedReference {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type IndexedReference = ({\n\ttype: 'IndexedReference';\n\tindex: number;\n}) & Span;";
+const TS_APPEND_CONTENT: &'static str = "export type IndexedReference = ({\n\ttype: \"IndexedReference\";\n\tindex: number;\n}) & Span;";
 
 impl<'a> Serialize for NamedReference<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -465,4 +462,4 @@ impl<'a> Serialize for NamedReference<'a> {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type NamedReference = ({\n\ttype: 'NamedReference';\n\tname: string;\n}) & Span;";
+    "export type NamedReference = ({\n\ttype: \"NamedReference\";\n\tname: string;\n}) & Span;";

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -55,7 +55,7 @@ impl Serialize for Language {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type Language = 'javascript' | 'typescript' | 'typescriptDefinition';";
+    "export type Language = \"javascript\" | \"typescript\" | \"typescriptDefinition\";";
 
 impl Serialize for ModuleKind {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -71,7 +71,7 @@ impl Serialize for ModuleKind {
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str =
-    "export type ModuleKind = 'script' | 'module' | 'unambiguous';";
+    "export type ModuleKind = \"script\" | \"module\" | \"unambiguous\";";
 
 impl Serialize for LanguageVariant {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -87,4 +87,4 @@ impl Serialize for LanguageVariant {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LanguageVariant = 'standard' | 'jsx';";
+const TS_APPEND_CONTENT: &'static str = "export type LanguageVariant = \"standard\" | \"jsx\";";

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -64,7 +64,7 @@ impl Serialize for AssignmentOperator {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type AssignmentOperator = '=' | '+=' | '-=' | '*=' | '/=' | '%=' | '<<=' | '>>=' | '>>>=' | '|=' | '^=' | '&=' | '&&=' | '||=' | '??=' | '**=';";
+const TS_APPEND_CONTENT: &'static str = "export type AssignmentOperator = \"=\" | \"+=\" | \"-=\" | \"*=\" | \"/=\" | \"%=\" | \"<<=\" | \">>=\" | \">>>=\" | \"|=\" | \"^=\" | \"&=\" | \"&&=\" | \"||=\" | \"??=\" | \"**=\";";
 
 impl Serialize for BinaryOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -138,7 +138,7 @@ impl Serialize for BinaryOperator {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type BinaryOperator = '==' | '!=' | '===' | '!==' | '<' | '<=' | '>' | '>=' | '<<' | '>>' | '>>>' | '+' | '-' | '*' | '/' | '%' | '|' | '^' | '&' | 'in' | 'instanceof' | '**';";
+const TS_APPEND_CONTENT: &'static str = "export type BinaryOperator = \"==\" | \"!=\" | \"===\" | \"!==\" | \"<\" | \"<=\" | \">\" | \">=\" | \"<<\" | \">>\" | \">>>\" | \"+\" | \"-\" | \"*\" | \"/\" | \"%\" | \"|\" | \"^\" | \"&\" | \"in\" | \"instanceof\" | \"**\";";
 
 impl Serialize for LogicalOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -155,7 +155,7 @@ impl Serialize for LogicalOperator {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type LogicalOperator = '||' | '&&' | '??';";
+const TS_APPEND_CONTENT: &'static str = "export type LogicalOperator = \"||\" | \"&&\" | \"??\";";
 
 impl Serialize for UnaryOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -184,8 +184,7 @@ impl Serialize for UnaryOperator {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str =
-    "export type UnaryOperator = '-' | '+' | '!' | '~' | 'typeof' | 'void' | 'delete';";
+const TS_APPEND_CONTENT: &'static str = "export type UnaryOperator = \"-\" | \"+\" | \"!\" | \"~\" | \"typeof\" | \"void\" | \"delete\";";
 
 impl Serialize for UpdateOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -201,4 +200,4 @@ impl Serialize for UpdateOperator {
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type UpdateOperator = '++' | '--';";
+const TS_APPEND_CONTENT: &'static str = "export type UpdateOperator = \"++\" | \"--\";";

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -163,13 +163,13 @@ fn serialize_enum(def: &EnumDef) -> TokenStream {
     }
 }
 
-// Untagged enums: "type Expression = BooleanLiteral | NullLiteral"
-// Tagged enums: "type PropertyKind = 'init' | 'get' | 'set'"
+// Untagged enums: `type Expression = BooleanLiteral | NullLiteral;`
+// Tagged enums: `type PropertyKind = "init" | "get" | "set";`
 fn typescript_enum(def: &EnumDef) -> String {
     let union = if def.markers.estree.untagged {
         def.all_variants().map(|var| type_to_string(var.fields[0].typ.name())).join(" | ")
     } else {
-        def.all_variants().map(|var| format!("'{}'", enum_variant_name(var, def))).join(" | ")
+        def.all_variants().map(|var| format!("\"{}\"", enum_variant_name(var, def))).join(" | ")
     };
     let ident = def.ident();
     format!("export type {ident} = {union};")
@@ -181,7 +181,7 @@ fn typescript_struct(def: &StructDef) -> String {
     let mut extends = vec![];
 
     if let Some(type_tag) = get_type_tag(def) {
-        fields.push_str(&format!("\n\ttype: '{type_tag}';"));
+        fields.push_str(&format!("\n\ttype: \"{type_tag}\";"));
     }
 
     for field in &def.fields {


### PR DESCRIPTION
Follow-on after #6404. Use double quotes in TS type defs, to match the code style `wasm_bindgen` uses for the types it generates.