### PR TITLE
fix(wasm): remove type defs for `ArrayExpressionElement` and `Elision`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -310,7 +310,7 @@ inherit_variants! {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(untagged)]
+#[estree(untagged, custom_ts_def)]
 pub enum ArrayExpressionElement<'a> {
     /// `...[3, 4]` in `const array = [1, 2, ...[3, 4], null];`
     SpreadElement(Box<'a, SpreadElement<'a>>) = 64,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -351,9 +351,6 @@ impl<'a> Serialize for ArrayExpressionElement<'a> {
     }
 }
 
-#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type ArrayExpressionElement = SpreadElement | Elision | BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;";
-
 impl<'a> Serialize for ObjectExpression<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -60,9 +60,6 @@ impl Serialize for Elision {
         serializer.serialize_none()
     }
 }
-#[cfg(feature = "serialize")]
-#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = "export type Elision = null;";
 
 /// Serialize `ArrayAssignmentTarget`, `ObjectAssignmentTarget`, `ObjectPattern`, `ArrayPattern`
 /// to be estree compatible, with `elements`/`properties` and `rest` fields combined.

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -25,12 +25,17 @@ impl Derive for DeriveESTree {
     fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
         let ts_type_def = match def {
             TypeDef::Enum(def) => typescript_enum(def),
-            TypeDef::Struct(def) => typescript_struct(def),
+            TypeDef::Struct(def) => Some(typescript_struct(def)),
         };
-        let ts_type_def = quote! {
-            #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-            const TS_APPEND_CONTENT: &'static str = #ts_type_def;
+        let ts_type_def = if let Some(ts_type_def) = ts_type_def {
+            quote! {
+                #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+                const TS_APPEND_CONTENT: &'static str = #ts_type_def;
+            }
+        } else {
+            TokenStream::new()
         };
+
         if let TypeDef::Struct(def) = def {
             if def
                 .markers
@@ -165,14 +170,18 @@ fn serialize_enum(def: &EnumDef) -> TokenStream {
 
 // Untagged enums: "type Expression = BooleanLiteral | NullLiteral"
 // Tagged enums: "type PropertyKind = 'init' | 'get' | 'set'"
-fn typescript_enum(def: &EnumDef) -> String {
+fn typescript_enum(def: &EnumDef) -> Option<String> {
+    if def.markers.estree.custom_ts_def {
+        return None;
+    }
+
     let union = if def.markers.estree.untagged {
         def.all_variants().map(|var| type_to_string(var.fields[0].typ.name())).join(" | ")
     } else {
         def.all_variants().map(|var| format!("'{}'", enum_variant_name(var, def))).join(" | ")
     };
     let ident = def.ident();
-    format!("export type {ident} = {union};")
+    Some(format!("export type {ident} = {union};"))
 }
 
 fn typescript_struct(def: &StructDef) -> String {

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -127,12 +127,14 @@ impl Parse for ESTreeStructAttribute {
 pub struct ESTreeEnumAttribute {
     pub rename_all: Option<String>,
     pub untagged: bool,
+    pub custom_ts_def: bool,
 }
 
 impl Parse for ESTreeEnumAttribute {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let mut rename_all = None;
         let mut untagged = false;
+        let mut custom_ts_def = false;
 
         loop {
             let ident = input.call(Ident::parse_any).unwrap().to_string();
@@ -151,6 +153,13 @@ impl Parse for ESTreeEnumAttribute {
                         untagged = true;
                     }
                 }
+                "custom_ts_def" => {
+                    if custom_ts_def {
+                        panic!("Duplicate estree(custom_ts_def)");
+                    } else {
+                        custom_ts_def = true;
+                    }
+                }
                 arg => panic!("Unsupported #[estree(...)] argument: {arg}"),
             }
             let comma = input.peek(Token![,]);
@@ -160,7 +169,7 @@ impl Parse for ESTreeEnumAttribute {
                 break;
             }
         }
-        Ok(Self { rename_all, untagged })
+        Ok(Self { rename_all, untagged, custom_ts_def })
     }
 }
 


### PR DESCRIPTION
Follow-on after #6404.

`ArrayExpressionElement` and `Elision` are not used in the TS types, because `ArrayExpression` has an override for the field it uses.

https://github.com/oxc-project/oxc/blob/002289b4b1b0d6fac080c4b12f4939c8f455272f/crates/oxc_ast/src/ast/js.rs#L293-L302

Prevent these TS type defs being emitted by introducing a new `#[estree(custom_ts_def)]` attr, to go with `#[estree(custom_serialize)]`.