### PR TITLE
refactor(ast_tools): give `GeneratorOutput` and `SideEffect` named fields

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -29,21 +29,23 @@ pub struct AstCodegenResult {
     pub outputs: Vec<SideEffect>,
 }
 
-pub struct SideEffect(/* path */ pub PathBuf, /* output */ pub Vec<u8>);
+pub struct SideEffect {
+    pub path: PathBuf,
+    pub content: Vec<u8>,
+}
 
 impl SideEffect {
     /// Apply the side-effect
     pub fn apply(self) -> std::io::Result<()> {
-        let Self(path, data) = self;
+        let Self { path, content } = self;
         let path = path.into_os_string();
         let path = path.to_str().unwrap();
-        write_all_to(&data, path)?;
+        write_all_to(&content, path)?;
         Ok(())
     }
 
     pub fn path(&self) -> String {
-        let Self(path, _) = self;
-        let path = path.to_string_lossy();
+        let path = self.path.to_string_lossy();
         path.replace('\\', "/")
     }
 }
@@ -51,13 +53,13 @@ impl SideEffect {
 impl From<(PathBuf, TokenStream)> for SideEffect {
     fn from((path, stream): (PathBuf, TokenStream)) -> Self {
         let content = pretty_print(&stream);
-        Self(path, content.as_bytes().into())
+        Self { path, content: content.into() }
     }
 }
 
 impl From<GeneratorOutput> for SideEffect {
     fn from(output: GeneratorOutput) -> Self {
-        Self::from((output.0, output.1))
+        Self::from((output.path, output.tokens))
     }
 }
 

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -28,9 +28,9 @@ impl Generator for AssertLayouts {
 
         let header = generated_header!();
 
-        GeneratorOutput(
-            output(crate::AST_CRATE, "assert_layouts.rs"),
-            quote! {
+        GeneratorOutput {
+            path: output(crate::AST_CRATE, "assert_layouts.rs"),
+            tokens: quote! {
                 #header
 
                 use std::mem::{align_of, offset_of, size_of};
@@ -55,7 +55,7 @@ impl Generator for AssertLayouts {
                 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]
                 const _: () = panic!("Platforms with pointer width other than 64 or 32 bit are not supported");
             },
-        )
+        }
     }
 }
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -34,9 +34,9 @@ impl Generator for AstBuilderGenerator {
 
         let header = generated_header!();
 
-        GeneratorOutput(
-            output(crate::AST_CRATE, "ast_builder.rs"),
-            quote! {
+        GeneratorOutput {
+            path: output(crate::AST_CRATE, "ast_builder.rs"),
+            tokens: quote! {
                 #header
 
                 #![allow(
@@ -64,7 +64,7 @@ impl Generator for AstBuilderGenerator {
                     #(#fns)*
                 }
             },
-        )
+        }
     }
 }
 

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -175,9 +175,9 @@ impl Generator for AstKindGenerator {
 
         let header = generated_header!();
 
-        GeneratorOutput(
-            output(crate::AST_CRATE, "ast_kind.rs"),
-            quote! {
+        GeneratorOutput {
+            path: output(crate::AST_CRATE, "ast_kind.rs"),
+            tokens: quote! {
                 #header
 
                 use oxc_span::{GetSpan, Span};
@@ -214,6 +214,6 @@ impl Generator for AstKindGenerator {
                     #(#as_ast_kind_impls)*
                 }
             },
-        )
+        }
     }
 }

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -27,7 +27,10 @@ pub trait Generator {
 }
 
 #[derive(Debug, Clone)]
-pub struct GeneratorOutput(/* output path */ pub PathBuf, pub TokenStream);
+pub struct GeneratorOutput {
+    pub path: PathBuf,
+    pub tokens: TokenStream,
+}
 
 macro_rules! define_generator {
     ($vis:vis struct $ident:ident $($lifetime:lifetime)? $($rest:tt)*) => {

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -28,13 +28,19 @@ define_generator! {
 
 impl Generator for VisitGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        GeneratorOutput(output(crate::AST_CRATE, "visit.rs"), generate_visit::<false>(ctx))
+        GeneratorOutput {
+            path: output(crate::AST_CRATE, "visit.rs"),
+            tokens: generate_visit::<false>(ctx),
+        }
     }
 }
 
 impl Generator for VisitMutGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        GeneratorOutput(output(crate::AST_CRATE, "visit_mut.rs"), generate_visit::<true>(ctx))
+        GeneratorOutput {
+            path: output(crate::AST_CRATE, "visit_mut.rs"),
+            tokens: generate_visit::<true>(ctx),
+        }
     }
 }
 


### PR DESCRIPTION
Pure refactor. Named fields are clearer.