### PR TITLE
feat(ast_tools): ability to generate text files

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -59,7 +59,10 @@ impl From<(PathBuf, TokenStream)> for SideEffect {
 
 impl From<GeneratorOutput> for SideEffect {
     fn from(output: GeneratorOutput) -> Self {
-        Self::from((output.path, output.tokens))
+        match output {
+            GeneratorOutput::Rust { path, tokens } => Self::from((path, tokens)),
+            GeneratorOutput::Text { path, content } => Self { path, content: content.into() },
+        }
     }
 }
 

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -28,7 +28,7 @@ impl Generator for AssertLayouts {
 
         let header = generated_header!();
 
-        GeneratorOutput {
+        GeneratorOutput::Rust {
             path: output(crate::AST_CRATE, "assert_layouts.rs"),
             tokens: quote! {
                 #header

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -34,7 +34,7 @@ impl Generator for AstBuilderGenerator {
 
         let header = generated_header!();
 
-        GeneratorOutput {
+        GeneratorOutput::Rust {
             path: output(crate::AST_CRATE, "ast_builder.rs"),
             tokens: quote! {
                 #header

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -175,7 +175,7 @@ impl Generator for AstKindGenerator {
 
         let header = generated_header!();
 
-        GeneratorOutput {
+        GeneratorOutput::Rust {
             path: output(crate::AST_CRATE, "ast_kind.rs"),
             tokens: quote! {
                 #header

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -27,9 +27,16 @@ pub trait Generator {
 }
 
 #[derive(Debug, Clone)]
-pub struct GeneratorOutput {
-    pub path: PathBuf,
-    pub tokens: TokenStream,
+pub enum GeneratorOutput {
+    Rust {
+        path: PathBuf,
+        tokens: TokenStream,
+    },
+    #[expect(dead_code)]
+    Text {
+        path: PathBuf,
+        content: String,
+    },
 }
 
 macro_rules! define_generator {

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -28,7 +28,7 @@ define_generator! {
 
 impl Generator for VisitGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        GeneratorOutput {
+        GeneratorOutput::Rust {
             path: output(crate::AST_CRATE, "visit.rs"),
             tokens: generate_visit::<false>(ctx),
         }
@@ -37,7 +37,7 @@ impl Generator for VisitGenerator {
 
 impl Generator for VisitMutGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        GeneratorOutput {
+        GeneratorOutput::Rust {
             path: output(crate::AST_CRATE, "visit_mut.rs"),
             tokens: generate_visit::<true>(ctx),
         }


### PR DESCRIPTION
This was originally in #6404 but I pulled it out to reduce that PR's diff.

Add ability (currently unused) to output arbitrary text files from `oxc_ast_tools` generators.