### PR TITLE
fix(linter/import): `import/no-duplicates` handles namespace imports correctly

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_duplicates.snap
+++ b/crates/oxc_linter/src/snapshots/no_duplicates.snap
@@ -209,7 +209,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
    ╭─[index.ts:1:8]
  1 │ import './foo'; import def, {x} from './foo'
-   ·        ───┬───                       ───────
+   ·        ───┬───                       ────────
    ·           ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
@@ -249,7 +249,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
    ╭─[index.ts:1:17]
  1 │ import {x} from './foo'; import def, {y} from './foo'
-   ·                 ───┬───                       ───────
+   ·                 ───┬───                       ────────
    ·                    ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
@@ -263,17 +263,17 @@ source: crates/oxc_linter/src/tester.rs
   help: Merge these imports into a single import statement
 
   ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
-   ╭─[index.ts:1:21]
+   ╭─[index.ts:1:46]
  1 │ import * as ns from './foo'; import {x} from './foo'; import {y} from './foo'
-   ·                     ───┬───                  ───────                  ───────
-   ·                        ╰── It is first imported here
+   ·                                              ───┬───                  ───────
+   ·                                                 ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
 
   ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
    ╭─[index.ts:1:17]
  1 │ import {x} from './foo'; import * as ns from './foo'; import {y} from './foo'; import './foo'
-   ·                 ───┬───                      ───────                  ───────         ───────
+   ·                 ───┬───                                               ───────         ───────
    ·                    ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
@@ -537,6 +537,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import {type x} from './foo'; import {type y} from './foo'
    ·                      ───┬───                       ───────
    ·                         ╰── It is first imported here
+   ╰────
+  help: Merge these imports into a single import statement
+
+  ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
+   ╭─[index.ts:1:38]
+ 1 │ import {AValue, type x, BValue} from './foo'; import {type y} from './foo'
+   ·                                      ───┬────
+   ·                                         ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
 


### PR DESCRIPTION
Closes #6660

- Value (i.e. not `import type`) namespace imports are now grouped correctly
- When grouping, consider _all_ import entries, not just the first one. Fixes a false negative when inlined `type` imports are used, e.g. `import { a, type b } from 'foo'`