### PR TITLE
feat(linter/eslint): show ignore patterns in `eslint/no-unused-vars` diagnostic messages

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
@@ -1,61 +1,95 @@
+use std::fmt;
+
 use cow_utils::CowUtils;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolFlags;
 use oxc_span::{GetSpan, Span};
 
-use super::Symbol;
+use super::{options::IgnorePattern, Symbol};
 
-fn pronoun_for_symbol(symbol_flags: SymbolFlags) -> &'static str {
+fn pronoun_for_symbol(
+    symbol_flags: SymbolFlags,
+) -> (/* singular */ &'static str, /* plural */ &'static str) {
     if symbol_flags.is_function() {
-        "Function"
+        ("Function", "functions")
     } else if symbol_flags.is_class() {
-        "Class"
+        ("Class", "classes")
     } else if symbol_flags.is_interface() {
-        "Interface"
+        ("Interface", "interfaces")
     } else if symbol_flags.is_type_alias() {
-        "Type alias"
+        ("Type alias", "type aliases")
     } else if symbol_flags.is_enum() {
-        "Enum"
+        ("Enum", "enums")
     } else if symbol_flags.is_enum_member() {
-        "Enum member"
+        ("Enum member", "enum members")
     } else if symbol_flags.is_type_import() {
-        "Type"
+        ("Type", "types")
     } else if symbol_flags.is_import() {
-        "Identifier"
+        ("Identifier", "identifiers")
+    } else if symbol_flags.is_catch_variable() {
+        ("Catch parameter", "caught errors")
     } else {
-        "Variable"
+        ("Variable", "variables")
     }
 }
 
-pub fn used_ignored(symbol: &Symbol<'_, '_>) -> OxcDiagnostic {
-    let pronoun = pronoun_for_symbol(symbol.flags());
+pub fn used_ignored<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
+    let (pronoun_singular, _) = pronoun_for_symbol(symbol.flags());
     let name = symbol.name();
 
-    OxcDiagnostic::warn(format!("{pronoun} '{name}' is marked as ignored but is used."))
+    let help_suffix = match pat {
+        IgnorePattern::None => ".".into(),
+        IgnorePattern::Default => {
+            name.strip_prefix('_').map_or(".".into(), |name| format!(" to '{name}'."))
+        }
+        IgnorePattern::Some(ref r) => {
+            format!(" to match the pattern /{r}/.")
+        }
+    };
+
+    OxcDiagnostic::warn(format!("{pronoun_singular} '{name}' is marked as ignored but is used."))
         .with_label(symbol.span().label(format!("'{name}' is declared here")))
-        .with_help(format!("Consider renaming this {}.", pronoun.cow_to_lowercase()))
+        .with_help(format!(
+            "Consider renaming this {}{help_suffix}",
+            pronoun_singular.cow_to_lowercase()
+        ))
 }
 /// Variable 'x' is declared but never used.
-pub fn declared(symbol: &Symbol<'_, '_>) -> OxcDiagnostic {
+pub fn declared<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
     let (verb, help) = if symbol.flags().is_catch_variable() {
         ("caught", "Consider handling this error.")
     } else {
         ("declared", "Consider removing this declaration.")
     };
-    let pronoun = pronoun_for_symbol(symbol.flags());
     let name = symbol.name();
+    let (pronoun, pronoun_plural) = pronoun_for_symbol(symbol.flags());
+    let suffix = pat.diagnostic_help(pronoun_plural);
 
-    OxcDiagnostic::warn(format!("{pronoun} '{name}' is {verb} but never used."))
+    OxcDiagnostic::warn(format!("{pronoun} '{name}' is {verb} but never used.{suffix}"))
         .with_label(symbol.span().label(format!("'{name}' is declared here")))
         .with_help(help)
 }
 
 /// Variable 'x' is assigned a value but never used.
-pub fn assign(symbol: &Symbol<'_, '_>, assign_span: Span) -> OxcDiagnostic {
-    let pronoun = pronoun_for_symbol(symbol.flags());
+pub fn assign<R>(
+    symbol: &Symbol<'_, '_>,
+    assign_span: Span,
+    pat: &IgnorePattern<R>,
+) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
     let name = symbol.name();
+    let (pronoun, pronoun_plural) = pronoun_for_symbol(symbol.flags());
+    let suffix = pat.diagnostic_help(pronoun_plural);
 
-    OxcDiagnostic::warn(format!("{pronoun} '{name}' is assigned a value but never used."))
+    OxcDiagnostic::warn(format!("{pronoun} '{name}' is assigned a value but never used.{suffix}"))
         .with_labels([
             symbol.span().label(format!("'{name}' is declared here")),
             assign_span.label("it was last assigned here"),
@@ -64,17 +98,21 @@ pub fn assign(symbol: &Symbol<'_, '_>, assign_span: Span) -> OxcDiagnostic {
 }
 
 /// Parameter 'x' is declared but never used.
-pub fn param(symbol: &Symbol<'_, '_>) -> OxcDiagnostic {
+pub fn param<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
     let name = symbol.name();
+    let suffix = pat.diagnostic_help("parameters");
 
-    OxcDiagnostic::warn(format!("Parameter '{name}' is declared but never used."))
+    OxcDiagnostic::warn(format!("Parameter '{name}' is declared but never used.{suffix}"))
         .with_label(symbol.span().label(format!("'{name}' is declared here")))
         .with_help("Consider removing this parameter.")
 }
 
 /// Identifier 'x' imported but never used.
 pub fn imported(symbol: &Symbol<'_, '_>) -> OxcDiagnostic {
-    let pronoun = pronoun_for_symbol(symbol.flags());
+    let (pronoun, _) = pronoun_for_symbol(symbol.flags());
     let name = symbol.name();
 
     OxcDiagnostic::warn(format!("{pronoun} '{name}' is imported but never used."))

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -271,6 +271,22 @@ impl<R> IgnorePattern<R> {
         }
     }
 }
+impl<R> IgnorePattern<R>
+where
+    R: std::fmt::Display,
+{
+    pub(super) fn diagnostic_help(&self, symbol_kind_plural: &str) -> Cow<'static, str> {
+        match self {
+            Self::None => Cow::Borrowed(""),
+            Self::Default => {
+                Cow::Owned(format!(" Unused {symbol_kind_plural} should start with a '_'."))
+            }
+            Self::Some(reg) => {
+                Cow::Owned(format!(" Unused {symbol_kind_plural} should match /{reg}/."))
+            }
+        }
+    }
+}
 
 impl From<Option<Regex>> for IgnorePattern<Regex> {
     #[inline]

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a=10
    ·     ┬
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a=10;
    ·     ┬
@@ -50,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a=10; a=20;
    ·     ┬     ┬
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a=10; (function() { var a = 1; alert(a); })();
    ·     ┬
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:16]
  1 │ var a=10, b=0, c=null; alert(a+b)
    ·                ┬
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ var a=10, b=0, c=null; setTimeout(function() { var b=2; alert(a+b+c); }, 0);
    ·           ┬
@@ -83,7 +83,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ var a=10, b=0, c=null; setTimeout(function() { var b=2; var c=2; alert(a+b+c); }, 0);
    ·           ┬
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:16]
  1 │ var a=10, b=0, c=null; setTimeout(function() { var b=2; var c=2; alert(a+b+c); }, 0);
    ·                ┬
@@ -148,7 +148,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ function f(a) {}; f();
    ·            ┬
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'z' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'z' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:18]
  1 │ function a(x, y, z){ return y; }; a();
    ·                  ┬
@@ -164,7 +164,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var min = Math.min
    ·     ─┬─
@@ -172,7 +172,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var min = {min: 1}
    ·     ─┬─
@@ -180,7 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Parameter 'baz' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'baz' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:20]
  1 │ Foo.bar = function(baz) { return 1; };
    ·                    ─┬─
@@ -268,7 +268,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this import.
 
-  ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:26]
  1 │ export function fn2({ x, y }) { console.log(x); };
    ·                          ┬
@@ -276,7 +276,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'y' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:25]
  1 │ export function fn2( x, y ) { console.log(x); };
    ·                         ┬
@@ -284,7 +284,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'max' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'max' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:22]
  1 │ /*exported max*/ var max = 1, min = {min: 1}
    ·                      ─┬─
@@ -292,7 +292,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'min' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:31]
  1 │ /*exported max*/ var max = 1, min = {min: 1}
    ·                               ─┬─
@@ -300,7 +300,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:22]
  1 │ /*exported x*/ var { x, y } = z
    ·                      ┬
@@ -308,7 +308,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'y' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'y' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:25]
  1 │ /*exported x*/ var { x, y } = z
    ·                         ┬
@@ -316,7 +316,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used. Unused variables should match /^_/.
    ╭─[no_unused_vars.tsx:1:13]
  1 │ var _a; var b;
    ·             ┬
@@ -324,7 +324,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c_' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'c_' is declared but never used. Unused variables should match /^_/.
    ╭─[no_unused_vars.tsx:1:37]
  1 │ var a; function foo() { var _b; var c_; } foo();
    ·                                     ─┬
@@ -332,7 +332,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /^_/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a, _b) { } foo();
    ·              ┬
@@ -340,7 +340,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should match /^_/.
    ╭─[no_unused_vars.tsx:1:21]
  1 │ function foo(a, _b, c) { return a; } foo();
    ·                     ┬
@@ -348,7 +348,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter '_a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter '_a' is declared but never used. Unused parameters should match /[iI]gnored/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(_a) { } foo();
    ·              ─┬
@@ -356,7 +356,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'secondItem' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'secondItem' is declared but never used. Unused variables should match /[iI]gnored/.
    ╭─[no_unused_vars.tsx:1:25]
  1 │ var [ firstItemIgnored, secondItem ] = items;
    ·                         ─────┬────
@@ -394,7 +394,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should match /ignore/.
    ╭─[no_unused_vars.tsx:3:20]
  2 │             const array = ['a', 'b', 'c'];
  3 │             const [a, _b, c] = array;
@@ -404,7 +404,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'c' is declared but never used. Unused variables should match /ignore/.
    ╭─[no_unused_vars.tsx:3:27]
  2 │             const array = ['a', 'b', 'c'];
  3 │             const [a, _b, c] = array;
@@ -414,7 +414,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'fooArray' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'fooArray' is declared but never used. Unused variables should match /ignore/.
    ╭─[no_unused_vars.tsx:4:19]
  3 │             const [a, _b, c] = array;
  4 │             const fooArray = ['foo'];
@@ -424,7 +424,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'barArray' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'barArray' is declared but never used. Unused variables should match /ignore/.
    ╭─[no_unused_vars.tsx:5:19]
  4 │             const fooArray = ['foo'];
  5 │             const barArray = ['bar'];
@@ -479,7 +479,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:22]
  1 │ (function(obj) { var name; for ( name in obj ) { i(); return; } })({});
    ·                      ──┬─        ──┬─
@@ -488,7 +488,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:22]
  1 │ (function(obj) { var name; for ( name in obj ) { } })({});
    ·                      ──┬─        ──┬─
@@ -497,7 +497,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:28]
  1 │ (function(obj) { for ( var name in obj ) { } })({});
    ·                            ──┬─
@@ -505,7 +505,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:23]
  1 │ (function(iter) { var name; for ( name of iter ) { i(); return; } })({});
    ·                       ──┬─        ──┬─
@@ -514,7 +514,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:23]
  1 │ (function(iter) { var name; for ( name of iter ) { } })({});
    ·                       ──┬─        ──┬─
@@ -523,7 +523,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'name' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'name' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:29]
  1 │ (function(iter) { for ( var name of iter ) { } })({});
    ·                             ──┬─
@@ -531,7 +531,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'type' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'type' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:12]
  1 │ const data = { type: 'coords', x: 1, y: 2 };
  2 │             const { type, ...coords } = data;
@@ -563,7 +563,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'coords' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'coords' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:21]
  1 │ const data = { type: 'coords', x: 3, y: 2 };
  2 │             const { type, ...coords } = data;
@@ -573,7 +573,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:19]
  1 │ const data = { vars: ['x','y'], x: 1, y: 2 };
  2 │             const { vars: [x], ...coords } = data;
@@ -583,7 +583,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:24]
  1 │ const data = { defaults: { x: 0 }, x: 1, y: 2 };
  2 │             const { defaults: { x }, ...coords } = data;
@@ -601,7 +601,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:25]
  1 │ export default function(a) {}
    ·                         ┬
@@ -609,7 +609,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:28]
  1 │ export default function(a, b) { console.log(a); }
    ·                            ┬
@@ -617,7 +617,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:26]
  1 │ export default (function(a) {});
    ·                          ┬
@@ -625,7 +625,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:29]
  1 │ export default (function(a, b) { console.log(a); });
    ·                             ┬
@@ -633,7 +633,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:17]
  1 │ export default (a) => {};
    ·                 ┬
@@ -641,7 +641,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:20]
  1 │ export default (a, b) => { console.log(a); };
    ·                    ┬
@@ -649,7 +649,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -657,7 +657,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -665,7 +665,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used. Unused caught errors should match /^ignore/.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -673,7 +673,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -681,7 +681,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -689,7 +689,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used. Unused caught errors should match /^ignore/.
    ╭─[no_unused_vars.tsx:1:35]
  1 │ try{}catch(ignoreErr){}try{}catch(err){};
    ·                                   ─┬─
@@ -697,7 +697,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'error' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'error' is caught but never used. Unused caught errors should match /^ignore/.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(error){}try{}catch(err){};
    ·            ──┬──
@@ -705,7 +705,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used. Unused caught errors should match /^ignore/.
    ╭─[no_unused_vars.tsx:1:31]
  1 │ try{}catch(error){}try{}catch(err){};
    ·                               ─┬─
@@ -713,7 +713,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -721,7 +721,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'err' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'err' is caught but never used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(err){};
    ·            ─┬─
@@ -729,7 +729,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 0; a = a + 1;
    ·     ┬      ┬
@@ -738,7 +738,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 0; a = a + a;
    ·     ┬      ┬
@@ -747,7 +747,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 0; a += a + 1;
    ·     ┬      ┬
@@ -756,7 +756,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 0; a++;
    ·     ┬      ┬
@@ -765,7 +765,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a) { a = a + 1 } foo();
    ·              ┬
@@ -773,7 +773,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a) { a += a + 1 } foo();
    ·              ┬
@@ -781,7 +781,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a) { a++ } foo();
    ·              ┬
@@ -789,7 +789,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 3; a = a * 5 + 6;
    ·     ┬      ┬
@@ -798,7 +798,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = 2, b = 4; a = a * 2 + b;
    ·     ┬             ┬
@@ -807,7 +807,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Parameter 'cb' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'cb' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(cb) { cb = function(a) { cb(1 + a); }; bar(not_cb); } foo();
    ·              ─┬
@@ -815,7 +815,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'cb' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'cb' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(cb) { cb = (function(a) { cb(1 + a); }, cb); } foo();
    ·              ─┬
@@ -823,7 +823,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:2:21]
  1 │ while (a) {
  2 │                 function foo(b) {
@@ -833,7 +833,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /c/.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ (function(a, b, c) {})
    ·           ┬
@@ -841,7 +841,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should match /c/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function(a, b, c) {})
    ·              ┬
@@ -849,7 +849,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /[cd]/.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ (function(a, b, {c, d}) {})
    ·           ┬
@@ -857,7 +857,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should match /[cd]/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function(a, b, {c, d}) {})
    ·              ┬
@@ -865,7 +865,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /c/.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ (function(a, b, {c, d}) {})
    ·           ┬
@@ -873,7 +873,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should match /c/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function(a, b, {c, d}) {})
    ·              ┬
@@ -881,7 +881,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'd' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'd' is declared but never used. Unused parameters should match /c/.
    ╭─[no_unused_vars.tsx:1:21]
  1 │ (function(a, b, {c, d}) {})
    ·                     ┬
@@ -889,7 +889,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /d/.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ (function(a, b, {c, d}) {})
    ·           ┬
@@ -897,7 +897,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should match /d/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function(a, b, {c, d}) {})
    ·              ┬
@@ -905,7 +905,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should match /d/.
    ╭─[no_unused_vars.tsx:1:18]
  1 │ (function(a, b, {c, d}) {})
    ·                  ┬
@@ -913,7 +913,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ({ a }, b ) { return b; })();
    ·              ┬
@@ -921,7 +921,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ({ a }, { b, c } ) { return b; })();
    ·              ┬
@@ -929,7 +929,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ (function ({ a }, { b, c } ) { return b; })();
    ·                        ┬
@@ -937,7 +937,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0;
    ·     ┬
@@ -948,7 +948,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0;
    ·     ┬
@@ -960,7 +960,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; x++, 0;
    ·     ┬      ┬
@@ -969,7 +969,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, x++;
    ·     ┬         ┬
@@ -978,7 +978,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, (1, x++);
    ·     ┬             ┬
@@ -987,7 +987,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = (x++, 0);
    ·     ┬             ┬
@@ -996,7 +996,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = ((0, x++), 0);
    ·     ┬                 ┬
@@ -1005,7 +1005,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; x += 1, 0;
    ·     ┬      ┬
@@ -1014,7 +1014,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, x += 1;
    ·     ┬         ┬
@@ -1023,7 +1023,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, (1, x += 1);
    ·     ┬             ┬
@@ -1032,7 +1032,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = (x += 1, 0);
    ·     ┬             ┬
@@ -1041,7 +1041,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = ((0, x += 1), 0);
    ·     ┬                 ┬
@@ -1050,7 +1050,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let z = 0;
    ·     ┬
@@ -1062,7 +1062,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let z = 0;
    ·     ┬
@@ -1074,7 +1074,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'z' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let z = 0;
    ·     ┬
@@ -1087,7 +1087,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, x = x+1;
    ·     ┬         ┬
@@ -1096,7 +1096,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; x = x+1, 0;
    ·     ┬      ┬
@@ -1105,7 +1105,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = ((0, x = x + 1), 0);
    ·     ┬                 ┬
@@ -1114,7 +1114,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; foo = (x = x+1, 0);
    ·     ┬             ┬
@@ -1123,7 +1123,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let x = 0; 0, (1, x=x+1);
    ·     ┬             ┬
@@ -1132,7 +1132,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ({ a, b }, { c } ) { return b; })();
    ·              ┬
@@ -1140,7 +1140,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ (function ({ a, b }, { c } ) { return b; })();
    ·                        ┬
@@ -1148,7 +1148,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ([ a ], b ) { return b; })();
    ·              ┬
@@ -1156,7 +1156,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ([ a ], [ b, c ] ) { return b; })();
    ·              ┬
@@ -1164,7 +1164,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ (function ([ a ], [ b, c ] ) { return b; })();
    ·                        ┬
@@ -1172,7 +1172,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ (function ([ a, b ], [ c ] ) { return b; })();
    ·              ┬
@@ -1180,7 +1180,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ (function ([ a, b ], [ c ] ) { return b; })();
    ·                        ┬
@@ -1204,7 +1204,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = function() { a(); };
    ·     ┬
@@ -1212,7 +1212,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ var a = function(){ return function() { a(); } };
    ·     ┬
@@ -1220,7 +1220,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:7]
  1 │ const a = () => () => { a(); };
    ·       ┬
@@ -1228,7 +1228,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'myArray' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'myArray' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let myArray = [1,2,3,4].filter((x) => x == 0);
    ·     ───┬───
@@ -1239,7 +1239,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:7]
  1 │ const a = 1; a += 1;
    ·       ┬      ┬
@@ -1248,7 +1248,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:7]
  1 │ const a = () => { a(); };
    ·       ┬
@@ -1256,7 +1256,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 'a';
    ·     ┬
@@ -1282,7 +1282,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'foo' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'foo' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let foo;
    ·     ─┬─
@@ -1307,7 +1307,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'c' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let c = 'c'
    ·     ┬
@@ -1376,7 +1376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       ─┬
    ·        ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this variable to match the pattern /^_/.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:7]
@@ -1384,7 +1384,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       ─┬
    ·        ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this variable to match the pattern /^_/.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:15]
@@ -1410,57 +1410,57 @@ source: crates/oxc_linter/src/tester.rs
    ·           ╰── 'ignored' is declared here
  2 │             foo(ignored);
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this variable to match the pattern /[iI]gnored/.
 
-  ⚠ eslint(no-unused-vars): Variable '_err' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_err' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:12]
  1 │ try{}catch(_err){console.error(_err)}
    ·            ──┬─
    ·              ╰── '_err' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'message' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'message' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:17]
  1 │ try {} catch ({ message }) { console.error(message); }
    ·                 ───┬───
    ·                    ╰── 'message' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:16]
  1 │ try {} catch ([_a, _b]) { doSomething(_a, _b); }
    ·                ─┬
    ·                 ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable '_b' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_b' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:20]
  1 │ try {} catch ([_a, _b]) { doSomething(_a, _b); }
    ·                    ─┬
    ·                     ╰── '_b' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:16]
  1 │ try {} catch ([_a, _b]) { doSomething(_a, _b); }
    ·                ─┬
    ·                 ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable '_b' is marked as ignored but is used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_b' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:20]
  1 │ try {} catch ([_a, _b]) { doSomething(_a, _b); }
    ·                    ─┬
    ·                     ╰── '_b' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this catch parameter.
 
-  ⚠ eslint(no-unused-vars): Variable '_' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_' is caught but never used. Unused caught errors should match /foo/.
    ╭─[no_unused_vars.tsx:3:13]
  2 │             try {
  3 │             } catch (_) {
@@ -1470,7 +1470,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable '_' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_' is caught but never used. Unused caught errors should match /ignored/.
    ╭─[no_unused_vars.tsx:3:13]
  2 │             try {
  3 │             } catch (_) {
@@ -1480,7 +1480,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'message' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'message' is caught but never used. Unused caught errors should match /foo/.
    ╭─[no_unused_vars.tsx:1:17]
  1 │ try {} catch ({ message, errors: [firstError] }) {}
    ·                 ───┬───
@@ -1488,7 +1488,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'firstError' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'firstError' is caught but never used. Unused caught errors should match /foo/.
    ╭─[no_unused_vars.tsx:1:35]
  1 │ try {} catch ({ message, errors: [firstError] }) {}
    ·                                   ─────┬────
@@ -1496,7 +1496,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable '$' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter '$' is caught but never used. Unused caught errors should match /\w/.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ try {} catch ({ stack: $ }) { $ = 'Something broke: ' + $; }
    ·                        ┬
@@ -1504,7 +1504,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Parameter '_' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter '_' is declared but never used. Unused parameters should match /ignored/.
    ╭─[no_unused_vars.tsx:2:4]
  1 │ 
  2 │             _ => { _ = _ + 1 };

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-arguments.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-arguments.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a) {} foo()
    ·              ┬
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a: number) {} foo()
    ·              ┬

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-classes.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-classes.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:32]
  1 │ export class Foo { constructor(a: number) {} }
    ·                                ┬
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'value' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'value' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:24]
  1 │ export class Foo { set(value) { } }
    ·                        ──┬──
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:3:24]
  2 │         export abstract class Foo {
  3 │             public bar(a: number): string {}

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-functions.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-functions.snap
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'interpolations' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'interpolations' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:3:46]
  2 │         export function log(message: string, ...interpolations: unknown[]): void;
  3 │         export function log(message: string, ...interpolations: unknown[]): void {
@@ -36,7 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'messages' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'messages' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:29]
  1 │ 
  2 │         export function log(...messages: unknown[]): void {

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-type-aliases.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-type-aliases.snap
@@ -25,7 +25,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'R' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'R' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:36]
  1 │ export type F<T> = T extends infer R ? /* R not used */ string : never
    ·                                    ┬

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-catch.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-catch.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Variable 'e' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'e' is caught but never used.
    ╭─[no_unused_vars.tsx:1:15]
  1 │ try {} catch (e) { }
    ·               ┬
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable '_' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_' is caught but never used.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ try {} catch(_) { }
    ·              ┬
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable '_' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter '_' is caught but never used.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ try {} catch(_) { }
    ·              ┬
@@ -25,7 +25,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider handling this error.
 
-  ⚠ eslint(no-unused-vars): Variable 'foo' is caught but never used.
+  ⚠ eslint(no-unused-vars): Catch parameter 'foo' is caught but never used. Unused caught errors should match /^ignored/.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ try {} catch(foo) { }
    ·              ─┬─

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-destructure.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-destructure.snap
@@ -49,7 +49,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'l' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'l' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:7]
  1 │ const l="",{e}=r
    ·       ┬
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'e' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'e' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:13]
  1 │ const l="",{e}=r
    ·             ┬

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-discarded-read.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-discarded-read.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:2:22]
  1 │ 
  2 │         function foo(a) { return (a, 0); }
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Variable 'I' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'I' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:15]
  1 │ 
  2 │         const I = (e) => (l) => {

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-reassignment.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-reassignment.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 1; a ||= 2;
    ·     ┬      ┬
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = a + 1;
    ·     ┬      ┬
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = a++ as any;
    ·     ┬          ┬
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = a as unknown as string as unknown as number;
    ·     ┬      ┬
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = ++a;
    ·     ┬            ┬
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = (0, ++a);
    ·     ┬                ┬
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; a = (a++, 0);
    ·     ┬           ┬
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; let b = (a++, 0); f(b);
    ·     ┬               ┬
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; let b = (0, (a++, 0)); f(b);
    ·     ┬                   ┬
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; let b = ((0, a++), 0); f(b);
    ·     ┬                   ┬
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you mean to use this variable?
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 0; let b = (a, 0) + 1; f(b);
    ·     ┬

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-self-use.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-self-use.snap
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'foo' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'foo' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:2:15]
  1 │ 
  2 │         const foo = () => {

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-simple.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-simple.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 1
    ·     ┬
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a: number = 1
    ·     ┬
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:5]
  1 │ let a = 1; a = 2
    ·     ┬      ┬
@@ -32,9 +32,9 @@ source: crates/oxc_linter/src/tester.rs
    ·     ─┬
    ·      ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable.
+  help: Consider renaming this variable to match the pattern /^_/.
 
-  ⚠ eslint(no-unused-vars): Variable 'fooBar' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'fooBar' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ const { foo: fooBar, baz } = obj; f(baz);
    ·              ───┬──

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-using.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-using.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:7]
  1 │ using a = 1;
    ·       ┬

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@typescript-eslint.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@typescript-eslint.snap
@@ -272,7 +272,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'x' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.ts:7:31]
  6 │                     namespace Bam {
  7 │                         const x = 1;
@@ -292,7 +292,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'foo' is assigned a value but never used.
+  ⚠ eslint(no-unused-vars): Variable 'foo' is assigned a value but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.ts:2:15]
  1 │ 
  2 │           let foo = 1;
@@ -333,7 +333,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │         
    ╰────
 
-  ⚠ eslint(no-unused-vars): Variable 'foo' is declared but never used.
+  ⚠ eslint(no-unused-vars): Variable 'foo' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.ts:1:7]
  1 │ const foo: number = 1;
    ·       ─┬─


### PR DESCRIPTION
Inform users what pattern an unused variable must match in diagnostic help messages.

```
  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used. Unused variables should start with a '_'.
   ╭─[no_unused_vars.tsx:1:5]
 1 │ var a=10
   ·     ┬
   ·     ╰── 'a' is declared here
   ╰────
  help: Consider removing this declaration.
```