### PR TITLE
perf(linter/no-unused-vars): use default IgnorePattern when /^_/ is provided as a pattern

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -6,12 +6,18 @@ use super::NoUnusedVars;
 use crate::{tester::Tester, FixKind, RuleMeta as _};
 
 // uncomment to only run a single test. useful for step-through debugging.
-// #[test]
-// fn test_debug() {
-//     let pass: Vec<&str> = vec![];
-//     let fail = vec![];
-//     Tester::new(NoUnusedVars::NAME, pass, fail).intentionally_allow_no_fix_tests().test();
-// }
+#[test]
+fn test_debug() {
+    let pass = vec![
+        (
+            "const [ a, _b, c ] = items;
+			console.log(a+c);",
+            Some(serde_json::json!([{ "destructuredArrayIgnorePattern": "^_" }])),
+        ), // { "ecmaVersion": 6 },
+    ];
+    let fail = vec![];
+    Tester::new(NoUnusedVars::NAME, pass, fail).intentionally_allow_no_fix_tests().test();
+}
 
 #[test]
 fn test_vars_simple() {

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@eslint.snap
@@ -316,7 +316,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used. Unused variables should match /^_/.
+  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:13]
  1 │ var _a; var b;
    ·             ┬
@@ -324,7 +324,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'c_' is declared but never used. Unused variables should match /^_/.
+  ⚠ eslint(no-unused-vars): Variable 'c_' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:37]
  1 │ var a; function foo() { var _b; var c_; } foo();
    ·                                     ─┬
@@ -332,7 +332,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should match /^_/.
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a, _b) { } foo();
    ·              ┬
@@ -340,7 +340,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
-  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should match /^_/.
+  ⚠ eslint(no-unused-vars): Parameter 'c' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:21]
  1 │ function foo(a, _b, c) { return a; } foo();
    ·                     ┬
@@ -1376,7 +1376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       ─┬
    ·        ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable to match the pattern /^_/.
+  help: Consider renaming this variable to 'a'.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:7]
@@ -1384,7 +1384,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       ─┬
    ·        ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable to match the pattern /^_/.
+  help: Consider renaming this variable to 'a'.
 
   ⚠ eslint(no-unused-vars): Variable '_a' is marked as ignored but is used.
    ╭─[no_unused_vars.tsx:1:15]

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-simple.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-simple.snap
@@ -32,7 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ─┬
    ·      ╰── '_a' is declared here
    ╰────
-  help: Consider renaming this variable to match the pattern /^_/.
+  help: Consider renaming this variable to 'a'.
 
   ⚠ eslint(no-unused-vars): Variable 'fooBar' is declared but never used. Unused variables should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]


### PR DESCRIPTION
Use `IgnorePattern::Default` even when `/^_/` is explicitly provided as a regex. This gives better diagnostic messages and lets us use `starts_with('_')` in more cases.