### PR TITLE
refactor(ast): change `plain_function` to accept `FunctionBody` as a required parameter

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -176,11 +176,21 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: Option<BindingIdentifier<'a>>,
         params: FormalParameters<'a>,
-        body: Option<FunctionBody<'a>>,
+        body: FunctionBody<'a>,
     ) -> Box<'a, Function<'a>> {
-        self.alloc(
-            self.function(r#type, span, id, false, false, false, NONE, NONE, params, NONE, body),
-        )
+        self.alloc(self.function(
+            r#type,
+            span,
+            id,
+            false,
+            false,
+            false,
+            NONE,
+            NONE,
+            params,
+            NONE,
+            Some(body),
+        ))
     }
 
     /* ---------- Modules ---------- */

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -336,13 +336,8 @@ impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
                 let items = ctx.ast.vec1(ctx.ast.plain_formal_parameter(SPAN, pattern));
                 ctx.ast.formal_parameters(SPAN, FormalParameterKind::FormalParameter, items, NONE)
             };
-            let function = ctx.ast.plain_function(
-                FunctionType::FunctionExpression,
-                SPAN,
-                None,
-                params,
-                Some(body),
-            );
+            let function =
+                ctx.ast.plain_function(FunctionType::FunctionExpression, SPAN, None, params, body);
             function.scope_id.set(Some(scope_id));
             *ctx.scopes_mut().get_flags_mut(scope_id) =
                 ScopeFlags::Function | ScopeFlags::StrictMode;


### PR DESCRIPTION
The `plain_function` method is used to construct js-only AST, and the `FunctionBody` is never empty in js