### PR TITLE
docs(macros): add `#![warn(missing_docs]` to `oxc_macros`

### DIFF
--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -1,3 +1,5 @@
+//! Macros for declaring lints and secret scanners.
+#![warn(missing_docs)]
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
@@ -99,6 +101,10 @@ pub fn declare_oxc_lint_test(input: TokenStream) -> TokenStream {
     declare_oxc_lint::declare_oxc_lint(metadata)
 }
 
+/// Declare all lint rules in a single macro. This create the `RuleEnum` struct,
+/// which is effectively a compile-time v-table for all lint rules. This
+/// bypasses object-safety requirements and allows for compile-time dispatch
+/// over a heterogeneous set of known lint rules.
 #[proc_macro]
 pub fn declare_all_lint_rules(input: TokenStream) -> TokenStream {
     let metadata = parse_macro_input!(input as declare_all_lint_rules::AllLintRulesMeta);


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/130