### PR TITLE
docs(ast): enable crate-wide warnings on missing doc comments

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)] // FIXME
+
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
 // Read [`macro@oxc_ast_macros::ast`] for more information.

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -1,5 +1,4 @@
 //! [JSX](https://facebook.github.io/jsx)
-#![warn(missing_docs)]
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -1,5 +1,4 @@
 //! Literals
-#![warn(missing_docs)]
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -2,6 +2,7 @@
 //!
 //! - [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec)
 //! - [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
+#![allow(missing_docs)] // FIXME
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -1,5 +1,4 @@
 //! [JSX](https://facebook.github.io/jsx)
-#![warn(missing_docs)]
 use std::fmt;
 
 use oxc_span::Atom;

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -1,5 +1,4 @@
 //! Literals
-#![warn(missing_docs)]
 
 use std::{
     borrow::Cow,

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)] // FIXME
 use oxc_span::Atom;
 use oxc_syntax::scope::ScopeId;
 

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7,7 +7,6 @@
     clippy::too_many_arguments,
     clippy::fn_params_excessive_bools
 )]
-#![warn(missing_docs)]
 
 use std::cell::Cell;
 

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,6 +1,9 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_kind.rs`
 
+#![allow(missing_docs)]
+// FIXME (in ast_tools/src/generators/ast_kind.rs)
+
 use oxc_span::{GetSpan, Span};
 
 #[allow(clippy::wildcard_imports)]

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -2,6 +2,7 @@
 // TODO: I'm not sure if it is a but or intentional but clippy needs this allowed both on this
 // module and the generated one.
 #![allow(clippy::self_named_module_files)]
+#![warn(missing_docs)]
 
 //! # Oxc AST
 //!
@@ -36,6 +37,7 @@ pub mod precedence;
 mod trivia;
 
 mod generated {
+    #![allow(missing_docs)]
     #[cfg(debug_assertions)]
     pub mod assert_layouts;
     pub mod ast_builder;
@@ -52,6 +54,7 @@ mod generated {
 }
 
 pub mod visit {
+    #![allow(missing_docs)]
     pub use crate::generated::{visit::*, visit_mut::*};
 }
 

--- a/crates/oxc_ast/src/precedence.rs
+++ b/crates/oxc_ast/src/precedence.rs
@@ -1,3 +1,4 @@
+//! [Expression precedence trait](GetPrecedence) implementations.
 use oxc_syntax::precedence::{GetPrecedence, Precedence};
 
 use crate::ast::{

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -1,4 +1,5 @@
 //! Trivias such as comments and irregular whitespaces
+#![allow(missing_docs)] // FIXME
 
 use std::{
     iter::FusedIterator,

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -45,7 +45,6 @@ impl Generator for AstBuilderGenerator {
                     clippy::too_many_arguments,
                     clippy::fn_params_excessive_bools,
                 )]
-                #![warn(missing_docs)]
 
                 ///@@line_break
                 use std::cell::Cell;

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -131,6 +131,8 @@ impl Generator for AstKindGenerator {
             path: output(crate::AST_CRATE, "ast_kind.rs"),
             tokens: quote! {
                 #header
+                #![allow(missing_docs)] ///@ FIXME (in ast_tools/src/generators/ast_kind.rs)
+                ///@@line_break
 
                 use oxc_span::{GetSpan, Span};
 


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/130