### PR TITLE
refactor(ast_tools): add `Derive::snake_name` method

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -22,6 +22,10 @@ impl Derive for DeriveESTree {
         "ESTree"
     }
 
+    fn snake_name() -> String {
+        "estree".to_string()
+    }
+
     fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
         let ts_type_def = match def {
             TypeDef::Enum(def) => typescript_enum(def),


### PR DESCRIPTION
Follow-on after #6404. Add `Derive::snake_name` method which defaults to `Self::trait_name().to_case(Case::Snake)`, but can be overridden. This allows moving the "special case" code for `ESTree` filename into `estree.rs`.