### PR TITLE
refactor(linter): add `run_on_jest_node` to run rules on only jest nodes

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -209,6 +209,12 @@ impl<'a> ContextHost<'a> {
 
         self
     }
+
+    /// Returns the framework hints for the target file.
+    #[inline]
+    pub fn frameworks(&self) -> FrameworkFlags {
+        self.frameworks
+    }
 }
 
 impl<'a> From<ContextHost<'a>> for Vec<Message<'a>> {

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -35,6 +35,7 @@ bitflags! {
         const Jest = 1 << 9;
         const Vitest = 1 << 10;
         const OtherTest = 1 << 11;
+        /// Flag for if any test frameworks are used, such as Jest or Vitest.
         const Test = Self::Jest.bits() | Self::Vitest.bits() | Self::OtherTest.bits();
     }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -27,6 +27,7 @@ use config::LintConfig;
 use context::ContextHost;
 use options::LintOptions;
 use oxc_semantic::{AstNode, Semantic};
+use utils::iter_possible_jest_call_node;
 
 pub use crate::{
     builder::LinterBuilder,
@@ -137,6 +138,14 @@ impl Linter {
         for node in semantic.nodes() {
             for (rule, ctx) in &rules {
                 rule.run(node, ctx);
+            }
+        }
+
+        if ctx_host.frameworks().is_test() && self.options.plugins.has_test() {
+            for jest_node in iter_possible_jest_call_node(semantic) {
+                for (rule, ctx) in &rules {
+                    rule.run_on_jest_node(&jest_node, ctx);
+                }
             }
         }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     context::{ContextHost, LintContext},
+    utils::PossibleJestNode,
     AllowWarnDeny, AstNode, FixKind, RuleEnum,
 };
 
@@ -34,6 +35,18 @@ pub trait Rule: Sized + Default + fmt::Debug {
     #[expect(unused_variables)]
     #[inline]
     fn run_once(&self, ctx: &LintContext) {}
+
+    /// Run on each Jest node (e.g. `it`, `describe`, `test`, `expect`, etc.).
+    /// This is only called if the Jest plugin is enabled and the file is a test file.
+    /// It should be used to run rules that are specific to Jest or Vitest.
+    #[expect(unused_variables)]
+    #[inline]
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+    }
 
     /// Check if a rule should be run at all.
     ///

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -61,7 +61,12 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let expanded = quote! {
         #(pub use self::#use_stmts::#struct_names;)*
 
-        use crate::{context::{ContextHost, LintContext}, rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta}, AstNode};
+        use crate::{
+            context::{ContextHost, LintContext},
+            rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta},
+            utils::PossibleJestNode,
+            AstNode
+        };
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -131,6 +136,16 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
             pub(super) fn run_once<'a>(&self, ctx: &LintContext<'a>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run_once(ctx)),*
+                }
+            }
+
+            pub(super) fn run_on_jest_node<'a, 'c>(
+                &self,
+                jest_node: &PossibleJestNode<'a, 'c>,
+                ctx: &'c LintContext<'a>,
+            ) {
+                match self {
+                    #(Self::#struct_names(rule) => rule.run_on_jest_node(jest_node, ctx)),*
                 }
             }
 


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/6038

Adds a new `run_on_jest_node` method for running lint rules which allows only Jest/Vitest nodes to be linted. This simplifies a number of Jest rules by removing the need to iterate/collect Jest nodes inside of them. Now, they can simply run on the Jest nodes that are passed to them directly. This also saves time by skipping the running of the rule if it is not a test file or the Jest/Vitest plugins are not enabled.