### PR TITLE
fix(editor): Update config sent to language server

### DIFF
--- a/editors/vscode/client/config.ts
+++ b/editors/vscode/client/config.ts
@@ -1,19 +1,19 @@
-import { ConfigurationChangeEvent, workspace, WorkspaceConfiguration } from 'vscode';
-import { IDisposable } from './types';
+import {ConfigurationChangeEvent, workspace, WorkspaceConfiguration} from 'vscode';
+import {IDisposable} from './types';
 
 export class ConfigService implements Config, IDisposable {
   private static readonly _namespace = 'oxc';
   private readonly _disposables: IDisposable[] = [];
   private _inner: WorkspaceConfiguration;
-  private _runTrigger: 'onSave' | 'onType';
+  private _runTrigger: Trigger;
   private _enable: boolean;
-  private _trace: 'off' | 'messages' | 'verbose';
+  private _trace: TraceLevel;
   private _configPath: string;
   private _binPath: string | undefined;
 
   public onConfigChange:
-    | ((this: ConfigService, config: ConfigurationChangeEvent) => void)
-    | undefined;
+      | ((this: ConfigService, config: ConfigurationChangeEvent) => void)
+      | undefined;
 
   constructor() {
     this._inner = workspace.getConfiguration(ConfigService._namespace);
@@ -25,13 +25,9 @@ export class ConfigService implements Config, IDisposable {
     this.onConfigChange = undefined;
 
     const disposeChangeListener = workspace.onDidChangeConfiguration(
-      this.onVscodeConfigChange.bind(this),
+        this.onVscodeConfigChange.bind(this),
     );
     this._disposables.push(disposeChangeListener);
-  }
-
-  get rawConfig(): WorkspaceConfiguration {
-    return this._inner;
   }
 
   get runTrigger(): Trigger {
@@ -41,8 +37,8 @@ export class ConfigService implements Config, IDisposable {
   set runTrigger(value: Trigger) {
     this._runTrigger = value;
     workspace
-      .getConfiguration(ConfigService._namespace)
-      .update('lint.run', value);
+    .getConfiguration(ConfigService._namespace)
+    .update('lint.run', value);
   }
 
   get enable(): boolean {
@@ -52,8 +48,8 @@ export class ConfigService implements Config, IDisposable {
   set enable(value: boolean) {
     this._enable = value;
     workspace
-      .getConfiguration(ConfigService._namespace)
-      .update('enable', value);
+    .getConfiguration(ConfigService._namespace)
+    .update('enable', value);
   }
 
   get trace(): TraceLevel {
@@ -63,8 +59,8 @@ export class ConfigService implements Config, IDisposable {
   set trace(value: TraceLevel) {
     this._trace = value;
     workspace
-      .getConfiguration(ConfigService._namespace)
-      .update('trace.server', value);
+    .getConfiguration(ConfigService._namespace)
+    .update('trace.server', value);
   }
 
   get configPath(): string {
@@ -74,8 +70,8 @@ export class ConfigService implements Config, IDisposable {
   set configPath(value: string) {
     this._configPath = value;
     workspace
-      .getConfiguration(ConfigService._namespace)
-      .update('configPath', value);
+    .getConfiguration(ConfigService._namespace)
+    .update('configPath', value);
   }
 
   get binPath(): string | undefined {
@@ -85,8 +81,8 @@ export class ConfigService implements Config, IDisposable {
   set binPath(value: string | undefined) {
     this._binPath = value;
     workspace
-      .getConfiguration(ConfigService._namespace)
-      .update('path.server', value);
+    .getConfiguration(ConfigService._namespace)
+    .update('path.server', value);
   }
 
   private onVscodeConfigChange(event: ConfigurationChangeEvent): void {
@@ -100,25 +96,30 @@ export class ConfigService implements Config, IDisposable {
     }
   }
 
+
   dispose() {
     for (const disposable of this._disposables) {
       disposable.dispose();
     }
   }
 
-  public toJSON(): Config {
+  public toLanguageServerConfig(): LanguageServerConfig {
     return {
-      runTrigger: this.runTrigger,
+      run: this.runTrigger,
       enable: this.enable,
-      trace: this.trace,
       configPath: this.configPath,
-      binPath: this.binPath,
     };
   }
 }
 
 type Trigger = 'onSave' | 'onType';
 type TraceLevel = 'off' | 'messages' | 'verbose';
+
+interface LanguageServerConfig {
+  configPath: string;
+  enable: boolean;
+  run: Trigger;
+}
 
 /**
  * See `"contributes.configuration"` in `package.json`

--- a/editors/vscode/client/config.ts
+++ b/editors/vscode/client/config.ts
@@ -1,5 +1,5 @@
-import {ConfigurationChangeEvent, workspace, WorkspaceConfiguration} from 'vscode';
-import {IDisposable} from './types';
+import { ConfigurationChangeEvent, workspace, WorkspaceConfiguration } from 'vscode';
+import { IDisposable } from './types';
 
 export class ConfigService implements Config, IDisposable {
   private static readonly _namespace = 'oxc';
@@ -12,8 +12,8 @@ export class ConfigService implements Config, IDisposable {
   private _binPath: string | undefined;
 
   public onConfigChange:
-      | ((this: ConfigService, config: ConfigurationChangeEvent) => void)
-      | undefined;
+    | ((this: ConfigService, config: ConfigurationChangeEvent) => void)
+    | undefined;
 
   constructor() {
     this._inner = workspace.getConfiguration(ConfigService._namespace);
@@ -25,7 +25,7 @@ export class ConfigService implements Config, IDisposable {
     this.onConfigChange = undefined;
 
     const disposeChangeListener = workspace.onDidChangeConfiguration(
-        this.onVscodeConfigChange.bind(this),
+      this.onVscodeConfigChange.bind(this),
     );
     this._disposables.push(disposeChangeListener);
   }
@@ -37,8 +37,8 @@ export class ConfigService implements Config, IDisposable {
   set runTrigger(value: Trigger) {
     this._runTrigger = value;
     workspace
-    .getConfiguration(ConfigService._namespace)
-    .update('lint.run', value);
+      .getConfiguration(ConfigService._namespace)
+      .update('lint.run', value);
   }
 
   get enable(): boolean {
@@ -48,8 +48,8 @@ export class ConfigService implements Config, IDisposable {
   set enable(value: boolean) {
     this._enable = value;
     workspace
-    .getConfiguration(ConfigService._namespace)
-    .update('enable', value);
+      .getConfiguration(ConfigService._namespace)
+      .update('enable', value);
   }
 
   get trace(): TraceLevel {
@@ -59,8 +59,8 @@ export class ConfigService implements Config, IDisposable {
   set trace(value: TraceLevel) {
     this._trace = value;
     workspace
-    .getConfiguration(ConfigService._namespace)
-    .update('trace.server', value);
+      .getConfiguration(ConfigService._namespace)
+      .update('trace.server', value);
   }
 
   get configPath(): string {
@@ -70,8 +70,8 @@ export class ConfigService implements Config, IDisposable {
   set configPath(value: string) {
     this._configPath = value;
     workspace
-    .getConfiguration(ConfigService._namespace)
-    .update('configPath', value);
+      .getConfiguration(ConfigService._namespace)
+      .update('configPath', value);
   }
 
   get binPath(): string | undefined {
@@ -81,8 +81,8 @@ export class ConfigService implements Config, IDisposable {
   set binPath(value: string | undefined) {
     this._binPath = value;
     workspace
-    .getConfiguration(ConfigService._namespace)
-    .update('path.server', value);
+      .getConfiguration(ConfigService._namespace)
+      .update('path.server', value);
   }
 
   private onVscodeConfigChange(event: ConfigurationChangeEvent): void {
@@ -95,7 +95,6 @@ export class ConfigService implements Config, IDisposable {
       this.onConfigChange?.call(this, event);
     }
   }
-
 
   dispose() {
     for (const disposable of this._disposables) {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -136,7 +136,6 @@ export async function activate(context: ExtensionContext) {
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
   // Options to control the language client
-  let clientConfig: any = JSON.parse(JSON.stringify(config.rawConfig));
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
     documentSelector: [
@@ -155,7 +154,7 @@ export async function activate(context: ExtensionContext) {
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },
     initializationOptions: {
-      settings: clientConfig,
+      settings: config.toLanguageServerConfig(),
     },
     outputChannel,
     traceOutputChannel,
@@ -200,7 +199,7 @@ export async function activate(context: ExtensionContext) {
 
     myStatusBarItem.backgroundColor = bgColor;
   }
-  updateStatsBar(clientConfig.enable);
+  updateStatsBar(config.enable);
   client.start();
 }
 


### PR DESCRIPTION
Syncs up the options from the language server `Options` struct with the values that the extension supplies.

I tend to avoid `toJSON` because it will be used by `JSON.stringify` when called and it's not well known.
There's no reason that `LanguageServerConfig` and `Config` have to both exist, but I think two types is easier to understand.