### PR TITLE
docs(ast): fix comment of `ClassElement::r#static`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1303,15 +1303,14 @@ impl<'a> ClassElement<'a> {
         matches!(self, Self::StaticBlock(_))
     }
 
-    /// Returns `true` if this [`ClassElement`] is a static block or has a
+    /// Returns `true` if this [`ClassElement`] is a property and has a
     /// static modifier.
     pub fn r#static(&self) -> bool {
         match self {
-            Self::StaticBlock(_) => true,
+            Self::TSIndexSignature(_) | Self::StaticBlock(_) => false,
             Self::MethodDefinition(def) => def.r#static,
             Self::PropertyDefinition(def) => def.r#static,
             Self::AccessorProperty(def) => def.r#static,
-            Self::TSIndexSignature(_) => false,
         }
     }
 

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1307,10 +1307,11 @@ impl<'a> ClassElement<'a> {
     /// static modifier.
     pub fn r#static(&self) -> bool {
         match self {
-            Self::TSIndexSignature(_) | Self::StaticBlock(_) => false,
+            Self::ClassElement(_) => true,
             Self::MethodDefinition(def) => def.r#static,
             Self::PropertyDefinition(def) => def.r#static,
             Self::AccessorProperty(def) => def.r#static,
+            Self::TSIndexSignature(_) => false,
         }
     }
 

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1307,7 +1307,7 @@ impl<'a> ClassElement<'a> {
     /// static modifier.
     pub fn r#static(&self) -> bool {
         match self {
-            Self::ClassElement(_) => true,
+            Self::StaticBlock(_) => true,
             Self::MethodDefinition(def) => def.r#static,
             Self::PropertyDefinition(def) => def.r#static,
             Self::AccessorProperty(def) => def.r#static,


### PR DESCRIPTION
The comment says: `Returns true if this ClassElement is a static block or has a static modifier.`