### PR TITLE
refactor(allocator): move `GetAddress` trait into `oxc_allocator`

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -1,0 +1,25 @@
+use std::ptr;
+
+use crate::Box;
+
+/// Memory address of an AST node in arena.
+///
+/// `Address` is generated from a `Box<T>`.
+/// AST nodes in a `Box` in an arena are guaranteed to never move in memory,
+/// so this address acts as a unique identifier for the duration of the arena's existence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Address(usize);
+
+/// Trait for getting the memory address of an AST node.
+pub trait GetAddress {
+    /// Get the memory address of a value allocated in the arena.
+    fn address(&self) -> Address;
+}
+
+impl<'a, T> GetAddress for Box<'a, T> {
+    /// Get the memory address of a value allocated in the arena.
+    #[inline]
+    fn address(&self) -> Address {
+        Address(ptr::addr_of!(**self) as usize)
+    }
+}

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -164,22 +164,6 @@ impl<'alloc, T: Hash> Hash for Box<'alloc, T> {
     }
 }
 
-/// Memory address of an AST node in arena.
-///
-/// `Address` is generated from a `Box<T>`.
-/// AST nodes in a `Box` in an arena are guaranteed to never move in memory,
-/// so this address acts as a unique identifier for the duration of the arena's existence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Address(usize);
-
-impl<'a, T> Box<'a, T> {
-    /// Get the memory address of a value allocated in the arena.
-    #[inline]
-    pub fn address(&self) -> Address {
-        Address(ptr::addr_of!(**self) as usize)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::hash::{DefaultHasher, Hash, Hasher};

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -47,12 +47,14 @@ use std::{
 pub use bumpalo::collections::String;
 use bumpalo::Bump;
 
+mod address;
 mod boxed;
 mod clone_in;
 mod convert;
 mod vec;
 
-pub use boxed::{Address, Box};
+pub use address::{Address, GetAddress};
+pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
 pub use vec::Vec;

--- a/crates/oxc_ast/src/address.rs
+++ b/crates/oxc_ast/src/address.rs
@@ -1,15 +1,10 @@
-//! Defines the `GetAddress` trait for getting the memory address of AST.
-
-use oxc_allocator::Address;
+use oxc_allocator::{Address, GetAddress};
 
 use crate::ast::Statement;
 
-/// Trait for getting the memory address of AST.
-pub trait GetAddress {
-    fn address(&self) -> Address;
-}
-
 impl<'a> GetAddress for Statement<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
     fn address(&self) -> Address {
         match self {
             Statement::BlockStatement(s) => s.address(),

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -14,9 +14,9 @@
 
 use std::cell::RefCell;
 
-use oxc_allocator::{Address, Vec as AVec};
+use oxc_allocator::{Address, GetAddress, Vec as AVec};
 
-use oxc_ast::{address::GetAddress, ast::*};
+use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
 use rustc_hash::FxHashMap;
 


### PR DESCRIPTION
Pure refactor. It makes more sense to me for `Address` and `GetAddress` to be defined in the same place. Also then we can use the trait for `impl GetAddress for Box`.