### PR TITLE
fix(ast)!: remove `AstKind::ExpressionArrayElement` and `AstKind::ClassHeritage`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1839,7 +1839,6 @@ pub struct Class<'a> {
     /// class Foo extends Bar {}
     /// //                ^^^
     /// ```
-    #[visit(as(ClassHeritage))]
     pub super_class: Option<Expression<'a>>,
     /// Type parameters passed to super class.
     ///

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -298,7 +298,6 @@ impl<'a> AstKind<'a> {
             Self::AssignmentTargetWithDefault(_) => "AssignmentTargetWithDefault".into(),
             Self::SpreadElement(_) => "SpreadElement".into(),
             Self::Elision(_) => "Elision".into(),
-            Self::ExpressionArrayElement(_) => "ExpressionArrayElement".into(),
             Self::BindingRestElement(_) => "BindingRestElement".into(),
 
             Self::Function(x) => format!("Function({})", or_anonymous(x.id.as_ref())).into(),
@@ -314,7 +313,6 @@ impl<'a> AstKind<'a> {
             Self::Class(c) => format!("Class({})", or_anonymous(c.id.as_ref())).into(),
             Self::TSClassImplements(_) => "TSClassImplements".into(),
             Self::ClassBody(_) => "ClassBody".into(),
-            Self::ClassHeritage(_) => "ClassHeritage".into(),
             Self::StaticBlock(_) => "StaticBlock".into(),
             Self::PropertyDefinition(_) => "PropertyDefinition".into(),
             Self::MethodDefinition(_) => "MethodDefinition".into(),

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -90,7 +90,6 @@ pub enum AstType {
     ArrowFunctionExpression,
     YieldExpression,
     Class,
-    ClassHeritage,
     ClassBody,
     MethodDefinition,
     PropertyDefinition,
@@ -175,7 +174,6 @@ pub enum AstType {
     JSXSpreadAttribute,
     JSXIdentifier,
     JSXText,
-    ExpressionArrayElement,
 }
 
 /// Untyped AST Node Kind
@@ -263,7 +261,6 @@ pub enum AstKind<'a> {
     ArrowFunctionExpression(&'a ArrowFunctionExpression<'a>),
     YieldExpression(&'a YieldExpression<'a>),
     Class(&'a Class<'a>),
-    ClassHeritage(&'a Expression<'a>),
     ClassBody(&'a ClassBody<'a>),
     MethodDefinition(&'a MethodDefinition<'a>),
     PropertyDefinition(&'a PropertyDefinition<'a>),
@@ -348,7 +345,6 @@ pub enum AstKind<'a> {
     JSXSpreadAttribute(&'a JSXSpreadAttribute<'a>),
     JSXIdentifier(&'a JSXIdentifier<'a>),
     JSXText(&'a JSXText<'a>),
-    ExpressionArrayElement(&'a Expression<'a>),
 }
 
 impl<'a> GetSpan for AstKind<'a> {
@@ -437,7 +433,6 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::ArrowFunctionExpression(it) => it.span(),
             Self::YieldExpression(it) => it.span(),
             Self::Class(it) => it.span(),
-            Self::ClassHeritage(it) => it.span(),
             Self::ClassBody(it) => it.span(),
             Self::MethodDefinition(it) => it.span(),
             Self::PropertyDefinition(it) => it.span(),
@@ -522,7 +517,6 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::JSXSpreadAttribute(it) => it.span(),
             Self::JSXIdentifier(it) => it.span(),
             Self::JSXText(it) => it.span(),
-            Self::ExpressionArrayElement(it) => it.span(),
         }
     }
 }
@@ -1260,15 +1254,6 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_class(&self) -> Option<&'a Class<'a>> {
         if let Self::Class(v) = self {
-            Some(*v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_class_heritage(&self) -> Option<&'a Expression<'a>> {
-        if let Self::ClassHeritage(v) = self {
             Some(*v)
         } else {
             None
@@ -2029,15 +2014,6 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_jsx_text(&self) -> Option<&'a JSXText<'a>> {
         if let Self::JSXText(v) = self {
-            Some(*v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_expression_array_element(&self) -> Option<&'a Expression<'a>> {
-        if let Self::ExpressionArrayElement(v) = self {
             Some(*v)
         } else {
             None

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -208,11 +208,6 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_expression_array_element(&mut self, it: &Expression<'a>) {
-        walk_expression_array_element(self, it);
-    }
-
-    #[inline]
     fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
         walk_arrow_function_expression(self, it);
     }
@@ -799,11 +794,6 @@ pub trait Visit<'a>: Sized {
     #[inline]
     fn visit_class(&mut self, it: &Class<'a>) {
         walk_class(self, it);
-    }
-
-    #[inline]
-    fn visit_class_heritage(&mut self, it: &Expression<'a>) {
-        walk_class_heritage(self, it);
     }
 
     #[inline]
@@ -1670,7 +1660,7 @@ pub mod walk {
             ArrayExpressionElement::SpreadElement(it) => visitor.visit_spread_element(it),
             ArrayExpressionElement::Elision(it) => visitor.visit_elision(it),
             match_expression!(ArrayExpressionElement) => {
-                visitor.visit_expression_array_element(it.to_expression())
+                visitor.visit_expression(it.to_expression())
             }
         }
         visitor.leave_node(kind);
@@ -1688,13 +1678,6 @@ pub mod walk {
     pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, it: &Elision) {
         let kind = AstKind::Elision(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_expression_array_element<'a, V: Visit<'a>>(visitor: &mut V, it: &Expression<'a>) {
-        let kind = AstKind::ExpressionArrayElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_expression(it);
         visitor.leave_node(kind);
     }
 
@@ -2950,7 +2933,7 @@ pub mod walk {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         if let Some(super_class) = &it.super_class {
-            visitor.visit_class_heritage(super_class);
+            visitor.visit_expression(super_class);
         }
         if let Some(super_type_parameters) = &it.super_type_parameters {
             visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
@@ -2960,13 +2943,6 @@ pub mod walk {
         }
         visitor.visit_class_body(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_class_heritage<'a, V: Visit<'a>>(visitor: &mut V, it: &Expression<'a>) {
-        let kind = AstKind::ClassHeritage(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_expression(it);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -200,11 +200,6 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_expression_array_element(&mut self, it: &mut Expression<'a>) {
-        walk_expression_array_element(self, it);
-    }
-
-    #[inline]
     fn visit_arrow_function_expression(&mut self, it: &mut ArrowFunctionExpression<'a>) {
         walk_arrow_function_expression(self, it);
     }
@@ -794,11 +789,6 @@ pub trait VisitMut<'a>: Sized {
     #[inline]
     fn visit_class(&mut self, it: &mut Class<'a>) {
         walk_class(self, it);
-    }
-
-    #[inline]
-    fn visit_class_heritage(&mut self, it: &mut Expression<'a>) {
-        walk_class_heritage(self, it);
     }
 
     #[inline]
@@ -1689,7 +1679,7 @@ pub mod walk_mut {
             ArrayExpressionElement::SpreadElement(it) => visitor.visit_spread_element(it),
             ArrayExpressionElement::Elision(it) => visitor.visit_elision(it),
             match_expression!(ArrayExpressionElement) => {
-                visitor.visit_expression_array_element(it.to_expression_mut())
+                visitor.visit_expression(it.to_expression_mut())
             }
         }
         visitor.leave_node(kind);
@@ -1707,16 +1697,6 @@ pub mod walk_mut {
     pub fn walk_elision<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Elision) {
         let kind = AstType::Elision;
         visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_expression_array_element<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Expression<'a>,
-    ) {
-        let kind = AstType::ExpressionArrayElement;
-        visitor.enter_node(kind);
-        visitor.visit_expression(it);
         visitor.leave_node(kind);
     }
 
@@ -3077,7 +3057,7 @@ pub mod walk_mut {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
         if let Some(super_class) = &mut it.super_class {
-            visitor.visit_class_heritage(super_class);
+            visitor.visit_expression(super_class);
         }
         if let Some(super_type_parameters) = &mut it.super_type_parameters {
             visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
@@ -3087,13 +3067,6 @@ pub mod walk_mut {
         }
         visitor.visit_class_body(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_class_heritage<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Expression<'a>) {
-        let kind = AstType::ClassHeritage;
-        visitor.enter_node(kind);
-        visitor.visit_expression(it);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -30,7 +30,6 @@ impl<'s, 'a> Symbol<'s, 'a> {
                 // e.g. `const x = [function foo() {}]`
                 // Only considered used if the array containing the symbol is used.
                 | AstKind::ArrayExpressionElement(_)
-                | AstKind::ExpressionArrayElement(_)
                 | AstKind::ArrayExpression(_)
                 // a ? b : function foo() {}
                 // Only considered used if the function is the test or the selected branch,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -199,7 +199,6 @@ impl<'s, 'a> Symbol<'s, 'a> {
                     return true;
                 }
                 AstKind::VariableDeclaration(_)
-                | AstKind::ExpressionArrayElement(_)
                 | AstKind::ArrayExpressionElement(_)
                 | AstKind::ArrayExpression(_)
                 | AstKind::ParenthesizedExpression(_)

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -293,12 +293,7 @@ fn get_parent_with_ignore<'a, 'b>(
     let mut node = node;
     loop {
         let parent = ctx.nodes().parent_node(node.id())?;
-        if !matches!(
-            parent.kind(),
-            AstKind::Argument(_)
-                | AstKind::ExpressionArrayElement(_)
-                | AstKind::ArrayExpressionElement(_)
-        ) {
+        if !matches!(parent.kind(), AstKind::Argument(_) | AstKind::ArrayExpressionElement(_)) {
             // we don't want to report `Promise.all([invalidExpectCall_1, invalidExpectCall_2])` twice.
             // so we need mark whether the node is the first item of an array.
             // if it not the first item, we ignore it in `find_promise_call_expression_node`.

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -57,7 +57,7 @@ impl Rule for PreferEventTarget {
         };
 
         match parent.kind() {
-            AstKind::ClassHeritage(_) => {}
+            AstKind::Class(_) => {}
             AstKind::NewExpression(new_expr) => {
                 let Expression::Identifier(callee_ident) = &new_expr.callee else {
                     return;

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -734,7 +734,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             self.visit_ts_type_parameter_declaration(type_parameters);
         }
         if let Some(super_class) = &class.super_class {
-            self.visit_class_heritage(super_class);
+            self.visit_expression(super_class);
         }
         if let Some(super_type_parameters) = &class.super_type_parameters {
             self.visit_ts_type_parameter_instantiation(super_type_parameters);

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -53,7 +53,7 @@ SCOPES
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 13
+            "node_id": 12
           }
         ]
       },
@@ -67,7 +67,7 @@ SCOPES
             "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
-            "node_id": 17
+            "node_id": 16
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
@@ -38,7 +38,7 @@ SCOPES
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 7
+            "node_id": 6
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -25,7 +25,7 @@ SCOPES
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
-                "node_id": 11
+                "node_id": 10
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -38,7 +38,7 @@ SCOPES
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
-            "node_id": 9
+            "node_id": 8
           }
         ]
       },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -25,7 +25,7 @@ SCOPES
                 "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "A",
-                "node_id": 7
+                "node_id": 6
               }
             ]
           }

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -84,11 +84,6 @@ pub fn blacklist((ident, _): &(Ident, Type)) -> bool {
     !BLACK_LIST.contains(&ident.to_string().as_str())
 }
 
-pub fn aliased_nodes() -> [(Ident, Type); 1] {
-    use syn::parse_quote as pq;
-    [(pq!(ExpressionArrayElement), pq!(Expression<'a>))]
-}
-
 pub fn process_types(def: &TypeDef, _: &LateCtx) -> Vec<(Ident, Type)> {
     let aliases = match def {
         TypeDef::Enum(enum_) => enum_
@@ -140,7 +135,6 @@ impl Generator for AstKindGenerator {
             )
             .flat_map(|it| process_types(it, ctx))
             .filter(blacklist)
-            .chain(aliased_nodes())
             .collect();
 
         let types: Vec<Variant> =


### PR DESCRIPTION
closes #6392