### PR TITLE
feat(linter): import/no-cycle should turn on ignore_types by default

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_cycle.snap
+++ b/crates/oxc_linter/src/snapshots/no_cycle.snap
@@ -264,15 +264,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[cycles/depth-zero.js:1:21]
- 1 │ import { foo } from "./typescript/ts-types-only-importing-type";
-   ·                     ───────────────────────────────────────────
-   ╰────
-  help: These paths form a cycle:
-        -> ./typescript/ts-types-only-importing-type - fixtures/import/cycles/typescript/ts-types-only-importing-type.ts
-        -> ../depth-zero - fixtures/import/cycles/depth-zero.js
-
-  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
-   ╭─[cycles/depth-zero.js:1:21]
  1 │ import { foo } from "./typescript/ts-types-some-type-imports";
    ·                     ─────────────────────────────────────────
    ╰────


### PR DESCRIPTION
closes #6759