### PR TITLE
fix(oxc_language_server): correct diagnostic link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
 name = "oxc_language_server"
 version = "0.0.1"
 dependencies = [
+ "cow-utils",
  "dashmap 6.1.0",
  "env_logger",
  "futures",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -29,6 +29,7 @@ oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 
+cow-utils = { workspace = true }
 dashmap = { workspace = true }
 env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }

--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use oxc_linter::loader::LINT_PARTIAL_LOADER_EXT;
 use std::{
     fs,
@@ -114,7 +115,11 @@ impl ErrorWithPosition {
         let code_description = code.as_ref().and_then(|code| {
             let (scope, number) = parse_diagnostic_code(code)?;
             Some(CodeDescription {
-                href: Url::from_str(&format!("{LINT_DOC_LINK_PREFIX}/{scope}/{number}")).ok()?,
+                href: Url::from_str(&format!(
+                    "{LINT_DOC_LINK_PREFIX}/{}/{number}",
+                    scope.strip_prefix("eslint-plugin-").unwrap_or(scope).cow_replace("-", "_")
+                ))
+                .ok()?,
             })
         });
         let message = self.miette_err.help().map_or_else(


### PR DESCRIPTION
Related to #6750 

The current correction may not be very good. I suggest that we unify the linter rule link of the website.
For example, changing `https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/alt-text.html` to `https://oxc.rs/docs/guide/usage/linter/rules/eslint-plugin-jsx-a11y/alt-text.html`