### PR TITLE
refactor(ast_tools): `TypeDef::name` return a `&str`

### DIFF
--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -86,7 +86,7 @@ impl Generator for AstKindGenerator {
             .into_iter()
             .filter(|def| {
                 let is_visitable = def.visitable();
-                let is_blacklisted = BLACK_LIST.contains(&def.name().as_str());
+                let is_blacklisted = BLACK_LIST.contains(&def.name());
                 is_visitable && !is_blacklisted
             })
             .map(|def| {

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -14,7 +14,7 @@ use crate::{
     markers::VisitArg,
     output,
     schema::{EnumDef, GetIdent, StructDef, ToType, TypeDef},
-    util::{StrExt, ToIdent, TokenStreamExt, TypeWrapper},
+    util::{StrExt, TokenStreamExt, TypeWrapper},
     Generator, GeneratorOutput,
 };
 
@@ -187,7 +187,7 @@ impl<'a> VisitBuilder<'a> {
         let (ident, as_type) = {
             debug_assert!(def.visitable(), "{def:?}");
 
-            let ident = def.name().to_ident();
+            let ident = def.ident();
             let as_type = def.to_type();
 
             (ident, if collection { parse_quote!(Vec<'a, #as_type>) } else { as_type })

--- a/tasks/ast_tools/src/schema/defs.rs
+++ b/tasks/ast_tools/src/schema/defs.rs
@@ -22,7 +22,7 @@ impl TypeDef {
         with_either!(self, it => it.id)
     }
 
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         with_either!(self, it => &it.name)
     }
 


### PR DESCRIPTION
It's generally an anti-pattern for functions to return `&String`. `&str` is preferable.