### PR TITLE
chore(tasks/lint_rules): sync rules with ESLint v9

### DIFF
--- a/tasks/lint_rules/package.json
+++ b/tasks/lint_rules/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@next/eslint-plugin-next": "latest",
     "@typescript-eslint/eslint-plugin": "latest",
-    "eslint": "latest",
+    "eslint": "^9.13.0",
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
     "eslint-plugin-jsdoc": "latest",
@@ -15,7 +15,7 @@
     "eslint-plugin-promise": "latest",
     "eslint-plugin-react": "latest",
     "eslint-plugin-react-hooks": "latest",
-    "eslint-plugin-react-perf": "latest",
+    "eslint-plugin-react-perf": "^3.3.3",
     "eslint-plugin-unicorn": "latest",
     "eslint-plugin-vitest": "latest"
   }

--- a/tasks/lint_rules/src/markdown-renderer.cjs
+++ b/tasks/lint_rules/src/markdown-renderer.cjs
@@ -129,7 +129,7 @@ exports.renderMarkdown = (pluginName, pluginMeta, ruleEntries) => {
     viewsRef.push({ name, ...entry });
 
     if (entry.isImplemented) counterRef.isImplemented++;
-    if (entry.isNotSupported) counterRef.isNotSupported++;
+    else if (entry.isNotSupported) counterRef.isNotSupported++;
     counterRef.total++;
   }
 


### PR DESCRIPTION
The previous version of the `react-perf` ESLint plugin was holding us back from updating this to ESLint V9. I've manually specified the ESLint version here, because we want to make sure we are running the latest major version of ESLint which changes a lot of things.

Also changed it so that rules which are not supported and also implemented do not get counted twice in the total count. For example, `eslint/no-with` is marked as not supported but it is still implemented. This was previously counted for both, which made it look like we had an additional rule implemented.