### PR TITLE
refactor(ast, transformer)!: remove `BlockStatement::new` methods

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -5,10 +5,7 @@ use std::{borrow::Cow, cell::Cell, fmt};
 use oxc_allocator::{Address, Box, FromIn, GetAddress, Vec};
 use oxc_span::{Atom, GetSpan, Span};
 use oxc_syntax::{
-    operator::UnaryOperator,
-    reference::ReferenceId,
-    scope::{ScopeFlags, ScopeId},
-    symbol::SymbolId,
+    operator::UnaryOperator, reference::ReferenceId, scope::ScopeFlags, symbol::SymbolId,
 };
 
 use crate::ast::*;
@@ -815,18 +812,6 @@ impl<'a> Directive<'a> {
     /// <https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive>
     pub fn is_use_strict(&self) -> bool {
         self.directive == "use strict"
-    }
-}
-
-impl<'a> BlockStatement<'a> {
-    #[allow(missing_docs)]
-    pub fn new(span: Span, body: Vec<'a, Statement<'a>>) -> Self {
-        Self { span, body, scope_id: Cell::default() }
-    }
-
-    #[allow(missing_docs)]
-    pub fn new_with_scope_id(span: Span, body: Vec<'a, Statement<'a>>, scope_id: ScopeId) -> Self {
-        Self { span, body, scope_id: Cell::new(Some(scope_id)) }
     }
 }
 

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -562,9 +562,8 @@ impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let scope_id = ctx.insert_scope_below_statement(&stmt, ScopeFlags::empty());
-        let block = BlockStatement::new_with_scope_id(span, ctx.ast.vec1(stmt), scope_id);
-        block.scope_id.set(Some(scope_id));
-        Statement::BlockStatement(ctx.ast.alloc(block))
+        let block = ctx.ast.alloc_block_statement_with_scope_id(span, ctx.ast.vec1(stmt), scope_id);
+        Statement::BlockStatement(block)
     }
 
     fn replace_for_statement_body_with_empty_block_if_ts(
@@ -583,8 +582,9 @@ impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
     ) {
         if stmt.is_typescript_syntax() {
             let scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
-            let block = BlockStatement::new_with_scope_id(stmt.span(), ctx.ast.vec(), scope_id);
-            *stmt = Statement::BlockStatement(ctx.ast.alloc(block));
+            let block =
+                ctx.ast.alloc_block_statement_with_scope_id(stmt.span(), ctx.ast.vec(), scope_id);
+            *stmt = Statement::BlockStatement(block);
         }
     }
 


### PR DESCRIPTION
First of a series of PRs removing `new` and `new_with_scope_id` etc methods from AST types. Following #6760, all AST node creation can now go via the AST builder.

This lays groundwork for Node IDs (#5689), as we'll need `NodeId`s to be generated in `AstBuilder`, so that all nodes receive an ID.