### PR TITLE
chore(minifier): remove duplicate minifier test

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
@@ -871,24 +871,6 @@ mod test {
 
     #[test]
     #[ignore]
-    fn test_object_literal() {
-        test("({})", "1");
-        test("({a:1})", "1");
-        test_same("({a:foo()})");
-        test_same("({'a':foo()})");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_array_literal() {
-        test("([])", "1");
-        test("([1])", "1");
-        test("([a])", "1");
-        test_same("([foo()])");
-    }
-
-    #[test]
-    #[ignore]
     fn test_remove_else_cause() {
         // test(
         // "function f() {" + " if(x) return 1;" + " else if(x) return 2;" + " else if(x) return 3 }",


### PR DESCRIPTION
these tests already exist below (and have been enabled)
https://github.com/oxc-project/oxc/blob/34fe7c00a393471309d336fcdcfef86402a9c8dc/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs#L576-L597

i suspect this was left in as a copy/pasta error