### PR TITLE
refactor(transformer): shorten code

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -15,7 +15,7 @@
 use std::cell::RefCell;
 
 use oxc_allocator::Vec;
-use oxc_ast::{ast::*, NONE};
+use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, TraverseCtx};
@@ -74,10 +74,8 @@ impl<'a> VarDeclarationsStore<'a> {
         init: Option<Expression<'a>>,
         ctx: &TraverseCtx<'a>,
     ) {
-        let ident = binding.create_binding_identifier(ctx);
-        let ident = ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
-        let ident = ctx.ast.binding_pattern(ident, NONE, false);
-        self.insert_binding_pattern(ident, init, ctx);
+        let pattern = binding.create_binding_pattern(ctx);
+        self.insert_binding_pattern(pattern, init, ctx);
     }
 
     /// Add a `VariableDeclarator` to be inserted at top of current enclosing statement block,

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -127,7 +127,7 @@
 use serde::Deserialize;
 
 use oxc_allocator::Vec;
-use oxc_ast::{ast::*, NONE};
+use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;
 use oxc_syntax::{
@@ -409,18 +409,10 @@ impl<'a> ArrowFunctions<'a> {
         this_var: &BoundIdentifier<'a>,
         ctx: &TraverseCtx<'a>,
     ) {
-        let binding_pattern = ctx.ast.binding_pattern(
-            ctx.ast.binding_pattern_kind_from_binding_identifier(
-                this_var.create_binding_identifier(ctx),
-            ),
-            NONE,
-            false,
-        );
-
         let variable_declarator = ctx.ast.variable_declarator(
             SPAN,
             VariableDeclarationKind::Var,
-            binding_pattern,
+            this_var.create_binding_pattern(ctx),
             Some(ctx.ast.expression_this(SPAN)),
             false,
         );

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -35,7 +35,7 @@
 
 use ropey::Rope;
 
-use oxc_ast::{ast::*, NONE};
+use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};
@@ -205,17 +205,10 @@ impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
     ) -> Option<VariableDeclarator<'a>> {
         let filename_var = self.filename_var.as_ref()?;
 
-        let var_kind = VariableDeclarationKind::Var;
-        let id = {
-            let ident = filename_var.create_binding_identifier(ctx);
-            let ident = ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
-            ctx.ast.binding_pattern(ident, NONE, false)
-        };
-        let decl = {
-            let init =
-                ctx.ast.expression_string_literal(SPAN, self.ctx.source_path.to_string_lossy());
-            ctx.ast.variable_declarator(SPAN, var_kind, id, Some(init), false)
-        };
+        let id = filename_var.create_binding_pattern(ctx);
+        let init = ctx.ast.expression_string_literal(SPAN, self.ctx.source_path.to_string_lossy());
+        let decl =
+            ctx.ast.variable_declarator(SPAN, VariableDeclarationKind::Var, id, Some(init), false);
         Some(decl)
     }
 


### PR DESCRIPTION
Use `BoundIdentifier::create_binding_pattern`, rather than writing out the code to create a `BindingPattern` manually each time.