### PR TITLE
refactor(transformer): methods only take `&TraverseCtx` where possible

### DIFF
--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -193,7 +193,7 @@ impl<'a> ModuleImportsStore<'a> {
     fn get_import(
         source: Atom<'a>,
         names: Vec<Import<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
         let specifiers = ctx.ast.vec_from_iter(names.into_iter().map(|import| match import {
             Import::Named(import) => {

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -72,7 +72,7 @@ impl<'a> VarDeclarationsStore<'a> {
         &self,
         binding: &BoundIdentifier<'a>,
         init: Option<Expression<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         let ident = binding.create_binding_identifier(ctx);
         let ident = ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
@@ -86,7 +86,7 @@ impl<'a> VarDeclarationsStore<'a> {
         &self,
         ident: BindingPattern<'a>,
         init: Option<Expression<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         let declarator =
             ctx.ast.variable_declarator(SPAN, VariableDeclarationKind::Var, ident, init, false);
@@ -94,7 +94,7 @@ impl<'a> VarDeclarationsStore<'a> {
     }
 
     /// Add a `VariableDeclarator` to be inserted at top of current enclosing statement block.
-    pub fn insert_declarator(&self, declarator: VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
+    pub fn insert_declarator(&self, declarator: VariableDeclarator<'a>, ctx: &TraverseCtx<'a>) {
         let mut stack = self.stack.borrow_mut();
         stack.last_mut_or_init(|| ctx.ast.vec()).push(declarator);
     }

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -407,7 +407,7 @@ impl<'a> ArrowFunctions<'a> {
         &mut self,
         statements: &mut Vec<'a, Statement<'a>>,
         this_var: &BoundIdentifier<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         let binding_pattern = ctx.ast.binding_pattern(
             ctx.ast.binding_pattern_kind_from_binding_identifier(

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -201,7 +201,7 @@ impl<'a, 'ctx> ReactJsxSource<'a, 'ctx> {
 
     pub fn get_filename_var_declarator(
         &self,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Option<VariableDeclarator<'a>> {
         let filename_var = self.filename_var.as_ref()?;
 


### PR DESCRIPTION
Methods which only need an immutable ref `&TraverseCtx` take that, instead of unnecessary `&mut TraverseCtx`.