### PR TITLE
refactor(transformer/react-refresh): dereference `ScopeId` as soon as possible

### DIFF
--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -646,7 +646,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         let target_scope_id = ctx
             .scopes()
             .ancestors(ctx.current_scope_id())
-            .find(|scope_id| ctx.scopes().get_flags(*scope_id).is_var())
+            .find(|&scope_id| ctx.scopes().get_flags(scope_id).is_var())
             .unwrap_or_else(|| ctx.current_scope_id());
 
         let binding = ctx.generate_uid("s", target_scope_id, SymbolFlags::FunctionScopedVariable);


### PR DESCRIPTION
Style nit. Dereference `&ScopeId` to `ScopeId` as early as possible. `&ScopeId` is 8 bytes, whereas `ScopeId` is 4 bytes.

In simple cases like this, compiler will optimize it anyway, but still I think it's a better pattern to dererence early. In more complicated cases, it will be better for performance, and in my opinion, it makes things clearer if vars called `scope_id` are always a `ScopeId`, not sometimes a `&ScopeId`.