### PR TITLE
refactor(minifier): dereference `SymbolId` as soon as possible

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -190,8 +190,8 @@ impl Mangler {
 
             // rename the variables
             for (symbol_to_rename, new_name) in symbols_to_rename_with_new_names {
-                for symbol_id in &symbol_to_rename.symbol_ids {
-                    symbol_table.set_name(*symbol_id, new_name.clone());
+                for &symbol_id in &symbol_to_rename.symbol_ids {
+                    symbol_table.set_name(symbol_id, new_name.clone());
                 }
             }
         }


### PR DESCRIPTION
Style nit. Dereference `&SymbolId` to `SymbolId` as early as possible. `&SymbolId` is 8 bytes, whereas `SymbolId` is 4 bytes.

In simple cases like these, compiler will optimize it anyway, but still I think it's a better pattern to dererence early. In more complicated cases, it will be better for performance, and in my opinion, it makes things clearer if vars called `symbol_id` are always a `SymbolId`, and not sometimes a `&SymbolId`.