### PR TITLE
refactor(traverse): `TraverseCtx::generate_binding` take an `Atom`

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -77,7 +77,7 @@ impl<'a> TypeScriptEnum<'a> {
         let enum_name = decl.id.name.clone();
         let func_scope_id = decl.scope_id.get().unwrap();
         let param_ident = ctx.generate_binding(
-            enum_name.to_compact_str(),
+            enum_name.clone(),
             func_scope_id,
             SymbolFlags::FunctionScopedVariable,
         );

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -306,18 +306,23 @@ impl<'a> TraverseCtx<'a> {
     /// Creates a symbol with the provided name and flags and adds it to the specified scope.
     pub fn generate_binding(
         &mut self,
-        name: CompactStr,
+        name: Atom<'a>,
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
-        let name_atom = self.ast.atom(&name);
+        let owned_name = name.to_compact_str();
 
         // Add binding to scope
-        let symbol_id =
-            self.symbols_mut().create_symbol(SPAN, name.clone(), flags, scope_id, NodeId::DUMMY);
-        self.scopes_mut().add_binding(scope_id, name, symbol_id);
+        let symbol_id = self.symbols_mut().create_symbol(
+            SPAN,
+            owned_name.clone(),
+            flags,
+            scope_id,
+            NodeId::DUMMY,
+        );
+        self.scopes_mut().add_binding(scope_id, owned_name, symbol_id);
 
-        BoundIdentifier::new(name_atom, symbol_id)
+        BoundIdentifier::new(name, symbol_id)
     }
 
     /// Generate binding in current scope.
@@ -325,7 +330,7 @@ impl<'a> TraverseCtx<'a> {
     /// Creates a symbol with the provided name and flags and adds it to the current scope.
     pub fn generate_in_current_scope(
         &mut self,
-        name: CompactStr,
+        name: Atom<'a>,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
         self.generate_binding(name, self.current_scope_id(), flags)
@@ -356,7 +361,14 @@ impl<'a> TraverseCtx<'a> {
     ) -> BoundIdentifier<'a> {
         // Get name for UID
         let name = self.generate_uid_name(name);
-        self.generate_binding(name, scope_id, flags)
+        let name_atom = self.ast.atom(&name);
+
+        // Add binding to scope
+        let symbol_id =
+            self.symbols_mut().create_symbol(SPAN, name.clone(), flags, scope_id, NodeId::DUMMY);
+        self.scopes_mut().add_binding(scope_id, name, symbol_id);
+
+        BoundIdentifier::new(name_atom, symbol_id)
     }
 
     /// Generate UID in current scope.


### PR DESCRIPTION
Follow-up after #6805.

`TraverseCtx::generate_binding` take an `Atom` instead of a `CompactStr`. If it's an existing var name (which it must be, otherwise we'd be using `TraverseCtx::generate_uid`), an `Atom` will already exist in the arena for this symbol name, so we'd be better off reusing it, rather than writing the same `Atom` into the arena again.