### PR TITLE
refactor(traverse): rename `TraverseScoping::generate_binding_in_current_scope`

### DIFF
--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -319,13 +319,13 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// Creates a symbol with the provided name and flags and adds it to the current scope.
     ///
-    /// This is a shortcut for `ctx.scoping.generate_in_current_scope`.
-    pub fn generate_in_current_scope(
+    /// This is a shortcut for `ctx.scoping.generate_binding_in_current_scope`.
+    pub fn generate_binding_in_current_scope(
         &mut self,
         name: Atom<'a>,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
-        self.scoping.generate_in_current_scope(name, flags)
+        self.scoping.generate_binding_in_current_scope(name, flags)
     }
 
     /// Generate UID var name.

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -187,7 +187,7 @@ impl TraverseScoping {
     /// Generate binding in current scope.
     ///
     /// Creates a symbol with the provided name and flags and adds it to the current scope.
-    pub fn generate_in_current_scope<'a>(
+    pub fn generate_binding_in_current_scope<'a>(
         &mut self,
         name: Atom<'a>,
         flags: SymbolFlags,


### PR DESCRIPTION
Rename `generate_in_current_scope` to `generate_binding_in_current_scope` - more descriptive name.