### PR TITLE
docs(napi): simplify + reformat README

### DIFF
--- a/npm/oxc-parser/README.md
+++ b/npm/oxc-parser/README.md
@@ -1,29 +1,22 @@
 # The JavaScript Oxidation Compiler
 
-See index.d.ts for `parseSync` and `parseAsync` API.
-
-## ESM
+See `index.d.ts` for `parseSync` and `parseAsync` API.
 
 ```javascript
 import assert from 'assert';
 import oxc from 'oxc-parser';
+
+const sourceText = "let foo: Foo = 'foo';";
+// Filename extension is used to determine which
+// dialect to parse source as
+const options = { sourceFilename: 'text.tsx' };
+
+test(oxc.parseSync(sourceText, options));
+test(await oxc.parseAsync(sourceText, options));
 
 function test(ret) {
   const program = JSON.parse(ret.program);
   assert(program.body.length == 1);
   assert(ret.errors.length == 0);
 }
-
-const sourceText = "let foo: Foo = 'foo';";
-const options = {
-  sourceFilename: 'text.tsx', // the extension is used to determine which dialect to parse
-};
-
-test(oxc.parseSync(sourceText, options));
-
-async function main() {
-  test(await oxc.parseAsync(sourceText, options));
-}
-
-main();
 ```


### PR DESCRIPTION
In particular:

* the long comment was scrolling off side of screen on [npm.com](https://www.npmjs.com/package/oxc-parser).
* the example is ESM, so can simplify it by using top level await.