### PR TITLE
chore(linter): add line break for consistent

### DIFF
--- a/crates/oxc_linter/src/rules/node/no_new_require.rs
+++ b/crates/oxc_linter/src/rules/node/no_new_require.rs
@@ -37,7 +37,8 @@ declare_oxc_lint!(
     /// var appHeader = new AppHeader();
     /// ```
     NoNewRequire,
-    restriction);
+    restriction
+);
 
 impl Rule for NoNewRequire {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
This regex expects always a line break before the closing bracet: https://github.com/oxc-project/eslint-plugin-oxlint/blob/main/scripts/traverse-rules.ts#L110