### PR TITLE
refactor(transformer): `StatementInjectorStore::insert_many_after` take an iterator

### DIFF
--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -86,7 +86,10 @@ impl<'a> StatementInjectorStore<'a> {
     }
 
     /// Add multiple statements to be inserted immediately after the target statement.
-    pub fn insert_many_after(&self, target: Address, stmts: Vec<Statement<'a>>) {
+    pub fn insert_many_after<S>(&self, target: Address, stmts: S)
+    where
+        S: IntoIterator<Item = Statement<'a>>,
+    {
         let mut insertions = self.insertions.borrow_mut();
         let adjacent_stmts = insertions.entry(target).or_default();
         adjacent_stmts.extend(

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -417,8 +417,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
             stmt.address(),
             self.assignments
                 .iter()
-                .map(|assignment| assignment.create_this_property_assignment(ctx))
-                .collect::<Vec<_>>(),
+                .map(|assignment| assignment.create_this_property_assignment(ctx)),
         );
         self.has_super_call = true;
     }


### PR DESCRIPTION
Follow-on after #6654.

Taking an `IntoIterator` avoids caller needing to construct a temporary `Vec`.