### PR TITLE
refactor(transformer): `StatementInjectorStore` methods take `&Statement` as target

### DIFF
--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -67,9 +67,9 @@ impl<'a> StatementInjectorStore<'a> {
 
     /// Add a statement to be inserted immediately before the target statement.
     #[expect(dead_code)]
-    pub fn insert_before(&self, target: Address, stmt: Statement<'a>) {
+    pub fn insert_before(&self, target: &Statement<'a>, stmt: Statement<'a>) {
         let mut insertions = self.insertions.borrow_mut();
-        let adjacent_stmts = insertions.entry(target).or_default();
+        let adjacent_stmts = insertions.entry(target.address()).or_default();
         let index = adjacent_stmts
             .iter()
             .position(|s| matches!(s.direction, Direction::After))
@@ -79,20 +79,20 @@ impl<'a> StatementInjectorStore<'a> {
 
     /// Add a statement to be inserted immediately after the target statement.
     #[expect(dead_code)]
-    pub fn insert_after(&self, target: Address, stmt: Statement<'a>) {
+    pub fn insert_after(&self, target: &Statement<'a>, stmt: Statement<'a>) {
         let mut insertions = self.insertions.borrow_mut();
-        let adjacent_stmts = insertions.entry(target).or_default();
+        let adjacent_stmts = insertions.entry(target.address()).or_default();
         adjacent_stmts.push(AdjacentStatement { stmt, direction: Direction::After });
     }
 
     /// Add multiple statements to be inserted immediately before the target statement.
     #[expect(dead_code)]
-    pub fn insert_many_before<S>(&self, target: Address, stmts: S)
+    pub fn insert_many_before<S>(&self, target: &Statement<'a>, stmts: S)
     where
         S: IntoIterator<Item = Statement<'a>>,
     {
         let mut insertions = self.insertions.borrow_mut();
-        let adjacent_stmts = insertions.entry(target).or_default();
+        let adjacent_stmts = insertions.entry(target.address()).or_default();
         adjacent_stmts.splice(
             0..0,
             stmts.into_iter().map(|stmt| AdjacentStatement { stmt, direction: Direction::Before }),
@@ -100,12 +100,12 @@ impl<'a> StatementInjectorStore<'a> {
     }
 
     /// Add multiple statements to be inserted immediately after the target statement.
-    pub fn insert_many_after<S>(&self, target: Address, stmts: S)
+    pub fn insert_many_after<S>(&self, target: &Statement<'a>, stmts: S)
     where
         S: IntoIterator<Item = Statement<'a>>,
     {
         let mut insertions = self.insertions.borrow_mut();
-        let adjacent_stmts = insertions.entry(target).or_default();
+        let adjacent_stmts = insertions.entry(target.address()).or_default();
         adjacent_stmts.extend(
             stmts.into_iter().map(|stmt| AdjacentStatement { stmt, direction: Direction::After }),
         );

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{GetAddress, Vec as ArenaVec};
+use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolFlags;
@@ -414,7 +414,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
 
         // Add assignments after super calls
         self.ctx.statement_injector.insert_many_after(
-            stmt.address(),
+            stmt,
             self.assignments
                 .iter()
                 .map(|assignment| assignment.create_this_property_assignment(ctx)),


### PR DESCRIPTION
This makes the use of `Address` an internal implementation detail of `StatementInjectorStore`. The caller shouldn't need to care about how `StatementInjectorStore` achieves its work. In future it might use `NodeId`, for instance.

We could broaden this in future so these methods take an `&A where A: GetAddress` if we need to, but for now taking a `&Statement` seems OK.