### PR TITLE
fix(types): Change @oxc/types package name

### DIFF
--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -1,4 +1,4 @@
-name: Release @oxc/types
+name: Release @oxc-project/types
 
 on:
   workflow_dispatch:
@@ -27,7 +27,7 @@ jobs:
         id: version
         with:
           static-checking: localIsNew
-          file-url: https://unpkg.com/@oxc/types/package.json
+          file-url: https://unpkg.com/@oxc-project/types/package.json
           file-name: npm/oxc-types/package.json
 
       - name: Set version name
@@ -38,7 +38,7 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
-    name: Release @oxc/types
+    name: Release @oxc-project/types
     runs-on: ubuntu-latest
     permissions:
       id-token: write # for `pnpm publish --provenance`

--- a/crates/oxc/src/napi/parse.rs
+++ b/crates/oxc/src/napi/parse.rs
@@ -21,7 +21,7 @@ pub struct ParserOptions {
 
 #[napi(object)]
 pub struct ParseResult {
-    #[napi(ts_type = "import(\"@oxc/types\").Program")]
+    #[napi(ts_type = "import(\"@oxc-project/types\").Program")]
     pub program: String,
     pub comments: Vec<Comment>,
     pub errors: Vec<String>,

--- a/crates/oxc_wasm/package.json
+++ b/crates/oxc_wasm/package.json
@@ -13,7 +13,7 @@
     "oxc_wasm.d.ts"
   ],
   "devDependencies": {
-    "@oxc/types": "workspace:^"
+    "@oxc-project/types": "workspace:^"
   },
   "main": "oxc_wasm.js",
   "types": "oxc_wasm.d.ts",

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -34,8 +34,8 @@ use crate::options::{OxcOptions, OxcRunOptions};
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
-import type { Program, Span } from "@oxc/types";
-export * from "@oxc/types";
+import type { Program, Span } from "@oxc-project/types";
+export * from "@oxc-project/types";
 "#;
 
 #[wasm_bindgen(getter_with_clone)]

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -91,7 +91,7 @@ export declare function moduleLexerSync(sourceText: string, options?: ParserOpti
 export declare function parseAsync(sourceText: string, options?: ParserOptions | undefined | null): Promise<ParseResult>
 
 export interface ParseResult {
-  program: import("@oxc/types").Program
+  program: import("@oxc-project/types").Program
   comments: Array<Comment>
   errors: Array<string>
 }

--- a/npm/oxc-parser/package.json
+++ b/npm/oxc-parser/package.json
@@ -24,6 +24,6 @@
     "bindings.js"
   ],
   "devDependencies": {
-    "@oxc/types": "workspace:^"
+    "@oxc-project/types": "workspace:^"
   }
 }

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@oxc/types",
+  "name": "@oxc-project/types",
   "version": "0.32.0",
   "description": "Types for Oxc AST nodes",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
 
   npm/oxc-parser:
     devDependencies:
-      '@oxc/types':
+      '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
 
@@ -70,7 +70,7 @@ importers:
 
   npm/oxc-wasm:
     devDependencies:
-      '@oxc/types':
+      '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
 
@@ -78,7 +78,7 @@ importers:
 
   npm/parser-wasm:
     devDependencies:
-      '@oxc/types':
+      '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
 
@@ -96,7 +96,7 @@ importers:
 
   wasm/parser:
     devDependencies:
-      '@oxc/types':
+      '@oxc-project/types':
         specifier: workspace:^
         version: link:../../npm/oxc-types
 

--- a/wasm/parser/package.json
+++ b/wasm/parser/package.json
@@ -27,7 +27,7 @@
     "web"
   ],
   "devDependencies": {
-    "@oxc/types": "workspace:^"
+    "@oxc-project/types": "workspace:^"
   },
   "scripts": {
     "build": "pnpm run build-node && pnpm run build-web && pnpm run copy-files && pnpm run clean-files",

--- a/wasm/parser/src/lib.rs
+++ b/wasm/parser/src/lib.rs
@@ -9,8 +9,8 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
-import type { Program } from "@oxc/types";
-export * from "@oxc/types";
+import type { Program } from "@oxc-project/types";
+export * from "@oxc-project/types";
 "#;
 
 #[derive(Debug, Default, Clone, Deserialize, Tsify)]


### PR DESCRIPTION
Closes #6862.

Possible options:
- `oxc-types`
- `@oxc-project/types`
- `@oxc-ast/types`
- `oxc-ast-types`