### PR TITLE
feat(allocator): add `AsArenaRef` trait

### DIFF
--- a/crates/oxc_allocator/src/arena_ref.rs
+++ b/crates/oxc_allocator/src/arena_ref.rs
@@ -1,0 +1,30 @@
+use crate::Box;
+use std::borrow::Cow;
+
+/// Cheap reference-to-reference conversion for
+/// [arena](crate::Allocator)-allocated types.
+///
+/// This trait is functionally equivalent to [`AsRef`] except
+/// 1. No `&` syntax sugar
+/// 2. Borrows are for the lifetime of the arena (`'alloc`)
+pub trait AsArenaRef<'alloc, T: ?Sized> {
+    /// Converts this type into a shared reference of the (usually inferred) input type.
+    fn as_arena_ref(&'alloc self) -> &'alloc T;
+}
+
+impl<'alloc, T: ?Sized> AsArenaRef<'alloc, T> for Box<'alloc, T> {
+    #[inline]
+    fn as_arena_ref(&'alloc self) -> &'alloc T {
+        self
+    }
+}
+
+impl<'alloc, T: ?Sized + 'alloc> AsArenaRef<'alloc, T> for Cow<'alloc, T>
+where
+    T: ToOwned,
+{
+    #[inline]
+    fn as_arena_ref(&'alloc self) -> &'alloc T {
+        self
+    }
+}

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -48,12 +48,14 @@ pub use bumpalo::collections::String;
 use bumpalo::Bump;
 
 mod address;
+mod arena_ref;
 mod boxed;
 mod clone_in;
 mod convert;
 mod vec;
 
 pub use address::{Address, GetAddress};
+pub use arena_ref::AsArenaRef;
 pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use oxc_allocator::{Allocator, CloneIn, FromIn};
+use oxc_allocator::{Allocator, AsArenaRef, CloneIn, FromIn};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
@@ -138,6 +138,12 @@ impl<'a> Deref for Atom<'a> {
 
 impl<'a> AsRef<str> for Atom<'a> {
     fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a> AsArenaRef<'a, str> for Atom<'a> {
+    fn as_arena_ref(&'a self) -> &'a str {
         self.as_str()
     }
 }


### PR DESCRIPTION
Adds a new trait `AsArenaRef<'alloc, T>` that allows `AsRef`-like borrows for `&'alloc T` instead of `&T`. See #6873 for details.