### PR TITLE
feat(traverse): implement `GetAddress` for `Ancestor`

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -3,12 +3,29 @@ use std::ptr;
 use crate::Box;
 
 /// Memory address of an AST node in arena.
-///
-/// `Address` is generated from a `Box<T>`.
-/// AST nodes in a `Box` in an arena are guaranteed to never move in memory,
-/// so this address acts as a unique identifier for the duration of the arena's existence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Address(usize);
+
+impl Address {
+    /// Dummy address.
+    ///
+    /// Never equal to any real `Address`, but is equal to itself.
+    pub const DUMMY: Self = Self(0);
+
+    /// Get the memory address of a pointer to an AST node in arena.
+    ///
+    /// The pointer must point to an AST node in the arena (not on the stack),
+    /// or the returned `Address` will be meaningless.
+    ///
+    /// If the AST node is in a `Box`, the address is guaranteed to be a unique identifier
+    /// for the duration of the arena's existence.
+    /// If the node is in a `Vec`, then the `Address` may not remain accurate if the `Vec`
+    /// is resized or has elements added or removed before this node.
+    #[inline]
+    pub fn from_ptr<T>(p: *const T) -> Self {
+        Self(p as usize)
+    }
+}
 
 /// Trait for getting the memory address of an AST node.
 pub trait GetAddress {
@@ -18,8 +35,11 @@ pub trait GetAddress {
 
 impl<'a, T> GetAddress for Box<'a, T> {
     /// Get the memory address of a value allocated in the arena.
+    ///
+    /// AST nodes in a `Box` in an arena are guaranteed to never move in memory,
+    /// so this address acts as a unique identifier for the duration of the arena's existence.
     #[inline]
     fn address(&self) -> Address {
-        Address(ptr::addr_of!(**self) as usize)
+        Address::from_ptr(ptr::addr_of!(**self))
     }
 }

--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -9,6 +9,7 @@ export default function generateAncestorsCode(types) {
     ancestorEnumVariants = '',
     isFunctions = '',
     ancestorTypes = '',
+    addressMatchArms = '',
     discriminant = 1;
   for (const type of Object.values(types)) {
     if (type.kind === 'enum') continue;
@@ -62,6 +63,13 @@ export default function generateAncestorsCode(types) {
         impl${lifetimes} ${structName} {
           ${methodsCode}
         }
+
+        impl${lifetimes} GetAddress for ${structName} {
+          #[inline]
+          fn address(&self) -> Address {
+            Address::from_ptr(self.0)
+          }
+        }
       `;
 
       const variantName = `${type.name}${fieldNameCamel}`;
@@ -75,6 +83,8 @@ export default function generateAncestorsCode(types) {
         (variantNamesForEnums[fieldTypeName] || (variantNamesForEnums[fieldTypeName] = []))
           .push(variantName);
       }
+
+      addressMatchArms += `Self::${variantName}(a) => a.address(),\n`;
     }
 
     if (variantNames.length > 0) {
@@ -114,7 +124,7 @@ export default function generateAncestorsCode(types) {
 
     use memoffset::offset_of;
 
-    use oxc_allocator::{Box, Vec};
+    use oxc_allocator::{Address, Box, GetAddress, Vec};
     use oxc_ast::ast::*;
     use oxc_syntax::scope::ScopeId;
 
@@ -155,6 +165,18 @@ export default function generateAncestorsCode(types) {
 
     impl<'a, 't> Ancestor<'a, 't> {
       ${isFunctions}
+    }
+
+    impl<'a, 't> GetAddress for Ancestor<'a, 't> {
+      /// Get memory address of node represented by \`Ancestor\` in the arena.
+      // Compiler should reduce this down to only a couple of assembly operations.
+      #[inline]
+      fn address(&self) -> Address {
+        match self {
+          Self::None => Address::DUMMY,
+          ${addressMatchArms}
+        }
+      }
     }
 
     ${ancestorTypes}

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -14,7 +14,7 @@ use std::{cell::Cell, marker::PhantomData};
 
 use memoffset::offset_of;
 
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{Address, Box, GetAddress, Vec};
 use oxc_ast::ast::*;
 use oxc_syntax::scope::ScopeId;
 
@@ -2198,6 +2198,311 @@ impl<'a, 't> Ancestor<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for Ancestor<'a, 't> {
+    /// Get memory address of node represented by `Ancestor` in the arena.
+    // Compiler should reduce this down to only a couple of assembly operations.
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::None => Address::DUMMY,
+            Self::ProgramHashbang(a) => a.address(),
+            Self::ProgramDirectives(a) => a.address(),
+            Self::ProgramBody(a) => a.address(),
+            Self::ArrayExpressionElements(a) => a.address(),
+            Self::ObjectExpressionProperties(a) => a.address(),
+            Self::ObjectPropertyKey(a) => a.address(),
+            Self::ObjectPropertyValue(a) => a.address(),
+            Self::ObjectPropertyInit(a) => a.address(),
+            Self::TemplateLiteralQuasis(a) => a.address(),
+            Self::TemplateLiteralExpressions(a) => a.address(),
+            Self::TaggedTemplateExpressionTag(a) => a.address(),
+            Self::TaggedTemplateExpressionQuasi(a) => a.address(),
+            Self::TaggedTemplateExpressionTypeParameters(a) => a.address(),
+            Self::ComputedMemberExpressionObject(a) => a.address(),
+            Self::ComputedMemberExpressionExpression(a) => a.address(),
+            Self::StaticMemberExpressionObject(a) => a.address(),
+            Self::StaticMemberExpressionProperty(a) => a.address(),
+            Self::PrivateFieldExpressionObject(a) => a.address(),
+            Self::PrivateFieldExpressionField(a) => a.address(),
+            Self::CallExpressionCallee(a) => a.address(),
+            Self::CallExpressionTypeParameters(a) => a.address(),
+            Self::CallExpressionArguments(a) => a.address(),
+            Self::NewExpressionCallee(a) => a.address(),
+            Self::NewExpressionArguments(a) => a.address(),
+            Self::NewExpressionTypeParameters(a) => a.address(),
+            Self::MetaPropertyMeta(a) => a.address(),
+            Self::MetaPropertyProperty(a) => a.address(),
+            Self::SpreadElementArgument(a) => a.address(),
+            Self::UpdateExpressionArgument(a) => a.address(),
+            Self::UnaryExpressionArgument(a) => a.address(),
+            Self::BinaryExpressionLeft(a) => a.address(),
+            Self::BinaryExpressionRight(a) => a.address(),
+            Self::PrivateInExpressionLeft(a) => a.address(),
+            Self::PrivateInExpressionRight(a) => a.address(),
+            Self::LogicalExpressionLeft(a) => a.address(),
+            Self::LogicalExpressionRight(a) => a.address(),
+            Self::ConditionalExpressionTest(a) => a.address(),
+            Self::ConditionalExpressionConsequent(a) => a.address(),
+            Self::ConditionalExpressionAlternate(a) => a.address(),
+            Self::AssignmentExpressionLeft(a) => a.address(),
+            Self::AssignmentExpressionRight(a) => a.address(),
+            Self::ArrayAssignmentTargetElements(a) => a.address(),
+            Self::ArrayAssignmentTargetRest(a) => a.address(),
+            Self::ObjectAssignmentTargetProperties(a) => a.address(),
+            Self::ObjectAssignmentTargetRest(a) => a.address(),
+            Self::AssignmentTargetRestTarget(a) => a.address(),
+            Self::AssignmentTargetWithDefaultBinding(a) => a.address(),
+            Self::AssignmentTargetWithDefaultInit(a) => a.address(),
+            Self::AssignmentTargetPropertyIdentifierBinding(a) => a.address(),
+            Self::AssignmentTargetPropertyIdentifierInit(a) => a.address(),
+            Self::AssignmentTargetPropertyPropertyName(a) => a.address(),
+            Self::AssignmentTargetPropertyPropertyBinding(a) => a.address(),
+            Self::SequenceExpressionExpressions(a) => a.address(),
+            Self::AwaitExpressionArgument(a) => a.address(),
+            Self::ChainExpressionExpression(a) => a.address(),
+            Self::ParenthesizedExpressionExpression(a) => a.address(),
+            Self::DirectiveExpression(a) => a.address(),
+            Self::BlockStatementBody(a) => a.address(),
+            Self::VariableDeclarationDeclarations(a) => a.address(),
+            Self::VariableDeclaratorId(a) => a.address(),
+            Self::VariableDeclaratorInit(a) => a.address(),
+            Self::ExpressionStatementExpression(a) => a.address(),
+            Self::IfStatementTest(a) => a.address(),
+            Self::IfStatementConsequent(a) => a.address(),
+            Self::IfStatementAlternate(a) => a.address(),
+            Self::DoWhileStatementBody(a) => a.address(),
+            Self::DoWhileStatementTest(a) => a.address(),
+            Self::WhileStatementTest(a) => a.address(),
+            Self::WhileStatementBody(a) => a.address(),
+            Self::ForStatementInit(a) => a.address(),
+            Self::ForStatementTest(a) => a.address(),
+            Self::ForStatementUpdate(a) => a.address(),
+            Self::ForStatementBody(a) => a.address(),
+            Self::ForInStatementLeft(a) => a.address(),
+            Self::ForInStatementRight(a) => a.address(),
+            Self::ForInStatementBody(a) => a.address(),
+            Self::ForOfStatementLeft(a) => a.address(),
+            Self::ForOfStatementRight(a) => a.address(),
+            Self::ForOfStatementBody(a) => a.address(),
+            Self::ContinueStatementLabel(a) => a.address(),
+            Self::BreakStatementLabel(a) => a.address(),
+            Self::ReturnStatementArgument(a) => a.address(),
+            Self::WithStatementObject(a) => a.address(),
+            Self::WithStatementBody(a) => a.address(),
+            Self::SwitchStatementDiscriminant(a) => a.address(),
+            Self::SwitchStatementCases(a) => a.address(),
+            Self::SwitchCaseTest(a) => a.address(),
+            Self::SwitchCaseConsequent(a) => a.address(),
+            Self::LabeledStatementLabel(a) => a.address(),
+            Self::LabeledStatementBody(a) => a.address(),
+            Self::ThrowStatementArgument(a) => a.address(),
+            Self::TryStatementBlock(a) => a.address(),
+            Self::TryStatementHandler(a) => a.address(),
+            Self::TryStatementFinalizer(a) => a.address(),
+            Self::CatchClauseParam(a) => a.address(),
+            Self::CatchClauseBody(a) => a.address(),
+            Self::CatchParameterPattern(a) => a.address(),
+            Self::BindingPatternKind(a) => a.address(),
+            Self::BindingPatternTypeAnnotation(a) => a.address(),
+            Self::AssignmentPatternLeft(a) => a.address(),
+            Self::AssignmentPatternRight(a) => a.address(),
+            Self::ObjectPatternProperties(a) => a.address(),
+            Self::ObjectPatternRest(a) => a.address(),
+            Self::BindingPropertyKey(a) => a.address(),
+            Self::BindingPropertyValue(a) => a.address(),
+            Self::ArrayPatternElements(a) => a.address(),
+            Self::ArrayPatternRest(a) => a.address(),
+            Self::BindingRestElementArgument(a) => a.address(),
+            Self::FunctionId(a) => a.address(),
+            Self::FunctionTypeParameters(a) => a.address(),
+            Self::FunctionThisParam(a) => a.address(),
+            Self::FunctionParams(a) => a.address(),
+            Self::FunctionReturnType(a) => a.address(),
+            Self::FunctionBody(a) => a.address(),
+            Self::FormalParametersItems(a) => a.address(),
+            Self::FormalParametersRest(a) => a.address(),
+            Self::FormalParameterDecorators(a) => a.address(),
+            Self::FormalParameterPattern(a) => a.address(),
+            Self::FunctionBodyDirectives(a) => a.address(),
+            Self::FunctionBodyStatements(a) => a.address(),
+            Self::ArrowFunctionExpressionTypeParameters(a) => a.address(),
+            Self::ArrowFunctionExpressionParams(a) => a.address(),
+            Self::ArrowFunctionExpressionReturnType(a) => a.address(),
+            Self::ArrowFunctionExpressionBody(a) => a.address(),
+            Self::YieldExpressionArgument(a) => a.address(),
+            Self::ClassDecorators(a) => a.address(),
+            Self::ClassId(a) => a.address(),
+            Self::ClassTypeParameters(a) => a.address(),
+            Self::ClassSuperClass(a) => a.address(),
+            Self::ClassSuperTypeParameters(a) => a.address(),
+            Self::ClassImplements(a) => a.address(),
+            Self::ClassBody(a) => a.address(),
+            Self::ClassBodyBody(a) => a.address(),
+            Self::MethodDefinitionDecorators(a) => a.address(),
+            Self::MethodDefinitionKey(a) => a.address(),
+            Self::MethodDefinitionValue(a) => a.address(),
+            Self::PropertyDefinitionDecorators(a) => a.address(),
+            Self::PropertyDefinitionKey(a) => a.address(),
+            Self::PropertyDefinitionValue(a) => a.address(),
+            Self::PropertyDefinitionTypeAnnotation(a) => a.address(),
+            Self::StaticBlockBody(a) => a.address(),
+            Self::AccessorPropertyDecorators(a) => a.address(),
+            Self::AccessorPropertyKey(a) => a.address(),
+            Self::AccessorPropertyValue(a) => a.address(),
+            Self::AccessorPropertyTypeAnnotation(a) => a.address(),
+            Self::ImportExpressionSource(a) => a.address(),
+            Self::ImportExpressionArguments(a) => a.address(),
+            Self::ImportDeclarationSpecifiers(a) => a.address(),
+            Self::ImportDeclarationSource(a) => a.address(),
+            Self::ImportDeclarationWithClause(a) => a.address(),
+            Self::ImportSpecifierImported(a) => a.address(),
+            Self::ImportSpecifierLocal(a) => a.address(),
+            Self::ImportDefaultSpecifierLocal(a) => a.address(),
+            Self::ImportNamespaceSpecifierLocal(a) => a.address(),
+            Self::WithClauseAttributesKeyword(a) => a.address(),
+            Self::WithClauseWithEntries(a) => a.address(),
+            Self::ImportAttributeKey(a) => a.address(),
+            Self::ImportAttributeValue(a) => a.address(),
+            Self::ExportNamedDeclarationDeclaration(a) => a.address(),
+            Self::ExportNamedDeclarationSpecifiers(a) => a.address(),
+            Self::ExportNamedDeclarationSource(a) => a.address(),
+            Self::ExportNamedDeclarationWithClause(a) => a.address(),
+            Self::ExportDefaultDeclarationDeclaration(a) => a.address(),
+            Self::ExportDefaultDeclarationExported(a) => a.address(),
+            Self::ExportAllDeclarationExported(a) => a.address(),
+            Self::ExportAllDeclarationSource(a) => a.address(),
+            Self::ExportAllDeclarationWithClause(a) => a.address(),
+            Self::ExportSpecifierLocal(a) => a.address(),
+            Self::ExportSpecifierExported(a) => a.address(),
+            Self::JSXElementOpeningElement(a) => a.address(),
+            Self::JSXElementClosingElement(a) => a.address(),
+            Self::JSXElementChildren(a) => a.address(),
+            Self::JSXOpeningElementName(a) => a.address(),
+            Self::JSXOpeningElementAttributes(a) => a.address(),
+            Self::JSXOpeningElementTypeParameters(a) => a.address(),
+            Self::JSXClosingElementName(a) => a.address(),
+            Self::JSXFragmentChildren(a) => a.address(),
+            Self::JSXNamespacedNameNamespace(a) => a.address(),
+            Self::JSXNamespacedNameProperty(a) => a.address(),
+            Self::JSXMemberExpressionObject(a) => a.address(),
+            Self::JSXMemberExpressionProperty(a) => a.address(),
+            Self::JSXExpressionContainerExpression(a) => a.address(),
+            Self::JSXAttributeName(a) => a.address(),
+            Self::JSXAttributeValue(a) => a.address(),
+            Self::JSXSpreadAttributeArgument(a) => a.address(),
+            Self::JSXSpreadChildExpression(a) => a.address(),
+            Self::TSThisParameterTypeAnnotation(a) => a.address(),
+            Self::TSEnumDeclarationId(a) => a.address(),
+            Self::TSEnumDeclarationMembers(a) => a.address(),
+            Self::TSEnumMemberId(a) => a.address(),
+            Self::TSEnumMemberInitializer(a) => a.address(),
+            Self::TSTypeAnnotationTypeAnnotation(a) => a.address(),
+            Self::TSLiteralTypeLiteral(a) => a.address(),
+            Self::TSConditionalTypeCheckType(a) => a.address(),
+            Self::TSConditionalTypeExtendsType(a) => a.address(),
+            Self::TSConditionalTypeTrueType(a) => a.address(),
+            Self::TSConditionalTypeFalseType(a) => a.address(),
+            Self::TSUnionTypeTypes(a) => a.address(),
+            Self::TSIntersectionTypeTypes(a) => a.address(),
+            Self::TSParenthesizedTypeTypeAnnotation(a) => a.address(),
+            Self::TSTypeOperatorTypeAnnotation(a) => a.address(),
+            Self::TSArrayTypeElementType(a) => a.address(),
+            Self::TSIndexedAccessTypeObjectType(a) => a.address(),
+            Self::TSIndexedAccessTypeIndexType(a) => a.address(),
+            Self::TSTupleTypeElementTypes(a) => a.address(),
+            Self::TSNamedTupleMemberElementType(a) => a.address(),
+            Self::TSNamedTupleMemberLabel(a) => a.address(),
+            Self::TSOptionalTypeTypeAnnotation(a) => a.address(),
+            Self::TSRestTypeTypeAnnotation(a) => a.address(),
+            Self::TSTypeReferenceTypeName(a) => a.address(),
+            Self::TSTypeReferenceTypeParameters(a) => a.address(),
+            Self::TSQualifiedNameLeft(a) => a.address(),
+            Self::TSQualifiedNameRight(a) => a.address(),
+            Self::TSTypeParameterInstantiationParams(a) => a.address(),
+            Self::TSTypeParameterName(a) => a.address(),
+            Self::TSTypeParameterConstraint(a) => a.address(),
+            Self::TSTypeParameterDefault(a) => a.address(),
+            Self::TSTypeParameterDeclarationParams(a) => a.address(),
+            Self::TSTypeAliasDeclarationId(a) => a.address(),
+            Self::TSTypeAliasDeclarationTypeParameters(a) => a.address(),
+            Self::TSTypeAliasDeclarationTypeAnnotation(a) => a.address(),
+            Self::TSClassImplementsExpression(a) => a.address(),
+            Self::TSClassImplementsTypeParameters(a) => a.address(),
+            Self::TSInterfaceDeclarationId(a) => a.address(),
+            Self::TSInterfaceDeclarationExtends(a) => a.address(),
+            Self::TSInterfaceDeclarationTypeParameters(a) => a.address(),
+            Self::TSInterfaceDeclarationBody(a) => a.address(),
+            Self::TSInterfaceBodyBody(a) => a.address(),
+            Self::TSPropertySignatureKey(a) => a.address(),
+            Self::TSPropertySignatureTypeAnnotation(a) => a.address(),
+            Self::TSIndexSignatureParameters(a) => a.address(),
+            Self::TSIndexSignatureTypeAnnotation(a) => a.address(),
+            Self::TSCallSignatureDeclarationTypeParameters(a) => a.address(),
+            Self::TSCallSignatureDeclarationThisParam(a) => a.address(),
+            Self::TSCallSignatureDeclarationParams(a) => a.address(),
+            Self::TSCallSignatureDeclarationReturnType(a) => a.address(),
+            Self::TSMethodSignatureKey(a) => a.address(),
+            Self::TSMethodSignatureTypeParameters(a) => a.address(),
+            Self::TSMethodSignatureThisParam(a) => a.address(),
+            Self::TSMethodSignatureParams(a) => a.address(),
+            Self::TSMethodSignatureReturnType(a) => a.address(),
+            Self::TSConstructSignatureDeclarationTypeParameters(a) => a.address(),
+            Self::TSConstructSignatureDeclarationParams(a) => a.address(),
+            Self::TSConstructSignatureDeclarationReturnType(a) => a.address(),
+            Self::TSIndexSignatureNameTypeAnnotation(a) => a.address(),
+            Self::TSInterfaceHeritageExpression(a) => a.address(),
+            Self::TSInterfaceHeritageTypeParameters(a) => a.address(),
+            Self::TSTypePredicateParameterName(a) => a.address(),
+            Self::TSTypePredicateTypeAnnotation(a) => a.address(),
+            Self::TSModuleDeclarationId(a) => a.address(),
+            Self::TSModuleDeclarationBody(a) => a.address(),
+            Self::TSModuleBlockDirectives(a) => a.address(),
+            Self::TSModuleBlockBody(a) => a.address(),
+            Self::TSTypeLiteralMembers(a) => a.address(),
+            Self::TSInferTypeTypeParameter(a) => a.address(),
+            Self::TSTypeQueryExprName(a) => a.address(),
+            Self::TSTypeQueryTypeParameters(a) => a.address(),
+            Self::TSImportTypeParameter(a) => a.address(),
+            Self::TSImportTypeQualifier(a) => a.address(),
+            Self::TSImportTypeAttributes(a) => a.address(),
+            Self::TSImportTypeTypeParameters(a) => a.address(),
+            Self::TSImportAttributesAttributesKeyword(a) => a.address(),
+            Self::TSImportAttributesElements(a) => a.address(),
+            Self::TSImportAttributeName(a) => a.address(),
+            Self::TSImportAttributeValue(a) => a.address(),
+            Self::TSFunctionTypeTypeParameters(a) => a.address(),
+            Self::TSFunctionTypeThisParam(a) => a.address(),
+            Self::TSFunctionTypeParams(a) => a.address(),
+            Self::TSFunctionTypeReturnType(a) => a.address(),
+            Self::TSConstructorTypeTypeParameters(a) => a.address(),
+            Self::TSConstructorTypeParams(a) => a.address(),
+            Self::TSConstructorTypeReturnType(a) => a.address(),
+            Self::TSMappedTypeTypeParameter(a) => a.address(),
+            Self::TSMappedTypeNameType(a) => a.address(),
+            Self::TSMappedTypeTypeAnnotation(a) => a.address(),
+            Self::TSTemplateLiteralTypeQuasis(a) => a.address(),
+            Self::TSTemplateLiteralTypeTypes(a) => a.address(),
+            Self::TSAsExpressionExpression(a) => a.address(),
+            Self::TSAsExpressionTypeAnnotation(a) => a.address(),
+            Self::TSSatisfiesExpressionExpression(a) => a.address(),
+            Self::TSSatisfiesExpressionTypeAnnotation(a) => a.address(),
+            Self::TSTypeAssertionExpression(a) => a.address(),
+            Self::TSTypeAssertionTypeAnnotation(a) => a.address(),
+            Self::TSImportEqualsDeclarationId(a) => a.address(),
+            Self::TSImportEqualsDeclarationModuleReference(a) => a.address(),
+            Self::TSExternalModuleReferenceExpression(a) => a.address(),
+            Self::TSNonNullExpressionExpression(a) => a.address(),
+            Self::DecoratorExpression(a) => a.address(),
+            Self::TSExportAssignmentExpression(a) => a.address(),
+            Self::TSNamespaceExportDeclarationId(a) => a.address(),
+            Self::TSInstantiationExpressionExpression(a) => a.address(),
+            Self::TSInstantiationExpressionTypeParameters(a) => a.address(),
+            Self::JSDocNullableTypeTypeAnnotation(a) => a.address(),
+            Self::JSDocNonNullableTypeTypeAnnotation(a) => a.address(),
+        }
+    }
+}
+
 pub(crate) const OFFSET_PROGRAM_SPAN: usize = offset_of!(Program, span);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TYPE: usize = offset_of!(Program, source_type);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TEXT: usize = offset_of!(Program, source_text);
@@ -2258,6 +2563,13 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ProgramWithoutHashbang<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ProgramWithoutDirectives<'a, 't>(
@@ -2305,6 +2617,13 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ProgramWithoutDirectives<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2359,6 +2678,13 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ProgramWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_ARRAY_EXPRESSION_SPAN: usize = offset_of!(ArrayExpression, span);
 pub(crate) const OFFSET_ARRAY_EXPRESSION_ELEMENTS: usize = offset_of!(ArrayExpression, elements);
 pub(crate) const OFFSET_ARRAY_EXPRESSION_TRAILING_COMMA: usize =
@@ -2383,6 +2709,13 @@ impl<'a, 't> ArrayExpressionWithoutElements<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_EXPRESSION_TRAILING_COMMA)
                 as *const Option<Span>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ArrayExpressionWithoutElements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2411,6 +2744,13 @@ impl<'a, 't> ObjectExpressionWithoutProperties<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_EXPRESSION_TRAILING_COMMA)
                 as *const Option<Span>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ObjectExpressionWithoutProperties<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2472,6 +2812,13 @@ impl<'a, 't> ObjectPropertyWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ObjectPropertyWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ObjectPropertyWithoutValue<'a, 't>(
@@ -2518,6 +2865,13 @@ impl<'a, 't> ObjectPropertyWithoutValue<'a, 't> {
     #[inline]
     pub fn computed(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_OBJECT_PROPERTY_COMPUTED) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for ObjectPropertyWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2569,6 +2923,13 @@ impl<'a, 't> ObjectPropertyWithoutInit<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ObjectPropertyWithoutInit<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TEMPLATE_LITERAL_SPAN: usize = offset_of!(TemplateLiteral, span);
 pub(crate) const OFFSET_TEMPLATE_LITERAL_QUASIS: usize = offset_of!(TemplateLiteral, quasis);
 pub(crate) const OFFSET_TEMPLATE_LITERAL_EXPRESSIONS: usize =
@@ -2596,6 +2957,13 @@ impl<'a, 't> TemplateLiteralWithoutQuasis<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TemplateLiteralWithoutQuasis<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TemplateLiteralWithoutExpressions<'a, 't>(
@@ -2615,6 +2983,13 @@ impl<'a, 't> TemplateLiteralWithoutExpressions<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TEMPLATE_LITERAL_QUASIS)
                 as *const Vec<'a, TemplateElement<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TemplateLiteralWithoutExpressions<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2659,6 +3034,13 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTag<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TaggedTemplateExpressionWithoutQuasi<'a, 't>(
@@ -2691,6 +3073,13 @@ impl<'a, 't> TaggedTemplateExpressionWithoutQuasi<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutQuasi<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TaggedTemplateExpressionWithoutTypeParameters<'a, 't>(
@@ -2720,6 +3109,13 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
                 as *const TemplateLiteral<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2763,6 +3159,13 @@ impl<'a, 't> ComputedMemberExpressionWithoutObject<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ComputedMemberExpressionWithoutObject<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ComputedMemberExpressionWithoutExpression<'a, 't>(
@@ -2791,6 +3194,13 @@ impl<'a, 't> ComputedMemberExpressionWithoutExpression<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_COMPUTED_MEMBER_EXPRESSION_OPTIONAL) as *const bool)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ComputedMemberExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2834,6 +3244,13 @@ impl<'a, 't> StaticMemberExpressionWithoutObject<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for StaticMemberExpressionWithoutObject<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct StaticMemberExpressionWithoutProperty<'a, 't>(
@@ -2862,6 +3279,13 @@ impl<'a, 't> StaticMemberExpressionWithoutProperty<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_STATIC_MEMBER_EXPRESSION_OPTIONAL) as *const bool)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for StaticMemberExpressionWithoutProperty<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2905,6 +3329,13 @@ impl<'a, 't> PrivateFieldExpressionWithoutObject<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for PrivateFieldExpressionWithoutObject<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct PrivateFieldExpressionWithoutField<'a, 't>(
@@ -2933,6 +3364,13 @@ impl<'a, 't> PrivateFieldExpressionWithoutField<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PRIVATE_FIELD_EXPRESSION_OPTIONAL) as *const bool)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for PrivateFieldExpressionWithoutField<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -2978,6 +3416,13 @@ impl<'a, 't> CallExpressionWithoutCallee<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for CallExpressionWithoutCallee<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct CallExpressionWithoutTypeParameters<'a, 't>(
@@ -3012,6 +3457,13 @@ impl<'a, 't> CallExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for CallExpressionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct CallExpressionWithoutArguments<'a, 't>(
@@ -3043,6 +3495,13 @@ impl<'a, 't> CallExpressionWithoutArguments<'a, 't> {
     #[inline]
     pub fn optional(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_OPTIONAL) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for CallExpressionWithoutArguments<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3082,6 +3541,13 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for NewExpressionWithoutCallee<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct NewExpressionWithoutArguments<'a, 't>(
@@ -3108,6 +3574,13 @@ impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for NewExpressionWithoutArguments<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3140,6 +3613,13 @@ impl<'a, 't> NewExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for NewExpressionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_META_PROPERTY_SPAN: usize = offset_of!(MetaProperty, span);
 pub(crate) const OFFSET_META_PROPERTY_META: usize = offset_of!(MetaProperty, meta);
 pub(crate) const OFFSET_META_PROPERTY_PROPERTY: usize = offset_of!(MetaProperty, property);
@@ -3166,6 +3646,13 @@ impl<'a, 't> MetaPropertyWithoutMeta<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for MetaPropertyWithoutMeta<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct MetaPropertyWithoutProperty<'a, 't>(
@@ -3187,6 +3674,13 @@ impl<'a, 't> MetaPropertyWithoutProperty<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for MetaPropertyWithoutProperty<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_SPREAD_ELEMENT_SPAN: usize = offset_of!(SpreadElement, span);
 pub(crate) const OFFSET_SPREAD_ELEMENT_ARGUMENT: usize = offset_of!(SpreadElement, argument);
 
@@ -3201,6 +3695,13 @@ impl<'a, 't> SpreadElementWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_SPREAD_ELEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for SpreadElementWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3236,6 +3737,13 @@ impl<'a, 't> UpdateExpressionWithoutArgument<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for UpdateExpressionWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_UNARY_EXPRESSION_SPAN: usize = offset_of!(UnaryExpression, span);
 pub(crate) const OFFSET_UNARY_EXPRESSION_OPERATOR: usize = offset_of!(UnaryExpression, operator);
 pub(crate) const OFFSET_UNARY_EXPRESSION_ARGUMENT: usize = offset_of!(UnaryExpression, argument);
@@ -3258,6 +3766,13 @@ impl<'a, 't> UnaryExpressionWithoutArgument<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_UNARY_EXPRESSION_OPERATOR) as *const UnaryOperator)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for UnaryExpressionWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3295,6 +3810,13 @@ impl<'a, 't> BinaryExpressionWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for BinaryExpressionWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct BinaryExpressionWithoutRight<'a, 't>(
@@ -3321,6 +3843,13 @@ impl<'a, 't> BinaryExpressionWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_BINARY_EXPRESSION_OPERATOR)
                 as *const BinaryOperator)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for BinaryExpressionWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3360,6 +3889,13 @@ impl<'a, 't> PrivateInExpressionWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for PrivateInExpressionWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct PrivateInExpressionWithoutRight<'a, 't>(
@@ -3387,6 +3923,13 @@ impl<'a, 't> PrivateInExpressionWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_PRIVATE_IN_EXPRESSION_OPERATOR)
                 as *const BinaryOperator)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for PrivateInExpressionWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3425,6 +3968,13 @@ impl<'a, 't> LogicalExpressionWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for LogicalExpressionWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct LogicalExpressionWithoutRight<'a, 't>(
@@ -3451,6 +4001,13 @@ impl<'a, 't> LogicalExpressionWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_LOGICAL_EXPRESSION_OPERATOR)
                 as *const LogicalOperator)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for LogicalExpressionWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3493,6 +4050,13 @@ impl<'a, 't> ConditionalExpressionWithoutTest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ConditionalExpressionWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ConditionalExpressionWithoutConsequent<'a, 't>(
@@ -3523,6 +4087,13 @@ impl<'a, 't> ConditionalExpressionWithoutConsequent<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ConditionalExpressionWithoutConsequent<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ConditionalExpressionWithoutAlternate<'a, 't>(
@@ -3550,6 +4121,13 @@ impl<'a, 't> ConditionalExpressionWithoutAlternate<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_CONDITIONAL_EXPRESSION_CONSEQUENT)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ConditionalExpressionWithoutAlternate<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3590,6 +4168,13 @@ impl<'a, 't> AssignmentExpressionWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentExpressionWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AssignmentExpressionWithoutRight<'a, 't>(
@@ -3617,6 +4202,13 @@ impl<'a, 't> AssignmentExpressionWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_EXPRESSION_LEFT)
                 as *const AssignmentTarget<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for AssignmentExpressionWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3659,6 +4251,13 @@ impl<'a, 't> ArrayAssignmentTargetWithoutElements<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrayAssignmentTargetWithoutElements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ArrayAssignmentTargetWithoutRest<'a, 't>(
@@ -3686,6 +4285,13 @@ impl<'a, 't> ArrayAssignmentTargetWithoutRest<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_TRAILING_COMMA)
                 as *const Option<Span>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ArrayAssignmentTargetWithoutRest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3720,6 +4326,13 @@ impl<'a, 't> ObjectAssignmentTargetWithoutProperties<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ObjectAssignmentTargetWithoutProperties<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ObjectAssignmentTargetWithoutRest<'a, 't>(
@@ -3744,6 +4357,13 @@ impl<'a, 't> ObjectAssignmentTargetWithoutRest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ObjectAssignmentTargetWithoutRest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_ASSIGNMENT_TARGET_REST_SPAN: usize = offset_of!(AssignmentTargetRest, span);
 pub(crate) const OFFSET_ASSIGNMENT_TARGET_REST_TARGET: usize =
     offset_of!(AssignmentTargetRest, target);
@@ -3759,6 +4379,13 @@ impl<'a, 't> AssignmentTargetRestWithoutTarget<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_TARGET_REST_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for AssignmentTargetRestWithoutTarget<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3793,6 +4420,13 @@ impl<'a, 't> AssignmentTargetWithDefaultWithoutBinding<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentTargetWithDefaultWithoutBinding<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AssignmentTargetWithDefaultWithoutInit<'a, 't>(
@@ -3814,6 +4448,13 @@ impl<'a, 't> AssignmentTargetWithDefaultWithoutInit<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_BINDING)
                 as *const AssignmentTarget<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for AssignmentTargetWithDefaultWithoutInit<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3849,6 +4490,13 @@ impl<'a, 't> AssignmentTargetPropertyIdentifierWithoutBinding<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentTargetPropertyIdentifierWithoutBinding<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AssignmentTargetPropertyIdentifierWithoutInit<'a, 't>(
@@ -3871,6 +4519,13 @@ impl<'a, 't> AssignmentTargetPropertyIdentifierWithoutInit<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_BINDING)
                 as *const IdentifierReference<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for AssignmentTargetPropertyIdentifierWithoutInit<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3906,6 +4561,13 @@ impl<'a, 't> AssignmentTargetPropertyPropertyWithoutName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentTargetPropertyPropertyWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AssignmentTargetPropertyPropertyWithoutBinding<'a, 't>(
@@ -3931,6 +4593,13 @@ impl<'a, 't> AssignmentTargetPropertyPropertyWithoutBinding<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentTargetPropertyPropertyWithoutBinding<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_SEQUENCE_EXPRESSION_SPAN: usize = offset_of!(SequenceExpression, span);
 pub(crate) const OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS: usize =
     offset_of!(SequenceExpression, expressions);
@@ -3949,6 +4618,13 @@ impl<'a, 't> SequenceExpressionWithoutExpressions<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for SequenceExpressionWithoutExpressions<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_AWAIT_EXPRESSION_SPAN: usize = offset_of!(AwaitExpression, span);
 pub(crate) const OFFSET_AWAIT_EXPRESSION_ARGUMENT: usize = offset_of!(AwaitExpression, argument);
 
@@ -3963,6 +4639,13 @@ impl<'a, 't> AwaitExpressionWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_AWAIT_EXPRESSION_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for AwaitExpressionWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -3984,6 +4667,13 @@ impl<'a, 't> ChainExpressionWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ChainExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_PARENTHESIZED_EXPRESSION_SPAN: usize =
     offset_of!(ParenthesizedExpression, span);
 pub(crate) const OFFSET_PARENTHESIZED_EXPRESSION_EXPRESSION: usize =
@@ -4002,6 +4692,13 @@ impl<'a, 't> ParenthesizedExpressionWithoutExpression<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PARENTHESIZED_EXPRESSION_SPAN) as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ParenthesizedExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4028,6 +4725,13 @@ impl<'a, 't> DirectiveWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for DirectiveWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_BLOCK_STATEMENT_SPAN: usize = offset_of!(BlockStatement, span);
 pub(crate) const OFFSET_BLOCK_STATEMENT_BODY: usize = offset_of!(BlockStatement, body);
 pub(crate) const OFFSET_BLOCK_STATEMENT_SCOPE_ID: usize = offset_of!(BlockStatement, scope_id);
@@ -4051,6 +4755,13 @@ impl<'a, 't> BlockStatementWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_BLOCK_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for BlockStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4085,6 +4796,13 @@ impl<'a, 't> VariableDeclarationWithoutDeclarations<'a, 't> {
     #[inline]
     pub fn declare(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_VARIABLE_DECLARATION_DECLARE) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for VariableDeclarationWithoutDeclarations<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4130,6 +4848,13 @@ impl<'a, 't> VariableDeclaratorWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for VariableDeclaratorWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct VariableDeclaratorWithoutInit<'a, 't>(
@@ -4165,6 +4890,13 @@ impl<'a, 't> VariableDeclaratorWithoutInit<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for VariableDeclaratorWithoutInit<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_EXPRESSION_STATEMENT_SPAN: usize = offset_of!(ExpressionStatement, span);
 pub(crate) const OFFSET_EXPRESSION_STATEMENT_EXPRESSION: usize =
     offset_of!(ExpressionStatement, expression);
@@ -4180,6 +4912,13 @@ impl<'a, 't> ExpressionStatementWithoutExpression<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_EXPRESSION_STATEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for ExpressionStatementWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4217,6 +4956,13 @@ impl<'a, 't> IfStatementWithoutTest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for IfStatementWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct IfStatementWithoutConsequent<'a, 't>(
@@ -4241,6 +4987,13 @@ impl<'a, 't> IfStatementWithoutConsequent<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_IF_STATEMENT_ALTERNATE)
                 as *const Option<Statement<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for IfStatementWithoutConsequent<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4270,6 +5023,13 @@ impl<'a, 't> IfStatementWithoutAlternate<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for IfStatementWithoutAlternate<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_DO_WHILE_STATEMENT_SPAN: usize = offset_of!(DoWhileStatement, span);
 pub(crate) const OFFSET_DO_WHILE_STATEMENT_BODY: usize = offset_of!(DoWhileStatement, body);
 pub(crate) const OFFSET_DO_WHILE_STATEMENT_TEST: usize = offset_of!(DoWhileStatement, test);
@@ -4295,6 +5055,13 @@ impl<'a, 't> DoWhileStatementWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for DoWhileStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct DoWhileStatementWithoutTest<'a, 't>(
@@ -4313,6 +5080,13 @@ impl<'a, 't> DoWhileStatementWithoutTest<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_DO_WHILE_STATEMENT_BODY) as *const Statement<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for DoWhileStatementWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4341,6 +5115,13 @@ impl<'a, 't> WhileStatementWithoutTest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for WhileStatementWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct WhileStatementWithoutBody<'a, 't>(
@@ -4359,6 +5140,13 @@ impl<'a, 't> WhileStatementWithoutBody<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_WHILE_STATEMENT_TEST) as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for WhileStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4412,6 +5200,13 @@ impl<'a, 't> ForStatementWithoutInit<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForStatementWithoutInit<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ForStatementWithoutTest<'a, 't>(
@@ -4455,6 +5250,13 @@ impl<'a, 't> ForStatementWithoutTest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForStatementWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ForStatementWithoutUpdate<'a, 't>(
@@ -4495,6 +5297,13 @@ impl<'a, 't> ForStatementWithoutUpdate<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_FOR_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ForStatementWithoutUpdate<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4544,6 +5353,13 @@ impl<'a, 't> ForStatementWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_FOR_IN_STATEMENT_SPAN: usize = offset_of!(ForInStatement, span);
 pub(crate) const OFFSET_FOR_IN_STATEMENT_LEFT: usize = offset_of!(ForInStatement, left);
 pub(crate) const OFFSET_FOR_IN_STATEMENT_RIGHT: usize = offset_of!(ForInStatement, right);
@@ -4586,6 +5402,13 @@ impl<'a, 't> ForInStatementWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForInStatementWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ForInStatementWithoutRight<'a, 't>(
@@ -4623,6 +5446,13 @@ impl<'a, 't> ForInStatementWithoutRight<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForInStatementWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ForInStatementWithoutBody<'a, 't>(
@@ -4657,6 +5487,13 @@ impl<'a, 't> ForInStatementWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ForInStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4708,6 +5545,13 @@ impl<'a, 't> ForOfStatementWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForOfStatementWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ForOfStatementWithoutRight<'a, 't>(
@@ -4747,6 +5591,13 @@ impl<'a, 't> ForOfStatementWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ForOfStatementWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4792,6 +5643,13 @@ impl<'a, 't> ForOfStatementWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ForOfStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_CONTINUE_STATEMENT_SPAN: usize = offset_of!(ContinueStatement, span);
 pub(crate) const OFFSET_CONTINUE_STATEMENT_LABEL: usize = offset_of!(ContinueStatement, label);
 
@@ -4806,6 +5664,13 @@ impl<'a, 't> ContinueStatementWithoutLabel<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CONTINUE_STATEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for ContinueStatementWithoutLabel<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4826,6 +5691,13 @@ impl<'a, 't> BreakStatementWithoutLabel<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for BreakStatementWithoutLabel<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_RETURN_STATEMENT_SPAN: usize = offset_of!(ReturnStatement, span);
 pub(crate) const OFFSET_RETURN_STATEMENT_ARGUMENT: usize = offset_of!(ReturnStatement, argument);
 
@@ -4840,6 +5712,13 @@ impl<'a, 't> ReturnStatementWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_RETURN_STATEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for ReturnStatementWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4866,6 +5745,13 @@ impl<'a, 't> WithStatementWithoutObject<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for WithStatementWithoutObject<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct WithStatementWithoutBody<'a, 't>(
@@ -4884,6 +5770,13 @@ impl<'a, 't> WithStatementWithoutBody<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_WITH_STATEMENT_OBJECT) as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for WithStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -4923,6 +5816,13 @@ impl<'a, 't> SwitchStatementWithoutDiscriminant<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for SwitchStatementWithoutDiscriminant<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct SwitchStatementWithoutCases<'a, 't>(
@@ -4953,6 +5853,13 @@ impl<'a, 't> SwitchStatementWithoutCases<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for SwitchStatementWithoutCases<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_SWITCH_CASE_SPAN: usize = offset_of!(SwitchCase, span);
 pub(crate) const OFFSET_SWITCH_CASE_TEST: usize = offset_of!(SwitchCase, test);
 pub(crate) const OFFSET_SWITCH_CASE_CONSEQUENT: usize = offset_of!(SwitchCase, consequent);
@@ -4979,6 +5886,13 @@ impl<'a, 't> SwitchCaseWithoutTest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for SwitchCaseWithoutTest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct SwitchCaseWithoutConsequent<'a, 't>(
@@ -4997,6 +5911,13 @@ impl<'a, 't> SwitchCaseWithoutConsequent<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_SWITCH_CASE_TEST) as *const Option<Expression<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for SwitchCaseWithoutConsequent<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5025,6 +5946,13 @@ impl<'a, 't> LabeledStatementWithoutLabel<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for LabeledStatementWithoutLabel<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct LabeledStatementWithoutBody<'a, 't>(
@@ -5047,6 +5975,13 @@ impl<'a, 't> LabeledStatementWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for LabeledStatementWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_THROW_STATEMENT_SPAN: usize = offset_of!(ThrowStatement, span);
 pub(crate) const OFFSET_THROW_STATEMENT_ARGUMENT: usize = offset_of!(ThrowStatement, argument);
 
@@ -5061,6 +5996,13 @@ impl<'a, 't> ThrowStatementWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_THROW_STATEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for ThrowStatementWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5099,6 +6041,13 @@ impl<'a, 't> TryStatementWithoutBlock<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TryStatementWithoutBlock<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TryStatementWithoutHandler<'a, 't>(
@@ -5129,6 +6078,13 @@ impl<'a, 't> TryStatementWithoutHandler<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TryStatementWithoutHandler<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TryStatementWithoutFinalizer<'a, 't>(
@@ -5156,6 +6112,13 @@ impl<'a, 't> TryStatementWithoutFinalizer<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_HANDLER)
                 as *const Option<Box<'a, CatchClause<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TryStatementWithoutFinalizer<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5194,6 +6157,13 @@ impl<'a, 't> CatchClauseWithoutParam<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for CatchClauseWithoutParam<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct CatchClauseWithoutBody<'a, 't>(
@@ -5224,6 +6194,13 @@ impl<'a, 't> CatchClauseWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for CatchClauseWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_CATCH_PARAMETER_SPAN: usize = offset_of!(CatchParameter, span);
 pub(crate) const OFFSET_CATCH_PARAMETER_PATTERN: usize = offset_of!(CatchParameter, pattern);
 
@@ -5238,6 +6215,13 @@ impl<'a, 't> CatchParameterWithoutPattern<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CATCH_PARAMETER_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for CatchParameterWithoutPattern<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5268,6 +6252,13 @@ impl<'a, 't> BindingPatternWithoutKind<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for BindingPatternWithoutKind<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct BindingPatternWithoutTypeAnnotation<'a, 't>(
@@ -5287,6 +6278,13 @@ impl<'a, 't> BindingPatternWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn optional(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_BINDING_PATTERN_OPTIONAL) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for BindingPatternWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5315,6 +6313,13 @@ impl<'a, 't> AssignmentPatternWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AssignmentPatternWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AssignmentPatternWithoutRight<'a, 't>(
@@ -5334,6 +6339,13 @@ impl<'a, 't> AssignmentPatternWithoutRight<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ASSIGNMENT_PATTERN_LEFT)
                 as *const BindingPattern<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for AssignmentPatternWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5363,6 +6375,13 @@ impl<'a, 't> ObjectPatternWithoutProperties<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ObjectPatternWithoutProperties<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ObjectPatternWithoutRest<'a, 't>(
@@ -5382,6 +6401,13 @@ impl<'a, 't> ObjectPatternWithoutRest<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_PATTERN_PROPERTIES)
                 as *const Vec<'a, BindingProperty<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ObjectPatternWithoutRest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5423,6 +6449,13 @@ impl<'a, 't> BindingPropertyWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for BindingPropertyWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct BindingPropertyWithoutValue<'a, 't>(
@@ -5454,6 +6487,13 @@ impl<'a, 't> BindingPropertyWithoutValue<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for BindingPropertyWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_ARRAY_PATTERN_SPAN: usize = offset_of!(ArrayPattern, span);
 pub(crate) const OFFSET_ARRAY_PATTERN_ELEMENTS: usize = offset_of!(ArrayPattern, elements);
 pub(crate) const OFFSET_ARRAY_PATTERN_REST: usize = offset_of!(ArrayPattern, rest);
@@ -5480,6 +6520,13 @@ impl<'a, 't> ArrayPatternWithoutElements<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrayPatternWithoutElements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ArrayPatternWithoutRest<'a, 't>(
@@ -5502,6 +6549,13 @@ impl<'a, 't> ArrayPatternWithoutRest<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrayPatternWithoutRest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_BINDING_REST_ELEMENT_SPAN: usize = offset_of!(BindingRestElement, span);
 pub(crate) const OFFSET_BINDING_REST_ELEMENT_ARGUMENT: usize =
     offset_of!(BindingRestElement, argument);
@@ -5517,6 +6571,13 @@ impl<'a, 't> BindingRestElementWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_BINDING_REST_ELEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for BindingRestElementWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5614,6 +6675,13 @@ impl<'a, 't> FunctionWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FunctionWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FunctionWithoutTypeParameters<'a, 't>(
@@ -5692,6 +6760,13 @@ impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for FunctionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5776,6 +6851,13 @@ impl<'a, 't> FunctionWithoutThisParam<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FunctionWithoutThisParam<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FunctionWithoutParams<'a, 't>(
@@ -5854,6 +6936,13 @@ impl<'a, 't> FunctionWithoutParams<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for FunctionWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -5938,6 +7027,13 @@ impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FunctionWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FunctionWithoutBody<'a, 't>(
@@ -6019,6 +7115,13 @@ impl<'a, 't> FunctionWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FunctionWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_FORMAL_PARAMETERS_SPAN: usize = offset_of!(FormalParameters, span);
 pub(crate) const OFFSET_FORMAL_PARAMETERS_KIND: usize = offset_of!(FormalParameters, kind);
 pub(crate) const OFFSET_FORMAL_PARAMETERS_ITEMS: usize = offset_of!(FormalParameters, items);
@@ -6054,6 +7157,13 @@ impl<'a, 't> FormalParametersWithoutItems<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FormalParametersWithoutItems<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FormalParametersWithoutRest<'a, 't>(
@@ -6081,6 +7191,13 @@ impl<'a, 't> FormalParametersWithoutRest<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETERS_ITEMS)
                 as *const Vec<'a, FormalParameter<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for FormalParametersWithoutRest<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6133,6 +7250,13 @@ impl<'a, 't> FormalParameterWithoutDecorators<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FormalParameterWithoutDecorators<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FormalParameterWithoutPattern<'a, 't>(
@@ -6173,6 +7297,13 @@ impl<'a, 't> FormalParameterWithoutPattern<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FormalParameterWithoutPattern<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_FUNCTION_BODY_SPAN: usize = offset_of!(FunctionBody, span);
 pub(crate) const OFFSET_FUNCTION_BODY_DIRECTIVES: usize = offset_of!(FunctionBody, directives);
 pub(crate) const OFFSET_FUNCTION_BODY_STATEMENTS: usize = offset_of!(FunctionBody, statements);
@@ -6199,6 +7330,13 @@ impl<'a, 't> FunctionBodyWithoutDirectives<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for FunctionBodyWithoutDirectives<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct FunctionBodyWithoutStatements<'a, 't>(
@@ -6218,6 +7356,13 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_DIRECTIVES)
                 as *const Vec<'a, Directive<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for FunctionBodyWithoutStatements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6301,6 +7446,13 @@ impl<'a, 't> ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ArrowFunctionExpressionWithoutParams<'a, 't>(
@@ -6361,6 +7513,13 @@ impl<'a, 't> ArrowFunctionExpressionWithoutParams<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6427,6 +7586,13 @@ impl<'a, 't> ArrowFunctionExpressionWithoutReturnType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ArrowFunctionExpressionWithoutBody<'a, 't>(
@@ -6490,6 +7656,13 @@ impl<'a, 't> ArrowFunctionExpressionWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ArrowFunctionExpressionWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_YIELD_EXPRESSION_SPAN: usize = offset_of!(YieldExpression, span);
 pub(crate) const OFFSET_YIELD_EXPRESSION_DELEGATE: usize = offset_of!(YieldExpression, delegate);
 pub(crate) const OFFSET_YIELD_EXPRESSION_ARGUMENT: usize = offset_of!(YieldExpression, argument);
@@ -6510,6 +7683,13 @@ impl<'a, 't> YieldExpressionWithoutArgument<'a, 't> {
     #[inline]
     pub fn delegate(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_YIELD_EXPRESSION_DELEGATE) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for YieldExpressionWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6606,6 +7786,13 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ClassWithoutDecorators<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ClassWithoutId<'a, 't>(pub(crate) *const Class<'a>, pub(crate) PhantomData<&'t ()>);
@@ -6679,6 +7866,13 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ClassWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6757,6 +7951,13 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ClassWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6839,6 +8040,13 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ClassWithoutSuperClass<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ClassWithoutSuperTypeParameters<'a, 't>(
@@ -6914,6 +8122,13 @@ impl<'a, 't> ClassWithoutSuperTypeParameters<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ClassWithoutSuperTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -6995,6 +8210,13 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ClassWithoutImplements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ClassWithoutBody<'a, 't>(pub(crate) *const Class<'a>, pub(crate) PhantomData<&'t ()>);
@@ -7073,6 +8295,13 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ClassWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_CLASS_BODY_SPAN: usize = offset_of!(ClassBody, span);
 pub(crate) const OFFSET_CLASS_BODY_BODY: usize = offset_of!(ClassBody, body);
 
@@ -7087,6 +8316,13 @@ impl<'a, 't> ClassBodyWithoutBody<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for ClassBodyWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -7178,6 +8414,13 @@ impl<'a, 't> MethodDefinitionWithoutDecorators<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for MethodDefinitionWithoutDecorators<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct MethodDefinitionWithoutKey<'a, 't>(
@@ -7252,6 +8495,13 @@ impl<'a, 't> MethodDefinitionWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for MethodDefinitionWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct MethodDefinitionWithoutValue<'a, 't>(
@@ -7322,6 +8572,13 @@ impl<'a, 't> MethodDefinitionWithoutValue<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_ACCESSIBILITY)
                 as *const Option<TSAccessibility>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for MethodDefinitionWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -7438,6 +8695,13 @@ impl<'a, 't> PropertyDefinitionWithoutDecorators<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for PropertyDefinitionWithoutDecorators<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct PropertyDefinitionWithoutKey<'a, 't>(
@@ -7524,6 +8788,13 @@ impl<'a, 't> PropertyDefinitionWithoutKey<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_ACCESSIBILITY)
                 as *const Option<TSAccessibility>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for PropertyDefinitionWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -7615,6 +8886,13 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for PropertyDefinitionWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct PropertyDefinitionWithoutTypeAnnotation<'a, 't>(
@@ -7703,6 +8981,13 @@ impl<'a, 't> PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_STATIC_BLOCK_SPAN: usize = offset_of!(StaticBlock, span);
 pub(crate) const OFFSET_STATIC_BLOCK_BODY: usize = offset_of!(StaticBlock, body);
 pub(crate) const OFFSET_STATIC_BLOCK_SCOPE_ID: usize = offset_of!(StaticBlock, scope_id);
@@ -7726,6 +9011,13 @@ impl<'a, 't> StaticBlockWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_STATIC_BLOCK_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for StaticBlockWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -7811,6 +9103,13 @@ impl<'a, 't> AccessorPropertyWithoutDecorators<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AccessorPropertyWithoutDecorators<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AccessorPropertyWithoutKey<'a, 't>(
@@ -7877,6 +9176,13 @@ impl<'a, 't> AccessorPropertyWithoutKey<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_ACCESSIBILITY)
                 as *const Option<TSAccessibility>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for AccessorPropertyWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -7948,6 +9254,13 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AccessorPropertyWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct AccessorPropertyWithoutTypeAnnotation<'a, 't>(
@@ -8016,6 +9329,13 @@ impl<'a, 't> AccessorPropertyWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for AccessorPropertyWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_IMPORT_EXPRESSION_SPAN: usize = offset_of!(ImportExpression, span);
 pub(crate) const OFFSET_IMPORT_EXPRESSION_SOURCE: usize = offset_of!(ImportExpression, source);
 pub(crate) const OFFSET_IMPORT_EXPRESSION_ARGUMENTS: usize =
@@ -8043,6 +9363,13 @@ impl<'a, 't> ImportExpressionWithoutSource<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportExpressionWithoutSource<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ImportExpressionWithoutArguments<'a, 't>(
@@ -8061,6 +9388,13 @@ impl<'a, 't> ImportExpressionWithoutArguments<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_EXPRESSION_SOURCE) as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ImportExpressionWithoutArguments<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8111,6 +9445,13 @@ impl<'a, 't> ImportDeclarationWithoutSpecifiers<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportDeclarationWithoutSpecifiers<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ImportDeclarationWithoutSource<'a, 't>(
@@ -8146,6 +9487,13 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_IMPORT_KIND)
                 as *const ImportOrExportKind)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ImportDeclarationWithoutSource<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8187,6 +9535,13 @@ impl<'a, 't> ImportDeclarationWithoutWithClause<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportDeclarationWithoutWithClause<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_IMPORT_SPECIFIER_SPAN: usize = offset_of!(ImportSpecifier, span);
 pub(crate) const OFFSET_IMPORT_SPECIFIER_IMPORTED: usize = offset_of!(ImportSpecifier, imported);
 pub(crate) const OFFSET_IMPORT_SPECIFIER_LOCAL: usize = offset_of!(ImportSpecifier, local);
@@ -8223,6 +9578,13 @@ impl<'a, 't> ImportSpecifierWithoutImported<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportSpecifierWithoutImported<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ImportSpecifierWithoutLocal<'a, 't>(
@@ -8253,6 +9615,13 @@ impl<'a, 't> ImportSpecifierWithoutLocal<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportSpecifierWithoutLocal<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_IMPORT_DEFAULT_SPECIFIER_SPAN: usize =
     offset_of!(ImportDefaultSpecifier, span);
 pub(crate) const OFFSET_IMPORT_DEFAULT_SPECIFIER_LOCAL: usize =
@@ -8274,6 +9643,13 @@ impl<'a, 't> ImportDefaultSpecifierWithoutLocal<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportDefaultSpecifierWithoutLocal<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_IMPORT_NAMESPACE_SPECIFIER_SPAN: usize =
     offset_of!(ImportNamespaceSpecifier, span);
 pub(crate) const OFFSET_IMPORT_NAMESPACE_SPECIFIER_LOCAL: usize =
@@ -8292,6 +9668,13 @@ impl<'a, 't> ImportNamespaceSpecifierWithoutLocal<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_NAMESPACE_SPECIFIER_SPAN) as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ImportNamespaceSpecifierWithoutLocal<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8322,6 +9705,13 @@ impl<'a, 't> WithClauseWithoutAttributesKeyword<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for WithClauseWithoutAttributesKeyword<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct WithClauseWithoutWithEntries<'a, 't>(
@@ -8341,6 +9731,13 @@ impl<'a, 't> WithClauseWithoutWithEntries<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_WITH_CLAUSE_ATTRIBUTES_KEYWORD)
                 as *const IdentifierName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for WithClauseWithoutWithEntries<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8369,6 +9766,13 @@ impl<'a, 't> ImportAttributeWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ImportAttributeWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ImportAttributeWithoutValue<'a, 't>(
@@ -8388,6 +9792,13 @@ impl<'a, 't> ImportAttributeWithoutValue<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_ATTRIBUTE_KEY)
                 as *const ImportAttributeKey<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ImportAttributeWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8452,6 +9863,13 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutDeclaration<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExportNamedDeclarationWithoutSpecifiers<'a, 't>(
@@ -8497,6 +9915,13 @@ impl<'a, 't> ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
                 as *const Option<Box<'a, WithClause<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8548,6 +9973,13 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutSource<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExportNamedDeclarationWithoutWithClause<'a, 't>(
@@ -8596,6 +10028,13 @@ impl<'a, 't> ExportNamedDeclarationWithoutWithClause<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutWithClause<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN: usize =
     offset_of!(ExportDefaultDeclaration, span);
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION: usize =
@@ -8627,6 +10066,13 @@ impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExportDefaultDeclarationWithoutExported<'a, 't>(
@@ -8648,6 +10094,13 @@ impl<'a, 't> ExportDefaultDeclarationWithoutExported<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
                 as *const ExportDefaultDeclarationKind<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutExported<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8699,6 +10152,13 @@ impl<'a, 't> ExportAllDeclarationWithoutExported<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportAllDeclarationWithoutExported<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExportAllDeclarationWithoutSource<'a, 't>(
@@ -8734,6 +10194,13 @@ impl<'a, 't> ExportAllDeclarationWithoutSource<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_ALL_DECLARATION_EXPORT_KIND)
                 as *const ImportOrExportKind)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ExportAllDeclarationWithoutSource<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8775,6 +10242,13 @@ impl<'a, 't> ExportAllDeclarationWithoutWithClause<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportAllDeclarationWithoutWithClause<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_EXPORT_SPECIFIER_SPAN: usize = offset_of!(ExportSpecifier, span);
 pub(crate) const OFFSET_EXPORT_SPECIFIER_LOCAL: usize = offset_of!(ExportSpecifier, local);
 pub(crate) const OFFSET_EXPORT_SPECIFIER_EXPORTED: usize = offset_of!(ExportSpecifier, exported);
@@ -8811,6 +10285,13 @@ impl<'a, 't> ExportSpecifierWithoutLocal<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for ExportSpecifierWithoutLocal<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExportSpecifierWithoutExported<'a, 't>(
@@ -8838,6 +10319,13 @@ impl<'a, 't> ExportSpecifierWithoutExported<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_SPECIFIER_EXPORT_KIND)
                 as *const ImportOrExportKind)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for ExportSpecifierWithoutExported<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8878,6 +10366,13 @@ impl<'a, 't> JSXElementWithoutOpeningElement<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXElementWithoutOpeningElement<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXElementWithoutClosingElement<'a, 't>(
@@ -8908,6 +10403,13 @@ impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXElementWithoutClosingElement<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXElementWithoutChildren<'a, 't>(
@@ -8935,6 +10437,13 @@ impl<'a, 't> JSXElementWithoutChildren<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
                 as *const Option<Box<'a, JSXClosingElement<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXElementWithoutChildren<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -8984,6 +10493,13 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXOpeningElementWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXOpeningElementWithoutAttributes<'a, 't>(
@@ -9018,6 +10534,13 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXOpeningElementWithoutAttributes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9058,6 +10581,13 @@ impl<'a, 't> JSXOpeningElementWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXOpeningElementWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_JSX_CLOSING_ELEMENT_SPAN: usize = offset_of!(JSXClosingElement, span);
 pub(crate) const OFFSET_JSX_CLOSING_ELEMENT_NAME: usize = offset_of!(JSXClosingElement, name);
 
@@ -9072,6 +10602,13 @@ impl<'a, 't> JSXClosingElementWithoutName<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_CLOSING_ELEMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXClosingElementWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9112,6 +10649,13 @@ impl<'a, 't> JSXFragmentWithoutChildren<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXFragmentWithoutChildren<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_JSX_NAMESPACED_NAME_SPAN: usize = offset_of!(JSXNamespacedName, span);
 pub(crate) const OFFSET_JSX_NAMESPACED_NAME_NAMESPACE: usize =
     offset_of!(JSXNamespacedName, namespace);
@@ -9140,6 +10684,13 @@ impl<'a, 't> JSXNamespacedNameWithoutNamespace<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXNamespacedNameWithoutNamespace<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXNamespacedNameWithoutProperty<'a, 't>(
@@ -9159,6 +10710,13 @@ impl<'a, 't> JSXNamespacedNameWithoutProperty<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_JSX_NAMESPACED_NAME_NAMESPACE)
                 as *const JSXIdentifier<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXNamespacedNameWithoutProperty<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9190,6 +10748,13 @@ impl<'a, 't> JSXMemberExpressionWithoutObject<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXMemberExpressionWithoutObject<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXMemberExpressionWithoutProperty<'a, 't>(
@@ -9212,6 +10777,13 @@ impl<'a, 't> JSXMemberExpressionWithoutProperty<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXMemberExpressionWithoutProperty<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_JSX_EXPRESSION_CONTAINER_SPAN: usize =
     offset_of!(JSXExpressionContainer, span);
 pub(crate) const OFFSET_JSX_EXPRESSION_CONTAINER_EXPRESSION: usize =
@@ -9230,6 +10802,13 @@ impl<'a, 't> JSXExpressionContainerWithoutExpression<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_EXPRESSION_CONTAINER_SPAN) as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXExpressionContainerWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9259,6 +10838,13 @@ impl<'a, 't> JSXAttributeWithoutName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXAttributeWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JSXAttributeWithoutValue<'a, 't>(
@@ -9280,6 +10866,13 @@ impl<'a, 't> JSXAttributeWithoutValue<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXAttributeWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_JSX_SPREAD_ATTRIBUTE_SPAN: usize = offset_of!(JSXSpreadAttribute, span);
 pub(crate) const OFFSET_JSX_SPREAD_ATTRIBUTE_ARGUMENT: usize =
     offset_of!(JSXSpreadAttribute, argument);
@@ -9298,6 +10891,13 @@ impl<'a, 't> JSXSpreadAttributeWithoutArgument<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for JSXSpreadAttributeWithoutArgument<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_JSX_SPREAD_CHILD_SPAN: usize = offset_of!(JSXSpreadChild, span);
 pub(crate) const OFFSET_JSX_SPREAD_CHILD_EXPRESSION: usize = offset_of!(JSXSpreadChild, expression);
 
@@ -9312,6 +10912,13 @@ impl<'a, 't> JSXSpreadChildWithoutExpression<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_SPREAD_CHILD_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXSpreadChildWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9336,6 +10943,13 @@ impl<'a, 't> TSThisParameterWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn this_span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_THIS_PARAMETER_THIS_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSThisParameterWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9387,6 +11001,13 @@ impl<'a, 't> TSEnumDeclarationWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSEnumDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSEnumDeclarationWithoutMembers<'a, 't>(
@@ -9427,6 +11048,13 @@ impl<'a, 't> TSEnumDeclarationWithoutMembers<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSEnumDeclarationWithoutMembers<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_ENUM_MEMBER_SPAN: usize = offset_of!(TSEnumMember, span);
 pub(crate) const OFFSET_TS_ENUM_MEMBER_ID: usize = offset_of!(TSEnumMember, id);
 pub(crate) const OFFSET_TS_ENUM_MEMBER_INITIALIZER: usize = offset_of!(TSEnumMember, initializer);
@@ -9453,6 +11081,13 @@ impl<'a, 't> TSEnumMemberWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSEnumMemberWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSEnumMemberWithoutInitializer<'a, 't>(
@@ -9474,6 +11109,13 @@ impl<'a, 't> TSEnumMemberWithoutInitializer<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSEnumMemberWithoutInitializer<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_TYPE_ANNOTATION_SPAN: usize = offset_of!(TSTypeAnnotation, span);
 pub(crate) const OFFSET_TS_TYPE_ANNOTATION_TYPE_ANNOTATION: usize =
     offset_of!(TSTypeAnnotation, type_annotation);
@@ -9492,6 +11134,13 @@ impl<'a, 't> TSTypeAnnotationWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeAnnotationWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_LITERAL_TYPE_SPAN: usize = offset_of!(TSLiteralType, span);
 pub(crate) const OFFSET_TS_LITERAL_TYPE_LITERAL: usize = offset_of!(TSLiteralType, literal);
 
@@ -9506,6 +11155,13 @@ impl<'a, 't> TSLiteralTypeWithoutLiteral<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_LITERAL_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSLiteralTypeWithoutLiteral<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9566,6 +11222,13 @@ impl<'a, 't> TSConditionalTypeWithoutCheckType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConditionalTypeWithoutCheckType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSConditionalTypeWithoutExtendsType<'a, 't>(
@@ -9608,6 +11271,13 @@ impl<'a, 't> TSConditionalTypeWithoutExtendsType<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CONDITIONAL_TYPE_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSConditionalTypeWithoutExtendsType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9657,6 +11327,13 @@ impl<'a, 't> TSConditionalTypeWithoutTrueType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConditionalTypeWithoutTrueType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSConditionalTypeWithoutFalseType<'a, 't>(
@@ -9702,6 +11379,13 @@ impl<'a, 't> TSConditionalTypeWithoutFalseType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConditionalTypeWithoutFalseType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_UNION_TYPE_SPAN: usize = offset_of!(TSUnionType, span);
 pub(crate) const OFFSET_TS_UNION_TYPE_TYPES: usize = offset_of!(TSUnionType, types);
 
@@ -9716,6 +11400,13 @@ impl<'a, 't> TSUnionTypeWithoutTypes<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_UNION_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSUnionTypeWithoutTypes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9736,6 +11427,13 @@ impl<'a, 't> TSIntersectionTypeWithoutTypes<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSIntersectionTypeWithoutTypes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_PARENTHESIZED_TYPE_SPAN: usize = offset_of!(TSParenthesizedType, span);
 pub(crate) const OFFSET_TS_PARENTHESIZED_TYPE_TYPE_ANNOTATION: usize =
     offset_of!(TSParenthesizedType, type_annotation);
@@ -9751,6 +11449,13 @@ impl<'a, 't> TSParenthesizedTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_PARENTHESIZED_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSParenthesizedTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9781,6 +11486,13 @@ impl<'a, 't> TSTypeOperatorWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeOperatorWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_ARRAY_TYPE_SPAN: usize = offset_of!(TSArrayType, span);
 pub(crate) const OFFSET_TS_ARRAY_TYPE_ELEMENT_TYPE: usize = offset_of!(TSArrayType, element_type);
 
@@ -9795,6 +11507,13 @@ impl<'a, 't> TSArrayTypeWithoutElementType<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_ARRAY_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSArrayTypeWithoutElementType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9826,6 +11545,13 @@ impl<'a, 't> TSIndexedAccessTypeWithoutObjectType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSIndexedAccessTypeWithoutObjectType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSIndexedAccessTypeWithoutIndexType<'a, 't>(
@@ -9848,6 +11574,13 @@ impl<'a, 't> TSIndexedAccessTypeWithoutIndexType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSIndexedAccessTypeWithoutIndexType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_TUPLE_TYPE_SPAN: usize = offset_of!(TSTupleType, span);
 pub(crate) const OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES: usize = offset_of!(TSTupleType, element_types);
 
@@ -9862,6 +11595,13 @@ impl<'a, 't> TSTupleTypeWithoutElementTypes<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TUPLE_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTupleTypeWithoutElementTypes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9901,6 +11641,13 @@ impl<'a, 't> TSNamedTupleMemberWithoutElementType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutElementType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSNamedTupleMemberWithoutLabel<'a, 't>(
@@ -9930,6 +11677,13 @@ impl<'a, 't> TSNamedTupleMemberWithoutLabel<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSNamedTupleMemberWithoutLabel<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_OPTIONAL_TYPE_SPAN: usize = offset_of!(TSOptionalType, span);
 pub(crate) const OFFSET_TS_OPTIONAL_TYPE_TYPE_ANNOTATION: usize =
     offset_of!(TSOptionalType, type_annotation);
@@ -9948,6 +11702,13 @@ impl<'a, 't> TSOptionalTypeWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSOptionalTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_REST_TYPE_SPAN: usize = offset_of!(TSRestType, span);
 pub(crate) const OFFSET_TS_REST_TYPE_TYPE_ANNOTATION: usize =
     offset_of!(TSRestType, type_annotation);
@@ -9963,6 +11724,13 @@ impl<'a, 't> TSRestTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_REST_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSRestTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -9993,6 +11761,13 @@ impl<'a, 't> TSTypeReferenceWithoutTypeName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypeReferenceWithoutTypeParameters<'a, 't>(
@@ -10012,6 +11787,13 @@ impl<'a, 't> TSTypeReferenceWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_TYPE_NAME)
                 as *const TSTypeName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10041,6 +11823,13 @@ impl<'a, 't> TSQualifiedNameWithoutLeft<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSQualifiedNameWithoutLeft<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSQualifiedNameWithoutRight<'a, 't>(
@@ -10059,6 +11848,13 @@ impl<'a, 't> TSQualifiedNameWithoutRight<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_QUALIFIED_NAME_LEFT) as *const TSTypeName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSQualifiedNameWithoutRight<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10081,6 +11877,13 @@ impl<'a, 't> TSTypeParameterInstantiationWithoutParams<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_SPAN)
                 as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeParameterInstantiationWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10138,6 +11941,13 @@ impl<'a, 't> TSTypeParameterWithoutName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeParameterWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypeParameterWithoutConstraint<'a, 't>(
@@ -10180,6 +11990,13 @@ impl<'a, 't> TSTypeParameterWithoutConstraint<'a, 't> {
     #[inline]
     pub fn r#const(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PARAMETER_CONST) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeParameterWithoutConstraint<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10228,6 +12045,13 @@ impl<'a, 't> TSTypeParameterWithoutDefault<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeParameterWithoutDefault<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_TYPE_PARAMETER_DECLARATION_SPAN: usize =
     offset_of!(TSTypeParameterDeclaration, span);
 pub(crate) const OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS: usize =
@@ -10246,6 +12070,13 @@ impl<'a, 't> TSTypeParameterDeclarationWithoutParams<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PARAMETER_DECLARATION_SPAN) as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeParameterDeclarationWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10309,6 +12140,13 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypeAliasDeclarationWithoutTypeParameters<'a, 't>(
@@ -10353,6 +12191,13 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ALIAS_DECLARATION_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10403,6 +12248,13 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_SPAN: usize = offset_of!(TSClassImplements, span);
 pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION: usize =
     offset_of!(TSClassImplements, expression);
@@ -10431,6 +12283,13 @@ impl<'a, 't> TSClassImplementsWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSClassImplementsWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSClassImplementsWithoutTypeParameters<'a, 't>(
@@ -10450,6 +12309,13 @@ impl<'a, 't> TSClassImplementsWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION)
                 as *const TSTypeName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSClassImplementsWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10522,6 +12388,13 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSInterfaceDeclarationWithoutExtends<'a, 't>(
@@ -10574,6 +12447,13 @@ impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutExtends<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10632,6 +12512,13 @@ impl<'a, 't> TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSInterfaceDeclarationWithoutBody<'a, 't>(
@@ -10687,6 +12574,13 @@ impl<'a, 't> TSInterfaceDeclarationWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_INTERFACE_BODY_SPAN: usize = offset_of!(TSInterfaceBody, span);
 pub(crate) const OFFSET_TS_INTERFACE_BODY_BODY: usize = offset_of!(TSInterfaceBody, body);
 
@@ -10701,6 +12595,13 @@ impl<'a, 't> TSInterfaceBodyWithoutBody<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_BODY_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInterfaceBodyWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10758,6 +12659,13 @@ impl<'a, 't> TSPropertySignatureWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSPropertySignatureWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSPropertySignatureWithoutTypeAnnotation<'a, 't>(
@@ -10801,6 +12709,13 @@ impl<'a, 't> TSPropertySignatureWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSPropertySignatureWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_SPAN: usize = offset_of!(TSIndexSignature, span);
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_PARAMETERS: usize =
     offset_of!(TSIndexSignature, parameters);
@@ -10835,6 +12750,13 @@ impl<'a, 't> TSIndexSignatureWithoutParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSIndexSignatureWithoutParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSIndexSignatureWithoutTypeAnnotation<'a, 't>(
@@ -10859,6 +12781,13 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn readonly(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_READONLY) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10913,6 +12842,13 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSCallSignatureDeclarationWithoutThisParam<'a, 't>(
@@ -10950,6 +12886,13 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -10993,6 +12936,13 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSCallSignatureDeclarationWithoutReturnType<'a, 't>(
@@ -11030,6 +12980,13 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
                 as *const Box<'a, FormalParameters<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11122,6 +13079,13 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSMethodSignatureWithoutKey<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSMethodSignatureWithoutTypeParameters<'a, 't>(
@@ -11190,6 +13154,13 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSMethodSignatureWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11264,6 +13235,13 @@ impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSMethodSignatureWithoutThisParam<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSMethodSignatureWithoutParams<'a, 't>(
@@ -11332,6 +13310,13 @@ impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSMethodSignatureWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11406,6 +13391,13 @@ impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSMethodSignatureWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SPAN: usize =
     offset_of!(TSConstructSignatureDeclaration, span);
 pub(crate) const OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS: usize =
@@ -11458,6 +13450,13 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSConstructSignatureDeclarationWithoutParams<'a, 't>(
@@ -11496,6 +13495,13 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11540,6 +13546,13 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_NAME_SPAN: usize =
     offset_of!(TSIndexSignatureName, span);
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_NAME_NAME: usize =
@@ -11565,6 +13578,13 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Atom<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11596,6 +13616,13 @@ impl<'a, 't> TSInterfaceHeritageWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSInterfaceHeritageWithoutTypeParameters<'a, 't>(
@@ -11615,6 +13642,13 @@ impl<'a, 't> TSInterfaceHeritageWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_EXPRESSION)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11652,6 +13686,13 @@ impl<'a, 't> TSTypePredicateWithoutParameterName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypePredicateWithoutParameterName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypePredicateWithoutTypeAnnotation<'a, 't>(
@@ -11676,6 +13717,13 @@ impl<'a, 't> TSTypePredicateWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn asserts(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PREDICATE_ASSERTS) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypePredicateWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11733,6 +13781,13 @@ impl<'a, 't> TSModuleDeclarationWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSModuleDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSModuleDeclarationWithoutBody<'a, 't>(
@@ -11778,6 +13833,13 @@ impl<'a, 't> TSModuleDeclarationWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSModuleDeclarationWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_MODULE_BLOCK_SPAN: usize = offset_of!(TSModuleBlock, span);
 pub(crate) const OFFSET_TS_MODULE_BLOCK_DIRECTIVES: usize = offset_of!(TSModuleBlock, directives);
 pub(crate) const OFFSET_TS_MODULE_BLOCK_BODY: usize = offset_of!(TSModuleBlock, body);
@@ -11804,6 +13866,13 @@ impl<'a, 't> TSModuleBlockWithoutDirectives<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSModuleBlockWithoutDirectives<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSModuleBlockWithoutBody<'a, 't>(
@@ -11826,6 +13895,13 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSModuleBlockWithoutBody<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_TYPE_LITERAL_SPAN: usize = offset_of!(TSTypeLiteral, span);
 pub(crate) const OFFSET_TS_TYPE_LITERAL_MEMBERS: usize = offset_of!(TSTypeLiteral, members);
 
@@ -11840,6 +13916,13 @@ impl<'a, 't> TSTypeLiteralWithoutMembers<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_LITERAL_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeLiteralWithoutMembers<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11858,6 +13941,13 @@ impl<'a, 't> TSInferTypeWithoutTypeParameter<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INFER_TYPE_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInferTypeWithoutTypeParameter<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11888,6 +13978,13 @@ impl<'a, 't> TSTypeQueryWithoutExprName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeQueryWithoutExprName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypeQueryWithoutTypeParameters<'a, 't>(
@@ -11907,6 +14004,13 @@ impl<'a, 't> TSTypeQueryWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_EXPR_NAME)
                 as *const TSTypeQueryExprName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -11961,6 +14065,13 @@ impl<'a, 't> TSImportTypeWithoutParameter<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportTypeWithoutParameter<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSImportTypeWithoutQualifier<'a, 't>(
@@ -12000,6 +14111,13 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSImportTypeWithoutQualifier<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12045,6 +14163,13 @@ impl<'a, 't> TSImportTypeWithoutAttributes<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportTypeWithoutAttributes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSImportTypeWithoutTypeParameters<'a, 't>(
@@ -12087,6 +14212,13 @@ impl<'a, 't> TSImportTypeWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportTypeWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_SPAN: usize = offset_of!(TSImportAttributes, span);
 pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD: usize =
     offset_of!(TSImportAttributes, attributes_keyword);
@@ -12115,6 +14247,13 @@ impl<'a, 't> TSImportAttributesWithoutAttributesKeyword<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportAttributesWithoutAttributesKeyword<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSImportAttributesWithoutElements<'a, 't>(
@@ -12134,6 +14273,13 @@ impl<'a, 't> TSImportAttributesWithoutElements<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
                 as *const IdentifierName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSImportAttributesWithoutElements<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12162,6 +14308,13 @@ impl<'a, 't> TSImportAttributeWithoutName<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportAttributeWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSImportAttributeWithoutValue<'a, 't>(
@@ -12181,6 +14334,13 @@ impl<'a, 't> TSImportAttributeWithoutValue<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTE_NAME)
                 as *const TSImportAttributeName<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSImportAttributeWithoutValue<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12230,6 +14390,13 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSFunctionTypeWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSFunctionTypeWithoutThisParam<'a, 't>(
@@ -12265,6 +14432,13 @@ impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
                 as *const Box<'a, TSTypeAnnotation<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSFunctionTypeWithoutThisParam<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12306,6 +14480,13 @@ impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSFunctionTypeWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSFunctionTypeWithoutReturnType<'a, 't>(
@@ -12341,6 +14522,13 @@ impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
                 as *const Box<'a, FormalParameters<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSFunctionTypeWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12388,6 +14576,13 @@ impl<'a, 't> TSConstructorTypeWithoutTypeParameters<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConstructorTypeWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSConstructorTypeWithoutParams<'a, 't>(
@@ -12423,6 +14618,13 @@ impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSConstructorTypeWithoutParams<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSConstructorTypeWithoutReturnType<'a, 't>(
@@ -12455,6 +14657,13 @@ impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
                 as *const Box<'a, FormalParameters<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSConstructorTypeWithoutReturnType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12522,6 +14731,13 @@ impl<'a, 't> TSMappedTypeWithoutTypeParameter<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSMappedTypeWithoutTypeParameter<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSMappedTypeWithoutNameType<'a, 't>(
@@ -12573,6 +14789,13 @@ impl<'a, 't> TSMappedTypeWithoutNameType<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSMappedTypeWithoutNameType<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12630,6 +14853,13 @@ impl<'a, 't> TSMappedTypeWithoutTypeAnnotation<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSMappedTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_TEMPLATE_LITERAL_TYPE_SPAN: usize =
     offset_of!(TSTemplateLiteralType, span);
 pub(crate) const OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS: usize =
@@ -12661,6 +14891,13 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTemplateLiteralTypeWithoutTypes<'a, 't>(
@@ -12682,6 +14919,13 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutTypes<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
                 as *const Vec<'a, TemplateElement<'a>>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTemplateLiteralTypeWithoutTypes<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12712,6 +14956,13 @@ impl<'a, 't> TSAsExpressionWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSAsExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSAsExpressionWithoutTypeAnnotation<'a, 't>(
@@ -12731,6 +14982,13 @@ impl<'a, 't> TSAsExpressionWithoutTypeAnnotation<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_AS_EXPRESSION_EXPRESSION)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSAsExpressionWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12763,6 +15021,13 @@ impl<'a, 't> TSSatisfiesExpressionWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSSatisfiesExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't>(
@@ -12782,6 +15047,13 @@ impl<'a, 't> TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_SATISFIES_EXPRESSION_EXPRESSION)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSSatisfiesExpressionWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12813,6 +15085,13 @@ impl<'a, 't> TSTypeAssertionWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSTypeAssertionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSTypeAssertionWithoutTypeAnnotation<'a, 't>(
@@ -12832,6 +15111,13 @@ impl<'a, 't> TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ASSERTION_EXPRESSION)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSTypeAssertionWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12876,6 +15162,13 @@ impl<'a, 't> TSImportEqualsDeclarationWithoutId<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportEqualsDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSImportEqualsDeclarationWithoutModuleReference<'a, 't>(
@@ -12908,6 +15201,13 @@ impl<'a, 't> TSImportEqualsDeclarationWithoutModuleReference<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSImportEqualsDeclarationWithoutModuleReference<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_EXTERNAL_MODULE_REFERENCE_SPAN: usize =
     offset_of!(TSExternalModuleReference, span);
 pub(crate) const OFFSET_TS_EXTERNAL_MODULE_REFERENCE_EXPRESSION: usize =
@@ -12929,6 +15229,13 @@ impl<'a, 't> TSExternalModuleReferenceWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSExternalModuleReferenceWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_NON_NULL_EXPRESSION_SPAN: usize = offset_of!(TSNonNullExpression, span);
 pub(crate) const OFFSET_TS_NON_NULL_EXPRESSION_EXPRESSION: usize =
     offset_of!(TSNonNullExpression, expression);
@@ -12944,6 +15251,13 @@ impl<'a, 't> TSNonNullExpressionWithoutExpression<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_NON_NULL_EXPRESSION_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSNonNullExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -12964,6 +15278,13 @@ impl<'a, 't> DecoratorWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for DecoratorWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 pub(crate) const OFFSET_TS_EXPORT_ASSIGNMENT_SPAN: usize = offset_of!(TSExportAssignment, span);
 pub(crate) const OFFSET_TS_EXPORT_ASSIGNMENT_EXPRESSION: usize =
     offset_of!(TSExportAssignment, expression);
@@ -12979,6 +15300,13 @@ impl<'a, 't> TSExportAssignmentWithoutExpression<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_EXPORT_ASSIGNMENT_SPAN) as *const Span) }
+    }
+}
+
+impl<'a, 't> GetAddress for TSExportAssignmentWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -13001,6 +15329,13 @@ impl<'a, 't> TSNamespaceExportDeclarationWithoutId<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_NAMESPACE_EXPORT_DECLARATION_SPAN)
                 as *const Span)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSNamespaceExportDeclarationWithoutId<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -13035,6 +15370,13 @@ impl<'a, 't> TSInstantiationExpressionWithoutExpression<'a, 't> {
     }
 }
 
+impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutExpression<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct TSInstantiationExpressionWithoutTypeParameters<'a, 't>(
@@ -13056,6 +15398,13 @@ impl<'a, 't> TSInstantiationExpressionWithoutTypeParameters<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_INSTANTIATION_EXPRESSION_EXPRESSION)
                 as *const Expression<'a>)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutTypeParameters<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -13081,6 +15430,13 @@ impl<'a, 't> JSDocNullableTypeWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn postfix(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JS_DOC_NULLABLE_TYPE_POSTFIX) as *const bool) }
+    }
+}
+
+impl<'a, 't> GetAddress for JSDocNullableTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }
 
@@ -13111,5 +15467,12 @@ impl<'a, 't> JSDocNonNullableTypeWithoutTypeAnnotation<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JS_DOC_NON_NULLABLE_TYPE_POSTFIX) as *const bool)
         }
+    }
+}
+
+impl<'a, 't> GetAddress for JSDocNonNullableTypeWithoutTypeAnnotation<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
     }
 }


### PR DESCRIPTION
Closes #6803. Allow getting `Address` of an `Ancestor`.