### PR TITLE
fix(transformer): only run typescript plugin for typescript source

### DIFF
--- a/crates/oxc/src/napi/transform.rs
+++ b/crates/oxc/src/napi/transform.rs
@@ -96,7 +96,10 @@ impl From<TransformOptions> for oxc_transformer::TransformOptions {
     fn from(options: TransformOptions) -> Self {
         Self {
             cwd: options.cwd.map(PathBuf::from).unwrap_or_default(),
-            typescript: options.typescript.map(Into::into).unwrap_or_default(),
+            typescript: options
+                .typescript
+                .map(oxc_transformer::TypeScriptOptions::from)
+                .unwrap_or_default(),
             jsx: options.jsx.map(Into::into).unwrap_or_default(),
             es2015: options.es2015.map(Into::into).unwrap_or_default(),
             ..Self::default()

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -92,7 +92,10 @@ impl<'a> Transformer<'a> {
         jsx::update_options_with_comments(&program.comments, &mut self.options, &self.ctx);
 
         let mut transformer = TransformerImpl {
-            x0_typescript: TypeScript::new(&self.options.typescript, &self.ctx),
+            x0_typescript: program
+                .source_type
+                .is_typescript()
+                .then(|| TypeScript::new(&self.options.typescript, &self.ctx)),
             x1_jsx: Jsx::new(self.options.jsx, ast_builder, &self.ctx),
             x2_es2022: ES2022::new(self.options.es2022),
             x2_es2021: ES2021::new(self.options.es2021, &self.ctx),
@@ -113,7 +116,7 @@ impl<'a> Transformer<'a> {
 
 struct TransformerImpl<'a, 'ctx> {
     // NOTE: all callbacks must run in order.
-    x0_typescript: TypeScript<'a, 'ctx>,
+    x0_typescript: Option<TypeScript<'a, 'ctx>>,
     x1_jsx: Jsx<'a, 'ctx>,
     x2_es2022: ES2022,
     x2_es2021: ES2021<'a, 'ctx>,
@@ -129,13 +132,17 @@ struct TransformerImpl<'a, 'ctx> {
 
 impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_program(program, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_program(program, ctx);
+        }
         self.x1_jsx.enter_program(program, ctx);
     }
 
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x1_jsx.exit_program(program, ctx);
-        self.x0_typescript.exit_program(program, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.exit_program(program, ctx);
+        }
         self.x3_es2015.exit_program(program, ctx);
         self.common.exit_program(program, ctx);
     }
@@ -147,7 +154,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         arrow: &mut ArrowFunctionExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_arrow_function_expression(arrow, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_arrow_function_expression(arrow, ctx);
+        }
     }
 
     fn enter_variable_declarator(
@@ -155,24 +164,34 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         decl: &mut VariableDeclarator<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_variable_declarator(decl, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_variable_declarator(decl, ctx);
+        }
     }
 
     fn enter_binding_pattern(&mut self, pat: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_binding_pattern(pat, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_binding_pattern(pat, ctx);
+        }
     }
 
     fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_call_expression(expr, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_call_expression(expr, ctx);
+        }
         self.x1_jsx.enter_call_expression(expr, ctx);
     }
 
     fn enter_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_class(class, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_class(class, ctx);
+        }
     }
 
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_class_body(body, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_class_body(body, ctx);
+        }
         self.x2_es2022.enter_class_body(body, ctx);
     }
 
@@ -189,12 +208,16 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         decl: &mut TSModuleDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_ts_module_declaration(decl, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_ts_module_declaration(decl, ctx);
+        }
     }
 
     #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_expression(expr, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_expression(expr, ctx);
+        }
         self.x2_es2021.enter_expression(expr, ctx);
         self.x2_es2020.enter_expression(expr, ctx);
         self.x2_es2018.enter_expression(expr, ctx);
@@ -214,7 +237,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut SimpleAssignmentTarget<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_simple_assignment_target(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_simple_assignment_target(node, ctx);
+        }
     }
 
     fn enter_assignment_target(
@@ -222,7 +247,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut AssignmentTarget<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_assignment_target(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_assignment_target(node, ctx);
+        }
     }
 
     fn enter_formal_parameter(
@@ -230,7 +257,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         param: &mut FormalParameter<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_formal_parameter(param, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_formal_parameter(param, ctx);
+        }
     }
 
     fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -238,13 +267,17 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     }
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.exit_function(func, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.exit_function(func, ctx);
+        }
         self.x1_jsx.exit_function(func, ctx);
         self.x3_es2015.exit_function(func, ctx);
     }
 
     fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_jsx_element(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_jsx_element(node, ctx);
+        }
     }
 
     fn enter_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -260,7 +293,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     }
 
     fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_jsx_fragment(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_jsx_fragment(node, ctx);
+        }
     }
 
     fn enter_jsx_opening_element(
@@ -268,7 +303,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         elem: &mut JSXOpeningElement<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_jsx_opening_element(elem, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_jsx_opening_element(elem, ctx);
+        }
         self.x1_jsx.enter_jsx_opening_element(elem, ctx);
     }
 
@@ -277,7 +314,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         def: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_method_definition(def, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_method_definition(def, ctx);
+        }
     }
 
     fn exit_method_definition(
@@ -285,12 +324,16 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         def: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.exit_method_definition(def, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.exit_method_definition(def, ctx);
+        }
         self.x2_es2017.exit_method_definition(def, ctx);
     }
 
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_new_expression(expr, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_new_expression(expr, ctx);
+        }
     }
 
     fn enter_property_definition(
@@ -298,7 +341,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         def: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_property_definition(def, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_property_definition(def, ctx);
+        }
     }
 
     fn enter_accessor_property(
@@ -306,12 +351,16 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut AccessorProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_accessor_property(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_accessor_property(node, ctx);
+        }
     }
 
     fn enter_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
         self.common.enter_statements(stmts, ctx);
-        self.x0_typescript.enter_statements(stmts, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_statements(stmts, ctx);
+        }
         self.x1_jsx.enter_statements(stmts, ctx);
     }
 
@@ -340,13 +389,17 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.exit_statements(stmts, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.exit_statements(stmts, ctx);
+        }
         self.x1_jsx.exit_statements(stmts, ctx);
         self.common.exit_statements(stmts, ctx);
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.exit_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.exit_statement(stmt, ctx);
+        }
         self.x2_es2017.exit_statement(stmt, ctx);
     }
 
@@ -355,23 +408,33 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         expr: &mut TaggedTemplateExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_tagged_template_expression(expr, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_tagged_template_expression(expr, ctx);
+        }
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_statement(stmt, ctx);
+        }
     }
 
     fn enter_declaration(&mut self, decl: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_declaration(decl, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_declaration(decl, ctx);
+        }
     }
 
     fn enter_if_statement(&mut self, stmt: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_if_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_if_statement(stmt, ctx);
+        }
     }
 
     fn enter_while_statement(&mut self, stmt: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_while_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_while_statement(stmt, ctx);
+        }
     }
 
     fn enter_do_while_statement(
@@ -379,19 +442,27 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         stmt: &mut DoWhileStatement<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_do_while_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_do_while_statement(stmt, ctx);
+        }
     }
 
     fn enter_for_statement(&mut self, stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_for_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_for_statement(stmt, ctx);
+        }
     }
 
     fn enter_for_of_statement(&mut self, stmt: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_for_of_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_for_of_statement(stmt, ctx);
+        }
     }
 
     fn enter_for_in_statement(&mut self, stmt: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.enter_for_in_statement(stmt, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_for_in_statement(stmt, ctx);
+        }
     }
 
     fn enter_catch_clause(&mut self, clause: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -403,7 +474,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut ImportDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_import_declaration(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_import_declaration(node, ctx);
+        }
     }
 
     fn enter_export_all_declaration(
@@ -411,7 +484,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut ExportAllDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_export_all_declaration(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_export_all_declaration(node, ctx);
+        }
     }
 
     fn enter_export_named_declaration(
@@ -419,7 +494,9 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         node: &mut ExportNamedDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_export_named_declaration(node, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_export_named_declaration(node, ctx);
+        }
     }
 
     fn enter_ts_export_assignment(
@@ -427,6 +504,8 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         export_assignment: &mut TSExportAssignment<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.enter_ts_export_assignment(export_assignment, ctx);
+        if let Some(typescript) = self.x0_typescript.as_mut() {
+            typescript.enter_ts_export_assignment(export_assignment, ctx);
+        }
     }
 }

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: d20b314c
 
 semantic_babel Summary:
 AST Parsed     : 2136/2136 (100.00%)
-Positive Passed: 1756/2136 (82.21%)
+Positive Passed: 1778/2136 (83.24%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
@@ -10,16 +10,6 @@ rebuilt        : SymbolId(0): ScopeId(4294967294)
 Symbol scope ID mismatch for "g":
 after transform: SymbolId(1): ScopeId(4294967294)
 rebuilt        : SymbolId(1): ScopeId(4294967294)
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["spawn"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/regression/10892/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
 semantic error: Unexpected new.target expression
@@ -35,106 +25,6 @@ semantic error: A 'return' statement can only be used within a function body.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/328/input.js
 semantic error: A 'return' statement can only be used within a function body.
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/modules/import-declaration-trailing-comma/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/301/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/92/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["$"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/93/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["decrypt", "encrypt"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/94/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["enc"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/95/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["crypto", "decrypt", "enc"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/97/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nil"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/98/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["crypto"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-default/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-default-and-named-specifiers/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-default-and-namespace-specifiers/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-default-as/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-jquery/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["$"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-named-as-specifier/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["baz"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-named-as-specifiers/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["baz", "xyz"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-named-specifier/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-named-specifiers/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "baz"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-named-specifiers-comma/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["bar", "baz"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-namespace-specifier/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-import-declaration/import-null-as-nil/input.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["nil"]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/statement-if/migrated_0003/input.js
 semantic error: Symbol scope ID mismatch for "a":

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: 06454619
 
 semantic_test262 Summary:
 AST Parsed     : 43851/43851 (100.00%)
-Positive Passed: 43651/43851 (99.54%)
+Positive Passed: 43671/43851 (99.59%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(3): ScopeId(4294967294)
@@ -1118,113 +1118,4 @@ tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
 rebuilt        : SymbolId(0): ScopeId(4294967294)
-
-tasks/coverage/test262/test/language/module-code/eval-rqstd-once.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dflt1", "dflt2", "dflt3", "global", "ns1", "ns3"]
-rebuilt        : ScopeId(0): ["global"]
-Symbol flags mismatch for "global":
-after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-
-tasks/coverage/test262/test/language/module-code/eval-rqstd-order.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dflt1", "dflt2", "dflt3", "ns1", "ns2"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/eval-self-once.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dflt1", "dflt2", "dflt3", "global", "ns", "ns1"]
-rebuilt        : ScopeId(0): ["global"]
-Symbol flags mismatch for "global":
-after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
-
-tasks/coverage/test262/test/language/module-code/import-attributes/allow-nlt-before-with.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/import-attributes/import-attribute-many.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/import-attributes/import-attribute-trlng-comma.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/import-attributes/import-attribute-value-string-double.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/import-attributes/import-attribute-value-string-single.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-ambiguous-as.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["y"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-ambiguous.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-dflt-thru-star-as.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-dflt-thru-star-dflt.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-not-found-as.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["y"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-not-found-dflt.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-named-err-not-found.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/instn-once.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dflt1", "dflt2", "dflt3", "ns", "ns1", "x"]
-rebuilt        : ScopeId(0): ["x"]
-Symbol flags mismatch for "x":
-after transform: SymbolId(5): SymbolFlags(BlockScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
-
-tasks/coverage/test262/test/language/module-code/instn-star-err-not-found.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["ns"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/top-level-await/module-import-rejection-body.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/top-level-await/module-import-rejection-tick.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/module-code/top-level-await/module-import-rejection.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["resolved"]
-rebuilt        : ScopeId(0): []
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: df9d1650
 
 semantic_typescript Summary:
 AST Parsed     : 6490/6490 (100.00%)
-Positive Passed: 2681/6490 (41.31%)
+Positive Passed: 2687/6490 (41.40%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -37284,17 +37284,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["dec"]
 
-tasks/coverage/typescript/tests/cases/compiler/usedImportNotElidedInJs.ts
-semantic error: Symbol flags mismatch for "moment":
-after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Import)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
-Symbol span mismatch for "moment":
-after transform: SymbolId(0): Span { start: 24, end: 30 }
-rebuilt        : SymbolId(1): Span { start: 103, end: 109 }
-Symbol redeclarations mismatch for "moment":
-after transform: SymbolId(0): [Span { start: 103, end: 109 }]
-rebuilt        : SymbolId(1): []
-
 tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
@@ -48974,16 +48963,6 @@ Unresolved references mismatch:
 after transform: ["Uint8Array"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["Point", "magnitude"]
-rebuilt        : ScopeId(0): ["magnitude"]
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportNamespacedType.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["dot2", "dummy"]
-rebuilt        : ScopeId(0): ["dot2"]
-
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
@@ -49080,11 +49059,6 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocAugments_qualifiedName.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["B", "a"]
-rebuilt        : ScopeId(0): ["B"]
-
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
@@ -49092,11 +49066,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): ["B"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
 semantic error: Bindings mismatch:
@@ -50710,11 +50679,6 @@ semantic error: Expected a semicolon or an implicit semicolon after a statement,
 
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts
 semantic error: Expected a semicolon or an implicit semicolon after a statement, but found none
-
-tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeAllowJsPackageSelfName2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAssignments.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -2,6 +2,5 @@ commit: df9d1650
 
 transformer_typescript Summary:
 AST Parsed     : 6490/6490 (100.00%)
-Positive Passed: 6488/6490 (99.97%)
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
+Positive Passed: 6489/6490 (99.98%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 355/1058
+Passed: 357/1058
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -12,7 +12,7 @@ Passed: 355/1058
 * babel-plugin-transform-react-jsx-source
 
 
-# babel-preset-env (108/585)
+# babel-preset-env (110/585)
 * .plugins-overlapping/chrome-49/input.js
 x Output mismatch
 
@@ -371,9 +371,6 @@ x Output mismatch
 x Output mismatch
 
 * corejs3/entry-require-es-proposals/input.js
-x Output mismatch
-
-* corejs3/entry-specified-imports/input.mjs
 x Output mismatch
 
 * corejs3/entry-stable/input.mjs
@@ -1220,9 +1217,6 @@ x Output mismatch
 x Output mismatch
 
 * modules/modules-commonjs/input.mjs
-x Output mismatch
-
-* modules/modules-false/input.mjs
 x Output mismatch
 
 * modules/modules-systemjs/input.mjs


### PR DESCRIPTION
closes #6865

TypeScript plugin changes import / export statements so it needs to be turned off for non-typescript files. This should also give a little performance boost for non-typescript files.