### PR TITLE
refactor(allocator): add `impl GetAddress for Address`

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -43,3 +43,11 @@ impl<'a, T> GetAddress for Box<'a, T> {
         Address::from_ptr(ptr::addr_of!(**self))
     }
 }
+
+impl GetAddress for Address {
+    /// Address of an `Address` is itself.
+    #[inline]
+    fn address(&self) -> Address {
+        *self
+    }
+}


### PR DESCRIPTION
This allows passing an `Address` to methods like `StatementInjectorStore::insert_before` if you want to.