### PR TITLE
refactor(minifier): remove extra compress options

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
@@ -2,15 +2,13 @@ use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
 
-use crate::{CompressOptions, CompressorPass};
+use crate::CompressorPass;
 
 /// Collapse variable declarations.
 ///
 /// `var a; var b = 1; var c = 2` => `var a, b = 1; c = 2`
 /// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java>
 pub struct CollapseVariableDeclarations {
-    options: CompressOptions,
-
     changed: bool,
 }
 
@@ -32,8 +30,8 @@ impl<'a> Traverse<'a> for CollapseVariableDeclarations {
 }
 
 impl<'a> CollapseVariableDeclarations {
-    pub fn new(options: CompressOptions) -> Self {
-        Self { options, changed: false }
+    pub fn new() -> Self {
+        Self { changed: false }
     }
 
     fn is_require_call(var_decl: &VariableDeclaration) -> bool {
@@ -58,7 +56,7 @@ impl<'a> CollapseVariableDeclarations {
     }
 
     fn join_vars(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
-        if !self.options.join_vars || stmts.len() < 2 {
+        if stmts.len() < 2 {
             return;
         }
 
@@ -115,11 +113,11 @@ impl<'a> CollapseVariableDeclarations {
 mod test {
     use oxc_allocator::Allocator;
 
-    use crate::{tester, CompressOptions};
+    use crate::tester;
 
     fn test(source_text: &str, expected: &str) {
         let allocator = Allocator::default();
-        let mut pass = super::CollapseVariableDeclarations::new(CompressOptions::default());
+        let mut pass = super::CollapseVariableDeclarations::new();
         tester::test(&allocator, source_text, expected, &mut pass);
     }
 

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -48,10 +48,7 @@ impl<'a> Compressor<'a> {
             &mut PeepholeRemoveDeadCode::new(),
             // TODO: MinimizeExitPoints
             &mut PeepholeMinimizeConditions::new(),
-            &mut PeepholeSubstituteAlternateSyntax::new(
-                /* in_fixed_loop */ true,
-                self.options,
-            ),
+            &mut PeepholeSubstituteAlternateSyntax::new(/* in_fixed_loop */ true),
             &mut PeepholeReplaceKnownMethods::new(),
             &mut PeepholeFoldConstants::new(),
         ];
@@ -77,11 +74,10 @@ impl<'a> Compressor<'a> {
 
         // Passes listed in `getFinalization` in `DefaultPassConfig`
         ExploitAssigns::new().build(program, &mut ctx);
-        CollapseVariableDeclarations::new(self.options).build(program, &mut ctx);
+        CollapseVariableDeclarations::new().build(program, &mut ctx);
 
         // Late latePeepholeOptimizations
-        PeepholeSubstituteAlternateSyntax::new(/* in_fixed_loop */ false, self.options)
-            .build(program, &mut ctx);
+        PeepholeSubstituteAlternateSyntax::new(/* in_fixed_loop */ false).build(program, &mut ctx);
     }
 
     fn dead_code_elimination(program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -2,11 +2,6 @@
 pub struct CompressOptions {
     pub dead_code_elimination: bool,
 
-    /// Various optimizations for boolean context, for example `!!a ? b : c` → `a ? b : c`.
-    ///
-    /// Default `true`
-    pub booleans: bool,
-
     /// Remove `debugger;` statements.
     ///
     /// Default `true`
@@ -16,26 +11,6 @@ pub struct CompressOptions {
     ///
     /// Default `false`
     pub drop_console: bool,
-
-    /// Attempt to evaluate constant expressions
-    ///
-    /// Default `true`
-    pub evaluate: bool,
-
-    /// Join consecutive var statements.
-    ///
-    /// Default `true`
-    pub join_vars: bool,
-
-    /// Optimizations for do, while and for loops when we can statically determine the condition
-    ///
-    /// Default `true`
-    pub loops: bool,
-
-    /// Transforms `typeof foo == "undefined" into `foo === void 0`
-    ///
-    /// Default `true`
-    pub typeofs: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -47,29 +22,11 @@ impl Default for CompressOptions {
 
 impl CompressOptions {
     pub fn all_true() -> Self {
-        Self {
-            dead_code_elimination: false,
-            booleans: true,
-            drop_debugger: true,
-            drop_console: true,
-            evaluate: true,
-            join_vars: true,
-            loops: true,
-            typeofs: true,
-        }
+        Self { dead_code_elimination: false, drop_debugger: true, drop_console: true }
     }
 
     pub fn all_false() -> Self {
-        Self {
-            dead_code_elimination: false,
-            booleans: false,
-            drop_debugger: false,
-            drop_console: false,
-            evaluate: false,
-            join_vars: false,
-            loops: false,
-            typeofs: false,
-        }
+        Self { dead_code_elimination: false, drop_debugger: false, drop_console: false }
     }
 
     pub fn dead_code_elimination() -> Self {

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -264,13 +264,8 @@ impl Oxc {
                 mangle: minifier_options.mangle.unwrap_or_default(),
                 compress: if minifier_options.compress.unwrap_or_default() {
                     CompressOptions {
-                        booleans: compress_options.booleans,
                         drop_console: compress_options.drop_console,
                         drop_debugger: compress_options.drop_debugger,
-                        evaluate: compress_options.evaluate,
-                        join_vars: compress_options.join_vars,
-                        loops: compress_options.loops,
-                        typeofs: compress_options.typeofs,
                         ..CompressOptions::default()
                     }
                 } else {

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -95,10 +95,7 @@ pub fn run() -> Result<(), io::Error> {
 
 fn minify_twice(file: &TestFile) -> String {
     let source_type = SourceType::from_path(&file.file_name).unwrap();
-    let options = MinifierOptions {
-        mangle: true,
-        compress: CompressOptions { evaluate: false, ..CompressOptions::default() },
-    };
+    let options = MinifierOptions { mangle: true, compress: CompressOptions::default() };
     // let source_text1 = minify(&file.source_text, source_type, options);
     // let source_text2 = minify(&source_text1, source_type, options);
     // assert!(source_text1 == source_text2, "Minification failed for {}", &file.file_name);


### PR DESCRIPTION
Closure Compiler and ESBuild does not have these kind of granularity.