### PR TITLE
refactor(ast_tools): move JS file header creation

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -61,7 +61,7 @@ impl From<GeneratorOutput> for SideEffect {
     fn from(output: GeneratorOutput) -> Self {
         match output {
             GeneratorOutput::Rust { path, tokens } => Self::from((path, tokens)),
-            GeneratorOutput::Text { path, content } => Self { path, content: content.into() },
+            GeneratorOutput::Javascript { path, code } => Self { path, content: code.into() },
         }
     }
 }
@@ -244,7 +244,7 @@ pub trait CodegenBase {
 }
 
 /// Creates a generated file warning + required information for a generated file.
-pub fn generate_header(file_path: &str) -> TokenStream {
+pub fn generate_rust_header(file_path: &str) -> TokenStream {
     let file_path = file_path.replace('\\', "/");
 
     // TODO: Add generation date, AST source hash, etc here.
@@ -254,4 +254,15 @@ pub fn generate_header(file_path: &str) -> TokenStream {
         #![doc = #edit_comment]
         //!@@line_break
     }
+}
+
+/// Creates a generated file warning + required information for a generated file.
+pub fn generate_javascript_header(file_path: &str) -> String {
+    let file_path = file_path.replace('\\', "/");
+
+    // TODO: Add generation date, AST source hash, etc here.
+    format!(
+        "// Auto-generated code, DO NOT EDIT DIRECTLY!\n\
+        // To edit this generated file you have to edit `{file_path}`\n\n"
+    )
 }

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -6,7 +6,7 @@ use proc_macro2::TokenStream;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    codegen::{generate_header, CodegenBase, LateCtx},
+    codegen::{generate_rust_header, CodegenBase, LateCtx},
     schema::TypeDef,
     Result,
 };
@@ -44,7 +44,7 @@ pub trait Derive: CodegenBase {
     // Standard methods
 
     fn template(module_paths: Vec<&str>, impls: TokenStream) -> TokenStream {
-        let header = generate_header(Self::file_path());
+        let header = generate_rust_header(Self::file_path());
         let prelude = Self::prelude();
 
         // from `x::y::z` to `crate::y::z::*`

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -24,14 +24,7 @@ define_generator!(TypescriptGenerator);
 
 impl Generator for TypescriptGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        let file = file!().replace('\\', "/");
-        let mut content = format!(
-            "\
-            // Auto-generated code, DO NOT EDIT DIRECTLY!\n\
-            // To edit this generated file you have to edit `{file}`\n\n\
-            {CUSTOM_TYPESCRIPT}\n\
-            "
-        );
+        let mut code = format!("{CUSTOM_TYPESCRIPT}\n");
 
         for def in ctx.schema() {
             if !def.generates_derive("ESTree") {
@@ -43,12 +36,13 @@ impl Generator for TypescriptGenerator {
             };
             let Some(ts_type_def) = ts_type_def else { continue };
 
-            content.push_str(&ts_type_def);
-            content.push_str("\n\n");
+            code.push_str(&ts_type_def);
+            code.push_str("\n\n");
         }
-        GeneratorOutput::Text {
+
+        GeneratorOutput::Javascript {
             path: output(crate::TYPESCRIPT_PACKAGE, "types.d.ts"),
-            content: format_typescript(&content),
+            code: format_typescript(&code),
         }
     }
 }


### PR DESCRIPTION
Move creation of generated JS/TS file headers out of individual generators.