### PR TITLE
refactor(ast_tools): run `rustfmt` only on generated files

### DIFF
--- a/tasks/ast_tools/src/fmt.rs
+++ b/tasks/ast_tools/src/fmt.rs
@@ -1,4 +1,7 @@
-use std::process::Command;
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
 
 use lazy_static::lazy_static;
 use proc_macro2::TokenStream;
@@ -9,12 +12,22 @@ use syn::parse_file;
 pub fn pretty_print(input: &TokenStream) -> String {
     let result = prettyplease::unparse(&parse_file(input.to_string().as_str()).unwrap());
     let result = COMMENT_REGEX.replace_all(&result, CommentReplacer).to_string();
-    result
+    rust_fmt(&result)
 }
 
-/// Run `cargo fmt`
-pub fn cargo_fmt() {
-    Command::new("cargo").arg("fmt").status().unwrap();
+pub fn rust_fmt(source_text: &str) -> String {
+    let mut rustfmt = Command::new("rustfmt")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to run rustfmt (is it installed?)");
+
+    let stdin = rustfmt.stdin.as_mut().unwrap();
+    stdin.write_all(source_text.as_bytes()).unwrap();
+    stdin.flush().unwrap();
+
+    let output = rustfmt.wait_with_output().unwrap();
+    String::from_utf8(output.stdout).unwrap()
 }
 
 /// Replace doc comments which start with `@` with plain comments or line breaks.

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -21,7 +21,6 @@ use derives::{
     DeriveCloneIn, DeriveContentEq, DeriveContentHash, DeriveESTree, DeriveGetSpan,
     DeriveGetSpanMut,
 };
-use fmt::cargo_fmt;
 use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, Generator, GeneratorOutput,
     TypescriptGenerator, VisitGenerator, VisitMutGenerator,
@@ -53,9 +52,6 @@ pub struct CliOptions {
     /// Runs all generators but won't write anything down.
     #[bpaf(switch)]
     dry_run: bool,
-    /// Don't run cargo fmt at the end
-    #[bpaf(switch)]
-    no_fmt: bool,
     /// Prints no logs.
     quiet: bool,
     /// Path of output `schema.json`.
@@ -100,10 +96,6 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             })
             .collect();
         write_ci_filter(SOURCE_PATHS, side_effects, ".github/.generated_ast_watch_list.yml")?;
-    }
-
-    if !cli_options.no_fmt {
-        cargo_fmt();
     }
 
     if let CliOptions { schema: Some(schema_path), dry_run: false, .. } = cli_options {


### PR DESCRIPTION
Run `rustfmt` only on individual files which codegen generates, rather than on the whole repo. This speeds up local development of `ast_tools` when you're on a slower machine.