### PR TITLE
fix(types): move @oxc-project/types to dependencies

### DIFF
--- a/crates/oxc_wasm/package.json
+++ b/crates/oxc_wasm/package.json
@@ -12,7 +12,7 @@
     "oxc_wasm.js",
     "oxc_wasm.d.ts"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@oxc-project/types": "workspace:^"
   },
   "main": "oxc_wasm.js",

--- a/npm/oxc-parser/package.json
+++ b/npm/oxc-parser/package.json
@@ -23,7 +23,7 @@
     "index.js",
     "bindings.js"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@oxc-project/types": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
   napi/transform: {}
 
   npm/oxc-parser:
-    devDependencies:
+    dependencies:
       '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
@@ -69,7 +69,7 @@ importers:
   npm/oxc-types: {}
 
   npm/oxc-wasm:
-    devDependencies:
+    dependencies:
       '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
@@ -77,7 +77,7 @@ importers:
   npm/oxlint: {}
 
   npm/parser-wasm:
-    devDependencies:
+    dependencies:
       '@oxc-project/types':
         specifier: workspace:^
         version: link:../oxc-types
@@ -95,7 +95,7 @@ importers:
         version: 7.4.3
 
   wasm/parser:
-    devDependencies:
+    dependencies:
       '@oxc-project/types':
         specifier: workspace:^
         version: link:../../npm/oxc-types

--- a/wasm/parser/package.json
+++ b/wasm/parser/package.json
@@ -25,7 +25,7 @@
     "node",
     "web"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@oxc-project/types": "workspace:^"
   },
   "scripts": {


### PR DESCRIPTION
Hotfix. NPM doesn't install devDependencies automatically, so types were missing.