### PR TITLE
perf(ast): reduce size of `Comment`

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -46,17 +46,17 @@ pub struct Comment {
     /// The span of the comment text (without leading/trailing delimiters).
     pub span: Span,
 
-    /// Line or block comment
-    pub kind: CommentKind,
-
-    /// Leading or trailing comment
-    pub position: CommentPosition,
-
     /// Start of token this leading comment is attached to.
     /// `/* Leading */ token`
     ///                ^ This start
     /// NOTE: Trailing comment attachment is not computed yet.
     pub attached_to: u32,
+
+    /// Line or block comment
+    pub kind: CommentKind,
+
+    /// Leading or trailing comment
+    pub position: CommentPosition,
 
     /// Whether this comment has a preceding newline.
     /// Used to avoid becoming a trailing comment in codegen.
@@ -73,9 +73,9 @@ impl Comment {
         let span = Span::new(start, end);
         Self {
             span,
+            attached_to: 0,
             kind,
             position: CommentPosition::Trailing,
-            attached_to: 0,
             preceded_by_newline: false,
             followed_by_newline: false,
         }

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1380,14 +1380,14 @@ const _: () = {
     assert!(size_of::<CommentPosition>() == 1usize);
     assert!(align_of::<CommentPosition>() == 1usize);
 
-    assert!(size_of::<Comment>() == 20usize);
+    assert!(size_of::<Comment>() == 16usize);
     assert!(align_of::<Comment>() == 4usize);
     assert!(offset_of!(Comment, span) == 0usize);
-    assert!(offset_of!(Comment, kind) == 8usize);
-    assert!(offset_of!(Comment, position) == 9usize);
-    assert!(offset_of!(Comment, attached_to) == 12usize);
-    assert!(offset_of!(Comment, preceded_by_newline) == 16usize);
-    assert!(offset_of!(Comment, followed_by_newline) == 17usize);
+    assert!(offset_of!(Comment, attached_to) == 8usize);
+    assert!(offset_of!(Comment, kind) == 12usize);
+    assert!(offset_of!(Comment, position) == 13usize);
+    assert!(offset_of!(Comment, preceded_by_newline) == 14usize);
+    assert!(offset_of!(Comment, followed_by_newline) == 15usize);
 
     assert!(size_of::<NumberBase>() == 1usize);
     assert!(align_of::<NumberBase>() == 1usize);
@@ -2939,14 +2939,14 @@ const _: () = {
     assert!(size_of::<CommentPosition>() == 1usize);
     assert!(align_of::<CommentPosition>() == 1usize);
 
-    assert!(size_of::<Comment>() == 20usize);
+    assert!(size_of::<Comment>() == 16usize);
     assert!(align_of::<Comment>() == 4usize);
     assert!(offset_of!(Comment, span) == 0usize);
-    assert!(offset_of!(Comment, kind) == 8usize);
-    assert!(offset_of!(Comment, position) == 9usize);
-    assert!(offset_of!(Comment, attached_to) == 12usize);
-    assert!(offset_of!(Comment, preceded_by_newline) == 16usize);
-    assert!(offset_of!(Comment, followed_by_newline) == 17usize);
+    assert!(offset_of!(Comment, attached_to) == 8usize);
+    assert!(offset_of!(Comment, kind) == 12usize);
+    assert!(offset_of!(Comment, position) == 13usize);
+    assert!(offset_of!(Comment, preceded_by_newline) == 14usize);
+    assert!(offset_of!(Comment, followed_by_newline) == 15usize);
 
     assert!(size_of::<NumberBase>() == 1usize);
     assert!(align_of::<NumberBase>() == 1usize);

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4256,9 +4256,9 @@ impl<'alloc> CloneIn<'alloc> for Comment {
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         Comment {
             span: CloneIn::clone_in(&self.span, allocator),
+            attached_to: CloneIn::clone_in(&self.attached_to, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             position: CloneIn::clone_in(&self.position, allocator),
-            attached_to: CloneIn::clone_in(&self.attached_to, allocator),
             preceded_by_newline: CloneIn::clone_in(&self.preceded_by_newline, allocator),
             followed_by_newline: CloneIn::clone_in(&self.followed_by_newline, allocator),
         }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -4226,9 +4226,9 @@ impl ContentEq for CommentPosition {
 
 impl ContentEq for Comment {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.kind, &other.kind)
+        ContentEq::content_eq(&self.attached_to, &other.attached_to)
+            && ContentEq::content_eq(&self.kind, &other.kind)
             && ContentEq::content_eq(&self.position, &other.position)
-            && ContentEq::content_eq(&self.attached_to, &other.attached_to)
             && ContentEq::content_eq(&self.preceded_by_newline, &other.preceded_by_newline)
             && ContentEq::content_eq(&self.followed_by_newline, &other.followed_by_newline)
     }

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -2388,9 +2388,9 @@ impl ContentHash for CommentPosition {
 
 impl ContentHash for Comment {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.attached_to, state);
         ContentHash::content_hash(&self.kind, state);
         ContentHash::content_hash(&self.position, state);
-        ContentHash::content_hash(&self.attached_to, state);
         ContentHash::content_hash(&self.preceded_by_newline, state);
         ContentHash::content_hash(&self.followed_by_newline, state);
     }


### PR DESCRIPTION
Reduce `Comment` from 20 bytes to 16. Because `Comment` has `#[ast]` attr, it's `#[repr(C)]` which means the fields don't get re-ordered by the compiler, so it contains excess padding. Moving `attached_to: u32` field removes the padding.

I am in favour of using `oxc_ast_tools` to re-order fields the same way the compiler does, which will solve this problem for all AST types. But may as well fix this one in meantime. Unlike most AST types, field order doesn't matter for `Comment` - it is not visited, so the field order has no semantic meaning.