### PR TITLE
refactor(ast): rename lifetime

### DIFF
--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -22,15 +22,15 @@ pub fn has_comments_between(comments: &[Comment], span: Span) -> bool {
 }
 
 /// Double-ended iterator over a range of comments, by starting position.
-pub struct CommentsRange<'a> {
-    comments: &'a [Comment],
+pub struct CommentsRange<'c> {
+    comments: &'c [Comment],
     range: (Bound<u32>, Bound<u32>),
     current_start: usize,
     current_end: usize,
 }
 
-impl<'a> CommentsRange<'a> {
-    fn new(comments: &'a [Comment], start: Bound<u32>, end: Bound<u32>) -> Self {
+impl<'c> CommentsRange<'c> {
+    fn new(comments: &'c [Comment], start: Bound<u32>, end: Bound<u32>) -> Self {
         // Directly skip all comments that are already known to start
         // outside the requested range.
         let partition_start = {


### PR DESCRIPTION
Rename lifetime to make clear it's for a temporary borrow, and not lifetime of the arena (which is what we conventionally use `'a` for).