### PR TITLE
refactor(ast_tools): remove const params for `Visit` generator

### DIFF
--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -27,7 +27,7 @@ impl Generator for VisitGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> Output {
         Output::Rust {
             path: output_path(crate::AST_CRATE, "visit.rs"),
-            tokens: generate_visit::<false>(ctx),
+            tokens: generate_visit(false, ctx),
         }
     }
 }
@@ -40,20 +40,20 @@ impl Generator for VisitMutGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> Output {
         Output::Rust {
             path: output_path(crate::AST_CRATE, "visit_mut.rs"),
-            tokens: generate_visit::<true>(ctx),
+            tokens: generate_visit(true, ctx),
         }
     }
 }
 
-fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
-    let (visits, walks) = VisitBuilder::new(ctx, MUT).build();
+fn generate_visit(is_mut: bool, ctx: &LateCtx) -> TokenStream {
+    let (visits, walks) = VisitBuilder::new(ctx, is_mut).build();
 
-    let walk_mod = if MUT { quote!(walk_mut) } else { quote!(walk) };
-    let trait_name = if MUT { quote!(VisitMut) } else { quote!(Visit) };
-    let ast_kind_type = if MUT { quote!(AstType) } else { quote!(AstKind) };
-    let ast_kind_life = if MUT { TokenStream::default() } else { quote!(<'a>) };
+    let walk_mod = if is_mut { quote!(walk_mut) } else { quote!(walk) };
+    let trait_name = if is_mut { quote!(VisitMut) } else { quote!(Visit) };
+    let ast_kind_type = if is_mut { quote!(AstType) } else { quote!(AstKind) };
+    let ast_kind_life = if is_mut { TokenStream::default() } else { quote!(<'a>) };
 
-    let may_alloc = if MUT {
+    let may_alloc = if is_mut {
         TokenStream::default()
     } else {
         quote! {


### PR DESCRIPTION
This function is large, so const param here was probably making the code slower, certainly slower compile time. Use a runtime value instead.