### PR TITLE
refactor(ast_tools): shorten code in `Visit` generator

### DIFF
--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -115,7 +115,6 @@ fn generate_visit(is_mut: bool, ctx: &LateCtx) -> TokenStream {
             #[inline]
             fn leave_scope(&mut self) {}
 
-            ///@@line_break
             #may_alloc
 
             #(#visits)*


### PR DESCRIPTION
Remove double line-break which formatting removes anyway.