### PR TITLE
refactor(napi): move custom types to bottom of file

### DIFF
--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1,39 +1,6 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`
 
-export interface FormalParameterRest extends Span {
-  type: 'RestElement';
-  argument: BindingPatternKind;
-  typeAnnotation: TSTypeAnnotation | null;
-  optional: boolean;
-}
-
-export type RegExpFlags = {
-  /** Global flag */
-  G: 1;
-  /** Ignore case flag */
-  I: 2;
-  /** Multiline flag */
-  M: 4;
-  /** DotAll flag */
-  S: 8;
-  /** Unicode flag */
-  U: 16;
-  /** Sticky flag */
-  Y: 32;
-  /** Indices flag */
-  D: 64;
-  /** Unicode sets flag */
-  V: 128;
-};
-
-export type JSXElementName =
-  | JSXIdentifier
-  | JSXNamespacedName
-  | JSXMemberExpression;
-
-export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
-
 export interface BooleanLiteral extends Span {
   type: 'BooleanLiteral';
   value: boolean;
@@ -2008,3 +1975,36 @@ export interface NamedReference extends Span {
   type: 'NamedReference';
   name: string;
 }
+
+export interface FormalParameterRest extends Span {
+  type: 'RestElement';
+  argument: BindingPatternKind;
+  typeAnnotation: TSTypeAnnotation | null;
+  optional: boolean;
+}
+
+export type RegExpFlags = {
+  /** Global flag */
+  G: 1;
+  /** Ignore case flag */
+  I: 2;
+  /** Multiline flag */
+  M: 4;
+  /** DotAll flag */
+  S: 8;
+  /** Unicode flag */
+  U: 16;
+  /** Sticky flag */
+  Y: 32;
+  /** Indices flag */
+  D: 64;
+  /** Unicode sets flag */
+  V: 128;
+};
+
+export type JSXElementName =
+  | JSXIdentifier
+  | JSXNamespacedName
+  | JSXMemberExpression;
+
+export type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -21,8 +21,7 @@ define_generator!(TypescriptGenerator);
 
 impl Generator for TypescriptGenerator {
     fn generate(&mut self, ctx: &LateCtx) -> Output {
-        let mut code = format!("{CUSTOM_TYPESCRIPT}\n");
-
+        let mut code = String::new();
         for def in ctx.schema() {
             if !def.generates_derive("ESTree") {
                 continue;
@@ -36,6 +35,8 @@ impl Generator for TypescriptGenerator {
             code.push_str(&ts_type_def);
             code.push_str("\n\n");
         }
+
+        code.push_str(CUSTOM_TYPESCRIPT);
 
         Output::Javascript { path: format!("{}/types.d.ts", crate::TYPESCRIPT_PACKAGE), code }
     }


### PR DESCRIPTION
Pure refactor. Doesn't matter much but I think it's preferable for the file not to start with the most random weird types.