### PR TITLE
refactor(transformer/react-refresh): avoid panic for `init` of `VariableDeclarator` isn't a `BindingIdentifier`

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 73/82
+Passed: 74/83
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -167,7 +167,7 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (30/32)
+# babel-plugin-transform-react-jsx (31/33)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/variable-declarator-with-function/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/variable-declarator-with-function/input.js
@@ -1,0 +1,4 @@
+const { name, length } = function (X) {
+  useContext(X);
+}
+const { ...args } = () => useContext(X);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/variable-declarator-with-function/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/variable-declarator-with-function/output.js
@@ -1,0 +1,9 @@
+var _s = $RefreshSig$(), _s2 = $RefreshSig$();
+const { name, length } = _s(function(X) {
+        _s();
+        useContext(X);
+}, "useContext{}");
+const { ...args } = _s2(() => {
+        _s2();
+        return useContext(X);
+}, "useContext{}");


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc/pull/6881#discussion_r1816597462