### PR TITLE
refactor(ast_tools): all runners produce `Vec<Output>`

### DIFF
--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -126,7 +126,6 @@ macro_rules! define_derive {
 
             impl $($lifetime)? Runner for $ident $($lifetime)? {
                 type Context = LateCtx;
-                type Output = Vec<Output>;
 
                 fn name(&self) -> &'static str {
                     stringify!($ident)

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -19,8 +19,8 @@ pub trait Generator {
 
     // Standard methods
 
-    fn output(&mut self, ctx: &LateCtx) -> Result<Output> {
-        Ok(self.generate(ctx))
+    fn output(&mut self, ctx: &LateCtx) -> Result<Vec<Output>> {
+        Ok(vec![self.generate(ctx)])
     }
 }
 
@@ -35,7 +35,6 @@ macro_rules! define_generator {
 
             impl $($lifetime)? Runner for $ident $($lifetime)? {
                 type Context = LateCtx;
-                type Output = Output;
 
                 fn name(&self) -> &'static str {
                     stringify!($ident)
@@ -45,7 +44,7 @@ macro_rules! define_generator {
                     file!()
                 }
 
-                fn run(&mut self, ctx: &LateCtx) -> Result<Output> {
+                fn run(&mut self, ctx: &LateCtx) -> Result<Vec<Output>> {
                     self.output(ctx)
                 }
             }

--- a/tasks/ast_tools/src/passes/mod.rs
+++ b/tasks/ast_tools/src/passes/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::{codegen::EarlyCtx, rust_ast::AstType, Result};
+use crate::{codegen::EarlyCtx, output::Output, rust_ast::AstType, Result};
 
 mod calc_layout;
 mod linker;
@@ -17,7 +17,7 @@ pub trait Pass {
     // Standard methods
 
     /// Run pass.
-    fn output(&mut self, ctx: &EarlyCtx) -> Result<()> {
+    fn output(&mut self, ctx: &EarlyCtx) -> Result<Vec<Output>> {
         // We sort by `TypeId`, so we have the same ordering as it's written in Rust source
         let mut unresolved = ctx.chronological_idents().collect::<VecDeque<_>>();
 
@@ -31,7 +31,7 @@ pub trait Pass {
                 unresolved.push_front(next);
             }
         }
-        Ok(())
+        Ok(vec![])
     }
 }
 
@@ -40,12 +40,12 @@ macro_rules! define_pass {
         const _: () = {
             use $crate::{
                 codegen::{EarlyCtx, Runner},
+                output::Output,
                 Result,
             };
 
             impl $($lifetime)? Runner for $ident $($lifetime)? {
                 type Context = EarlyCtx;
-                type Output = ();
 
                 fn name(&self) -> &'static str {
                     stringify!($ident)
@@ -55,7 +55,7 @@ macro_rules! define_pass {
                     file!()
                 }
 
-                fn run(&mut self, ctx: &Self::Context) -> Result<()> {
+                fn run(&mut self, ctx: &Self::Context) -> Result<Vec<Output>> {
                     self.output(ctx)
                 }
             }


### PR DESCRIPTION
Standardize all the different `Runner`s to produce `Vec<Output>`.