### PR TITLE
refactor(ast_tools): simplify logging

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::{
-    log, logln,
+    log, log_result,
     output::{Output, RawOutput},
     passes::Pass,
     rust_ast::{self, AstRef},
@@ -155,18 +155,11 @@ fn run_passes<C>(runners: &mut [Box<dyn Runner<Context = C>>], ctx: &C) -> Resul
         log!("{} {}... ", runner.verb(), runner.name());
 
         let result = runner.run(ctx);
-        match result {
-            Ok(runner_outputs) => {
-                logln!("Done!");
-                let generator_path = runner.file_path();
-                outputs
-                    .extend(runner_outputs.into_iter().map(|output| output.output(generator_path)));
-            }
-            Err(err) => {
-                logln!("FAILED");
-                return Err(err);
-            }
-        }
+        log_result!(result);
+        let runner_outputs = result?;
+
+        let generator_path = runner.file_path();
+        outputs.extend(runner_outputs.into_iter().map(|output| output.output(generator_path)));
     }
     Ok(outputs)
 }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -90,9 +90,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let paths = outputs
             .into_iter()
             .map(|output| {
-                log!("Writing {}...", &output.path);
                 output.write_to_file().unwrap();
-                logln!(" Done!");
                 output.path
             })
             .collect();
@@ -128,10 +126,7 @@ fn write_ci_filter(inputs: &[&str], paths: Vec<String>, output_path: &str) -> st
     push_item("tasks/ast_tools/src/**");
     push_item(output_path);
 
-    log!("Writing {output_path}...");
-    write_all_to(output.as_bytes(), output_path)?;
-    logln!(" Done!");
-    Ok(())
+    write_all_to(output.as_bytes(), output_path)
 }
 
 #[macro_use]
@@ -156,13 +151,32 @@ mod logger {
         }
     }
 
-    macro_rules! logln {
-        ($fmt:literal $(, $args:expr)*) => {
-            $crate::log!("{}\n", format!($fmt $(, $args)*));
-        }
+    macro_rules! log_success {
+        () => {
+            $crate::log!("Done!\n");
+        };
     }
 
-    pub(super) use {log, logln};
+    macro_rules! log_failed {
+        () => {
+            $crate::log!("FAILED\n");
+        };
+    }
+
+    macro_rules! log_result {
+        ($result:expr) => {
+            match &($result) {
+                Ok(_) => {
+                    $crate::log_success!();
+                }
+                Err(_) => {
+                    $crate::log_failed!();
+                }
+            }
+        };
+    }
+
+    pub(super) use {log, log_failed, log_result, log_success};
 }
 
-pub(crate) use logger::{log, logln};
+pub(crate) use logger::{log, log_failed, log_result, log_success};

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -6,6 +6,8 @@ use std::{
 
 use proc_macro2::TokenStream;
 
+use crate::{log, log_result};
+
 mod javascript;
 mod rust;
 use javascript::print_javascript;
@@ -57,10 +59,16 @@ pub fn output_path(krate: &str, path: &str) -> String {
 /// Write data to file.
 pub fn write_all_to<P: AsRef<Path>>(data: &[u8], path: P) -> io::Result<()> {
     let path = path.as_ref();
+    log!("Write {}... ", path.to_string_lossy());
+    let result = write_all_impl(data, path);
+    log_result!(result);
+    result
+}
+
+fn write_all_impl(data: &[u8], path: &Path) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     let mut file = fs::File::create(path)?;
-    file.write_all(data)?;
-    Ok(())
+    file.write_all(data)
 }


### PR DESCRIPTION
* Replace `logln!` macro with `log_result!` to log result of an action.
* Move logging for writing files into one place.