### PR TITLE
refactor(ast_tools): rename `Output::into_raw` method

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -159,7 +159,7 @@ fn run_passes<C>(runners: &mut [Box<dyn Runner<Context = C>>], ctx: &C) -> Resul
         let runner_outputs = result?;
 
         let generator_path = runner.file_path();
-        outputs.extend(runner_outputs.into_iter().map(|output| output.output(generator_path)));
+        outputs.extend(runner_outputs.into_iter().map(|output| output.into_raw(generator_path)));
     }
     Ok(outputs)
 }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -122,7 +122,7 @@ fn generate_ci_filter(outputs: &[RawOutput]) -> RawOutput {
 
     log_success!();
 
-    Output::Yaml { path: GITHUB_WATCH_LIST_PATH.to_string(), code }.output(file!())
+    Output::Yaml { path: GITHUB_WATCH_LIST_PATH.to_string(), code }.into_raw(file!())
 }
 
 #[macro_use]

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -25,7 +25,7 @@ pub enum Output {
 }
 
 impl Output {
-    pub fn output(self, generator_path: &str) -> RawOutput {
+    pub fn into_raw(self, generator_path: &str) -> RawOutput {
         let (path, code) = match self {
             Self::Rust { path, tokens } => {
                 let code = print_rust(&tokens, generator_path);


### PR DESCRIPTION
Rename `Output::output` to `Output::into_raw` - more descriptive name.