### PR TITLE
refactor(ast_tools): remove repeated code in `Output` methods

### DIFF
--- a/tasks/ast_tools/src/output/javascript.rs
+++ b/tasks/ast_tools/src/output/javascript.rs
@@ -12,8 +12,6 @@ pub fn print_javascript(code: &str, generator_path: &str) -> String {
 
 /// Creates a generated file warning + required information for a generated file.
 fn generate_header(generator_path: &str) -> String {
-    let generator_path = generator_path.replace('\\', "/");
-
     // TODO: Add generation date, AST source hash, etc here.
     format!(
         "// Auto-generated code, DO NOT EDIT DIRECTLY!\n\

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -32,17 +32,19 @@ pub enum Output {
 
 impl Output {
     pub fn into_raw(self, generator_path: &str) -> RawOutput {
+        let generator_path = generator_path.replace('\\', "/");
+
         let (path, code) = match self {
             Self::Rust { path, tokens } => {
-                let code = print_rust(&tokens, generator_path);
+                let code = print_rust(&tokens, &generator_path);
                 (path, code)
             }
             Self::Javascript { path, code } => {
-                let code = print_javascript(&code, generator_path);
+                let code = print_javascript(&code, &generator_path);
                 (path, code)
             }
             Self::Yaml { path, code } => {
-                let code = print_yaml(&code, generator_path);
+                let code = print_yaml(&code, &generator_path);
                 (path, code)
             }
             Self::Raw { path, code } => (path, code),

--- a/tasks/ast_tools/src/output/rust.rs
+++ b/tasks/ast_tools/src/output/rust.rs
@@ -24,8 +24,6 @@ pub fn print_rust(tokens: &TokenStream, generator_path: &str) -> String {
 
 /// Creates a generated file warning + required information for a generated file.
 fn generate_header(generator_path: &str) -> TokenStream {
-    let generator_path = generator_path.replace('\\', "/");
-
     // TODO: Add generation date, AST source hash, etc here.
     let edit_comment = format!("@ To edit this generated file you have to edit `{generator_path}`");
     quote! {

--- a/tasks/ast_tools/src/output/yaml.rs
+++ b/tasks/ast_tools/src/output/yaml.rs
@@ -6,8 +6,6 @@ pub fn print_yaml(code: &str, generator_path: &str) -> String {
 
 /// Creates a generated file warning + required information for a generated file.
 fn generate_header(generator_path: &str) -> String {
-    let generator_path = generator_path.replace('\\', "/");
-
     // TODO: Add generation date, AST source hash, etc here.
     format!(
         "# Auto-generated code, DO NOT EDIT DIRECTLY!\n\


### PR DESCRIPTION
`generator_path.replace('\\', "/")` was repeated in each module for that generates outputs. Move it, to reduce repetition.