### PR TITLE
refactor(ast_tools): replace `str::replace` with `CowUtils::cow_replace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ version = "0.0.0"
 dependencies = [
  "bpaf",
  "convert_case",
+ "cow-utils",
  "itertools",
  "lazy_static",
  "prettyplease",

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 [dependencies]
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 convert_case = { workspace = true }
+cow-utils = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 prettyplease = { workspace = true }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::disallowed_methods)]
-
 use std::{cell::RefCell, io::Read, path::PathBuf, rc::Rc};
 
 use bpaf::{Bpaf, Parser};

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+use cow_utils::CowUtils;
 use proc_macro2::TokenStream;
 
 use crate::{log, log_result};
@@ -32,7 +33,7 @@ pub enum Output {
 
 impl Output {
     pub fn into_raw(self, generator_path: &str) -> RawOutput {
-        let generator_path = generator_path.replace('\\', "/");
+        let generator_path = generator_path.cow_replace('\\', "/");
 
         let (path, code) = match self {
             Self::Rust { path, tokens } => {

--- a/tasks/ast_tools/src/passes/calc_layout.rs
+++ b/tasks/ast_tools/src/passes/calc_layout.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 
+use cow_utils::CowUtils;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use quote::ToTokens;
@@ -223,14 +224,10 @@ fn calc_type_layout(ty: &TypeAnalysis, ctx: &EarlyCtx) -> Result<PlatformLayout>
                 panic!();
             };
 
-            let typ = typ
-                .path
-                .segments
-                .first()
-                .map(|it| it.to_token_stream().to_string().replace(' ', ""))
-                .expect("We only accept single segment types.");
+            let typ = typ.path.segments.first().unwrap().to_token_stream().to_string();
+            let typ = &*typ.cow_replace(' ', "");
 
-            if let Some(typ) = WELL_KNOWN.get(typ.as_str()) {
+            if let Some(typ) = WELL_KNOWN.get(typ) {
                 typ.clone()
             } else {
                 panic!("Unsupported type: {:#?}", ty.typ.to_token_stream().to_string())

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -287,6 +287,7 @@ fn create_type_ref(ty: &Type, ctx: &EarlyCtx) -> TypeRef {
     let ident = ty.get_ident();
     let id = ident.as_ident().and_then(|id| ctx.type_id(&id.to_string()));
     let transparent_id = ctx.type_id(&ident.inner_ident().to_string());
+    #[expect(clippy::disallowed_methods)]
     let raw = ty.to_token_stream().to_string().replace(' ', "");
     TypeRef {
         id,


### PR DESCRIPTION
Obey our clippy-enforced policy to prefer `CowUtils::cow_replace`.