### PR TITLE
fix(editor): Fix onConfigChange to send the correct config for didChangeConfiguration notification

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -175,7 +175,7 @@ export async function activate(context: ExtensionContext) {
   });
 
   config.onConfigChange = function onConfigChange() {
-    let settings = this.toLanguageServerConfig()
+    let settings = this.toLanguageServerConfig();
     updateStatsBar(settings.enable);
     client.sendNotification('workspace/didChangeConfiguration', { settings });
   };

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -175,7 +175,7 @@ export async function activate(context: ExtensionContext) {
   });
 
   config.onConfigChange = function onConfigChange() {
-    let settings: any = JSON.parse(JSON.stringify(this));
+    let settings = this.toLanguageServerConfig()
     updateStatsBar(settings.enable);
     client.sendNotification('workspace/didChangeConfiguration', { settings });
   };


### PR DESCRIPTION
This currently fails because it sends over data that the language server isn't prepared to deserialize.  This updates to send over the correct `LanguageServerConfig` type.