### PR TITLE
feat(editor): Listen to config file changes and trigger a didChangeConfiguration update

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -150,8 +150,12 @@ export async function activate(context: ExtensionContext) {
       scheme: 'file',
     })),
     synchronize: {
-      // Notify the server about file changes to '.clientrc files contained in the workspace
-      fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
+      // Notify the server about file config changes in the workspace
+      fileEvents: [
+        workspace.createFileSystemWatcher('**/.eslintr{c,c.json}'),
+        workspace.createFileSystemWatcher('**/.oxlint{.json,rc.json,rc}'),
+        workspace.createFileSystemWatcher('**/oxlint{.json,rc.json}'),
+      ],
     },
     initializationOptions: {
       settings: config.toLanguageServerConfig(),


### PR DESCRIPTION
Watch eslint and oxlint config files for changes.  When these files change, a `didChangeConfiguration` event will be sent to the language server.

Ref https://github.com/oxc-project/oxc/issues/7308.