### PR TITLE
fix(ecmascript): allow getting PropName for object methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,9 @@ version = "0.34.0"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "oxc_allocator",
  "oxc_ast",
+ "oxc_parser",
  "oxc_span",
  "oxc_syntax",
 ]

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -28,6 +28,11 @@ oxc_syntax = { workspace = true, features = ["to_js_string"] }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 
+[dev-dependencies]
+# Parser and allocator are only used in tests to make testing easier
+oxc_allocator = { workspace = true }
+oxc_parser = { workspace = true }
+
 [features]
 default = []
 side_effects = []


### PR DESCRIPTION
Working on some lint rules and noticed that PropName didn't seem to be working as intended. According to the spec, we should definitely allow get/set/methods to have prop names:

https://tc39.es/ecma262/#sec-static-semantics-propname

<img width="694" alt="image" src="https://github.com/user-attachments/assets/60fdfeec-2320-4cd9-a786-901728e459b2">

However, we still need to retain this logic for checking `__proto__` because it has special rules.
