### PR TITLE
refactor(ast_tools): faster formatting Rust code

### DIFF
--- a/napi/transform/test/transform.test.mjs
+++ b/napi/transform/test/transform.test.mjs
@@ -35,10 +35,10 @@ describe('react refresh plugin', () => {
 
   it('matches output', () => {
     const ret = oxc.transform('test.tsx', code, { jsx: { refresh: {} } });
-    console.log(ret.code)
+    console.log(ret.code);
     assert.equal(
       ret.code,
-`import { useState } from "react";
+      `import { useState } from "react";
 import { jsxs as _jsxs } from "react/jsx-runtime";
 var _s = $RefreshSig$();
 export const App = () => {
@@ -53,7 +53,7 @@ _s(App, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");
 _c = App;
 var _c;
 $RefreshReg$(_c, "App");
-`
+`,
     );
   });
 });

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -47,7 +47,7 @@ impl Output {
 
         let (path, code) = match self {
             Self::Rust { path, tokens } => {
-                let code = print_rust(&tokens, &generator_path);
+                let code = print_rust(tokens, &generator_path);
                 (path, code)
             }
             Self::Javascript { path, code } => {

--- a/tasks/ast_tools/src/output/rust.rs
+++ b/tasks/ast_tools/src/output/rust.rs
@@ -6,13 +6,13 @@ use std::{
 use lazy_static::lazy_static;
 use proc_macro2::TokenStream;
 use regex::{Captures, Regex, Replacer};
-use syn::parse_file;
+use syn::parse2;
 
 use super::add_header;
 
 /// Format Rust code, and add header.
-pub fn print_rust(tokens: &TokenStream, generator_path: &str) -> String {
-    let code = prettyplease::unparse(&parse_file(tokens.to_string().as_str()).unwrap());
+pub fn print_rust(tokens: TokenStream, generator_path: &str) -> String {
+    let code = prettyplease::unparse(&parse2(tokens).unwrap());
     let code = COMMENT_REGEX.replace_all(&code, CommentReplacer).to_string();
     let code = add_header(&code, generator_path, "//");
     rust_fmt(&code)


### PR DESCRIPTION
Speed up formatting Rust code. Don't convert to string and then re-parse, allow `syn` to skip a step by using existing `TokenStream`.