### PR TITLE
test(linter): improve test failure output

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -356,17 +356,44 @@ impl Tester {
 
     fn test_pass(&mut self) {
         for TestCase { source, rule_config, eslint_config, path } in self.expect_pass.clone() {
-            let result = self.run(&source, rule_config, &eslint_config, path, ExpectFixKind::None);
+            let result =
+                self.run(&source, rule_config.clone(), &eslint_config, path, ExpectFixKind::None);
             let passed = result == TestResult::Passed;
-            assert!(passed, "expect test to pass: {source} {}", self.snapshot);
+            let config = rule_config.map_or_else(
+                || "\n\n------------------------\n".to_string(),
+                |v| {
+                    format!(
+                        "\n-------- rule config --------\n{}",
+                        serde_json::to_string_pretty(&v).unwrap()
+                    )
+                },
+            );
+            assert!(
+                passed,
+                "expected test to pass, but it failed:\n\n-------- source --------\n\n{source}\n\n-------- error --------\n{}{config}\n",
+                self.snapshot
+            );
         }
     }
 
     fn test_fail(&mut self) {
         for TestCase { source, rule_config, eslint_config, path } in self.expect_fail.clone() {
-            let result = self.run(&source, rule_config, &eslint_config, path, ExpectFixKind::None);
+            let result =
+                self.run(&source, rule_config.clone(), &eslint_config, path, ExpectFixKind::None);
             let failed = result == TestResult::Failed;
-            assert!(failed, "expect test to fail: {source}");
+            let config = rule_config.map_or_else(
+                || "\n\n------------------------".to_string(),
+                |v| {
+                    format!(
+                        "\n-------- rule config --------\n{}",
+                        serde_json::to_string_pretty(&v).unwrap()
+                    )
+                },
+            );
+            assert!(
+                failed,
+                "expected test to fail, but it passed:\n\n-------- source --------\n\n{source}{config}\n",
+            );
         }
     }
 


### PR DESCRIPTION
Improves the test output when a test fails, based on the type of expectation. The output now includes the config that was passed, as well as the source code that failed. Additional formatting makes it a little bit easier to parse.

Before:

<img width="818" alt="Screenshot 2024-10-27 at 11 54 02 PM" src="https://github.com/user-attachments/assets/bac4079c-566a-403b-adde-acdc709baceb">

&nbsp;

<img width="792" alt="Screenshot 2024-10-27 at 11 54 56 PM" src="https://github.com/user-attachments/assets/16074216-00ad-4cdc-9f47-09142242111d">

---

After:

<img width="784" alt="Screenshot 2024-10-27 at 11 49 36 PM" src="https://github.com/user-attachments/assets/5d687562-55f4-4e4f-aa3a-c90b90b714e8">


&nbsp;

<img width="820" alt="Screenshot 2024-10-27 at 11 58 56 PM" src="https://github.com/user-attachments/assets/0725d362-7aed-4fd0-9fab-93a7687aca6d">

