### PR TITLE
perf(parser): does `assert_unchecked!` have a runtime cost?

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -122,11 +122,11 @@ macro_rules! ascii_byte_handler {
     ($id:ident($lex:ident) $body:expr) => {
         byte_handler!($id($lex) {
             // SAFETY: This macro is only used for ASCII characters
-            unsafe {
-                use assert_unchecked::assert_unchecked;
-                assert_unchecked!(!$lex.source.is_eof());
-                assert_unchecked!($lex.source.peek_byte_unchecked() < 128);
-            }
+            // unsafe {
+                // use assert_unchecked::assert_unchecked;
+                // assert_unchecked!(!$lex.source.is_eof());
+                // assert_unchecked!($lex.source.peek_byte_unchecked() < 128);
+            // }
             $body
         });
     };


### PR DESCRIPTION
https://docs.rs/assert-unchecked/latest/assert_unchecked/macro.assert_unchecked.html

> the boolean expression itself will likely not appear

```
#[macro_export]
macro_rules! assert_unchecked {
    ($cond:expr) => (assert_unchecked!($cond,));
    ($expr:expr, $($arg:tt)*) => ({
        #[cfg(debug_assertions)]
        {
            unsafe fn __needs_unsafe(){}
            __needs_unsafe();
            assert!($expr, $($arg)*);
        }
        #[cfg(not(debug_assertions))]
        {
            if !($expr) { core::hint::unreachable_unchecked() }
        }
    })
}
```

🤔 