### PR TITLE
fix(parser): do not double-parse modifiers of ts index signature in class

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -984,6 +984,7 @@ pub struct TSIndexSignature<'a> {
     pub parameters: Vec<'a, TSIndexSignatureName<'a>>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
     pub readonly: bool,
+    pub r#static: bool,
 }
 
 #[ast(visit)]

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1036,6 +1036,7 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, parameters) == 8usize);
     assert!(offset_of!(TSIndexSignature, type_annotation) == 40usize);
     assert!(offset_of!(TSIndexSignature, readonly) == 48usize);
+    assert!(offset_of!(TSIndexSignature, r#static) == 49usize);
 
     assert!(size_of::<TSCallSignatureDeclaration>() == 64usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8usize);
@@ -2595,6 +2596,7 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, parameters) == 8usize);
     assert!(offset_of!(TSIndexSignature, type_annotation) == 24usize);
     assert!(offset_of!(TSIndexSignature, readonly) == 28usize);
+    assert!(offset_of!(TSIndexSignature, r#static) == 29usize);
 
     assert!(size_of::<TSCallSignatureDeclaration>() == 44usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7239,6 +7239,7 @@ impl<'a> AstBuilder<'a> {
     /// - parameters
     /// - type_annotation
     /// - readonly
+    /// - r#static
     #[inline]
     pub fn class_element_ts_index_signature<T1>(
         self,
@@ -7246,6 +7247,7 @@ impl<'a> AstBuilder<'a> {
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
+        r#static: bool,
     ) -> ClassElement<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
@@ -7255,6 +7257,7 @@ impl<'a> AstBuilder<'a> {
             parameters,
             type_annotation,
             readonly,
+            r#static,
         )))
     }
 
@@ -11824,6 +11827,7 @@ impl<'a> AstBuilder<'a> {
     /// - parameters
     /// - type_annotation
     /// - readonly
+    /// - r#static
     #[inline]
     pub fn ts_signature_index_signature<T1>(
         self,
@@ -11831,6 +11835,7 @@ impl<'a> AstBuilder<'a> {
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
+        r#static: bool,
     ) -> TSSignature<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
@@ -11840,6 +11845,7 @@ impl<'a> AstBuilder<'a> {
             parameters,
             type_annotation,
             readonly,
+            r#static,
         )))
     }
 
@@ -12040,6 +12046,7 @@ impl<'a> AstBuilder<'a> {
     /// - parameters
     /// - type_annotation
     /// - readonly
+    /// - r#static
     #[inline]
     pub fn ts_index_signature<T1>(
         self,
@@ -12047,6 +12054,7 @@ impl<'a> AstBuilder<'a> {
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
+        r#static: bool,
     ) -> TSIndexSignature<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
@@ -12056,6 +12064,7 @@ impl<'a> AstBuilder<'a> {
             parameters,
             type_annotation: type_annotation.into_in(self.allocator),
             readonly,
+            r#static,
         }
     }
 
@@ -12068,6 +12077,7 @@ impl<'a> AstBuilder<'a> {
     /// - parameters
     /// - type_annotation
     /// - readonly
+    /// - r#static
     #[inline]
     pub fn alloc_ts_index_signature<T1>(
         self,
@@ -12075,12 +12085,13 @@ impl<'a> AstBuilder<'a> {
         parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
+        r#static: bool,
     ) -> Box<'a, TSIndexSignature<'a>>
     where
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         Box::new_in(
-            self.ts_index_signature(span, parameters, type_annotation, readonly),
+            self.ts_index_signature(span, parameters, type_annotation, readonly, r#static),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3369,6 +3369,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'old_alloc
             parameters: CloneIn::clone_in(&self.parameters, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             readonly: CloneIn::clone_in(&self.readonly, allocator),
+            r#static: CloneIn::clone_in(&self.r#static, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -3450,6 +3450,7 @@ impl<'a> ContentEq for TSIndexSignature<'a> {
         ContentEq::content_eq(&self.parameters, &other.parameters)
             && ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
             && ContentEq::content_eq(&self.readonly, &other.readonly)
+            && ContentEq::content_eq(&self.r#static, &other.r#static)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -1841,6 +1841,7 @@ impl<'a> ContentHash for TSIndexSignature<'a> {
         ContentHash::content_hash(&self.parameters, state);
         ContentHash::content_hash(&self.type_annotation, state);
         ContentHash::content_hash(&self.readonly, state);
+        ContentHash::content_hash(&self.r#static, state);
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2552,6 +2552,7 @@ impl<'a> Serialize for TSIndexSignature<'a> {
         map.serialize_entry("parameters", &self.parameters)?;
         map.serialize_entry("typeAnnotation", &self.type_annotation)?;
         map.serialize_entry("readonly", &self.readonly)?;
+        map.serialize_entry("static", &self.r#static)?;
         map.end()
     }
 }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -229,9 +229,9 @@ impl<'a> ParserImpl<'a> {
         }
 
         if self.is_at_ts_index_signature_member() {
-            if let TSSignature::TSIndexSignature(sig) = self.parse_ts_index_signature_member()? {
-                return Ok(Some(ClassElement::TSIndexSignature(sig)));
-            }
+            return Ok(Some(self.ast.class_element_from_ts_index_signature(
+                self.parse_ts_index_signature_member(span, &modifiers)?,
+            )));
         }
 
         // * ...

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -696,6 +696,23 @@ mod test {
         assert_eq!(ret.errors.first().unwrap().to_string(), "Source length exceeds 4 GiB limit");
     }
 
+    #[test]
+    fn class_index_signature_modifiers() {
+        use oxc_ast::ast::*;
+        let allocator = Allocator::default();
+        let source_type = SourceType::ts();
+        let source = "class Foo { readonly [a: string]: string }";
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        let Statement::ClassDeclaration(class_decl) = &ret.program.body[0] else {
+            panic!("expected Statement::ClassDeclaration");
+        };
+        let ClassElement::TSIndexSignature(index_sig) = &class_decl.body.body[0] else {
+            panic!("expected ClassElement::TSIndexSignature");
+        };
+        assert!(index_sig.readonly);
+        assert_eq!(index_sig.span.start as usize, source.find("readonly").unwrap());
+    }
+
     // Source with length MAX_LEN parses OK.
     // This test takes over 1 minute on an M1 Macbook Pro unless compiled in release mode.
     // `not(debug_assertions)` is a proxy for detecting release mode.

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -206,7 +206,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_type_signature(&mut self) -> Result<Option<TSSignature<'a>>> {
         if self.is_at_ts_index_signature_member() {
-            return self.parse_ts_index_signature_member().map(Some);
+            return self.parse_ts_index_signature_member_with_modifiers().map(Some);
         }
 
         match self.cur_kind() {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1267,12 +1267,24 @@ impl<'a> ParserImpl<'a> {
         ))
     }
 
-    pub(crate) fn parse_ts_index_signature_member(&mut self) -> Result<TSSignature<'a>> {
-        let span = self.start_span();
+    pub(crate) fn parse_ts_index_signature_member_with_modifiers(
+        &mut self,
+    ) -> Result<TSSignature<'a>> {
+        let start_span = self.start_span();
 
         let modifiers = self.parse_class_element_modifiers(false);
+        Ok(self.ast.ts_signature_from_ts_index_signature(
+            self.parse_ts_index_signature_member(start_span, &modifiers)?,
+        ))
+    }
+
+    pub(crate) fn parse_ts_index_signature_member(
+        &mut self,
+        start_span: Span,
+        modifiers: &Modifiers<'a>,
+    ) -> Result<TSIndexSignature<'a>> {
         self.verify_modifiers(
-            &modifiers,
+            modifiers,
             ModifierFlags::READONLY,
             diagnostics::cannot_appear_on_an_index_signature,
         );
@@ -1288,8 +1300,8 @@ impl<'a> ParserImpl<'a> {
         if let Some(type_annotation) = type_annotation {
             self.bump(Kind::Comma);
             self.bump(Kind::Semicolon);
-            Ok(self.ast.ts_signature_index_signature(
-                self.end_span(span),
+            Ok(self.ast.ts_index_signature(
+                self.end_span(start_span),
                 parameters,
                 type_annotation,
                 readonly,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1285,10 +1285,11 @@ impl<'a> ParserImpl<'a> {
     ) -> Result<TSIndexSignature<'a>> {
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::READONLY,
+            ModifierFlags::READONLY | ModifierFlags::STATIC,
             diagnostics::cannot_appear_on_an_index_signature,
         );
         let readonly = modifiers.contains(ModifierKind::Readonly);
+        let r#static = modifiers.contains(ModifierKind::Static);
 
         self.bump(Kind::LBrack);
         let index_name = self.parse_ts_index_signature_name()?;
@@ -1305,6 +1306,7 @@ impl<'a> ParserImpl<'a> {
                 parameters,
                 type_annotation,
                 readonly,
+                r#static,
             ))
         } else {
             Err(self.unexpected())

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -12722,6 +12722,7 @@ pub(crate) const OFFSET_TS_INDEX_SIGNATURE_PARAMETERS: usize =
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION: usize =
     offset_of!(TSIndexSignature, type_annotation);
 pub(crate) const OFFSET_TS_INDEX_SIGNATURE_READONLY: usize = offset_of!(TSIndexSignature, readonly);
+pub(crate) const OFFSET_TS_INDEX_SIGNATURE_STATIC: usize = offset_of!(TSIndexSignature, r#static);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -12747,6 +12748,11 @@ impl<'a, 't> TSIndexSignatureWithoutParameters<'a, 't> {
     #[inline]
     pub fn readonly(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_READONLY) as *const bool) }
+    }
+
+    #[inline]
+    pub fn r#static(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_STATIC) as *const bool) }
     }
 }
 
@@ -12781,6 +12787,11 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
     #[inline]
     pub fn readonly(self) -> &'t bool {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_READONLY) as *const bool) }
+    }
+
+    #[inline]
+    pub fn r#static(self) -> &'t bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_STATIC) as *const bool) }
     }
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1393,6 +1393,7 @@ export interface TSIndexSignature extends Span {
   parameters: Array<TSIndexSignatureName>;
   typeAnnotation: TSTypeAnnotation;
   readonly: boolean;
+  static: boolean;
 }
 
 export interface TSCallSignatureDeclaration extends Span {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: d20b314c
 parser_babel Summary:
 AST Parsed     : 2126/2136 (99.53%)
 Positive Passed: 2116/2136 (99.06%)
-Negative Passed: 1385/1500 (92.33%)
+Negative Passed: 1387/1500 (92.47%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -49,9 +49,7 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/invalid-modifiers-order/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-readonly/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-incompatible/input.ts
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-invalid-order/input.ts
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-override-errors/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-binding-patterns/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-fields-modifier-abstract/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/function/input.ts
@@ -10215,6 +10213,54 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │   constructor(private, public, static) {
    ·                                ──────
  3 │   }
+   ╰────
+
+  × TS(1071): 'abstract' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:2:3]
+ 1 │ class C {
+ 2 │   abstract [key: string]: string;
+   ·   ────────
+ 3 │   declare [key: string]: string;
+   ╰────
+
+  × TS(1071): 'declare' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:3:3]
+ 2 │   abstract [key: string]: string;
+ 3 │   declare [key: string]: string;
+   ·   ───────
+ 4 │   private [key: string]: string;
+   ╰────
+
+  × TS(1071): 'private' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:4:3]
+ 3 │   declare [key: string]: string;
+ 4 │   private [key: string]: string;
+   ·   ───────
+ 5 │   public [key: string]: string;
+   ╰────
+
+  × TS(1071): 'public' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:5:3]
+ 4 │   private [key: string]: string;
+ 5 │   public [key: string]: string;
+   ·   ──────
+ 6 │   protected [key: string]: string;
+   ╰────
+
+  × TS(1071): 'protected' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-index-signatures/input.ts:6:3]
+ 5 │   public [key: string]: string;
+ 6 │   protected [key: string]: string;
+   ·   ─────────
+ 7 │ }
+   ╰────
+
+  × TS(1071): 'override' modifier cannot appear on an index signature.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-override-errors/input.ts:3:3]
+ 2 │   override constructor() {}
+ 3 │   override [x: string]: any;
+   ·   ────────
+ 4 │ }
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: df9d1650
 parser_typescript Summary:
 AST Parsed     : 6481/6490 (99.86%)
 Positive Passed: 6470/6490 (99.69%)
-Negative Passed: 1237/5738 (21.56%)
+Negative Passed: 1239/5738 (21.59%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration10.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration11.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration13.ts
@@ -2405,8 +2405,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/c
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperProperties.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperStatementPosition.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/superPropertyInConstructorBeforeSuperCall.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/staticIndexers.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts
@@ -2531,6 +2529,8 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/p
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature4.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature5.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum4.ts
@@ -3800,8 +3800,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration5.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration7.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration8.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration1.ts
@@ -13994,6 +13992,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
   help: either remove this super, or extend the class
 
+  × TS(1071): 'private' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts:4:5]
+ 3 │ class C {
+ 4 │     private [x: string]: string;
+   ·     ───────
+ 5 │ }
+   ╰────
+
+  × TS(1071): 'private' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts:8:5]
+ 7 │ class D {
+ 8 │     private [x: number]: string;
+   ·     ───────
+ 9 │ }
+   ╰────
+
+  × TS(1071): 'private' modifier cannot appear on an index signature.
+    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer.ts:12:5]
+ 11 │ class E<T> {
+ 12 │     private [x: string]: T;
+    ·     ───────
+ 13 │ }
+    ╰────
+
   × Expected `,` but found `[`
    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts:4:13]
  3 │ var x = {
@@ -14002,6 +14024,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·             ╰── `,` expected
  5 │ }
    ╰────
+
+  × TS(1071): 'public' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts:4:5]
+ 3 │ class C {
+ 4 │     public [x: string]: string;
+   ·     ──────
+ 5 │ }
+   ╰────
+
+  × TS(1071): 'public' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts:8:5]
+ 7 │ class D {
+ 8 │     public [x: number]: string;
+   ·     ──────
+ 9 │ }
+   ╰────
+
+  × TS(1071): 'public' modifier cannot appear on an index signature.
+    ╭─[typescript/tests/cases/conformance/classes/indexMemberDeclarations/publicIndexer.ts:12:5]
+ 11 │ class E<T> {
+ 12 │     public [x: string]: T;
+    ·     ──────
+ 13 │ }
+    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[typescript/tests/cases/conformance/classes/members/accessibility/privateInstanceMemberAccessibility.ts:12:12]
@@ -15099,38 +15145,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  8 │     static set x(v) {  } // error
    ·                ┬
    ·                ╰── It can not be redeclared here
- 9 │ }
-   ╰────
-
-  × TS(1071): 'static' modifier cannot appear on an index signature.
-    ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature4.ts:12:5]
- 11 │ interface IB {
- 12 │     static [s: string]: number;
-    ·     ──────
- 13 │     static [s: number]: 42 | 233;
-    ╰────
-
-  × TS(1071): 'static' modifier cannot appear on an index signature.
-    ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature4.ts:13:5]
- 12 │     static [s: string]: number;
- 13 │     static [s: number]: 42 | 233;
-    ·     ──────
- 14 │ }
-    ╰────
-
-  × TS(1071): 'static' modifier cannot appear on an index signature.
-   ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature5.ts:7:5]
- 6 │ interface I {
- 7 │     static readonly [s: string]: number;
-   ·     ──────
- 8 │     static readonly [s: number]: 42 | 233
-   ╰────
-
-  × TS(1071): 'static' modifier cannot appear on an index signature.
-   ╭─[typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature5.ts:8:5]
- 7 │     static readonly [s: string]: number;
- 8 │     static readonly [s: number]: 42 | 233
-   ·     ──────
  9 │ }
    ╰────
 
@@ -20797,11 +20811,27 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    · ─
    ╰────
 
-  × TS(1071): 'export' modifier cannot appear on an index signature.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration9.ts:2:4]
+  × TS(1071): 'public' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration7.ts:2:4]
+ 1 │ class C {
+ 2 │    public [x: string]: string;
+   ·    ──────
+ 3 │ }
+   ╰────
+
+  × TS(1071): 'private' modifier cannot appear on an index signature.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration8.ts:2:4]
+ 1 │ class C {
+ 2 │    private [x: string]: string;
+   ·    ───────
+ 3 │ }
+   ╰────
+
+  × Unexpected token
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration9.ts:2:11]
  1 │ class C {
  2 │    export [x: string]: string;
-   ·    ──────
+   ·           ─
  3 │ }
    ╰────
 


### PR DESCRIPTION
Modifiers of ts index signatures in classes are parsed twice. The first one is ignored and the second one is always empty, causing the incorrect `readonly` and `span` in ast. https://oxc-project.github.io/oxc/playground/?code=3YCAAICvgICAgICAgICxG4jI43W9aqTWr3Wzy1UcIvgVm0uDVLP%2FHYReSN%2FJ0Mhppm0XIo%2F7DW7cd39qCwCA