### PR TITLE
[POC] perf(ast): use pointer instead of slice for identifier names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ dependencies = [
  "cow-utils",
  "itertools",
  "lazy_static",
+ "oxc-miette",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -4,7 +4,7 @@
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
 // Read [`macro@oxc_ast_macros::ast`] for more information.
 
-use std::cell::Cell;
+use std::{cell::Cell, marker::PhantomData};
 
 use oxc_allocator::{Box, CloneIn, Vec};
 use oxc_ast_macros::ast;
@@ -205,7 +205,8 @@ pub use match_expression;
 #[estree(type = "Identifier")]
 pub struct IdentifierName<'a> {
     pub span: Span,
-    pub name: Atom<'a>,
+    pub(crate) source_ptr: *const u8,
+    pub(crate) marker: PhantomData<Atom<'a>>,
 }
 
 /// `x` inside `func` in `const x = 0; function func() { console.log(x); }`
@@ -220,7 +221,9 @@ pub struct IdentifierName<'a> {
 pub struct IdentifierReference<'a> {
     pub span: Span,
     /// The name of the identifier being referenced.
-    pub name: Atom<'a>,
+    // pub name: Atom<'a>,
+    pub(crate) source_ptr: *const u8,
+    pub(crate) marker: PhantomData<Atom<'a>>,
     /// Reference ID
     ///
     /// Identifies what identifier this refers to, and how it is used. This is
@@ -243,7 +246,8 @@ pub struct IdentifierReference<'a> {
 pub struct BindingIdentifier<'a> {
     pub span: Span,
     /// The identifier name being bound.
-    pub name: Atom<'a>,
+    pub(crate) source_ptr: *const u8,
+    pub(crate) marker: PhantomData<Atom<'a>>,
     /// Unique identifier for this binding.
     ///
     /// This gets initialized during [`semantic analysis`] in the bind step. If
@@ -266,7 +270,9 @@ pub struct BindingIdentifier<'a> {
 #[estree(type = "Identifier")]
 pub struct LabelIdentifier<'a> {
     pub span: Span,
-    pub name: Atom<'a>,
+    // pub name: Atom<'a>,
+    pub(crate) source_ptr: *const u8,
+    pub(crate) marker: PhantomData<Atom<'a>>,
 }
 
 /// `this` in `return this.prop;`

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -4,6 +4,8 @@
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
 // Read [`macro@oxc_ast_macros::ast`] for more information.
 
+use std::marker::PhantomData;
+
 use oxc_allocator::{Box, CloneIn, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
@@ -421,7 +423,9 @@ pub struct JSXIdentifier<'a> {
     /// Node location in source code
     pub span: Span,
     /// The name of the identifier.
-    pub name: Atom<'a>,
+    // pub name: Atom<'a>,
+    pub(crate) source_ptr: *const u8,
+    pub(crate) marker: PhantomData<Atom<'a>>,
 }
 
 // 1.4 JSX Children

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -14,7 +14,7 @@ impl<'a> TSEnumMemberName<'a> {
     /// Get the name of this enum member if it can be determined statically.
     pub fn static_name(&self) -> Option<&'a str> {
         match self {
-            Self::StaticIdentifier(ident) => Some(ident.name.as_str()),
+            Self::StaticIdentifier(ident) => Some(ident.name()),
             Self::StaticStringLiteral(lit) => Some(lit.value.as_str()),
             Self::NumericLiteral(lit) => Some(lit.raw),
             Self::StaticTemplateLiteral(lit) => lit.quasi().map(Into::into),
@@ -100,7 +100,7 @@ impl<'a> TSTypeName<'a> {
     /// Returns `true` if this is a reference to `const`.
     pub fn is_const(&self) -> bool {
         if let TSTypeName::IdentifierReference(ident) = self {
-            if ident.name == "const" {
+            if ident.name() == "const" {
                 return true;
             }
         }
@@ -220,7 +220,7 @@ impl<'a> TSModuleDeclarationName<'a> {
     /// Get the static name of this module declaration name.
     pub fn name(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(ident) => ident.name.clone(),
+            Self::Identifier(ident) => ident.name().into(),
             Self::StringLiteral(lit) => lit.value.clone(),
         }
     }
@@ -286,7 +286,7 @@ impl<'a> Decorator<'a> {
     /// ```
     pub fn name(&self) -> Option<&'a str> {
         match &self.expression {
-            Expression::Identifier(ident) => Some(ident.name.as_str()),
+            Expression::Identifier(ident) => Some(ident.name()),
             expr @ match_member_expression!(Expression) => {
                 expr.to_member_expression().static_property_name()
             }

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -65,12 +65,12 @@ impl<'a> AstKind<'a> {
         matches!(self, Self::Function(_) | Self::ArrowFunctionExpression(_))
     }
 
-    pub fn identifier_name(self) -> Option<Atom<'a>> {
+    pub fn identifier_name(self) -> Option<&'a str> {
         match self {
-            Self::BindingIdentifier(ident) => Some(ident.name.clone()),
-            Self::IdentifierReference(ident) => Some(ident.name.clone()),
-            Self::LabelIdentifier(ident) => Some(ident.name.clone()),
-            Self::IdentifierName(ident) => Some(ident.name.clone()),
+            Self::BindingIdentifier(ident) => Some(ident.name()),
+            Self::IdentifierReference(ident) => Some(ident.name()),
+            Self::LabelIdentifier(ident) => Some(ident.name()),
+            Self::IdentifierName(ident) => Some(ident.name()),
             _ => None,
         }
     }
@@ -90,7 +90,7 @@ impl<'a> AstKind<'a> {
 
     pub fn is_specific_id_reference(&self, name: &str) -> bool {
         match self {
-            Self::IdentifierReference(ident) => ident.name == name,
+            Self::IdentifierReference(ident) => ident.name() == name,
             _ => false,
         }
     }
@@ -188,7 +188,7 @@ impl<'a> AstKind<'a> {
 
         #[inline]
         fn or_anonymous<'a>(id: Option<&BindingIdentifier<'a>>) -> Cow<'a, str> {
-            id.map_or_else(|| ANONYMOUS.as_ref(), |id| id.name.as_str()).into()
+            id.map_or_else(|| ANONYMOUS.as_ref(), |id| id.name()).into()
         }
 
         match self {
@@ -208,7 +208,7 @@ impl<'a> AstKind<'a> {
             Self::ForStatement(_) => "ForStatement".into(),
             Self::ForStatementInit(_) => "ForStatementInit".into(),
             Self::IfStatement(_) => "IfStatement".into(),
-            Self::LabeledStatement(l) => format!("LabeledStatement({})", l.label.name).into(),
+            Self::LabeledStatement(l) => format!("LabeledStatement({})", l.label.name()).into(),
             Self::ReturnStatement(_) => "ReturnStatement".into(),
             Self::SwitchStatement(_) => "SwitchStatement".into(),
             Self::ThrowStatement(_) => "ThrowStatement".into(),
@@ -226,10 +226,10 @@ impl<'a> AstKind<'a> {
             )
             .into(),
 
-            Self::IdentifierName(x) => format!("IdentifierName({})", x.name).into(),
-            Self::IdentifierReference(x) => format!("IdentifierReference({})", x.name).into(),
-            Self::BindingIdentifier(x) => format!("BindingIdentifier({})", x.name).into(),
-            Self::LabelIdentifier(x) => format!("LabelIdentifier({})", x.name).into(),
+            Self::IdentifierName(x) => format!("IdentifierName({})", x.name()).into(),
+            Self::IdentifierReference(x) => format!("IdentifierReference({})", x.name()).into(),
+            Self::BindingIdentifier(x) => format!("BindingIdentifier({})", x.name()).into(),
+            Self::LabelIdentifier(x) => format!("LabelIdentifier({})", x.name()).into(),
             Self::PrivateIdentifier(x) => format!("PrivateIdentifier({})", x.name).into(),
 
             Self::NumericLiteral(n) => format!("NumericLiteral({})", n.value).into(),
@@ -263,7 +263,7 @@ impl<'a> AstKind<'a> {
             Self::MemberExpression(_) => "MemberExpression".into(),
             Self::NewExpression(n) => {
                 let callee = match &n.callee {
-                    Expression::Identifier(id) => Some(id.name.as_str()),
+                    Expression::Identifier(id) => Some(id.name()),
                     match_member_expression!(Expression) => {
                         n.callee.to_member_expression().static_property_name()
                     }
@@ -325,7 +325,7 @@ impl<'a> AstKind<'a> {
 
             Self::ModuleDeclaration(_) => "ModuleDeclaration".into(),
             Self::ImportDeclaration(_) => "ImportDeclaration".into(),
-            Self::ImportSpecifier(i) => format!("ImportSpecifier({})", i.local.name).into(),
+            Self::ImportSpecifier(i) => format!("ImportSpecifier({})", i.local.name()).into(),
             Self::ExportSpecifier(e) => format!("ExportSpecifier({})", e.local.name()).into(),
             Self::ImportDefaultSpecifier(_) => "ImportDefaultSpecifier".into(),
             Self::ImportNamespaceSpecifier(_) => "ImportNamespaceSpecifier".into(),
@@ -379,7 +379,9 @@ impl<'a> AstKind<'a> {
             Self::TSNonNullExpression(_) => "TSNonNullExpression".into(),
             Self::TSInstantiationExpression(_) => "TSInstantiationExpression".into(),
 
-            Self::TSEnumDeclaration(decl) => format!("TSEnumDeclaration({})", &decl.id.name).into(),
+            Self::TSEnumDeclaration(decl) => {
+                format!("TSEnumDeclaration({})", &decl.id.name()).into()
+            }
 
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -67,27 +67,23 @@ const _: () = {
     assert!(size_of::<Expression>() == 16usize);
     assert!(align_of::<Expression>() == 8usize);
 
-    assert!(size_of::<IdentifierName>() == 24usize);
+    assert!(size_of::<IdentifierName>() == 32usize);
     assert!(align_of::<IdentifierName>() == 8usize);
     assert!(offset_of!(IdentifierName, span) == 0usize);
-    assert!(offset_of!(IdentifierName, name) == 8usize);
 
-    assert!(size_of::<IdentifierReference>() == 32usize);
+    assert!(size_of::<IdentifierReference>() == 40usize);
     assert!(align_of::<IdentifierReference>() == 8usize);
     assert!(offset_of!(IdentifierReference, span) == 0usize);
-    assert!(offset_of!(IdentifierReference, name) == 8usize);
-    assert!(offset_of!(IdentifierReference, reference_id) == 24usize);
+    assert!(offset_of!(IdentifierReference, reference_id) == 32usize);
 
-    assert!(size_of::<BindingIdentifier>() == 32usize);
+    assert!(size_of::<BindingIdentifier>() == 40usize);
     assert!(align_of::<BindingIdentifier>() == 8usize);
     assert!(offset_of!(BindingIdentifier, span) == 0usize);
-    assert!(offset_of!(BindingIdentifier, name) == 8usize);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 24usize);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 32usize);
 
-    assert!(size_of::<LabelIdentifier>() == 24usize);
+    assert!(size_of::<LabelIdentifier>() == 32usize);
     assert!(align_of::<LabelIdentifier>() == 8usize);
     assert!(offset_of!(LabelIdentifier, span) == 0usize);
-    assert!(offset_of!(LabelIdentifier, name) == 8usize);
 
     assert!(size_of::<ThisExpression>() == 8usize);
     assert!(align_of::<ThisExpression>() == 4usize);
@@ -166,12 +162,12 @@ const _: () = {
     assert!(offset_of!(ComputedMemberExpression, expression) == 24usize);
     assert!(offset_of!(ComputedMemberExpression, optional) == 40usize);
 
-    assert!(size_of::<StaticMemberExpression>() == 56usize);
+    assert!(size_of::<StaticMemberExpression>() == 64usize);
     assert!(align_of::<StaticMemberExpression>() == 8usize);
     assert!(offset_of!(StaticMemberExpression, span) == 0usize);
     assert!(offset_of!(StaticMemberExpression, object) == 8usize);
     assert!(offset_of!(StaticMemberExpression, property) == 24usize);
-    assert!(offset_of!(StaticMemberExpression, optional) == 48usize);
+    assert!(offset_of!(StaticMemberExpression, optional) == 56usize);
 
     assert!(size_of::<PrivateFieldExpression>() == 56usize);
     assert!(align_of::<PrivateFieldExpression>() == 8usize);
@@ -195,11 +191,11 @@ const _: () = {
     assert!(offset_of!(NewExpression, arguments) == 24usize);
     assert!(offset_of!(NewExpression, type_parameters) == 56usize);
 
-    assert!(size_of::<MetaProperty>() == 56usize);
+    assert!(size_of::<MetaProperty>() == 72usize);
     assert!(align_of::<MetaProperty>() == 8usize);
     assert!(offset_of!(MetaProperty, span) == 0usize);
     assert!(offset_of!(MetaProperty, meta) == 8usize);
-    assert!(offset_of!(MetaProperty, property) == 32usize);
+    assert!(offset_of!(MetaProperty, property) == 40usize);
 
     assert!(size_of::<SpreadElement>() == 24usize);
     assert!(align_of::<SpreadElement>() == 8usize);
@@ -296,11 +292,11 @@ const _: () = {
     assert!(size_of::<AssignmentTargetProperty>() == 16usize);
     assert!(align_of::<AssignmentTargetProperty>() == 8usize);
 
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 56usize);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 64usize);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 8usize);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0usize);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 40usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 48usize);
 
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 40usize);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 8usize);
@@ -436,12 +432,12 @@ const _: () = {
     assert!(offset_of!(ForOfStatement, body) == 48usize);
     assert!(offset_of!(ForOfStatement, scope_id) == 64usize);
 
-    assert!(size_of::<ContinueStatement>() == 32usize);
+    assert!(size_of::<ContinueStatement>() == 40usize);
     assert!(align_of::<ContinueStatement>() == 8usize);
     assert!(offset_of!(ContinueStatement, span) == 0usize);
     assert!(offset_of!(ContinueStatement, label) == 8usize);
 
-    assert!(size_of::<BreakStatement>() == 32usize);
+    assert!(size_of::<BreakStatement>() == 40usize);
     assert!(align_of::<BreakStatement>() == 8usize);
     assert!(offset_of!(BreakStatement, span) == 0usize);
     assert!(offset_of!(BreakStatement, label) == 8usize);
@@ -470,11 +466,11 @@ const _: () = {
     assert!(offset_of!(SwitchCase, test) == 8usize);
     assert!(offset_of!(SwitchCase, consequent) == 24usize);
 
-    assert!(size_of::<LabeledStatement>() == 48usize);
+    assert!(size_of::<LabeledStatement>() == 56usize);
     assert!(align_of::<LabeledStatement>() == 8usize);
     assert!(offset_of!(LabeledStatement, span) == 0usize);
     assert!(offset_of!(LabeledStatement, label) == 8usize);
-    assert!(offset_of!(LabeledStatement, body) == 32usize);
+    assert!(offset_of!(LabeledStatement, body) == 40usize);
 
     assert!(size_of::<ThrowStatement>() == 24usize);
     assert!(align_of::<ThrowStatement>() == 8usize);
@@ -544,20 +540,20 @@ const _: () = {
     assert!(offset_of!(BindingRestElement, span) == 0usize);
     assert!(offset_of!(BindingRestElement, argument) == 8usize);
 
-    assert!(size_of::<Function>() == 104usize);
+    assert!(size_of::<Function>() == 112usize);
     assert!(align_of::<Function>() == 8usize);
     assert!(offset_of!(Function, r#type) == 0usize);
     assert!(offset_of!(Function, span) == 4usize);
     assert!(offset_of!(Function, id) == 16usize);
-    assert!(offset_of!(Function, generator) == 48usize);
-    assert!(offset_of!(Function, r#async) == 49usize);
-    assert!(offset_of!(Function, declare) == 50usize);
-    assert!(offset_of!(Function, type_parameters) == 56usize);
-    assert!(offset_of!(Function, this_param) == 64usize);
-    assert!(offset_of!(Function, params) == 72usize);
-    assert!(offset_of!(Function, return_type) == 80usize);
-    assert!(offset_of!(Function, body) == 88usize);
-    assert!(offset_of!(Function, scope_id) == 96usize);
+    assert!(offset_of!(Function, generator) == 56usize);
+    assert!(offset_of!(Function, r#async) == 57usize);
+    assert!(offset_of!(Function, declare) == 58usize);
+    assert!(offset_of!(Function, type_parameters) == 64usize);
+    assert!(offset_of!(Function, this_param) == 72usize);
+    assert!(offset_of!(Function, params) == 80usize);
+    assert!(offset_of!(Function, return_type) == 88usize);
+    assert!(offset_of!(Function, body) == 96usize);
+    assert!(offset_of!(Function, scope_id) == 104usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
@@ -604,20 +600,20 @@ const _: () = {
     assert!(offset_of!(YieldExpression, delegate) == 8usize);
     assert!(offset_of!(YieldExpression, argument) == 16usize);
 
-    assert!(size_of::<Class>() == 160usize);
+    assert!(size_of::<Class>() == 168usize);
     assert!(align_of::<Class>() == 8usize);
     assert!(offset_of!(Class, r#type) == 0usize);
     assert!(offset_of!(Class, span) == 4usize);
     assert!(offset_of!(Class, decorators) == 16usize);
     assert!(offset_of!(Class, id) == 48usize);
-    assert!(offset_of!(Class, type_parameters) == 80usize);
-    assert!(offset_of!(Class, super_class) == 88usize);
-    assert!(offset_of!(Class, super_type_parameters) == 104usize);
-    assert!(offset_of!(Class, implements) == 112usize);
-    assert!(offset_of!(Class, body) == 144usize);
-    assert!(offset_of!(Class, r#abstract) == 152usize);
-    assert!(offset_of!(Class, declare) == 153usize);
-    assert!(offset_of!(Class, scope_id) == 156usize);
+    assert!(offset_of!(Class, type_parameters) == 88usize);
+    assert!(offset_of!(Class, super_class) == 96usize);
+    assert!(offset_of!(Class, super_type_parameters) == 112usize);
+    assert!(offset_of!(Class, implements) == 120usize);
+    assert!(offset_of!(Class, body) == 152usize);
+    assert!(offset_of!(Class, r#abstract) == 160usize);
+    assert!(offset_of!(Class, declare) == 161usize);
+    assert!(offset_of!(Class, scope_id) == 164usize);
 
     assert!(size_of::<ClassType>() == 1usize);
     assert!(align_of::<ClassType>() == 1usize);
@@ -717,36 +713,36 @@ const _: () = {
     assert!(size_of::<ImportDeclarationSpecifier>() == 16usize);
     assert!(align_of::<ImportDeclarationSpecifier>() == 8usize);
 
-    assert!(size_of::<ImportSpecifier>() == 88usize);
+    assert!(size_of::<ImportSpecifier>() == 104usize);
     assert!(align_of::<ImportSpecifier>() == 8usize);
     assert!(offset_of!(ImportSpecifier, span) == 0usize);
     assert!(offset_of!(ImportSpecifier, imported) == 8usize);
-    assert!(offset_of!(ImportSpecifier, local) == 48usize);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 80usize);
+    assert!(offset_of!(ImportSpecifier, local) == 56usize);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 96usize);
 
-    assert!(size_of::<ImportDefaultSpecifier>() == 40usize);
+    assert!(size_of::<ImportDefaultSpecifier>() == 48usize);
     assert!(align_of::<ImportDefaultSpecifier>() == 8usize);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0usize);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8usize);
 
-    assert!(size_of::<ImportNamespaceSpecifier>() == 40usize);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 48usize);
     assert!(align_of::<ImportNamespaceSpecifier>() == 8usize);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0usize);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8usize);
 
-    assert!(size_of::<WithClause>() == 64usize);
+    assert!(size_of::<WithClause>() == 72usize);
     assert!(align_of::<WithClause>() == 8usize);
     assert!(offset_of!(WithClause, span) == 0usize);
     assert!(offset_of!(WithClause, attributes_keyword) == 8usize);
-    assert!(offset_of!(WithClause, with_entries) == 32usize);
+    assert!(offset_of!(WithClause, with_entries) == 40usize);
 
-    assert!(size_of::<ImportAttribute>() == 64usize);
+    assert!(size_of::<ImportAttribute>() == 72usize);
     assert!(align_of::<ImportAttribute>() == 8usize);
     assert!(offset_of!(ImportAttribute, span) == 0usize);
     assert!(offset_of!(ImportAttribute, key) == 8usize);
-    assert!(offset_of!(ImportAttribute, value) == 40usize);
+    assert!(offset_of!(ImportAttribute, value) == 48usize);
 
-    assert!(size_of::<ImportAttributeKey>() == 32usize);
+    assert!(size_of::<ImportAttributeKey>() == 40usize);
     assert!(align_of::<ImportAttributeKey>() == 8usize);
 
     assert!(size_of::<ExportNamedDeclaration>() == 96usize);
@@ -758,31 +754,31 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, export_kind) == 80usize);
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 88usize);
 
-    assert!(size_of::<ExportDefaultDeclaration>() == 64usize);
+    assert!(size_of::<ExportDefaultDeclaration>() == 72usize);
     assert!(align_of::<ExportDefaultDeclaration>() == 8usize);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0usize);
     assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8usize);
     assert!(offset_of!(ExportDefaultDeclaration, exported) == 24usize);
 
-    assert!(size_of::<ExportAllDeclaration>() == 88usize);
+    assert!(size_of::<ExportAllDeclaration>() == 96usize);
     assert!(align_of::<ExportAllDeclaration>() == 8usize);
     assert!(offset_of!(ExportAllDeclaration, span) == 0usize);
     assert!(offset_of!(ExportAllDeclaration, exported) == 8usize);
-    assert!(offset_of!(ExportAllDeclaration, source) == 48usize);
-    assert!(offset_of!(ExportAllDeclaration, with_clause) == 72usize);
-    assert!(offset_of!(ExportAllDeclaration, export_kind) == 80usize);
+    assert!(offset_of!(ExportAllDeclaration, source) == 56usize);
+    assert!(offset_of!(ExportAllDeclaration, with_clause) == 80usize);
+    assert!(offset_of!(ExportAllDeclaration, export_kind) == 88usize);
 
-    assert!(size_of::<ExportSpecifier>() == 96usize);
+    assert!(size_of::<ExportSpecifier>() == 112usize);
     assert!(align_of::<ExportSpecifier>() == 8usize);
     assert!(offset_of!(ExportSpecifier, span) == 0usize);
     assert!(offset_of!(ExportSpecifier, local) == 8usize);
-    assert!(offset_of!(ExportSpecifier, exported) == 48usize);
-    assert!(offset_of!(ExportSpecifier, export_kind) == 88usize);
+    assert!(offset_of!(ExportSpecifier, exported) == 56usize);
+    assert!(offset_of!(ExportSpecifier, export_kind) == 104usize);
 
     assert!(size_of::<ExportDefaultDeclarationKind>() == 16usize);
     assert!(align_of::<ExportDefaultDeclarationKind>() == 8usize);
 
-    assert!(size_of::<ModuleExportName>() == 40usize);
+    assert!(size_of::<ModuleExportName>() == 48usize);
     assert!(align_of::<ModuleExportName>() == 8usize);
 
     assert!(size_of::<TSThisParameter>() == 24usize);
@@ -791,14 +787,14 @@ const _: () = {
     assert!(offset_of!(TSThisParameter, this_span) == 8usize);
     assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
 
-    assert!(size_of::<TSEnumDeclaration>() == 80usize);
+    assert!(size_of::<TSEnumDeclaration>() == 88usize);
     assert!(align_of::<TSEnumDeclaration>() == 8usize);
     assert!(offset_of!(TSEnumDeclaration, span) == 0usize);
     assert!(offset_of!(TSEnumDeclaration, id) == 8usize);
-    assert!(offset_of!(TSEnumDeclaration, members) == 40usize);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 72usize);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 73usize);
-    assert!(offset_of!(TSEnumDeclaration, scope_id) == 76usize);
+    assert!(offset_of!(TSEnumDeclaration, members) == 48usize);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 80usize);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 81usize);
+    assert!(offset_of!(TSEnumDeclaration, scope_id) == 84usize);
 
     assert!(size_of::<TSEnumMember>() == 40usize);
     assert!(align_of::<TSEnumMember>() == 8usize);
@@ -874,12 +870,12 @@ const _: () = {
     assert!(offset_of!(TSTupleType, span) == 0usize);
     assert!(offset_of!(TSTupleType, element_types) == 8usize);
 
-    assert!(size_of::<TSNamedTupleMember>() == 56usize);
+    assert!(size_of::<TSNamedTupleMember>() == 64usize);
     assert!(align_of::<TSNamedTupleMember>() == 8usize);
     assert!(offset_of!(TSNamedTupleMember, span) == 0usize);
     assert!(offset_of!(TSNamedTupleMember, element_type) == 8usize);
     assert!(offset_of!(TSNamedTupleMember, label) == 24usize);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 48usize);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 56usize);
 
     assert!(size_of::<TSOptionalType>() == 24usize);
     assert!(align_of::<TSOptionalType>() == 8usize);
@@ -959,7 +955,7 @@ const _: () = {
     assert!(size_of::<TSTypeName>() == 16usize);
     assert!(align_of::<TSTypeName>() == 8usize);
 
-    assert!(size_of::<TSQualifiedName>() == 48usize);
+    assert!(size_of::<TSQualifiedName>() == 56usize);
     assert!(align_of::<TSQualifiedName>() == 8usize);
     assert!(offset_of!(TSQualifiedName, span) == 0usize);
     assert!(offset_of!(TSQualifiedName, left) == 8usize);
@@ -970,29 +966,29 @@ const _: () = {
     assert!(offset_of!(TSTypeParameterInstantiation, span) == 0usize);
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8usize);
 
-    assert!(size_of::<TSTypeParameter>() == 80usize);
+    assert!(size_of::<TSTypeParameter>() == 88usize);
     assert!(align_of::<TSTypeParameter>() == 8usize);
     assert!(offset_of!(TSTypeParameter, span) == 0usize);
     assert!(offset_of!(TSTypeParameter, name) == 8usize);
-    assert!(offset_of!(TSTypeParameter, constraint) == 40usize);
-    assert!(offset_of!(TSTypeParameter, default) == 56usize);
-    assert!(offset_of!(TSTypeParameter, r#in) == 72usize);
-    assert!(offset_of!(TSTypeParameter, out) == 73usize);
-    assert!(offset_of!(TSTypeParameter, r#const) == 74usize);
+    assert!(offset_of!(TSTypeParameter, constraint) == 48usize);
+    assert!(offset_of!(TSTypeParameter, default) == 64usize);
+    assert!(offset_of!(TSTypeParameter, r#in) == 80usize);
+    assert!(offset_of!(TSTypeParameter, out) == 81usize);
+    assert!(offset_of!(TSTypeParameter, r#const) == 82usize);
 
     assert!(size_of::<TSTypeParameterDeclaration>() == 40usize);
     assert!(align_of::<TSTypeParameterDeclaration>() == 8usize);
     assert!(offset_of!(TSTypeParameterDeclaration, span) == 0usize);
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8usize);
 
-    assert!(size_of::<TSTypeAliasDeclaration>() == 72usize);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 80usize);
     assert!(align_of::<TSTypeAliasDeclaration>() == 8usize);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0usize);
     assert!(offset_of!(TSTypeAliasDeclaration, id) == 8usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 40usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 48usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 64usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 68usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 48usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 56usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 72usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 76usize);
 
     assert!(size_of::<TSAccessibility>() == 1usize);
     assert!(align_of::<TSAccessibility>() == 1usize);
@@ -1003,15 +999,15 @@ const _: () = {
     assert!(offset_of!(TSClassImplements, expression) == 8usize);
     assert!(offset_of!(TSClassImplements, type_parameters) == 24usize);
 
-    assert!(size_of::<TSInterfaceDeclaration>() == 96usize);
+    assert!(size_of::<TSInterfaceDeclaration>() == 104usize);
     assert!(align_of::<TSInterfaceDeclaration>() == 8usize);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0usize);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8usize);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 40usize);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 72usize);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 80usize);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 88usize);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 92usize);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 48usize);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 80usize);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 88usize);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 96usize);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 100usize);
 
     assert!(size_of::<TSInterfaceBody>() == 40usize);
     assert!(align_of::<TSInterfaceBody>() == 8usize);
@@ -1091,19 +1087,19 @@ const _: () = {
     assert!(size_of::<TSTypePredicateName>() == 16usize);
     assert!(align_of::<TSTypePredicateName>() == 8usize);
 
-    assert!(size_of::<TSModuleDeclaration>() == 72usize);
+    assert!(size_of::<TSModuleDeclaration>() == 80usize);
     assert!(align_of::<TSModuleDeclaration>() == 8usize);
     assert!(offset_of!(TSModuleDeclaration, span) == 0usize);
     assert!(offset_of!(TSModuleDeclaration, id) == 8usize);
-    assert!(offset_of!(TSModuleDeclaration, body) == 48usize);
-    assert!(offset_of!(TSModuleDeclaration, kind) == 64usize);
-    assert!(offset_of!(TSModuleDeclaration, declare) == 65usize);
-    assert!(offset_of!(TSModuleDeclaration, scope_id) == 68usize);
+    assert!(offset_of!(TSModuleDeclaration, body) == 56usize);
+    assert!(offset_of!(TSModuleDeclaration, kind) == 72usize);
+    assert!(offset_of!(TSModuleDeclaration, declare) == 73usize);
+    assert!(offset_of!(TSModuleDeclaration, scope_id) == 76usize);
 
     assert!(size_of::<TSModuleDeclarationKind>() == 1usize);
     assert!(align_of::<TSModuleDeclarationKind>() == 1usize);
 
-    assert!(size_of::<TSModuleDeclarationName>() == 40usize);
+    assert!(size_of::<TSModuleDeclarationName>() == 48usize);
     assert!(align_of::<TSModuleDeclarationName>() == 8usize);
 
     assert!(size_of::<TSModuleDeclarationBody>() == 16usize);
@@ -1143,19 +1139,19 @@ const _: () = {
     assert!(offset_of!(TSImportType, attributes) == 48usize);
     assert!(offset_of!(TSImportType, type_parameters) == 56usize);
 
-    assert!(size_of::<TSImportAttributes>() == 64usize);
+    assert!(size_of::<TSImportAttributes>() == 72usize);
     assert!(align_of::<TSImportAttributes>() == 8usize);
     assert!(offset_of!(TSImportAttributes, span) == 0usize);
     assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 32usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 40usize);
 
-    assert!(size_of::<TSImportAttribute>() == 56usize);
+    assert!(size_of::<TSImportAttribute>() == 64usize);
     assert!(align_of::<TSImportAttribute>() == 8usize);
     assert!(offset_of!(TSImportAttribute, span) == 0usize);
     assert!(offset_of!(TSImportAttribute, name) == 8usize);
-    assert!(offset_of!(TSImportAttribute, value) == 40usize);
+    assert!(offset_of!(TSImportAttribute, value) == 48usize);
 
-    assert!(size_of::<TSImportAttributeName>() == 32usize);
+    assert!(size_of::<TSImportAttributeName>() == 40usize);
     assert!(align_of::<TSImportAttributeName>() == 8usize);
 
     assert!(size_of::<TSFunctionType>() == 40usize);
@@ -1211,12 +1207,12 @@ const _: () = {
     assert!(offset_of!(TSTypeAssertion, expression) == 8usize);
     assert!(offset_of!(TSTypeAssertion, type_annotation) == 24usize);
 
-    assert!(size_of::<TSImportEqualsDeclaration>() == 64usize);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 72usize);
     assert!(align_of::<TSImportEqualsDeclaration>() == 8usize);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0usize);
     assert!(offset_of!(TSImportEqualsDeclaration, id) == 8usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 40usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 56usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 48usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 64usize);
 
     assert!(size_of::<TSModuleReference>() == 16usize);
     assert!(align_of::<TSModuleReference>() == 8usize);
@@ -1241,7 +1237,7 @@ const _: () = {
     assert!(offset_of!(TSExportAssignment, span) == 0usize);
     assert!(offset_of!(TSExportAssignment, expression) == 8usize);
 
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 32usize);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 40usize);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 8usize);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0usize);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8usize);
@@ -1309,13 +1305,13 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 16usize);
     assert!(align_of::<JSXElementName>() == 8usize);
 
-    assert!(size_of::<JSXNamespacedName>() == 56usize);
+    assert!(size_of::<JSXNamespacedName>() == 72usize);
     assert!(align_of::<JSXNamespacedName>() == 8usize);
     assert!(offset_of!(JSXNamespacedName, span) == 0usize);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 32usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 40usize);
 
-    assert!(size_of::<JSXMemberExpression>() == 48usize);
+    assert!(size_of::<JSXMemberExpression>() == 56usize);
     assert!(align_of::<JSXMemberExpression>() == 8usize);
     assert!(offset_of!(JSXMemberExpression, span) == 0usize);
     assert!(offset_of!(JSXMemberExpression, object) == 8usize);
@@ -1356,10 +1352,9 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 16usize);
     assert!(align_of::<JSXAttributeValue>() == 8usize);
 
-    assert!(size_of::<JSXIdentifier>() == 24usize);
+    assert!(size_of::<JSXIdentifier>() == 32usize);
     assert!(align_of::<JSXIdentifier>() == 8usize);
     assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
 
     assert!(size_of::<JSXChild>() == 16usize);
     assert!(align_of::<JSXChild>() == 8usize);
@@ -1626,27 +1621,23 @@ const _: () = {
     assert!(size_of::<Expression>() == 8usize);
     assert!(align_of::<Expression>() == 4usize);
 
-    assert!(size_of::<IdentifierName>() == 16usize);
+    assert!(size_of::<IdentifierName>() == 20usize);
     assert!(align_of::<IdentifierName>() == 4usize);
     assert!(offset_of!(IdentifierName, span) == 0usize);
-    assert!(offset_of!(IdentifierName, name) == 8usize);
 
-    assert!(size_of::<IdentifierReference>() == 20usize);
+    assert!(size_of::<IdentifierReference>() == 24usize);
     assert!(align_of::<IdentifierReference>() == 4usize);
     assert!(offset_of!(IdentifierReference, span) == 0usize);
-    assert!(offset_of!(IdentifierReference, name) == 8usize);
-    assert!(offset_of!(IdentifierReference, reference_id) == 16usize);
+    assert!(offset_of!(IdentifierReference, reference_id) == 20usize);
 
-    assert!(size_of::<BindingIdentifier>() == 20usize);
+    assert!(size_of::<BindingIdentifier>() == 24usize);
     assert!(align_of::<BindingIdentifier>() == 4usize);
     assert!(offset_of!(BindingIdentifier, span) == 0usize);
-    assert!(offset_of!(BindingIdentifier, name) == 8usize);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 16usize);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 20usize);
 
-    assert!(size_of::<LabelIdentifier>() == 16usize);
+    assert!(size_of::<LabelIdentifier>() == 20usize);
     assert!(align_of::<LabelIdentifier>() == 4usize);
     assert!(offset_of!(LabelIdentifier, span) == 0usize);
-    assert!(offset_of!(LabelIdentifier, name) == 8usize);
 
     assert!(size_of::<ThisExpression>() == 8usize);
     assert!(align_of::<ThisExpression>() == 4usize);
@@ -1725,12 +1716,12 @@ const _: () = {
     assert!(offset_of!(ComputedMemberExpression, expression) == 16usize);
     assert!(offset_of!(ComputedMemberExpression, optional) == 24usize);
 
-    assert!(size_of::<StaticMemberExpression>() == 36usize);
+    assert!(size_of::<StaticMemberExpression>() == 40usize);
     assert!(align_of::<StaticMemberExpression>() == 4usize);
     assert!(offset_of!(StaticMemberExpression, span) == 0usize);
     assert!(offset_of!(StaticMemberExpression, object) == 8usize);
     assert!(offset_of!(StaticMemberExpression, property) == 16usize);
-    assert!(offset_of!(StaticMemberExpression, optional) == 32usize);
+    assert!(offset_of!(StaticMemberExpression, optional) == 36usize);
 
     assert!(size_of::<PrivateFieldExpression>() == 36usize);
     assert!(align_of::<PrivateFieldExpression>() == 4usize);
@@ -1754,11 +1745,11 @@ const _: () = {
     assert!(offset_of!(NewExpression, arguments) == 16usize);
     assert!(offset_of!(NewExpression, type_parameters) == 32usize);
 
-    assert!(size_of::<MetaProperty>() == 40usize);
+    assert!(size_of::<MetaProperty>() == 48usize);
     assert!(align_of::<MetaProperty>() == 4usize);
     assert!(offset_of!(MetaProperty, span) == 0usize);
     assert!(offset_of!(MetaProperty, meta) == 8usize);
-    assert!(offset_of!(MetaProperty, property) == 24usize);
+    assert!(offset_of!(MetaProperty, property) == 28usize);
 
     assert!(size_of::<SpreadElement>() == 16usize);
     assert!(align_of::<SpreadElement>() == 4usize);
@@ -1855,11 +1846,11 @@ const _: () = {
     assert!(size_of::<AssignmentTargetProperty>() == 8usize);
     assert!(align_of::<AssignmentTargetProperty>() == 4usize);
 
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 36usize);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 40usize);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 4usize);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0usize);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8usize);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 28usize);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 32usize);
 
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 24usize);
     assert!(align_of::<AssignmentTargetPropertyProperty>() == 4usize);
@@ -1995,12 +1986,12 @@ const _: () = {
     assert!(offset_of!(ForOfStatement, body) == 28usize);
     assert!(offset_of!(ForOfStatement, scope_id) == 36usize);
 
-    assert!(size_of::<ContinueStatement>() == 24usize);
+    assert!(size_of::<ContinueStatement>() == 28usize);
     assert!(align_of::<ContinueStatement>() == 4usize);
     assert!(offset_of!(ContinueStatement, span) == 0usize);
     assert!(offset_of!(ContinueStatement, label) == 8usize);
 
-    assert!(size_of::<BreakStatement>() == 24usize);
+    assert!(size_of::<BreakStatement>() == 28usize);
     assert!(align_of::<BreakStatement>() == 4usize);
     assert!(offset_of!(BreakStatement, span) == 0usize);
     assert!(offset_of!(BreakStatement, label) == 8usize);
@@ -2029,11 +2020,11 @@ const _: () = {
     assert!(offset_of!(SwitchCase, test) == 8usize);
     assert!(offset_of!(SwitchCase, consequent) == 16usize);
 
-    assert!(size_of::<LabeledStatement>() == 32usize);
+    assert!(size_of::<LabeledStatement>() == 36usize);
     assert!(align_of::<LabeledStatement>() == 4usize);
     assert!(offset_of!(LabeledStatement, span) == 0usize);
     assert!(offset_of!(LabeledStatement, label) == 8usize);
-    assert!(offset_of!(LabeledStatement, body) == 24usize);
+    assert!(offset_of!(LabeledStatement, body) == 28usize);
 
     assert!(size_of::<ThrowStatement>() == 16usize);
     assert!(align_of::<ThrowStatement>() == 4usize);
@@ -2103,20 +2094,20 @@ const _: () = {
     assert!(offset_of!(BindingRestElement, span) == 0usize);
     assert!(offset_of!(BindingRestElement, argument) == 8usize);
 
-    assert!(size_of::<Function>() == 60usize);
+    assert!(size_of::<Function>() == 64usize);
     assert!(align_of::<Function>() == 4usize);
     assert!(offset_of!(Function, r#type) == 0usize);
     assert!(offset_of!(Function, span) == 4usize);
     assert!(offset_of!(Function, id) == 12usize);
-    assert!(offset_of!(Function, generator) == 32usize);
-    assert!(offset_of!(Function, r#async) == 33usize);
-    assert!(offset_of!(Function, declare) == 34usize);
-    assert!(offset_of!(Function, type_parameters) == 36usize);
-    assert!(offset_of!(Function, this_param) == 40usize);
-    assert!(offset_of!(Function, params) == 44usize);
-    assert!(offset_of!(Function, return_type) == 48usize);
-    assert!(offset_of!(Function, body) == 52usize);
-    assert!(offset_of!(Function, scope_id) == 56usize);
+    assert!(offset_of!(Function, generator) == 36usize);
+    assert!(offset_of!(Function, r#async) == 37usize);
+    assert!(offset_of!(Function, declare) == 38usize);
+    assert!(offset_of!(Function, type_parameters) == 40usize);
+    assert!(offset_of!(Function, this_param) == 44usize);
+    assert!(offset_of!(Function, params) == 48usize);
+    assert!(offset_of!(Function, return_type) == 52usize);
+    assert!(offset_of!(Function, body) == 56usize);
+    assert!(offset_of!(Function, scope_id) == 60usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
@@ -2163,20 +2154,20 @@ const _: () = {
     assert!(offset_of!(YieldExpression, delegate) == 8usize);
     assert!(offset_of!(YieldExpression, argument) == 12usize);
 
-    assert!(size_of::<Class>() == 92usize);
+    assert!(size_of::<Class>() == 96usize);
     assert!(align_of::<Class>() == 4usize);
     assert!(offset_of!(Class, r#type) == 0usize);
     assert!(offset_of!(Class, span) == 4usize);
     assert!(offset_of!(Class, decorators) == 12usize);
     assert!(offset_of!(Class, id) == 28usize);
-    assert!(offset_of!(Class, type_parameters) == 48usize);
-    assert!(offset_of!(Class, super_class) == 52usize);
-    assert!(offset_of!(Class, super_type_parameters) == 60usize);
-    assert!(offset_of!(Class, implements) == 64usize);
-    assert!(offset_of!(Class, body) == 80usize);
-    assert!(offset_of!(Class, r#abstract) == 84usize);
-    assert!(offset_of!(Class, declare) == 85usize);
-    assert!(offset_of!(Class, scope_id) == 88usize);
+    assert!(offset_of!(Class, type_parameters) == 52usize);
+    assert!(offset_of!(Class, super_class) == 56usize);
+    assert!(offset_of!(Class, super_type_parameters) == 64usize);
+    assert!(offset_of!(Class, implements) == 68usize);
+    assert!(offset_of!(Class, body) == 84usize);
+    assert!(offset_of!(Class, r#abstract) == 88usize);
+    assert!(offset_of!(Class, declare) == 89usize);
+    assert!(offset_of!(Class, scope_id) == 92usize);
 
     assert!(size_of::<ClassType>() == 1usize);
     assert!(align_of::<ClassType>() == 1usize);
@@ -2276,36 +2267,36 @@ const _: () = {
     assert!(size_of::<ImportDeclarationSpecifier>() == 8usize);
     assert!(align_of::<ImportDeclarationSpecifier>() == 4usize);
 
-    assert!(size_of::<ImportSpecifier>() == 56usize);
+    assert!(size_of::<ImportSpecifier>() == 64usize);
     assert!(align_of::<ImportSpecifier>() == 4usize);
     assert!(offset_of!(ImportSpecifier, span) == 0usize);
     assert!(offset_of!(ImportSpecifier, imported) == 8usize);
-    assert!(offset_of!(ImportSpecifier, local) == 32usize);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 52usize);
+    assert!(offset_of!(ImportSpecifier, local) == 36usize);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 60usize);
 
-    assert!(size_of::<ImportDefaultSpecifier>() == 28usize);
+    assert!(size_of::<ImportDefaultSpecifier>() == 32usize);
     assert!(align_of::<ImportDefaultSpecifier>() == 4usize);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0usize);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8usize);
 
-    assert!(size_of::<ImportNamespaceSpecifier>() == 28usize);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 32usize);
     assert!(align_of::<ImportNamespaceSpecifier>() == 4usize);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0usize);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8usize);
 
-    assert!(size_of::<WithClause>() == 40usize);
+    assert!(size_of::<WithClause>() == 44usize);
     assert!(align_of::<WithClause>() == 4usize);
     assert!(offset_of!(WithClause, span) == 0usize);
     assert!(offset_of!(WithClause, attributes_keyword) == 8usize);
-    assert!(offset_of!(WithClause, with_entries) == 24usize);
+    assert!(offset_of!(WithClause, with_entries) == 28usize);
 
-    assert!(size_of::<ImportAttribute>() == 44usize);
+    assert!(size_of::<ImportAttribute>() == 48usize);
     assert!(align_of::<ImportAttribute>() == 4usize);
     assert!(offset_of!(ImportAttribute, span) == 0usize);
     assert!(offset_of!(ImportAttribute, key) == 8usize);
-    assert!(offset_of!(ImportAttribute, value) == 28usize);
+    assert!(offset_of!(ImportAttribute, value) == 32usize);
 
-    assert!(size_of::<ImportAttributeKey>() == 20usize);
+    assert!(size_of::<ImportAttributeKey>() == 24usize);
     assert!(align_of::<ImportAttributeKey>() == 4usize);
 
     assert!(size_of::<ExportNamedDeclaration>() == 56usize);
@@ -2317,31 +2308,31 @@ const _: () = {
     assert!(offset_of!(ExportNamedDeclaration, export_kind) == 48usize);
     assert!(offset_of!(ExportNamedDeclaration, with_clause) == 52usize);
 
-    assert!(size_of::<ExportDefaultDeclaration>() == 40usize);
+    assert!(size_of::<ExportDefaultDeclaration>() == 44usize);
     assert!(align_of::<ExportDefaultDeclaration>() == 4usize);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0usize);
     assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8usize);
     assert!(offset_of!(ExportDefaultDeclaration, exported) == 16usize);
 
-    assert!(size_of::<ExportAllDeclaration>() == 56usize);
+    assert!(size_of::<ExportAllDeclaration>() == 60usize);
     assert!(align_of::<ExportAllDeclaration>() == 4usize);
     assert!(offset_of!(ExportAllDeclaration, span) == 0usize);
     assert!(offset_of!(ExportAllDeclaration, exported) == 8usize);
-    assert!(offset_of!(ExportAllDeclaration, source) == 32usize);
-    assert!(offset_of!(ExportAllDeclaration, with_clause) == 48usize);
-    assert!(offset_of!(ExportAllDeclaration, export_kind) == 52usize);
+    assert!(offset_of!(ExportAllDeclaration, source) == 36usize);
+    assert!(offset_of!(ExportAllDeclaration, with_clause) == 52usize);
+    assert!(offset_of!(ExportAllDeclaration, export_kind) == 56usize);
 
-    assert!(size_of::<ExportSpecifier>() == 60usize);
+    assert!(size_of::<ExportSpecifier>() == 68usize);
     assert!(align_of::<ExportSpecifier>() == 4usize);
     assert!(offset_of!(ExportSpecifier, span) == 0usize);
     assert!(offset_of!(ExportSpecifier, local) == 8usize);
-    assert!(offset_of!(ExportSpecifier, exported) == 32usize);
-    assert!(offset_of!(ExportSpecifier, export_kind) == 56usize);
+    assert!(offset_of!(ExportSpecifier, exported) == 36usize);
+    assert!(offset_of!(ExportSpecifier, export_kind) == 64usize);
 
     assert!(size_of::<ExportDefaultDeclarationKind>() == 8usize);
     assert!(align_of::<ExportDefaultDeclarationKind>() == 4usize);
 
-    assert!(size_of::<ModuleExportName>() == 24usize);
+    assert!(size_of::<ModuleExportName>() == 28usize);
     assert!(align_of::<ModuleExportName>() == 4usize);
 
     assert!(size_of::<TSThisParameter>() == 20usize);
@@ -2350,14 +2341,14 @@ const _: () = {
     assert!(offset_of!(TSThisParameter, this_span) == 8usize);
     assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
 
-    assert!(size_of::<TSEnumDeclaration>() == 52usize);
+    assert!(size_of::<TSEnumDeclaration>() == 56usize);
     assert!(align_of::<TSEnumDeclaration>() == 4usize);
     assert!(offset_of!(TSEnumDeclaration, span) == 0usize);
     assert!(offset_of!(TSEnumDeclaration, id) == 8usize);
-    assert!(offset_of!(TSEnumDeclaration, members) == 28usize);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 44usize);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 45usize);
-    assert!(offset_of!(TSEnumDeclaration, scope_id) == 48usize);
+    assert!(offset_of!(TSEnumDeclaration, members) == 32usize);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 48usize);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 49usize);
+    assert!(offset_of!(TSEnumDeclaration, scope_id) == 52usize);
 
     assert!(size_of::<TSEnumMember>() == 24usize);
     assert!(align_of::<TSEnumMember>() == 4usize);
@@ -2433,12 +2424,12 @@ const _: () = {
     assert!(offset_of!(TSTupleType, span) == 0usize);
     assert!(offset_of!(TSTupleType, element_types) == 8usize);
 
-    assert!(size_of::<TSNamedTupleMember>() == 36usize);
+    assert!(size_of::<TSNamedTupleMember>() == 40usize);
     assert!(align_of::<TSNamedTupleMember>() == 4usize);
     assert!(offset_of!(TSNamedTupleMember, span) == 0usize);
     assert!(offset_of!(TSNamedTupleMember, element_type) == 8usize);
     assert!(offset_of!(TSNamedTupleMember, label) == 16usize);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 32usize);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 36usize);
 
     assert!(size_of::<TSOptionalType>() == 16usize);
     assert!(align_of::<TSOptionalType>() == 4usize);
@@ -2518,7 +2509,7 @@ const _: () = {
     assert!(size_of::<TSTypeName>() == 8usize);
     assert!(align_of::<TSTypeName>() == 4usize);
 
-    assert!(size_of::<TSQualifiedName>() == 32usize);
+    assert!(size_of::<TSQualifiedName>() == 36usize);
     assert!(align_of::<TSQualifiedName>() == 4usize);
     assert!(offset_of!(TSQualifiedName, span) == 0usize);
     assert!(offset_of!(TSQualifiedName, left) == 8usize);
@@ -2529,29 +2520,29 @@ const _: () = {
     assert!(offset_of!(TSTypeParameterInstantiation, span) == 0usize);
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8usize);
 
-    assert!(size_of::<TSTypeParameter>() == 48usize);
+    assert!(size_of::<TSTypeParameter>() == 52usize);
     assert!(align_of::<TSTypeParameter>() == 4usize);
     assert!(offset_of!(TSTypeParameter, span) == 0usize);
     assert!(offset_of!(TSTypeParameter, name) == 8usize);
-    assert!(offset_of!(TSTypeParameter, constraint) == 28usize);
-    assert!(offset_of!(TSTypeParameter, default) == 36usize);
-    assert!(offset_of!(TSTypeParameter, r#in) == 44usize);
-    assert!(offset_of!(TSTypeParameter, out) == 45usize);
-    assert!(offset_of!(TSTypeParameter, r#const) == 46usize);
+    assert!(offset_of!(TSTypeParameter, constraint) == 32usize);
+    assert!(offset_of!(TSTypeParameter, default) == 40usize);
+    assert!(offset_of!(TSTypeParameter, r#in) == 48usize);
+    assert!(offset_of!(TSTypeParameter, out) == 49usize);
+    assert!(offset_of!(TSTypeParameter, r#const) == 50usize);
 
     assert!(size_of::<TSTypeParameterDeclaration>() == 24usize);
     assert!(align_of::<TSTypeParameterDeclaration>() == 4usize);
     assert!(offset_of!(TSTypeParameterDeclaration, span) == 0usize);
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8usize);
 
-    assert!(size_of::<TSTypeAliasDeclaration>() == 48usize);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 52usize);
     assert!(align_of::<TSTypeAliasDeclaration>() == 4usize);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0usize);
     assert!(offset_of!(TSTypeAliasDeclaration, id) == 8usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 28usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 32usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 40usize);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 44usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 32usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 36usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 44usize);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 48usize);
 
     assert!(size_of::<TSAccessibility>() == 1usize);
     assert!(align_of::<TSAccessibility>() == 1usize);
@@ -2562,15 +2553,15 @@ const _: () = {
     assert!(offset_of!(TSClassImplements, expression) == 8usize);
     assert!(offset_of!(TSClassImplements, type_parameters) == 16usize);
 
-    assert!(size_of::<TSInterfaceDeclaration>() == 60usize);
+    assert!(size_of::<TSInterfaceDeclaration>() == 64usize);
     assert!(align_of::<TSInterfaceDeclaration>() == 4usize);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0usize);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8usize);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 28usize);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 44usize);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 48usize);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 52usize);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56usize);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 32usize);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 48usize);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 52usize);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 56usize);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 60usize);
 
     assert!(size_of::<TSInterfaceBody>() == 24usize);
     assert!(align_of::<TSInterfaceBody>() == 4usize);
@@ -2650,19 +2641,19 @@ const _: () = {
     assert!(size_of::<TSTypePredicateName>() == 12usize);
     assert!(align_of::<TSTypePredicateName>() == 4usize);
 
-    assert!(size_of::<TSModuleDeclaration>() == 48usize);
+    assert!(size_of::<TSModuleDeclaration>() == 52usize);
     assert!(align_of::<TSModuleDeclaration>() == 4usize);
     assert!(offset_of!(TSModuleDeclaration, span) == 0usize);
     assert!(offset_of!(TSModuleDeclaration, id) == 8usize);
-    assert!(offset_of!(TSModuleDeclaration, body) == 32usize);
-    assert!(offset_of!(TSModuleDeclaration, kind) == 40usize);
-    assert!(offset_of!(TSModuleDeclaration, declare) == 41usize);
-    assert!(offset_of!(TSModuleDeclaration, scope_id) == 44usize);
+    assert!(offset_of!(TSModuleDeclaration, body) == 36usize);
+    assert!(offset_of!(TSModuleDeclaration, kind) == 44usize);
+    assert!(offset_of!(TSModuleDeclaration, declare) == 45usize);
+    assert!(offset_of!(TSModuleDeclaration, scope_id) == 48usize);
 
     assert!(size_of::<TSModuleDeclarationKind>() == 1usize);
     assert!(align_of::<TSModuleDeclarationKind>() == 1usize);
 
-    assert!(size_of::<TSModuleDeclarationName>() == 24usize);
+    assert!(size_of::<TSModuleDeclarationName>() == 28usize);
     assert!(align_of::<TSModuleDeclarationName>() == 4usize);
 
     assert!(size_of::<TSModuleDeclarationBody>() == 8usize);
@@ -2702,19 +2693,19 @@ const _: () = {
     assert!(offset_of!(TSImportType, attributes) == 28usize);
     assert!(offset_of!(TSImportType, type_parameters) == 32usize);
 
-    assert!(size_of::<TSImportAttributes>() == 40usize);
+    assert!(size_of::<TSImportAttributes>() == 44usize);
     assert!(align_of::<TSImportAttributes>() == 4usize);
     assert!(offset_of!(TSImportAttributes, span) == 0usize);
     assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 24usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 28usize);
 
-    assert!(size_of::<TSImportAttribute>() == 36usize);
+    assert!(size_of::<TSImportAttribute>() == 40usize);
     assert!(align_of::<TSImportAttribute>() == 4usize);
     assert!(offset_of!(TSImportAttribute, span) == 0usize);
     assert!(offset_of!(TSImportAttribute, name) == 8usize);
-    assert!(offset_of!(TSImportAttribute, value) == 28usize);
+    assert!(offset_of!(TSImportAttribute, value) == 32usize);
 
-    assert!(size_of::<TSImportAttributeName>() == 20usize);
+    assert!(size_of::<TSImportAttributeName>() == 24usize);
     assert!(align_of::<TSImportAttributeName>() == 4usize);
 
     assert!(size_of::<TSFunctionType>() == 24usize);
@@ -2770,12 +2761,12 @@ const _: () = {
     assert!(offset_of!(TSTypeAssertion, expression) == 8usize);
     assert!(offset_of!(TSTypeAssertion, type_annotation) == 16usize);
 
-    assert!(size_of::<TSImportEqualsDeclaration>() == 40usize);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 44usize);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4usize);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0usize);
     assert!(offset_of!(TSImportEqualsDeclaration, id) == 8usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 28usize);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 36usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 32usize);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 40usize);
 
     assert!(size_of::<TSModuleReference>() == 8usize);
     assert!(align_of::<TSModuleReference>() == 4usize);
@@ -2800,7 +2791,7 @@ const _: () = {
     assert!(offset_of!(TSExportAssignment, span) == 0usize);
     assert!(offset_of!(TSExportAssignment, expression) == 8usize);
 
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 24usize);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 28usize);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 4usize);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0usize);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8usize);
@@ -2868,13 +2859,13 @@ const _: () = {
     assert!(size_of::<JSXElementName>() == 8usize);
     assert!(align_of::<JSXElementName>() == 4usize);
 
-    assert!(size_of::<JSXNamespacedName>() == 40usize);
+    assert!(size_of::<JSXNamespacedName>() == 48usize);
     assert!(align_of::<JSXNamespacedName>() == 4usize);
     assert!(offset_of!(JSXNamespacedName, span) == 0usize);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 24usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 28usize);
 
-    assert!(size_of::<JSXMemberExpression>() == 32usize);
+    assert!(size_of::<JSXMemberExpression>() == 36usize);
     assert!(align_of::<JSXMemberExpression>() == 4usize);
     assert!(offset_of!(JSXMemberExpression, span) == 0usize);
     assert!(offset_of!(JSXMemberExpression, object) == 8usize);
@@ -2915,10 +2906,9 @@ const _: () = {
     assert!(size_of::<JSXAttributeValue>() == 8usize);
     assert!(align_of::<JSXAttributeValue>() == 4usize);
 
-    assert!(size_of::<JSXIdentifier>() == 16usize);
+    assert!(size_of::<JSXIdentifier>() == 20usize);
     assert!(align_of::<JSXIdentifier>() == 4usize);
     assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
 
     assert!(size_of::<JSXChild>() == 8usize);
     assert!(align_of::<JSXChild>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -559,13 +559,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn expression_identifier_reference<A>(self, span: Span, name: A) -> Expression<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Expression::Identifier(self.alloc(self.identifier_reference(span, name)))
+    pub fn expression_identifier_reference(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Expression<'a> {
+        Expression::Identifier(self.alloc(self.identifier_reference(span, source_ptr, marker)))
     }
 
     /// Convert an [`IdentifierReference`] into an [`Expression::Identifier`]
@@ -1584,13 +1587,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn identifier_name<A>(self, span: Span, name: A) -> IdentifierName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        IdentifierName { span, name: name.into_in(self.allocator) }
+    pub fn identifier_name(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> IdentifierName<'a> {
+        IdentifierName { span, source_ptr, marker }
     }
 
     /// Build an [`IdentifierName`], and store it in the memory arena.
@@ -1599,13 +1605,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn alloc_identifier_name<A>(self, span: Span, name: A) -> Box<'a, IdentifierName<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.identifier_name(span, name), self.allocator)
+    pub fn alloc_identifier_name(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Box<'a, IdentifierName<'a>> {
+        Box::new_in(self.identifier_name(span, source_ptr, marker), self.allocator)
     }
 
     /// Build an [`IdentifierReference`].
@@ -1614,17 +1623,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn identifier_reference<A>(self, span: Span, name: A) -> IdentifierReference<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        IdentifierReference {
-            span,
-            name: name.into_in(self.allocator),
-            reference_id: Default::default(),
-        }
+    pub fn identifier_reference(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> IdentifierReference<'a> {
+        IdentifierReference { span, source_ptr, marker, reference_id: Default::default() }
     }
 
     /// Build an [`IdentifierReference`], and store it in the memory arena.
@@ -1633,17 +1641,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn alloc_identifier_reference<A>(
+    pub fn alloc_identifier_reference(
         self,
         span: Span,
-        name: A,
-    ) -> Box<'a, IdentifierReference<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.identifier_reference(span, name), self.allocator)
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Box<'a, IdentifierReference<'a>> {
+        Box::new_in(self.identifier_reference(span, source_ptr, marker), self.allocator)
     }
 
     /// Build an [`IdentifierReference`] with `ReferenceId`.
@@ -1652,21 +1659,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     /// - reference_id: Reference ID
     #[inline]
-    pub fn identifier_reference_with_reference_id<A>(
+    pub fn identifier_reference_with_reference_id(
         self,
         span: Span,
-        name: A,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
         reference_id: ReferenceId,
-    ) -> IdentifierReference<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
+    ) -> IdentifierReference<'a> {
         IdentifierReference {
             span,
-            name: name.into_in(self.allocator),
+            source_ptr,
+            marker,
             reference_id: Cell::new(Some(reference_id)),
         }
     }
@@ -1677,20 +1684,19 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     /// - reference_id: Reference ID
     #[inline]
-    pub fn alloc_identifier_reference_with_reference_id<A>(
+    pub fn alloc_identifier_reference_with_reference_id(
         self,
         span: Span,
-        name: A,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
         reference_id: ReferenceId,
-    ) -> Box<'a, IdentifierReference<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
+    ) -> Box<'a, IdentifierReference<'a>> {
         Box::new_in(
-            self.identifier_reference_with_reference_id(span, name, reference_id),
+            self.identifier_reference_with_reference_id(span, source_ptr, marker, reference_id),
             self.allocator,
         )
     }
@@ -1701,17 +1707,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     #[inline]
-    pub fn binding_identifier<A>(self, span: Span, name: A) -> BindingIdentifier<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        BindingIdentifier {
-            span,
-            name: name.into_in(self.allocator),
-            symbol_id: Default::default(),
-        }
+    pub fn binding_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> BindingIdentifier<'a> {
+        BindingIdentifier { span, source_ptr, marker, symbol_id: Default::default() }
     }
 
     /// Build a [`BindingIdentifier`], and store it in the memory arena.
@@ -1720,13 +1725,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     #[inline]
-    pub fn alloc_binding_identifier<A>(self, span: Span, name: A) -> Box<'a, BindingIdentifier<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.binding_identifier(span, name), self.allocator)
+    pub fn alloc_binding_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Box<'a, BindingIdentifier<'a>> {
+        Box::new_in(self.binding_identifier(span, source_ptr, marker), self.allocator)
     }
 
     /// Build a [`BindingIdentifier`] with `SymbolId`.
@@ -1735,23 +1743,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     /// - symbol_id: Unique identifier for this binding.
     #[inline]
-    pub fn binding_identifier_with_symbol_id<A>(
+    pub fn binding_identifier_with_symbol_id(
         self,
         span: Span,
-        name: A,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
         symbol_id: SymbolId,
-    ) -> BindingIdentifier<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        BindingIdentifier {
-            span,
-            name: name.into_in(self.allocator),
-            symbol_id: Cell::new(Some(symbol_id)),
-        }
+    ) -> BindingIdentifier<'a> {
+        BindingIdentifier { span, source_ptr, marker, symbol_id: Cell::new(Some(symbol_id)) }
     }
 
     /// Build a [`BindingIdentifier`] with `SymbolId`, and store it in the memory arena.
@@ -1760,19 +1763,21 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     /// - symbol_id: Unique identifier for this binding.
     #[inline]
-    pub fn alloc_binding_identifier_with_symbol_id<A>(
+    pub fn alloc_binding_identifier_with_symbol_id(
         self,
         span: Span,
-        name: A,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
         symbol_id: SymbolId,
-    ) -> Box<'a, BindingIdentifier<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), self.allocator)
+    ) -> Box<'a, BindingIdentifier<'a>> {
+        Box::new_in(
+            self.binding_identifier_with_symbol_id(span, source_ptr, marker, symbol_id),
+            self.allocator,
+        )
     }
 
     /// Build a [`LabelIdentifier`].
@@ -1781,13 +1786,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn label_identifier<A>(self, span: Span, name: A) -> LabelIdentifier<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        LabelIdentifier { span, name: name.into_in(self.allocator) }
+    pub fn label_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> LabelIdentifier<'a> {
+        LabelIdentifier { span, source_ptr, marker }
     }
 
     /// Build a [`LabelIdentifier`], and store it in the memory arena.
@@ -1796,13 +1804,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn alloc_label_identifier<A>(self, span: Span, name: A) -> Box<'a, LabelIdentifier<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.label_identifier(span, name), self.allocator)
+    pub fn alloc_label_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Box<'a, LabelIdentifier<'a>> {
+        Box::new_in(self.label_identifier(span, source_ptr, marker), self.allocator)
     }
 
     /// Build a [`ThisExpression`].
@@ -2107,13 +2118,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn property_key_identifier_name<A>(self, span: Span, name: A) -> PropertyKey<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        PropertyKey::StaticIdentifier(self.alloc(self.identifier_name(span, name)))
+    pub fn property_key_identifier_name(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> PropertyKey<'a> {
+        PropertyKey::StaticIdentifier(self.alloc(self.identifier_name(span, source_ptr, marker)))
     }
 
     /// Convert an [`IdentifierName`] into a [`PropertyKey::StaticIdentifier`]
@@ -3001,18 +3015,17 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn simple_assignment_target_identifier_reference<A>(
+    pub fn simple_assignment_target_identifier_reference(
         self,
         span: Span,
-        name: A,
-    ) -> SimpleAssignmentTarget<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> SimpleAssignmentTarget<'a> {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(
-            self.alloc(self.identifier_reference(span, name)),
+            self.alloc(self.identifier_reference(span, source_ptr, marker)),
         )
     }
 
@@ -5906,17 +5919,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     #[inline]
-    pub fn binding_pattern_kind_binding_identifier<A>(
+    pub fn binding_pattern_kind_binding_identifier(
         self,
         span: Span,
-        name: A,
-    ) -> BindingPatternKind<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        BindingPatternKind::BindingIdentifier(self.alloc(self.binding_identifier(span, name)))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> BindingPatternKind<'a> {
+        BindingPatternKind::BindingIdentifier(
+            self.alloc(self.binding_identifier(span, source_ptr, marker)),
+        )
     }
 
     /// Convert a [`BindingIdentifier`] into a [`BindingPatternKind::BindingIdentifier`]
@@ -8268,17 +8282,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn import_attribute_key_identifier_name<A>(
+    pub fn import_attribute_key_identifier_name(
         self,
         span: Span,
-        name: A,
-    ) -> ImportAttributeKey<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        ImportAttributeKey::Identifier(self.identifier_name(span, name))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> ImportAttributeKey<'a> {
+        ImportAttributeKey::Identifier(self.identifier_name(span, source_ptr, marker))
     }
 
     /// Convert an [`IdentifierName`] into an [`ImportAttributeKey::Identifier`]
@@ -8705,13 +8718,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn module_export_name_identifier_name<A>(self, span: Span, name: A) -> ModuleExportName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        ModuleExportName::IdentifierName(self.identifier_name(span, name))
+    pub fn module_export_name_identifier_name(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> ModuleExportName<'a> {
+        ModuleExportName::IdentifierName(self.identifier_name(span, source_ptr, marker))
     }
 
     /// Convert an [`IdentifierName`] into a [`ModuleExportName::IdentifierName`]
@@ -8727,17 +8743,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn module_export_name_identifier_reference<A>(
+    pub fn module_export_name_identifier_reference(
         self,
         span: Span,
-        name: A,
-    ) -> ModuleExportName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        ModuleExportName::IdentifierReference(self.identifier_reference(span, name))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> ModuleExportName<'a> {
+        ModuleExportName::IdentifierReference(self.identifier_reference(span, source_ptr, marker))
     }
 
     /// Convert an [`IdentifierReference`] into a [`ModuleExportName::IdentifierReference`]
@@ -8961,13 +8976,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn ts_enum_member_name_identifier_name<A>(self, span: Span, name: A) -> TSEnumMemberName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSEnumMemberName::StaticIdentifier(self.alloc(self.identifier_name(span, name)))
+    pub fn ts_enum_member_name_identifier_name(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> TSEnumMemberName<'a> {
+        TSEnumMemberName::StaticIdentifier(
+            self.alloc(self.identifier_name(span, source_ptr, marker)),
+        )
     }
 
     /// Convert an [`IdentifierName`] into a [`TSEnumMemberName::StaticIdentifier`]
@@ -11196,13 +11216,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn ts_type_name_identifier_reference<A>(self, span: Span, name: A) -> TSTypeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSTypeName::IdentifierReference(self.alloc(self.identifier_reference(span, name)))
+    pub fn ts_type_name_identifier_reference(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> TSTypeName<'a> {
+        TSTypeName::IdentifierReference(
+            self.alloc(self.identifier_reference(span, source_ptr, marker)),
+        )
     }
 
     /// Convert an [`IdentifierReference`] into a [`TSTypeName::IdentifierReference`]
@@ -12633,17 +12658,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn ts_type_predicate_name_identifier_name<A>(
+    pub fn ts_type_predicate_name_identifier_name(
         self,
         span: Span,
-        name: A,
-    ) -> TSTypePredicateName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSTypePredicateName::Identifier(self.alloc(self.identifier_name(span, name)))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> TSTypePredicateName<'a> {
+        TSTypePredicateName::Identifier(self.alloc(self.identifier_name(span, source_ptr, marker)))
     }
 
     /// Convert an [`IdentifierName`] into a [`TSTypePredicateName::Identifier`]
@@ -12772,17 +12796,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The identifier name being bound.
+    /// - source_ptr: The identifier name being bound.
+    /// - marker
     #[inline]
-    pub fn ts_module_declaration_name_binding_identifier<A>(
+    pub fn ts_module_declaration_name_binding_identifier(
         self,
         span: Span,
-        name: A,
-    ) -> TSModuleDeclarationName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSModuleDeclarationName::Identifier(self.binding_identifier(span, name))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> TSModuleDeclarationName<'a> {
+        TSModuleDeclarationName::Identifier(self.binding_identifier(span, source_ptr, marker))
     }
 
     /// Convert a [`BindingIdentifier`] into a [`TSModuleDeclarationName::Identifier`]
@@ -13236,17 +13259,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name
+    /// - source_ptr
+    /// - marker
     #[inline]
-    pub fn ts_import_attribute_name_identifier_name<A>(
+    pub fn ts_import_attribute_name_identifier_name(
         self,
         span: Span,
-        name: A,
-    ) -> TSImportAttributeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSImportAttributeName::Identifier(self.identifier_name(span, name))
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> TSImportAttributeName<'a> {
+        TSImportAttributeName::Identifier(self.identifier_name(span, source_ptr, marker))
     }
 
     /// Convert an [`IdentifierName`] into a [`TSImportAttributeName::Identifier`]
@@ -14281,13 +14303,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: Node location in source code
-    /// - name: The name of the identifier.
+    /// - source_ptr: The name of the identifier.
+    /// - marker
     #[inline]
-    pub fn jsx_element_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXElementName::Identifier(self.alloc(self.jsx_identifier(span, name)))
+    pub fn jsx_element_name_jsx_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> JSXElementName<'a> {
+        JSXElementName::Identifier(self.alloc(self.jsx_identifier(span, source_ptr, marker)))
     }
 
     /// Convert a [`JSXIdentifier`] into a [`JSXElementName::Identifier`]
@@ -14305,13 +14330,18 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn jsx_element_name_identifier_reference<A>(self, span: Span, name: A) -> JSXElementName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXElementName::IdentifierReference(self.alloc(self.identifier_reference(span, name)))
+    pub fn jsx_element_name_identifier_reference(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> JSXElementName<'a> {
+        JSXElementName::IdentifierReference(
+            self.alloc(self.identifier_reference(span, source_ptr, marker)),
+        )
     }
 
     /// Convert an [`IdentifierReference`] into a [`JSXElementName::IdentifierReference`]
@@ -14479,18 +14509,17 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier being referenced.
+    /// - source_ptr: The name of the identifier being referenced.
+    /// - marker
     #[inline]
-    pub fn jsx_member_expression_object_identifier_reference<A>(
+    pub fn jsx_member_expression_object_identifier_reference(
         self,
         span: Span,
-        name: A,
-    ) -> JSXMemberExpressionObject<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> JSXMemberExpressionObject<'a> {
         JSXMemberExpressionObject::IdentifierReference(
-            self.alloc(self.identifier_reference(span, name)),
+            self.alloc(self.identifier_reference(span, source_ptr, marker)),
         )
     }
 
@@ -14768,13 +14797,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: Node location in source code
-    /// - name: The name of the identifier.
+    /// - source_ptr: The name of the identifier.
+    /// - marker
     #[inline]
-    pub fn jsx_attribute_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXAttributeName::Identifier(self.alloc(self.jsx_identifier(span, name)))
+    pub fn jsx_attribute_name_jsx_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> JSXAttributeName<'a> {
+        JSXAttributeName::Identifier(self.alloc(self.jsx_identifier(span, source_ptr, marker)))
     }
 
     /// Convert a [`JSXIdentifier`] into a [`JSXAttributeName::Identifier`]
@@ -14951,13 +14983,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: Node location in source code
-    /// - name: The name of the identifier.
+    /// - source_ptr: The name of the identifier.
+    /// - marker
     #[inline]
-    pub fn jsx_identifier<A>(self, span: Span, name: A) -> JSXIdentifier<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXIdentifier { span, name: name.into_in(self.allocator) }
+    pub fn jsx_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> JSXIdentifier<'a> {
+        JSXIdentifier { span, source_ptr, marker }
     }
 
     /// Build a [`JSXIdentifier`], and store it in the memory arena.
@@ -14966,13 +15001,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: Node location in source code
-    /// - name: The name of the identifier.
+    /// - source_ptr: The name of the identifier.
+    /// - marker
     #[inline]
-    pub fn alloc_jsx_identifier<A>(self, span: Span, name: A) -> Box<'a, JSXIdentifier<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.jsx_identifier(span, name), self.allocator)
+    pub fn alloc_jsx_identifier(
+        self,
+        span: Span,
+        source_ptr: *const u8,
+        marker: PhantomData<Atom<'a>>,
+    ) -> Box<'a, JSXIdentifier<'a>> {
+        Box::new_in(self.jsx_identifier(span, source_ptr, marker), self.allocator)
     }
 
     /// Build a [`JSXChild::Text`]

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -239,7 +239,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierName<'old_alloc> 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierName {
             span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
+            source_ptr: CloneIn::clone_in(&self.source_ptr, allocator),
+            marker: CloneIn::clone_in(&self.marker, allocator),
         }
     }
 }
@@ -249,7 +250,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'old_al
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierReference {
             span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
+            source_ptr: CloneIn::clone_in(&self.source_ptr, allocator),
+            marker: CloneIn::clone_in(&self.marker, allocator),
             reference_id: Default::default(),
         }
     }
@@ -260,7 +262,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'old_allo
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingIdentifier {
             span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
+            source_ptr: CloneIn::clone_in(&self.source_ptr, allocator),
+            marker: CloneIn::clone_in(&self.marker, allocator),
             symbol_id: Default::default(),
         }
     }
@@ -271,7 +274,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'old_alloc>
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabelIdentifier {
             span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
+            source_ptr: CloneIn::clone_in(&self.source_ptr, allocator),
+            marker: CloneIn::clone_in(&self.marker, allocator),
         }
     }
 }
@@ -4191,7 +4195,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'old_alloc> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXIdentifier {
             span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
+            source_ptr: CloneIn::clone_in(&self.source_ptr, allocator),
+            marker: CloneIn::clone_in(&self.marker, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -275,25 +275,29 @@ impl<'a> ContentEq for Expression<'a> {
 
 impl<'a> ContentEq for IdentifierName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.source_ptr, &other.source_ptr)
+            && ContentEq::content_eq(&self.marker, &other.marker)
     }
 }
 
 impl<'a> ContentEq for IdentifierReference<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.source_ptr, &other.source_ptr)
+            && ContentEq::content_eq(&self.marker, &other.marker)
     }
 }
 
 impl<'a> ContentEq for BindingIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.source_ptr, &other.source_ptr)
+            && ContentEq::content_eq(&self.marker, &other.marker)
     }
 }
 
 impl<'a> ContentEq for LabelIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.source_ptr, &other.source_ptr)
+            && ContentEq::content_eq(&self.marker, &other.marker)
     }
 }
 
@@ -4169,7 +4173,8 @@ impl<'a> ContentEq for JSXAttributeValue<'a> {
 
 impl<'a> ContentEq for JSXIdentifier<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.source_ptr, &other.source_ptr)
+            && ContentEq::content_eq(&self.marker, &other.marker)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -128,25 +128,29 @@ impl<'a> ContentHash for Expression<'a> {
 
 impl<'a> ContentHash for IdentifierName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.source_ptr, state);
+        ContentHash::content_hash(&self.marker, state);
     }
 }
 
 impl<'a> ContentHash for IdentifierReference<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.source_ptr, state);
+        ContentHash::content_hash(&self.marker, state);
     }
 }
 
 impl<'a> ContentHash for BindingIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.source_ptr, state);
+        ContentHash::content_hash(&self.marker, state);
     }
 }
 
 impl<'a> ContentHash for LabelIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.source_ptr, state);
+        ContentHash::content_hash(&self.marker, state);
     }
 }
 
@@ -2345,7 +2349,8 @@ impl<'a> ContentHash for JSXAttributeValue<'a> {
 
 impl<'a> ContentHash for JSXIdentifier<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.name, state);
+        ContentHash::content_hash(&self.source_ptr, state);
+        ContentHash::content_hash(&self.marker, state);
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -167,7 +167,8 @@ impl<'a> Serialize for IdentifierName<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "Identifier")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("sourcePtr", &self.source_ptr)?;
+        map.serialize_entry("marker", &self.marker)?;
         map.end()
     }
 }
@@ -177,7 +178,8 @@ impl<'a> Serialize for IdentifierReference<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "Identifier")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("sourcePtr", &self.source_ptr)?;
+        map.serialize_entry("marker", &self.marker)?;
         map.end()
     }
 }
@@ -187,7 +189,8 @@ impl<'a> Serialize for BindingIdentifier<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "Identifier")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("sourcePtr", &self.source_ptr)?;
+        map.serialize_entry("marker", &self.marker)?;
         map.end()
     }
 }
@@ -197,7 +200,8 @@ impl<'a> Serialize for LabelIdentifier<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "Identifier")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("sourcePtr", &self.source_ptr)?;
+        map.serialize_entry("marker", &self.marker)?;
         map.end()
     }
 }
@@ -3231,7 +3235,8 @@ impl<'a> Serialize for JSXIdentifier<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "JSXIdentifier")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("sourcePtr", &self.source_ptr)?;
+        map.serialize_entry("marker", &self.marker)?;
         map.end()
     }
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -96,22 +96,26 @@ export type Expression =
 
 export interface IdentifierName extends Span {
   type: 'Identifier';
-  name: string;
+  sourcePtr: number;
+  marker: string;
 }
 
 export interface IdentifierReference extends Span {
   type: 'Identifier';
-  name: string;
+  sourcePtr: number;
+  marker: string;
 }
 
 export interface BindingIdentifier extends Span {
   type: 'Identifier';
-  name: string;
+  sourcePtr: number;
+  marker: string;
 }
 
 export interface LabelIdentifier extends Span {
   type: 'Identifier';
-  name: string;
+  sourcePtr: number;
+  marker: string;
 }
 
 export interface ThisExpression extends Span {
@@ -1734,7 +1738,8 @@ export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElem
 
 export interface JSXIdentifier extends Span {
   type: 'JSXIdentifier';
-  name: string;
+  sourcePtr: number;
+  marker: string;
 }
 
 export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -27,3 +27,4 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 syn = { workspace = true, features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro"] }
+miette = { workspace = true }

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -19,6 +19,7 @@ convert_case = { workspace = true }
 cow-utils = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
+miette = { workspace = true }
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
@@ -27,4 +28,3 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 syn = { workspace = true, features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro"] }
-miette = { workspace = true }

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -127,9 +127,10 @@ fn type_to_string(ty: &TypeName) -> String {
         }
         .to_string(),
         TypeName::Vec(type_name) => format!("Array<{}>", type_to_string(type_name)),
-        TypeName::Box(type_name) | TypeName::Ref(type_name) | TypeName::Complex(type_name) => {
-            type_to_string(type_name)
-        }
+        TypeName::Box(type_name)
+        | TypeName::Ref(type_name)
+        | TypeName::Ptr(type_name)
+        | TypeName::Complex(type_name) => type_to_string(type_name),
         TypeName::Opt(type_name) => format!("{} | null", type_to_string(type_name)),
     }
 }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -64,6 +64,7 @@ pub struct CliOptions {
 }
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    initialize_miette();
     let cli_options = cli_options().run();
 
     if cli_options.quiet {
@@ -102,6 +103,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn initialize_miette() {
+    miette::set_hook(Box::new(|_| Box::new(miette::MietteHandlerOpts::new().build()))).unwrap();
 }
 
 fn generate_ci_filter(outputs: &[RawOutput]) -> RawOutput {

--- a/tasks/ast_tools/src/schema/to_type.rs
+++ b/tasks/ast_tools/src/schema/to_type.rs
@@ -1,3 +1,4 @@
+use miette::{Context, IntoDiagnostic};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{parse_quote, parse_str, Type};
@@ -15,7 +16,10 @@ pub trait ToType {
 
 impl ToType for TypeRef {
     fn to_type(&self) -> Type {
-        parse_str(self.raw()).unwrap()
+        parse_str(self.raw())
+            .into_diagnostic()
+            .with_context(|| format!("Failed to parse type reference {:?}", self.raw()))
+            .unwrap()
     }
 
     fn to_type_elide(&self) -> Type {


### PR DESCRIPTION
> This is a very rough proof-of-concept

Many different AST nodes store both a span and an `Atom<'a>`, which has redundant information. `Atom<'a>` is a fat pointer storing a length, but we already have that information in the form of `Span::offset`.

This POC shows how we can shave a byte off all AST nodes that use both a `Span` and an `Atom<'a>` (i.e. all identifiers) by using a thin pointer over an `Atom<'a>`, then using `Span::offset` to get an `&str` slice as needed.