### PR TITLE
feat(ast): Label AST fields with #[ts]

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -425,6 +425,7 @@ pub struct TaggedTemplateExpression<'a> {
     pub span: Span,
     pub tag: Expression<'a>,
     pub quasi: TemplateLiteral<'a>,
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -544,6 +545,7 @@ pub struct PrivateFieldExpression<'a> {
 pub struct CallExpression<'a> {
     pub span: Span,
     pub callee: Expression<'a>,
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     pub arguments: Vec<'a, Argument<'a>>,
     pub optional: bool, // for optional chaining
@@ -568,6 +570,7 @@ pub struct NewExpression<'a> {
     pub span: Span,
     pub callee: Expression<'a>,
     pub arguments: Vec<'a, Argument<'a>>,
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -1088,6 +1091,7 @@ pub struct VariableDeclaration<'a> {
     pub span: Span,
     pub kind: VariableDeclarationKind,
     pub declarations: Vec<'a, VariableDeclarator<'a>>,
+    #[ts]
     pub declare: bool,
 }
 
@@ -1120,6 +1124,7 @@ pub struct VariableDeclarator<'a> {
     pub kind: VariableDeclarationKind,
     pub id: BindingPattern<'a>,
     pub init: Option<Expression<'a>>,
+    #[ts]
     pub definite: bool,
 }
 
@@ -1441,7 +1446,9 @@ pub struct BindingPattern<'a> {
     )]
     #[span]
     pub kind: BindingPatternKind<'a>,
+    #[ts]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    #[ts]
     pub optional: bool,
 }
 
@@ -1582,7 +1589,9 @@ pub struct Function<'a> {
     /// ```
     pub generator: bool,
     pub r#async: bool,
+    #[ts]
     pub declare: bool,
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     /// Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
     ///
@@ -1600,12 +1609,14 @@ pub struct Function<'a> {
     ///     return this.admin;
     /// });
     /// ```
+    #[ts]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     /// Function parameters.
     ///
     /// Does not include `this` parameters used by some TypeScript functions.
     pub params: Box<'a, FormalParameters<'a>>,
     /// The TypeScript return type annotation.
+    #[ts]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// The function body.
     ///
@@ -1657,10 +1668,14 @@ pub struct FormalParameters<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct FormalParameter<'a> {
     pub span: Span,
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     pub pattern: BindingPattern<'a>,
+    #[ts]
     pub accessibility: Option<TSAccessibility>,
+    #[ts]
     pub readonly: bool,
+    #[ts]
     pub r#override: bool,
 }
 
@@ -1702,8 +1717,10 @@ pub struct ArrowFunctionExpression<'a> {
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
     pub expression: bool,
     pub r#async: bool,
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
+    #[ts]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// See `expression` for whether this arrow expression returns an expression.
     pub body: Box<'a, FunctionBody<'a>>,
@@ -1740,10 +1757,12 @@ pub struct Class<'a> {
     /// @Bar() // <-- Decorator
     /// class Foo {}
     /// ```
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     /// Class identifier, AKA the name
     pub id: Option<BindingIdentifier<'a>>,
     #[scope(enter_before)]
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     /// Super class. When present, this will usually be an [`IdentifierReference`].
     ///
@@ -1760,6 +1779,7 @@ pub struct Class<'a> {
     /// class Foo<T> extends Bar<T> {}
     /// //                       ^
     /// ```
+    #[ts]
     pub super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     /// Interface implementation clause for TypeScript classes.
     ///
@@ -1769,6 +1789,7 @@ pub struct Class<'a> {
     /// class Foo implements Bar {}
     /// //                   ^^^
     /// ```
+    #[ts]
     pub implements: Option<Vec<'a, TSClassImplements<'a>>>,
     pub body: Box<'a, ClassBody<'a>>,
     /// Whether the class is abstract
@@ -1778,6 +1799,7 @@ pub struct Class<'a> {
     /// class Foo {}          // true
     /// abstract class Bar {} // false
     /// ```
+    #[ts]
     pub r#abstract: bool,
     /// Whether the class was `declare`ed
     ///
@@ -1785,6 +1807,7 @@ pub struct Class<'a> {
     /// ```ts
     /// declare class Foo {}
     /// ```
+    #[ts]
     pub declare: bool,
     /// Id of the scope created by the [`Class`], including type parameters and
     /// statements within the [`ClassBody`].
@@ -1868,6 +1891,7 @@ pub struct MethodDefinition<'a> {
     /// This will always be true when an `abstract` modifier is used on the method.
     pub r#type: MethodDefinitionType,
     pub span: Span,
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     pub key: PropertyKey<'a>,
     #[visit(args(flags = match self.kind {
@@ -1880,8 +1904,11 @@ pub struct MethodDefinition<'a> {
     pub kind: MethodDefinitionKind,
     pub computed: bool,
     pub r#static: bool,
+    #[ts]
     pub r#override: bool,
+    #[ts]
     pub optional: bool,
+    #[ts]
     pub accessibility: Option<TSAccessibility>,
 }
 
@@ -1903,6 +1930,7 @@ pub struct PropertyDefinition<'a> {
     /// Decorators applied to the property.
     ///
     /// See [`Decorator`] for more information.
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     /// The expression used to declare the property.
     pub key: PropertyKey<'a>,
@@ -1945,16 +1973,22 @@ pub struct PropertyDefinition<'a> {
     ///   x: number         // false
     /// }
     /// ```
+    #[ts]
     pub declare: bool,
+    #[ts]
     pub r#override: bool,
     /// `true` when created with an optional modifier (`?`)
+    #[ts]
     pub optional: bool,
+    #[ts]
     pub definite: bool,
     /// `true` when declared with a `readonly` modifier
+    #[ts]
     pub readonly: bool,
     /// Type annotation on the property.
     ///
     /// Will only ever be [`Some`] for TypeScript files.
+    #[ts]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// Accessibility modifier.
     ///
@@ -1970,6 +2004,7 @@ pub struct PropertyDefinition<'a> {
     ///   readonly z           // None
     /// }
     /// ```
+    #[ts]
     pub accessibility: Option<TSAccessibility>,
 }
 
@@ -2116,6 +2151,7 @@ pub struct AccessorProperty<'a> {
     /// Decorators applied to the accessor property.
     ///
     /// See [`Decorator`] for more information.
+    #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     /// The expression used to declare the property.
     pub key: PropertyKey<'a>,
@@ -2126,10 +2162,12 @@ pub struct AccessorProperty<'a> {
     /// Property was declared with a `static` modifier
     pub r#static: bool,
     /// Property has a `!` after its key.
+    #[ts]
     pub definite: bool,
     /// Type annotation on the property.
     ///
     /// Will only ever be [`Some`] for TypeScript files.
+    #[ts]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// Accessibility modifier.
     ///
@@ -2145,6 +2183,7 @@ pub struct AccessorProperty<'a> {
     ///   accessor z           // None
     /// }
     /// ```
+    #[ts]
     pub accessibility: Option<TSAccessibility>,
 }
 
@@ -2166,8 +2205,10 @@ pub struct ImportDeclaration<'a> {
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     /// Some(vec![]) for empty assertion
+    #[ts]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
     /// `import type { foo } from 'bar'`
+    #[ts]
     pub import_kind: ImportOrExportKind,
 }
 
@@ -2204,6 +2245,7 @@ pub struct ImportSpecifier<'a> {
     /// //              ^^^
     /// ```
     pub local: BindingIdentifier<'a>,
+    #[ts]
     pub import_kind: ImportOrExportKind,
 }
 
@@ -2283,8 +2325,10 @@ pub struct ExportNamedDeclaration<'a> {
     pub specifiers: Vec<'a, ExportSpecifier<'a>>,
     pub source: Option<StringLiteral<'a>>,
     /// `export type { foo }`
+    #[ts]
     pub export_kind: ImportOrExportKind,
     /// Some(vec![]) for empty assertion
+    #[ts]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
 }
 
@@ -2324,7 +2368,9 @@ pub struct ExportAllDeclaration<'a> {
     pub exported: Option<ModuleExportName<'a>>,
     pub source: StringLiteral<'a>,
     /// Will be `Some(vec![])` for empty assertion
+    #[ts]
     pub with_clause: Option<Box<'a, WithClause<'a>>>, // Some(vec![]) for empty assertion
+    #[ts]
     pub export_kind: ImportOrExportKind, // `export type *`
 }
 
@@ -2346,6 +2392,7 @@ pub struct ExportSpecifier<'a> {
     pub span: Span,
     pub local: ModuleExportName<'a>,
     pub exported: ModuleExportName<'a>,
+    #[ts]
     pub export_kind: ImportOrExportKind, // `export type *`
 }
 

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -78,6 +78,7 @@ pub struct JSXOpeningElement<'a> {
     /// List of JSX attributes. In React-like applications, these become props.
     pub attributes: Vec<'a, JSXAttributeItem<'a>>,
     /// Type parameters for generic JSX elements.
+    #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -53,6 +53,10 @@ mod ast;
 /// However, Instead of expanding the derive at compile-time, We do this process on PR submits via `ast_tools` code generation.
 /// These derived implementations would be output in the `crates/oxc_ast/src/generated` directory.
 ///
+/// ## `#[ts]`:
+///
+/// Marks a struct field as only relevant for TypeScript ASTs.
+///
 /// # Derive Helper Attributes:
 ///
 /// These are helper attributes that are only meaningful when their respective trait is derived via `generate_derive`.
@@ -81,7 +85,10 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// The only purpose is to allow the occurrence of helper attributes used with the `tasks/ast_tools`.
 ///
 /// Read [`macro@ast`] for further details.
-#[proc_macro_derive(Ast, attributes(scope, visit, span, generate_derive, clone_in, estree, tsify))]
+#[proc_macro_derive(
+    Ast,
+    attributes(scope, visit, span, generate_derive, clone_in, estree, tsify, ts)
+)]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()
 }


### PR DESCRIPTION
I think I found all of the AST fields that are typescript-only but I could be wrong. I did label decorators as `#[ts]` but not sure if that's correct.