### PR TITLE
refactor(transformer/typescript): pass `&mut T` not `&mut ArenaBox<T>`

### DIFF
--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,4 +1,3 @@
-use oxc_allocator::Box as ArenaBox;
 use oxc_ast::{ast::*, NONE};
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
@@ -51,7 +50,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptModule<'a, 'ctx> {
 impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
     fn transform_ts_import_equals(
         &self,
-        decl: &mut ArenaBox<'a, TSImportEqualsDeclaration<'a>>,
+        decl: &mut TSImportEqualsDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Declaration<'a> {
         let kind = VariableDeclarationKind::Var;


### PR DESCRIPTION
`&mut ArenaBox<T>` is a double-reference. `&mut T` is shorter and easier to read.