### PR TITLE
refactor(transformer): clean up TransformerOptions

### DIFF
--- a/crates/oxc_transformer/src/env/options.rs
+++ b/crates/oxc_transformer/src/env/options.rs
@@ -1,9 +1,7 @@
 use serde::Deserialize;
 use serde_json::Value;
 
-use oxc_diagnostics::Error;
-
-use super::targets::{query::Targets, Versions};
+use super::targets::query::Targets;
 
 fn default_as_true() -> bool {
     true
@@ -53,12 +51,4 @@ pub struct EnvOptions {
 
     #[deprecated = "Not Implemented"]
     pub shipped_proposals: bool,
-}
-
-impl EnvOptions {
-    /// # Errors
-    ///
-    pub fn get_targets(&self) -> Result<Versions, Error> {
-        self.targets.clone().get_targets()
-    }
 }

--- a/crates/oxc_transformer/src/es2015/options.rs
+++ b/crates/oxc_transformer/src/es2015/options.rs
@@ -1,7 +1,5 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 use super::ArrowFunctionsOptions;
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -9,22 +7,4 @@ use super::ArrowFunctionsOptions;
 pub struct ES2015Options {
     #[serde(skip)]
     pub arrow_function: Option<ArrowFunctionsOptions>,
-}
-
-impl ES2015Options {
-    pub fn with_arrow_function(
-        &mut self,
-        arrow_function: Option<ArrowFunctionsOptions>,
-    ) -> &mut Self {
-        self.arrow_function = arrow_function;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            arrow_function: can_enable_plugin("transform-arrow-functions", targets, bugfixes)
-                .then(Default::default),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2016/options.rs
+++ b/crates/oxc_transformer/src/es2016/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2016Options {
     #[serde(skip)]
     pub exponentiation_operator: bool,
-}
-
-impl ES2016Options {
-    pub fn with_exponentiation_operator(&mut self, enable: bool) -> &mut Self {
-        self.exponentiation_operator = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            exponentiation_operator: can_enable_plugin(
-                "transform-exponentiation-operator",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2017/options.rs
+++ b/crates/oxc_transformer/src/es2017/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2017Options {
     #[serde(skip)]
     pub async_to_generator: bool,
-}
-
-impl ES2017Options {
-    pub fn with_async_to_generator(&mut self, enable: bool) -> &mut Self {
-        self.async_to_generator = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            async_to_generator: can_enable_plugin(
-                "transform-async-to-generator",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2018/options.rs
+++ b/crates/oxc_transformer/src/es2018/options.rs
@@ -1,7 +1,5 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 use super::ObjectRestSpreadOptions;
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -9,26 +7,4 @@ use super::ObjectRestSpreadOptions;
 pub struct ES2018Options {
     #[serde(skip)]
     pub object_rest_spread: Option<ObjectRestSpreadOptions>,
-}
-
-impl ES2018Options {
-    pub fn with_object_rest_spread(
-        &mut self,
-        option: Option<ObjectRestSpreadOptions>,
-    ) -> &mut Self {
-        self.object_rest_spread = option;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            object_rest_spread: can_enable_plugin(
-                "transform-object-rest-spread",
-                targets,
-                bugfixes,
-            )
-            .then(Default::default),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2019/options.rs
+++ b/crates/oxc_transformer/src/es2019/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2019Options {
     #[serde(skip)]
     pub optional_catch_binding: bool,
-}
-
-impl ES2019Options {
-    pub fn with_optional_catch_binding(&mut self, enable: bool) -> &mut Self {
-        self.optional_catch_binding = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            optional_catch_binding: can_enable_plugin(
-                "transform-optional-catch-binding",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2020/options.rs
+++ b/crates/oxc_transformer/src/es2020/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2020Options {
     #[serde(skip)]
     pub nullish_coalescing_operator: bool,
-}
-
-impl ES2020Options {
-    pub fn with_nullish_coalescing_operator(&mut self, enable: bool) -> &mut Self {
-        self.nullish_coalescing_operator = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            nullish_coalescing_operator: can_enable_plugin(
-                "transform-nullish-coalescing-operator",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2021/options.rs
+++ b/crates/oxc_transformer/src/es2021/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2021Options {
     #[serde(skip)]
     pub logical_assignment_operators: bool,
-}
-
-impl ES2021Options {
-    pub fn with_logical_assignment_operators(&mut self, enable: bool) -> &mut Self {
-        self.logical_assignment_operators = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            logical_assignment_operators: can_enable_plugin(
-                "transform-logical-assignment-operators",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/es2022/options.rs
+++ b/crates/oxc_transformer/src/es2022/options.rs
@@ -1,28 +1,8 @@
 use serde::Deserialize;
 
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ES2022Options {
     #[serde(skip)]
     pub class_static_block: bool,
-}
-
-impl ES2022Options {
-    pub fn with_class_static_block(&mut self, enable: bool) -> &mut Self {
-        self.class_static_block = enable;
-        self
-    }
-
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            class_static_block: can_enable_plugin(
-                "transform-class-static-block",
-                targets,
-                bugfixes,
-            ),
-        }
-    }
 }

--- a/crates/oxc_transformer/src/options/babel.rs
+++ b/crates/oxc_transformer/src/options/babel.rs
@@ -4,30 +4,48 @@ use serde::Deserialize;
 use serde_json::Value;
 
 /// Babel options
+///
+/// <https://babel.dev/docs/options#plugin-and-preset-options>
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BabelOptions {
+    // Primary options
     pub cwd: Option<PathBuf>,
-    pub source_type: Option<String>,
+
+    // Config Loading options
+
+    // Plugin and Preset options
     #[serde(default)]
     pub plugins: Vec<Value>, // Can be a string or an array
+
     #[serde(default)]
     pub presets: Vec<Value>, // Can be a string or an array
+
+    // Misc options
+    pub source_type: Option<String>,
+
     #[serde(default)]
     pub assumptions: Value,
+
     // Test options
     pub throws: Option<String>,
+
     #[serde(rename = "BABEL_8_BREAKING")]
     pub babel_8_breaking: Option<bool>,
+
     /// Babel test helper for running tests on specific operating systems
     pub os: Option<Vec<TestOs>>,
+
     // Parser options for babel-parser
     #[serde(default)]
     pub allow_return_outside_function: bool,
+
     #[serde(default)]
     pub allow_await_outside_function: bool,
+
     #[serde(default)]
     pub allow_undeclared_exports: bool,
+
     #[serde(default = "default_as_true")]
     pub external_helpers: bool,
 }

--- a/crates/oxc_transformer/src/regexp/options.rs
+++ b/crates/oxc_transformer/src/regexp/options.rs
@@ -1,49 +1,26 @@
-use crate::env::{can_enable_plugin, Versions};
-
 #[derive(Default, Debug, Clone, Copy)]
 pub struct RegExpOptions {
     /// Enables plugin to transform the RegExp literal has `y` flag
     pub sticky_flag: bool,
+
     /// Enables plugin to transform the RegExp literal has `u` flag
     pub unicode_flag: bool,
+
     /// Enables plugin to transform the RegExp literal has `s` flag
     pub dot_all_flag: bool,
+
     /// Enables plugin to transform the RegExp literal has `(?<=)` or `(?<!)` lookbehind assertions
     pub look_behind_assertions: bool,
+
     /// Enables plugin to transform the RegExp literal has `(?<name>x)` named capture groups
     pub named_capture_groups: bool,
+
     /// Enables plugin to transform the RegExp literal has `\p{}` and `\P{}` unicode property escapes
     pub unicode_property_escapes: bool,
+
     /// Enables plugin to transform `d` flag
     pub match_indices: bool,
+
     /// Enables plugin to transform the RegExp literal has `v` flag
     pub set_notation: bool,
-}
-
-impl RegExpOptions {
-    #[must_use]
-    pub fn from_targets_and_bugfixes(targets: Option<&Versions>, bugfixes: bool) -> Self {
-        Self {
-            sticky_flag: can_enable_plugin("transform-sticky-regex", targets, bugfixes),
-            unicode_flag: can_enable_plugin("transform-unicode-regex", targets, bugfixes),
-            dot_all_flag: can_enable_plugin("transform-dotall-regex", targets, bugfixes),
-            look_behind_assertions: can_enable_plugin(
-                "esbuild-regexp-lookbehind-assertions",
-                targets,
-                bugfixes,
-            ),
-            named_capture_groups: can_enable_plugin(
-                "transform-named-capturing-groups-regex",
-                targets,
-                bugfixes,
-            ),
-            unicode_property_escapes: can_enable_plugin(
-                "transform-unicode-property-regex",
-                targets,
-                bugfixes,
-            ),
-            match_indices: can_enable_plugin("esbuild-regexp-match-indices", targets, bugfixes),
-            set_notation: can_enable_plugin("transform-unicode-sets-regex", targets, bugfixes),
-        }
-    }
 }


### PR DESCRIPTION
This is a work towards https://github.com/oxc-project/oxc/issues/6982

Next PR will try and make sense of env options vs babel options vs targets and bugfixes, I'm super confused right now.