### PR TITLE
refactor(data_structures): add `read` method to `NonNull` shim

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -295,7 +295,7 @@ impl<T> NonEmptyStack<T> {
         debug_assert!(self.cursor < self.end);
         // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
         // and points to a valid initialized `T`
-        let value = self.cursor.as_ptr().read();
+        let value = self.cursor.read();
         // SAFETY: Caller guarantees there's at least 2 entries on stack, so subtracting 1
         // cannot be out of bounds
         self.cursor = self.cursor.sub(1);

--- a/crates/oxc_data_structures/src/stack/non_null.rs
+++ b/crates/oxc_data_structures/src/stack/non_null.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, ptr::NonNull as NativeNonNull};
 
-/// Wrapper around `NonNull<T>`, which adds methods `add`, `sub`, `offset_from` and `byte_offset_from`.
+/// Wrapper around `NonNull<T>`, which adds methods `add`, `sub`, `offset_from`, `byte_offset_from`,
+/// and `read`.
 /// These methods exist on `std::ptr::NonNull`, and became stable in Rust 1.80.0, but are not yet
 /// stable in our MSRV.
 ///
@@ -8,7 +9,7 @@ use std::{cmp::Ordering, ptr::NonNull as NativeNonNull};
 /// and make code using them easier to understand.
 ///
 /// Once we bump MSRV and these methods are natively supported, this type can be removed.
-/// `#[expect(clippy::incompatible_msrv)]` on `non_null_add_is_not_stable` below will trigger
+/// `#[expect(clippy::incompatible_msrv)]` on `_non_null_add_is_not_stable` below will trigger
 /// a lint warning when that happens.
 /// Then this module can be deleted, and all uses of this type can be switched to `std::ptr::NonNull`.
 #[derive(Debug)]
@@ -70,6 +71,11 @@ impl<T> NonNull<T> {
     #[inline]
     pub unsafe fn as_mut<'t>(mut self) -> &'t mut T {
         self.0.as_mut()
+    }
+
+    #[inline]
+    pub unsafe fn read(self) -> T {
+        self.0.as_ptr().read()
     }
 }
 

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -307,7 +307,7 @@ impl<T> Stack<T> {
         // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
         // and points to a valid initialized `T`, if stack is not empty.
         // Caller guarantees stack was not empty.
-        self.cursor.as_ptr().read()
+        self.cursor.read()
     }
 
     /// Get number of entries on stack.


### PR DESCRIPTION
Emulate [`NonNull::read`](https://doc.rust-lang.org/beta/std/ptr/struct.NonNull.html#method.read) method in `NonNull` shim. This is more ergonomic, and will be ideal usage once our MSRV reaches 1.80.0 and we can remove the shim.