### PR TITLE
refactor(data_structures): add `#[repr(transparent)]` to `NonNull` shim

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_null.rs
+++ b/crates/oxc_data_structures/src/stack/non_null.rs
@@ -13,6 +13,7 @@ use std::{cmp::Ordering, ptr::NonNull as NativeNonNull};
 /// a lint warning when that happens.
 /// Then this module can be deleted, and all uses of this type can be switched to `std::ptr::NonNull`.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct NonNull<T>(NativeNonNull<T>);
 
 #[cfg(clippy)]


### PR DESCRIPTION
Ensure `NonNull` shim is a pure wrapper around `std::ptr::NonNull`. This should be the case anyway, but make sure.