### PR TITLE
refactor(data_structures): make all methods of `NonNull` shim `#[inline(always)]`

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_null.rs
+++ b/crates/oxc_data_structures/src/stack/non_null.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::inline_always)]
+
 use std::{cmp::Ordering, ptr::NonNull as NativeNonNull};
 
 /// Wrapper around `NonNull<T>`, which adds methods `add`, `sub`, `offset_from`, `byte_offset_from`,
@@ -23,58 +25,58 @@ unsafe fn _non_null_add_is_not_stable(ptr: NativeNonNull<u8>) -> NativeNonNull<u
 }
 
 impl<T> NonNull<T> {
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
         Self(NativeNonNull::new_unchecked(ptr))
     }
 
-    #[inline]
+    #[inline(always)]
     pub const fn dangling() -> Self {
         Self(NativeNonNull::dangling())
     }
 
-    #[inline]
+    #[inline(always)]
     pub const fn as_ptr(self) -> *mut T {
         self.0.as_ptr()
     }
 
-    #[inline]
+    #[inline(always)]
     pub const fn cast<U>(self) -> NonNull<U> {
         // SAFETY: `self` is non-null, so it's still non-null after casting
         unsafe { NonNull::new_unchecked(self.as_ptr().cast()) }
     }
 
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn add(self, count: usize) -> Self {
         NonNull(NativeNonNull::new_unchecked(self.as_ptr().add(count)))
     }
 
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn sub(self, count: usize) -> Self {
         NonNull(NativeNonNull::new_unchecked(self.as_ptr().sub(count)))
     }
 
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn offset_from(self, origin: Self) -> isize {
         self.as_ptr().offset_from(origin.as_ptr())
     }
 
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn byte_offset_from(self, origin: Self) -> isize {
         self.as_ptr().byte_offset_from(origin.as_ptr())
     }
 
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn as_ref<'t>(self) -> &'t T {
         self.0.as_ref()
     }
 
-    #[inline]
+    #[inline(always)]
     pub unsafe fn as_mut<'t>(mut self) -> &'t mut T {
         self.0.as_mut()
     }
 
-    #[inline]
+    #[inline(always)]
     pub unsafe fn read(self) -> T {
         self.0.as_ptr().read()
     }
@@ -83,7 +85,7 @@ impl<T> NonNull<T> {
 impl<T> Copy for NonNull<T> {}
 
 impl<T> Clone for NonNull<T> {
-    #[inline]
+    #[inline(always)]
     fn clone(&self) -> Self {
         *self
     }
@@ -92,21 +94,21 @@ impl<T> Clone for NonNull<T> {
 impl<T> Eq for NonNull<T> {}
 
 impl<T> PartialEq for NonNull<T> {
-    #[inline]
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
 impl<T> Ord for NonNull<T> {
-    #[inline]
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_ptr().cmp(&other.as_ptr())
     }
 }
 
 impl<T> PartialOrd for NonNull<T> {
-    #[inline]
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }


### PR DESCRIPTION
All these methods are trivial and should always be inlined.