### PR TITLE
perf(transformer/arrow-function): store scope_id to avoid going through scopes

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -7,23 +7,28 @@ mod options;
 pub use arrow_functions::{ArrowFunctions, ArrowFunctionsOptions};
 pub use options::ES2015Options;
 
-pub struct ES2015<'a> {
+use crate::context::TransformCtx;
+
+pub struct ES2015<'a, 'ctx> {
     options: ES2015Options,
 
     // Plugins
-    arrow_functions: ArrowFunctions<'a>,
+    arrow_functions: ArrowFunctions<'a, 'ctx>,
 }
 
-impl<'a> ES2015<'a> {
-    pub fn new(options: ES2015Options) -> Self {
+impl<'a, 'ctx> ES2015<'a, 'ctx> {
+    pub fn new(options: ES2015Options, ctx: &'ctx TransformCtx<'a>) -> Self {
         Self {
-            arrow_functions: ArrowFunctions::new(options.arrow_function.unwrap_or_default()),
+            arrow_functions: ArrowFunctions::new(
+                options.arrow_function.clone().unwrap_or_default(),
+                ctx,
+            ),
             options,
         }
     }
 }
 
-impl<'a> Traverse<'a> for ES2015<'a> {
+impl<'a, 'ctx> Traverse<'a> for ES2015<'a, 'ctx> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.arrow_function.is_some() {
             self.arrow_functions.exit_program(program, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -106,7 +106,7 @@ impl<'a> Transformer<'a> {
             x2_es2018: ES2018::new(self.options.env.es2018, &self.ctx),
             x2_es2016: ES2016::new(self.options.env.es2016, &self.ctx),
             x2_es2017: ES2017::new(self.options.env.es2017, &self.ctx),
-            x3_es2015: ES2015::new(self.options.env.es2015),
+            x3_es2015: ES2015::new(self.options.env.es2015, &self.ctx),
             x4_regexp: RegExp::new(self.options.env.regexp, &self.ctx),
             common: Common::new(&self.ctx),
         };
@@ -127,7 +127,7 @@ struct TransformerImpl<'a, 'ctx> {
     x2_es2018: ES2018<'a, 'ctx>,
     x2_es2017: ES2017<'a, 'ctx>,
     x2_es2016: ES2016<'a, 'ctx>,
-    x3_es2015: ES2015<'a>,
+    x3_es2015: ES2015<'a, 'ctx>,
     x4_regexp: RegExp<'a, 'ctx>,
     common: Common<'a, 'ctx>,
 }


### PR DESCRIPTION
Not sure if this will boost performance, so create a PR to see the benchmark