### PR TITLE
style(transformer/common): Split up `StatementInjectorStore` methods into blocks

### DIFF
--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -60,20 +60,24 @@ pub struct StatementInjectorStore<'a> {
     insertions: RefCell<FxHashMap<Address, Vec<AdjacentStatement<'a>>>>,
 }
 
+// Public methods
 impl<'a> StatementInjectorStore<'a> {
     /// Create new `StatementInjectorStore`.
     pub fn new() -> Self {
         Self { insertions: RefCell::new(FxHashMap::default()) }
     }
+}
 
-    // Each of the `insert_before` / `insert_after` functions is split into 2 parts:
-    //
-    // 1. Outer function which is generic over any `GetAddress`.
-    // 2. Inner function which is non-generic and takes `Address`.
-    //
-    // Outer functions are marked `#[inline]`, as `GetAddress::address` is generally only 1 or 2 instructions.
-    // The non-trivial inner functions are not marked `#[inline]` - compiler can decide whether to inline or not.
-
+// Insertion methods.
+//
+// Each of these functions is split into 2 parts:
+//
+// 1. Public outer function which is generic over any `GetAddress`.
+// 2. Private inner function which is non-generic and takes `Address`.
+//
+// Outer functions are marked `#[inline]`, as `GetAddress::address` is generally only 1 or 2 instructions.
+// The non-trivial inner functions are not marked `#[inline]` - compiler can decide whether to inline or not.
+impl<'a> StatementInjectorStore<'a> {
     /// Add a statement to be inserted immediately before the target statement.
     #[expect(dead_code)]
     #[inline]
@@ -145,7 +149,10 @@ impl<'a> StatementInjectorStore<'a> {
             stmts.into_iter().map(|stmt| AdjacentStatement { stmt, direction: Direction::After }),
         );
     }
+}
 
+// Internal methods
+impl<'a> StatementInjectorStore<'a> {
     /// Insert statements immediately before / after the target statement.
     fn insert_into_statements(
         &self,


### PR DESCRIPTION
Pure refactor. Split up the `impl`s into multiple blocks with comments for each block, to make it clearer.