### PR TITLE
refactor(transformer): use `*_with_scope_id` builder methods where possible

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -10,7 +10,7 @@ use std::mem;
 
 use oxc_allocator::{Allocator, Box, FromIn, String, Vec};
 use oxc_span::{Atom, GetSpan, Span};
-use oxc_syntax::{number::NumberBase, operator::UnaryOperator};
+use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
 use crate::ast::*;
 use crate::AstBuilder;
@@ -234,18 +234,19 @@ impl<'a> AstBuilder<'a> {
         self.formal_parameter(span, self.vec(), pattern, None, false, false)
     }
 
-    /// Create a [`Function`] with no "extras", i.e. decorators, type
-    /// annotations, accessibility modifiers, etc.
+    /// Create a [`Function`] with no "extras".
+    /// i.e. no decorators, type annotations, accessibility modifiers, etc.
     #[inline]
-    pub fn plain_function(
+    pub fn alloc_plain_function_with_scope_id(
         self,
         r#type: FunctionType,
         span: Span,
         id: Option<BindingIdentifier<'a>>,
         params: FormalParameters<'a>,
         body: FunctionBody<'a>,
+        scope_id: ScopeId,
     ) -> Box<'a, Function<'a>> {
-        self.alloc(self.function(
+        self.alloc_function_with_scope_id(
             r#type,
             span,
             id,
@@ -257,7 +258,8 @@ impl<'a> AstBuilder<'a> {
             params,
             NONE,
             Some(body),
-        ))
+            scope_id,
+        )
     }
 
     /* ---------- Modules ---------- */

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -383,7 +383,7 @@ impl<'a> ArrowFunctions<'a> {
         let flags = ctx.scopes_mut().get_flags_mut(scope_id);
         *flags &= !ScopeFlags::Arrow;
 
-        let new_function = ctx.ast.function(
+        Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
             FunctionType::FunctionExpression,
             arrow_function_expr.span,
             None,
@@ -395,10 +395,8 @@ impl<'a> ArrowFunctions<'a> {
             arrow_function_expr.params,
             arrow_function_expr.return_type,
             Some(body),
-        );
-        new_function.scope_id.set(Some(scope_id));
-
-        Expression::FunctionExpression(ctx.ast.alloc(new_function))
+            scope_id,
+        ))
     }
 
     /// Insert `var _this = this;` at the top of the statements.

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -117,10 +117,18 @@ impl<'a, 'ctx> Traverse<'a> for NullishCoalescingOperator<'a, 'ctx> {
                 ctx.ast.vec(),
                 ctx.ast.vec1(ctx.ast.statement_expression(SPAN, new_expr)),
             );
-            let arrow_function =
-                ctx.ast.arrow_function_expression(SPAN, true, false, NONE, params, NONE, body);
-            arrow_function.scope_id.set(Some(current_scope_id));
-            let arrow_function = ctx.ast.expression_from_arrow_function(arrow_function);
+            let arrow_function = Expression::ArrowFunctionExpression(
+                ctx.ast.alloc_arrow_function_expression_with_scope_id(
+                    SPAN,
+                    true,
+                    false,
+                    NONE,
+                    params,
+                    NONE,
+                    body,
+                    current_scope_id,
+                ),
+            );
             // `(x) => x;` -> `((x) => x)();`
             new_expr = ctx.ast.expression_call(SPAN, arrow_function, NONE, ctx.ast.vec(), false);
         } else {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -567,7 +567,8 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
                     Some(ctx.ast.expression_array(SPAN, custom_hooks_in_scope, None)),
                 )),
             );
-            let function = ctx.ast.function(
+            let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
+            let function = Argument::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
                 FunctionType::FunctionExpression,
                 SPAN,
                 None,
@@ -579,10 +580,9 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
                 formal_parameters,
                 NONE,
                 Some(function_body),
-            );
-            let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
-            function.scope_id.set(Some(scope_id));
-            arguments.push(ctx.ast.argument_expression(ctx.ast.expression_from_function(function)));
+                scope_id,
+            ));
+            arguments.push(function);
         }
 
         // TODO: Handle var hoisted in ctx API

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -101,7 +101,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         let statements = self.transform_ts_enum_members(&mut decl.members, &ident, ctx);
         let body = ast.alloc_function_body(decl.span, ast.vec(), statements);
-        let function = ctx.ast.function(
+        let callee = Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
             FunctionType::FunctionExpression,
             SPAN,
             None,
@@ -113,9 +113,8 @@ impl<'a> TypeScriptEnum<'a> {
             params,
             None::<TSTypeAnnotation>,
             Some(body),
-        );
-        function.scope_id.set(Some(func_scope_id));
-        let callee = ctx.ast.expression_from_function(function);
+            func_scope_id,
+        ));
 
         let var_symbol_id = decl.id.symbol_id.get().unwrap();
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -336,12 +336,17 @@ impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
                 let items = ctx.ast.vec1(ctx.ast.plain_formal_parameter(SPAN, pattern));
                 ctx.ast.formal_parameters(SPAN, FormalParameterKind::FormalParameter, items, NONE)
             };
-            let function =
-                ctx.ast.plain_function(FunctionType::FunctionExpression, SPAN, None, params, body);
-            function.scope_id.set(Some(scope_id));
+            let function_expr =
+                Expression::FunctionExpression(ctx.ast.alloc_plain_function_with_scope_id(
+                    FunctionType::FunctionExpression,
+                    SPAN,
+                    None,
+                    params,
+                    body,
+                    scope_id,
+                ));
             *ctx.scopes_mut().get_flags_mut(scope_id) =
                 ScopeFlags::Function | ScopeFlags::StrictMode;
-            let function_expr = ctx.ast.expression_from_function(function);
             ctx.ast.expression_parenthesized(SPAN, function_expr)
         };
 


### PR DESCRIPTION
In transformer, use `AstBuilder::function_with_scope_id` and `AstBuilder::arrow_function_expression_with_scope_id` function where possible, rather than creating a function and then setting the `scope_id` on it afterwards.
