### PR TITLE
fix(cli): Explicitly turn on tree shaking plugin by default, add option to disable

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -245,6 +245,14 @@ pub struct EnablePlugins {
     )]
     pub typescript_plugin: OverrideToggle,
 
+    /// Disable tree shaking plugin, which is turned on by default
+    #[bpaf(
+        long("disable-tree-shaking-plugin"),
+        flag(OverrideToggle::Disable, OverrideToggle::NotSet),
+        hide_usage
+    )]
+    pub tree_shaking_plugin: OverrideToggle,
+
     /// Enable the experimental import plugin and detect ESM problems.
     /// It is recommended to use along side with the `--tsconfig` option.
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
@@ -361,6 +369,7 @@ impl EnablePlugins {
         self.promise_plugin.inspect(|yes| plugins.set(LintPlugins::PROMISE, yes));
         self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
         self.security_plugin.inspect(|yes| plugins.set(LintPlugins::SECURITY, yes));
+        self.tree_shaking_plugin.inspect(|yes| plugins.set(LintPlugins::TREE_SHAKING, yes));
 
         // Without this, jest plugins adapted to vitest will not be enabled.
         if self.vitest_plugin.is_enabled() && self.jest_plugin.is_not_set() {

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -40,12 +40,14 @@ bitflags! {
         const NODE = 1 << 12;
         /// Custom security rules made by the Oxc team
         const SECURITY = 1 << 13;
+        /// `eslint-plugin-tree-shaking`
+        const TREE_SHAKING = 1 << 14;
     }
 }
 impl Default for LintPlugins {
     #[inline]
     fn default() -> Self {
-        LintPlugins::REACT | LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC
+        LintPlugins::REACT | LintPlugins::UNICORN | LintPlugins::TYPESCRIPT | LintPlugins::OXC | LintPlugins::TREE_SHAKING
     }
 }
 
@@ -66,6 +68,7 @@ impl From<LintPluginOptions> for LintPlugins {
         plugins.set(LintPlugins::PROMISE, options.promise);
         plugins.set(LintPlugins::NODE, options.node);
         plugins.set(LintPlugins::SECURITY, options.security);
+        plugins.set(LintPlugins::TREE_SHAKING, options.tree_shaking);
         plugins
     }
 }
@@ -116,6 +119,7 @@ impl From<&str> for LintPlugins {
             "promise" => LintPlugins::PROMISE,
             "node" => LintPlugins::NODE,
             "security" | "oxc-security" => LintPlugins::SECURITY,
+            "tree-shaking" | "tree_shaking" => LintPlugins::TREE_SHAKING,
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             _ => LintPlugins::empty(),
@@ -140,6 +144,7 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::SECURITY => "security",
+            LintPlugins::TREE_SHAKING => "tree-shaking",
             _ => "",
         }
     }
@@ -230,6 +235,7 @@ pub struct LintPluginOptions {
     pub promise: bool,
     pub node: bool,
     pub security: bool,
+    pub tree_shaking: bool,
 }
 
 impl Default for LintPluginOptions {
@@ -249,6 +255,7 @@ impl Default for LintPluginOptions {
             promise: false,
             node: false,
             security: false,
+            tree_shaking: true,
         }
     }
 }
@@ -272,6 +279,7 @@ impl LintPluginOptions {
             promise: false,
             node: false,
             security: false,
+            tree_shaking: false,
         }
     }
 
@@ -293,6 +301,7 @@ impl LintPluginOptions {
             promise: true,
             node: true,
             security: true,
+            tree_shaking: true,
         }
     }
 }
@@ -317,6 +326,7 @@ impl<S: AsRef<str>> FromIterator<(S, bool)> for LintPluginOptions {
                 LintPlugins::PROMISE => options.promise = enabled,
                 LintPlugins::NODE => options.node = enabled,
                 LintPlugins::SECURITY => options.security = enabled,
+                LintPlugins::TREE_SHAKING => options.tree_shaking = enabled,
                 _ => {} // ignored
             }
         }
@@ -350,6 +360,7 @@ mod test {
                 && self.promise == other.promise
                 && self.node == other.node
                 && self.security == other.security
+                && self.tree_shaking == other.tree_shaking
         }
     }
 
@@ -390,6 +401,7 @@ mod test {
             promise: false,
             node: false,
             security: false,
+            tree_shaking: true,
         };
         assert_eq!(plugins, expected);
     }


### PR DESCRIPTION
Closes #7031 

Explicitly marks the tree shaking plugin as ON by default. Adds `--disable-tree-shaking-plugin` option to disable.