### PR TITLE
refactor(parser): add `ParserImpl::alloc` method

### DIFF
--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -58,7 +58,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.binding_pattern_kind_object_pattern(
             self.end_span(span),
             list,
-            rest.map(|r| self.ast.alloc(r)),
+            rest.map(|r| self.alloc(r)),
         ))
     }
 
@@ -75,7 +75,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.binding_pattern_kind_array_pattern(
             self.end_span(span),
             list,
-            rest.map(|r| self.ast.alloc(r)),
+            rest.map(|r| self.alloc(r)),
         ))
     }
 

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -376,7 +376,7 @@ impl<'a> ParserImpl<'a> {
         match self.cur_kind() {
             Kind::PrivateIdentifier => {
                 let private_ident = self.parse_private_identifier();
-                Ok((PropertyKey::PrivateIdentifier(self.ast.alloc(private_ident)), false))
+                Ok((PropertyKey::PrivateIdentifier(self.alloc(private_ident)), false))
             }
             _ => self.parse_property_name(),
         }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -39,7 +39,7 @@ impl<'a> ParserImpl<'a> {
 
         self.asi()?;
 
-        Ok(Statement::VariableDeclaration(self.ast.alloc(using_decl)))
+        Ok(Statement::VariableDeclaration(self.alloc(using_decl)))
     }
 
     pub(crate) fn parse_variable_declaration(

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -382,7 +382,7 @@ impl<'a> ParserImpl<'a> {
         )
         .parse()
         {
-            Ok(regular_expression) => Some(self.ast.alloc(regular_expression)),
+            Ok(regular_expression) => Some(self.alloc(regular_expression)),
             Err(diagnostic) => {
                 self.error(diagnostic);
                 None

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -15,13 +15,11 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
         match expr {
             Expression::ArrayExpression(array_expr) => {
                 ArrayAssignmentTarget::cover(array_expr.unbox(), p)
-                    .map(|pat| p.ast.alloc(pat))
-                    .map(AssignmentTarget::ArrayAssignmentTarget)
+                    .map(|pat| AssignmentTarget::ArrayAssignmentTarget(p.alloc(pat)))
             }
             Expression::ObjectExpression(object_expr) => {
                 ObjectAssignmentTarget::cover(object_expr.unbox(), p)
-                    .map(|pat| p.ast.alloc(pat))
-                    .map(AssignmentTarget::ObjectAssignmentTarget)
+                    .map(|pat| AssignmentTarget::ObjectAssignmentTarget(p.alloc(pat)))
             }
             _ => SimpleAssignmentTarget::cover(expr, p).map(AssignmentTarget::from),
         }
@@ -103,7 +101,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
                 let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p)?;
-                Ok(AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.ast.alloc(target)))
+                Ok(AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target)))
             }
             expr => {
                 let target = AssignmentTarget::cover(expr, p)?;

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -136,11 +136,11 @@ impl<'a> ParserImpl<'a> {
         let identifier = self.parse_identifier_reference()?;
         let key = self.ast.alloc_identifier_name(identifier.span, identifier.name.clone());
         // IdentifierReference ({ foo })
-        let value = Expression::Identifier(self.ast.alloc(identifier.clone()));
+        let value = Expression::Identifier(self.alloc(identifier.clone()));
         // CoverInitializedName ({ foo = bar })
         let init = if self.eat(Kind::Eq) {
             let right = self.parse_assignment_expression_or_higher()?;
-            let left = AssignmentTarget::AssignmentTargetIdentifier(self.ast.alloc(identifier));
+            let left = AssignmentTarget::AssignmentTargetIdentifier(self.alloc(identifier));
             Some(self.ast.expression_assignment(
                 self.end_span(span),
                 AssignmentOperator::Assign,
@@ -199,7 +199,7 @@ impl<'a> ParserImpl<'a> {
             }
             _ => {
                 let ident = self.parse_identifier_name()?;
-                PropertyKey::StaticIdentifier(self.ast.alloc(ident))
+                PropertyKey::StaticIdentifier(self.alloc(ident))
             }
         };
         Ok((key, computed))

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -325,11 +325,11 @@ impl<'a> ParserImpl<'a> {
         }
 
         if matches!(self.cur_kind(), Kind::In | Kind::Of) {
-            let init = ForStatementLeft::VariableDeclaration(self.ast.alloc(using_decl));
+            let init = ForStatementLeft::VariableDeclaration(self.alloc(using_decl));
             return self.parse_for_in_or_of_loop(span, r#await, init);
         }
 
-        let init = Some(ForStatementInit::VariableDeclaration(self.ast.alloc(using_decl)));
+        let init = Some(ForStatementInit::VariableDeclaration(self.alloc(using_decl)));
         self.parse_for_loop(span, init, r#await)
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -168,14 +168,12 @@ impl<'a> ParserImpl<'a> {
         };
 
         let element_name = if is_reference {
-            let identifier = self.ast.identifier_reference(identifier.span, identifier.name);
-            JSXElementName::IdentifierReference(self.ast.alloc(identifier))
+            let identifier = self.ast.alloc_identifier_reference(identifier.span, identifier.name);
+            JSXElementName::IdentifierReference(identifier)
         } else if name == "this" {
-            JSXElementName::ThisExpression(
-                self.ast.alloc(self.ast.this_expression(identifier.span)),
-            )
+            JSXElementName::ThisExpression(self.ast.alloc_this_expression(identifier.span))
         } else {
-            JSXElementName::Identifier(self.ast.alloc(identifier))
+            JSXElementName::Identifier(self.alloc(identifier))
         };
         Ok(element_name)
     }
@@ -189,11 +187,11 @@ impl<'a> ParserImpl<'a> {
         object: JSXIdentifier<'a>,
     ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
         let mut object = if object.name == "this" {
-            let object = self.ast.this_expression(object.span);
-            JSXMemberExpressionObject::ThisExpression(self.ast.alloc(object))
+            let object = self.ast.alloc_this_expression(object.span);
+            JSXMemberExpressionObject::ThisExpression(object)
         } else {
-            let object = self.ast.identifier_reference(object.span, object.name);
-            JSXMemberExpressionObject::IdentifierReference(self.ast.alloc(object))
+            let object = self.ast.alloc_identifier_reference(object.span, object.name);
+            JSXMemberExpressionObject::IdentifierReference(object)
         };
 
         let mut span = span;
@@ -381,14 +379,14 @@ impl<'a> ParserImpl<'a> {
             ));
         }
 
-        Ok(JSXAttributeName::Identifier(self.ast.alloc(identifier)))
+        Ok(JSXAttributeName::Identifier(self.alloc(identifier)))
     }
 
     fn parse_jsx_attribute_value(&mut self) -> Result<JSXAttributeValue<'a>> {
         match self.cur_kind() {
             Kind::Str => self
                 .parse_literal_string()
-                .map(|str_lit| JSXAttributeValue::StringLiteral(self.ast.alloc(str_lit))),
+                .map(|str_lit| JSXAttributeValue::StringLiteral(self.alloc(str_lit))),
             Kind::LCurly => {
                 let expr = self.parse_jsx_expression_container(/* is_jsx_child */ false)?;
                 Ok(JSXAttributeValue::ExpressionContainer(expr))

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -85,7 +85,7 @@ mod lexer;
 pub mod lexer;
 
 use context::{Context, StatementContext};
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, Box as ArenaBox};
 use oxc_ast::{
     ast::{Expression, Program},
     AstBuilder,
@@ -534,6 +534,11 @@ impl<'a> ParserImpl<'a> {
         if self.source_type.is_unambiguous() {
             self.source_type = self.source_type.with_script(true);
         }
+    }
+
+    #[inline]
+    fn alloc<T>(&self, value: T) -> ArenaBox<'a, T> {
+        self.ast.alloc(value)
     }
 }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -270,8 +270,8 @@ impl<'a> ParserImpl<'a> {
         let constraint = self.try_parse(Self::try_parse_constraint_of_infer_type).unwrap_or(None);
         let span = self.end_span(span);
         let ts_type_parameter =
-            self.ast.ts_type_parameter(span, name, constraint, None, false, false, false);
-        Ok(self.ast.alloc(ts_type_parameter))
+            self.ast.alloc_ts_type_parameter(span, name, constraint, None, false, false, false);
+        Ok(ts_type_parameter)
     }
 
     fn parse_postfix_type_or_higher(&mut self) -> Result<TSType<'a>> {
@@ -380,7 +380,7 @@ impl<'a> ParserImpl<'a> {
                 if self.peek_at(Kind::Is) && !self.peek_token().is_on_new_line {
                     return self.parse_this_type_predicate(this_type);
                 }
-                Ok(TSType::TSThisType(self.ast.alloc(this_type)))
+                Ok(TSType::TSThisType(self.alloc(this_type)))
             }
             Kind::Typeof => {
                 if self.peek_at(Kind::Import) {
@@ -583,7 +583,7 @@ impl<'a> ParserImpl<'a> {
         let name = self.parse_binding_identifier()?;
         self.expect(Kind::In)?;
         let constraint = self.parse_ts_type()?;
-        let type_parameter = self.ast.alloc(self.ast.ts_type_parameter(
+        let type_parameter = self.alloc(self.ast.ts_type_parameter(
             self.end_span(type_parameter_span),
             name,
             Some(constraint),
@@ -758,8 +758,8 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_type_name(&mut self) -> Result<TSTypeName<'a>> {
         let span = self.start_span();
         let ident = self.parse_identifier_name()?;
-        let ident = self.ast.identifier_reference(ident.span, ident.name);
-        let mut left = TSTypeName::IdentifierReference(self.ast.alloc(ident));
+        let ident = self.ast.alloc_identifier_reference(ident.span, ident.name);
+        let mut left = TSTypeName::IdentifierReference(ident);
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name()?;
             left = self.ast.ts_type_name_qualified_name(self.end_span(span), left, right);


### PR DESCRIPTION
Pure refactor. Introduce `ParserImpl::alloc` method. Shorten `self.ast.alloc(...)` to `self.alloc(...)`.

Also reduce `alloc` calls by using `AstBuilder` methods which already allocate where possible.