### PR TITLE
refactor(transformer): use `ctx.alloc` over `ctx.ast.alloc` where possible

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -415,7 +415,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         if function_name.is_none() && !Self::is_function_length_affected(&params) {
             return self.create_async_to_generator_call(
                 params,
-                ctx.ast.alloc(body),
+                ctx.alloc(body),
                 generator_function_id,
                 ctx,
             );
@@ -448,7 +448,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             let statement = self.create_async_to_generator_declaration(
                 &bound_ident,
                 params,
-                ctx.ast.alloc(body),
+                ctx.alloc(body),
                 generator_function_id,
                 ctx,
             );


### PR DESCRIPTION
Pure refactor. Just shorten code a little.