### PR TITLE
fix(linter): check is_reference_to_global_variable in `no-array-constructor` rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -2,6 +2,7 @@ use oxc_ast::ast::Expression;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -68,7 +69,11 @@ impl Rule for NoArrayConstructor {
             }
         };
 
-        if callee.is_global_reference_name("Array", ctx.symbols())
+        let Expression::Identifier(ident) = &callee else {
+            return;
+        };
+
+        if ident.is_global_reference_name("Array", ctx.symbols())
             && arguments.len() != 1
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -68,12 +68,7 @@ impl Rule for NoArrayConstructor {
             }
         };
 
-        let Expression::Identifier(ident) = &callee else {
-            return;
-        };
-
-        if ctx.semantic().is_reference_to_global_variable(ident)
-            && callee.is_specific_id("Array")
+        if callee.is_global_reference_name("Array", ctx.symbols())
             && arguments.len() != 1
             && type_parameters.is_none()
             && !optional


### PR DESCRIPTION
Hello,

I am currently reading through the code as I work on contributing by creating some ESLint rules.
Along the way, I noticed an incompatibility in certain cases within the `no-array-constructor` rule.

In this PR, I added test cases and modified the code to include a check for is_reference_to_global_variable.

The relevant ESLint behavior can be verified in the following playground.

https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tYXJyYXktY29uc3RydWN0b3I6IFwiZXJyb3JcIiovXG5cbi8vIGlmIGNvbW1lbnQgb3V0IGJlbG93LCBuZXh0IGxpbmUgYXMgZXJyb3JcbnZhciBBcnJheTsgbmV3IEFycmF5KCk7XG5cbm5ldyBBcnJheSgpOyIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSIsInBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=