### PR TITLE
refactor(parser): do not use `AstBuilder::*_from_*` methods

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -212,12 +212,12 @@ impl<'a> ParserImpl<'a> {
             let ident = match ident {
                 Expression::Identifier(ident) => {
                     let ident = ident.unbox();
-                    self.ast.binding_identifier(ident.span, ident.name)
+                    self.ast.alloc_binding_identifier(ident.span, ident.name)
                 }
                 _ => unreachable!(),
             };
             let params_span = self.end_span(ident.span);
-            let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
+            let ident = BindingPatternKind::BindingIdentifier(ident);
             let pattern = self.ast.binding_pattern(ident, NONE, false);
             let formal_parameter = self.ast.plain_formal_parameter(params_span, pattern);
             self.ast.alloc_formal_parameters(

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -37,7 +37,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_binding_pattern_identifier(&mut self) -> Result<BindingPatternKind<'a>> {
         let ident = self.parse_binding_identifier()?;
-        Ok(self.ast.binding_pattern_kind_from_binding_identifier(ident))
+        Ok(BindingPatternKind::BindingIdentifier(self.alloc(ident)))
     }
 
     /// Section 14.3.3 Object Binding Pattern

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -55,7 +55,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_class_expression(&mut self) -> Result<Expression<'a>> {
         let class =
             self.parse_class(self.start_span(), ClassType::ClassExpression, &Modifiers::empty())?;
-        Ok(self.ast.expression_from_class(class))
+        Ok(Expression::ClassExpression(class))
     }
 
     fn parse_class(
@@ -231,8 +231,7 @@ impl<'a> ParserImpl<'a> {
         if self.is_at_ts_index_signature_member() {
             return self
                 .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| self.ast.class_element_from_ts_index_signature(sig))
-                .map(Some);
+                .map(|sig| Some(ClassElement::TSIndexSignature(self.alloc(sig))));
         }
 
         // * ...

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -57,7 +57,7 @@ impl<'a> ParserImpl<'a> {
     /// `PrimaryExpression`: Identifier Reference
     pub(crate) fn parse_identifier_expression(&mut self) -> Result<Expression<'a>> {
         let ident = self.parse_identifier_reference()?;
-        Ok(self.ast.expression_from_identifier_reference(ident))
+        Ok(Expression::Identifier(self.alloc(ident)))
     }
 
     pub(crate) fn parse_identifier_reference(&mut self) -> Result<IdentifierReference<'a>> {
@@ -198,7 +198,7 @@ impl<'a> ParserImpl<'a> {
             Kind::LParen => self.parse_parenthesized_expression(span),
             Kind::Slash | Kind::SlashEq => self
                 .parse_literal_regexp()
-                .map(|literal| self.ast.expression_from_reg_exp_literal(literal)),
+                .map(|literal| Expression::RegExpLiteral(self.alloc(literal))),
             // JSXElement, JSXFragment
             Kind::LAngle if self.source_type.is_jsx() => self.parse_jsx_expression(),
             _ => self.parse_identifier_expression(),
@@ -253,21 +253,21 @@ impl<'a> ParserImpl<'a> {
         match self.cur_kind() {
             Kind::Str => self
                 .parse_literal_string()
-                .map(|literal| self.ast.expression_from_string_literal(literal)),
+                .map(|literal| Expression::StringLiteral(self.alloc(literal))),
             Kind::True | Kind::False => self
                 .parse_literal_boolean()
-                .map(|literal| self.ast.expression_from_boolean_literal(literal)),
+                .map(|literal| Expression::BooleanLiteral(self.alloc(literal))),
             Kind::Null => {
                 let literal = self.parse_literal_null();
-                Ok(self.ast.expression_from_null_literal(literal))
+                Ok(Expression::NullLiteral(self.alloc(literal)))
             }
             kind if kind.is_number() => {
                 if self.cur_src().ends_with('n') {
                     self.parse_literal_bigint()
-                        .map(|literal| self.ast.expression_from_big_int_literal(literal))
+                        .map(|literal| Expression::BigIntLiteral(self.alloc(literal)))
                 } else {
                     self.parse_literal_number()
-                        .map(|literal| self.ast.expression_from_numeric_literal(literal))
+                        .map(|literal| Expression::NumericLiteral(self.alloc(literal)))
                 }
             }
             _ => Err(self.unexpected()),
@@ -488,7 +488,7 @@ impl<'a> ParserImpl<'a> {
         tagged: bool,
     ) -> Result<Expression<'a>> {
         self.parse_template_literal(tagged)
-            .map(|template_literal| self.ast.expression_from_template_literal(template_literal))
+            .map(|template_literal| Expression::TemplateLiteral(self.alloc(template_literal)))
     }
 
     fn parse_tagged_template(

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -250,8 +250,7 @@ impl<'a> ParserImpl<'a> {
         let id = self.parse_function_id(func_kind, r#async, generator)?;
         let function =
             self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty())?;
-
-        Ok(self.ast.expression_from_function(function))
+        Ok(Expression::FunctionExpression(function))
     }
 
     /// Section 15.4 Method Definitions

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -106,7 +106,7 @@ impl<'a> ParserImpl<'a> {
                         self.end_span(span),
                         PropertyKind::Init,
                         key,
-                        self.ast.expression_from_function(method),
+                        Expression::FunctionExpression(method),
                         /* init */ None,
                         /* method */ true,
                         /* shorthand */ false,
@@ -227,7 +227,7 @@ impl<'a> ParserImpl<'a> {
         let generator = self.eat(Kind::Star);
         let (key, computed) = self.parse_property_name()?;
         let method = self.parse_method(r#async, generator)?;
-        let value = self.ast.expression_from_function(method);
+        let value = Expression::FunctionExpression(method);
         Ok(self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Init,
@@ -247,7 +247,7 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Get)?;
         let (key, computed) = self.parse_property_name()?;
         let method = self.parse_method(false, false)?;
-        let value = self.ast.expression_from_function(method);
+        let value = Expression::FunctionExpression(method);
         Ok(self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Get,
@@ -272,7 +272,7 @@ impl<'a> ParserImpl<'a> {
             self.end_span(span),
             PropertyKind::Set,
             key,
-            self.ast.expression_from_function(method),
+            Expression::FunctionExpression(method),
             /* init */ None,
             /* method */ false,
             /* shorthand */ false,

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -72,29 +72,29 @@ impl<'a> ParserImpl<'a> {
             Kind::LBrack => {
                 let node = self.parse_computed_property_name()?;
                 self.check_invalid_ts_enum_computed_property(&node);
-                Ok(self.ast.ts_enum_member_name_expression(node))
+                Ok(TSEnumMemberName::from(node))
             }
             Kind::Str => {
-                let node = self.parse_literal_string()?;
-                Ok(self.ast.ts_enum_member_name_from_string_literal(node))
+                let literal = self.parse_literal_string()?;
+                Ok(TSEnumMemberName::StaticStringLiteral(self.alloc(literal)))
             }
             Kind::NoSubstitutionTemplate | Kind::TemplateHead => {
-                let node = self.parse_template_literal(false)?;
-                if !node.expressions.is_empty() {
+                let literal = self.parse_template_literal(false)?;
+                if !literal.expressions.is_empty() {
                     self.error(diagnostics::computed_property_names_not_allowed_in_enums(
-                        node.span(),
+                        literal.span(),
                     ));
                 }
-                Ok(self.ast.ts_enum_member_name_from_template_literal(node))
+                Ok(TSEnumMemberName::StaticTemplateLiteral(self.alloc(literal)))
             }
             kind if kind.is_number() => {
-                let node = self.parse_literal_number()?;
-                self.error(diagnostics::enum_member_cannot_have_numeric_name(node.span()));
-                Ok(self.ast.ts_enum_member_name_from_numeric_literal(node))
+                let literal = self.parse_literal_number()?;
+                self.error(diagnostics::enum_member_cannot_have_numeric_name(literal.span()));
+                Ok(TSEnumMemberName::StaticNumericLiteral(self.alloc(literal)))
             }
             _ => {
-                let node = self.parse_identifier_name()?;
-                Ok(self.ast.ts_enum_member_name_from_identifier_name(node))
+                let ident_name = self.parse_identifier_name()?;
+                Ok(TSEnumMemberName::StaticIdentifier(self.alloc(ident_name)))
             }
         }
     }
@@ -210,8 +210,7 @@ impl<'a> ParserImpl<'a> {
             let modifiers = self.parse_modifiers(false, false, false);
             return self
                 .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| self.ast.ts_signature_from_ts_index_signature(sig))
-                .map(Some);
+                .map(|sig| Some(TSSignature::TSIndexSignature(self.alloc(sig))));
         }
 
         match self.cur_kind() {
@@ -462,8 +461,8 @@ impl<'a> ParserImpl<'a> {
                 expression,
             )
         } else {
-            let node = self.parse_ts_type_name()?;
-            self.ast.ts_module_reference_type_name(node)
+            let type_name = self.parse_ts_type_name()?;
+            TSModuleReference::from(type_name)
         };
 
         self.asi()?;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -639,7 +639,7 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.bump_any(); // `bump `typeof`
         let entity_name = self.parse_ts_type_name()?; // TODO: parseEntityName
-        let entity_name = self.ast.ts_type_query_expr_name_type_name(entity_name);
+        let entity_name = TSTypeQueryExprName::from(entity_name);
         let type_arguments =
             if self.cur_token().is_on_new_line { None } else { self.try_parse_type_arguments()? };
         Ok(self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments))
@@ -722,10 +722,10 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `asserts`
         let parameter_name = if self.at(Kind::This) {
-            self.ast.ts_type_predicate_name_from_ts_this_type(self.parse_this_type_node())
+            TSTypePredicateName::This(self.parse_this_type_node())
         } else {
-            let node = self.parse_identifier_name()?;
-            self.ast.ts_type_predicate_name_from_identifier_name(node)
+            let ident_name = self.parse_identifier_name()?;
+            TSTypePredicateName::Identifier(self.alloc(ident_name))
         };
         let mut type_annotation = None;
         if self.eat(Kind::Is) {
@@ -1107,7 +1107,7 @@ impl<'a> ParserImpl<'a> {
         let ty = self.parse_ts_type()?;
         if let Some(id) = type_predicate_variable {
             let type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
-            let parameter_name = self.ast.ts_type_predicate_name_from_identifier_name(id);
+            let parameter_name = TSTypePredicateName::Identifier(self.alloc(id));
             return Ok(self.ast.ts_type_type_predicate(
                 self.end_span(span),
                 parameter_name,


### PR DESCRIPTION
Preparation for #7073. Avoid using `AstBuilder::*_from_*` methods to construct enums, use explicit construction instead.

Before:

```rs
let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
```

After:

```rs
let ident = BindingPatternKind::BindingIdentifier(ident);
```

Often this produces shorter code, as well as (in my opinion) being easier to read.