### PR TITLE
refactor(traverse): do not use `AstBuilder::*_from_*` methods

### DIFF
--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -1,5 +1,8 @@
 use oxc_ast::{
-    ast::{AssignmentTarget, BindingIdentifier, BindingPattern, Expression, IdentifierReference},
+    ast::{
+        AssignmentTarget, BindingIdentifier, BindingPattern, BindingPatternKind, Expression,
+        IdentifierReference,
+    },
     NONE,
 };
 use oxc_span::{Atom, Span, SPAN};
@@ -60,7 +63,7 @@ impl<'a> BoundIdentifier<'a> {
     /// Create `BindingPattern` for this binding
     pub fn create_binding_pattern(&self, ctx: &TraverseCtx<'a>) -> BindingPattern<'a> {
         let ident = self.create_binding_identifier(ctx);
-        let binding_pattern_kind = ctx.ast.binding_pattern_kind_from_binding_identifier(ident);
+        let binding_pattern_kind = BindingPatternKind::BindingIdentifier(ctx.alloc(ident));
         ctx.ast.binding_pattern(binding_pattern_kind, NONE, false)
     }
 
@@ -238,7 +241,7 @@ impl<'a> BoundIdentifier<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let ident = self.create_spanned_reference(span, flags, ctx);
-        ctx.ast.expression_from_identifier_reference(ident)
+        Expression::Identifier(ctx.alloc(ident))
     }
 
     /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`
@@ -249,6 +252,6 @@ impl<'a> BoundIdentifier<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> AssignmentTarget<'a> {
         let ident = self.create_spanned_reference(span, flags, ctx);
-        AssignmentTarget::from(ctx.ast.simple_assignment_target_from_identifier_reference(ident))
+        AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident))
     }
 }


### PR DESCRIPTION
Preparation for #7073. Avoid using `AstBuilder::*_from_*` methods to construct enums, use explicit construction instead.

Before:

```rs
let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
```

After:

```rs
let ident = BindingPatternKind::BindingIdentifier(ident);
```

Often this produces shorter code, as well as (in my opinion) being easier to read.