### PR TITLE
refactor(isolated_declarations): do not use `AstBuilder::*_from_*` methods

### DIFF
--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -332,7 +332,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         );
                         transformed_stmts.insert(
                             declaration.span,
-                            Statement::from(self.ast.declaration_from_variable(decl)),
+                            Statement::VariableDeclaration(self.ast.alloc(decl)),
                         );
                         transformed_spans.insert(declaration.span);
                     }
@@ -378,9 +378,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     if decl.specifiers.is_none() {
                         new_stm.push(stmt.clone_in(self.ast.allocator));
                     } else if let Some(new_decl) = self.transform_import_declaration(decl) {
-                        new_stm.push(Statement::from(
-                            self.ast.module_declaration_from_import_declaration(new_decl),
-                        ));
+                        new_stm.push(Statement::ImportDeclaration(new_decl));
                     }
                 }
                 Statement::VariableDeclaration(decl) => {
@@ -391,14 +389,14 @@ impl<'a> IsolatedDeclarations<'a> {
                                 transformed_variable_declarator.remove(&declarator.span)
                             }),
                         );
-                        new_stm.push(Statement::from(self.ast.declaration_from_variable(
-                            self.ast.variable_declaration(
+                        new_stm.push(Statement::VariableDeclaration(
+                            self.ast.alloc_variable_declaration(
                                 decl.span,
                                 decl.kind,
                                 declarations,
                                 self.is_declare(),
                             ),
-                        )));
+                        ));
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Preparation for #7073. Avoid using `AstBuilder::*_from_*` methods to construct enums, use explicit construction instead.

Before:

```rs
let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
```

After:

```rs
let ident = BindingPatternKind::BindingIdentifier(ident);
```

Often this produces shorter code, as well as (in my opinion) being easier to read.