### PR TITLE
refactor(minifier): do not use `AstBuilder::*_from_*` methods

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
@@ -215,15 +215,13 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
                                 .declarations
                                 .splice(0..0, ctx.ast.move_vec(&mut var_init.declarations));
                         } else {
-                            var_decl = Some(ctx.ast.move_variable_declaration(var_init));
+                            var_decl =
+                                Some(ctx.ast.alloc(ctx.ast.move_variable_declaration(var_init)));
                         }
                     }
                     Some(var_decl.map_or_else(
                         || ctx.ast.statement_empty(SPAN),
-                        |var_decl| {
-                            ctx.ast
-                                .statement_declaration(ctx.ast.declaration_from_variable(var_decl))
-                        },
+                        Statement::VariableDeclaration,
                     ))
                 }
                 None => {
@@ -231,10 +229,7 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
                     keep_var.visit_statement(&for_stmt.body);
                     Some(keep_var.get_variable_declaration().map_or_else(
                         || ctx.ast.statement_empty(SPAN),
-                        |var_decl| {
-                            ctx.ast
-                                .statement_declaration(ctx.ast.declaration_from_variable(var_decl))
-                        },
+                        Statement::VariableDeclaration,
                     ))
                 }
                 _ => None,
@@ -315,9 +310,7 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
 
                     return Some(ctx.ast.statement_expression(
                         template_lit.span,
-                        ctx.ast.expression_from_sequence(
-                            ctx.ast.sequence_expression(template_lit.span, expressions),
-                        ),
+                        ctx.ast.expression_sequence(template_lit.span, expressions),
                     ));
                 }
                 Expression::FunctionExpression(function_expr) if function_expr.id.is_none() => {
@@ -390,9 +383,7 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
 
         Some(ctx.ast.statement_expression(
             array_expr.span,
-            ctx.ast.expression_from_sequence(
-                ctx.ast.sequence_expression(array_expr.span, transformed_elements),
-            ),
+            ctx.ast.expression_sequence(array_expr.span, transformed_elements),
         ))
     }
 

--- a/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
@@ -46,27 +46,20 @@ impl PeepholeReplaceKnownMethods {
         let Expression::StaticMemberExpression(member) = &call_expr.callee else { return };
         if let Expression::StringLiteral(string_lit) = &member.object {
             let replacement = match member.property.name.as_str() {
-                "toLowerCase" | "toUpperCase" | "trim" => {
-                    let transformed_value =
-                        match member.property.name.as_str() {
-                            "toLowerCase" => Some(ctx.ast.string_literal(
-                                call_expr.span,
-                                string_lit.value.cow_to_lowercase(),
-                            )),
-                            "toUpperCase" => Some(ctx.ast.string_literal(
-                                call_expr.span,
-                                string_lit.value.cow_to_uppercase(),
-                            )),
-                            "trim" => Some(
-                                ctx.ast.string_literal(call_expr.span, string_lit.value.trim()),
-                            ),
-                            _ => None,
-                        };
-
-                    transformed_value.map(|transformed_value| {
-                        ctx.ast.expression_from_string_literal(transformed_value)
-                    })
-                }
+                "toLowerCase" | "toUpperCase" | "trim" => match member.property.name.as_str() {
+                    "toLowerCase" => Some(ctx.ast.expression_string_literal(
+                        call_expr.span,
+                        string_lit.value.cow_to_lowercase(),
+                    )),
+                    "toUpperCase" => Some(ctx.ast.expression_string_literal(
+                        call_expr.span,
+                        string_lit.value.cow_to_uppercase(),
+                    )),
+                    "trim" => Some(
+                        ctx.ast.expression_string_literal(call_expr.span, string_lit.value.trim()),
+                    ),
+                    _ => None,
+                },
                 "indexOf" | "lastIndexOf" => Self::try_fold_string_index_of(
                     call_expr.span,
                     call_expr,
@@ -131,12 +124,12 @@ impl PeepholeReplaceKnownMethods {
         };
 
         #[expect(clippy::cast_precision_loss)]
-        return Some(ctx.ast.expression_from_numeric_literal(ctx.ast.numeric_literal(
+        return Some(ctx.ast.expression_numeric_literal(
             span,
             result as f64,
             result.to_string(),
             NumberBase::Decimal,
-        )));
+        ));
     }
 
     fn try_fold_string_substring_or_slice<'a>(
@@ -181,8 +174,9 @@ impl PeepholeReplaceKnownMethods {
             }
         };
 
-        return Some(ctx.ast.expression_from_string_literal(
-            ctx.ast.string_literal(span, string_lit.value.as_str().substring(start_idx, end_idx)),
+        return Some(ctx.ast.expression_string_literal(
+            span,
+            string_lit.value.as_str().substring(start_idx, end_idx),
         ));
     }
 
@@ -216,7 +210,7 @@ impl PeepholeReplaceKnownMethods {
             .char_at(char_at_index)
             .map_or(String::new(), |v| v.to_string());
 
-        return Some(ctx.ast.expression_from_string_literal(ctx.ast.string_literal(span, result)));
+        return Some(ctx.ast.expression_string_literal(span, result));
     }
 
     fn try_fold_string_char_code_at<'a>(
@@ -240,12 +234,12 @@ impl PeepholeReplaceKnownMethods {
         let result = string_lit.value.as_str().char_code_at(char_at_index)?;
 
         #[expect(clippy::cast_lossless)]
-        Some(ctx.ast.expression_from_numeric_literal(ctx.ast.numeric_literal(
+        Some(ctx.ast.expression_numeric_literal(
             span,
             result as f64,
             result.to_string(),
             NumberBase::Decimal,
-        )))
+        ))
     }
     fn try_fold_string_replace_or_string_replace_all<'a>(
         span: Span,
@@ -287,7 +281,7 @@ impl PeepholeReplaceKnownMethods {
             _ => unreachable!(),
         };
 
-        Some(ctx.ast.expression_from_string_literal(ctx.ast.string_literal(span, result)))
+        Some(ctx.ast.expression_string_literal(span, result))
     }
 }
 

--- a/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
+++ b/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
@@ -138,9 +138,7 @@ impl<'a> StatementFusion {
                     init.as_expression_mut().unwrap()
                 } else {
                     for_stmt.init =
-                        Some(ctx.ast.for_statement_init_expression(
-                            ctx.ast.expression_sequence(SPAN, exprs),
-                        ));
+                        Some(ForStatementInit::from(ctx.ast.expression_sequence(SPAN, exprs)));
                     return;
                 }
             }

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::Box as ArenaBox;
 use oxc_ast::{ast::*, AstBuilder, Visit, NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_span::{Atom, Span, SPAN};
@@ -60,7 +61,7 @@ impl<'a> KeepVar<'a> {
         self.all_hoisted
     }
 
-    pub fn get_variable_declaration(self) -> Option<VariableDeclaration<'a>> {
+    pub fn get_variable_declaration(self) -> Option<ArenaBox<'a, VariableDeclaration<'a>>> {
         if self.vars.is_empty() {
             return None;
         }
@@ -72,14 +73,11 @@ impl<'a> KeepVar<'a> {
             self.ast.variable_declarator(span, kind, id, None, false)
         }));
 
-        let decl = self.ast.variable_declaration(SPAN, kind, decls, false);
+        let decl = self.ast.alloc_variable_declaration(SPAN, kind, decls, false);
         Some(decl)
     }
 
     pub fn get_variable_declaration_statement(self) -> Option<Statement<'a>> {
-        let stmt = self.ast.statement_declaration(
-            self.ast.declaration_from_variable(self.get_variable_declaration()?),
-        );
-        Some(stmt)
+        self.get_variable_declaration().map(Statement::VariableDeclaration)
     }
 }


### PR DESCRIPTION
Preparation for #7073. Avoid using `AstBuilder::*_from_*` methods to construct enums, use explicit construction instead.

Before:

```rs
let ident = self.ast.binding_pattern_kind_from_binding_identifier(ident);
```

After:

```rs
let ident = BindingPatternKind::BindingIdentifier(ident);
```

Often this produces shorter code, as well as (in my opinion) being easier to read.