### PR TITLE
fix(linter): remove confusing help text for now

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -126,12 +126,9 @@ impl Runner for LintRunner {
             Err(err) => match err {
                 LinterBuilderError::UnknownRules { rules } => {
                     let rules = rules.iter().map(|r| r.full_name()).collect::<Vec<_>>().join("\n");
-                    let error = Error::from(
-                        OxcDiagnostic::warn(format!(
+                    let error = Error::from(OxcDiagnostic::warn(format!(
                         "The following rules do not match the currently supported rules:\n{rules}"
-                    ))
-                        .with_help("Check that the plugin that contains this rule is enabled."),
-                    );
+                    )));
                     return CliRunResult::LintError { error: format!("{error:?}") };
                 }
             },


### PR DESCRIPTION
It's possible that the rule may not exist at all, or it's part of a disabled plugin. The help text doesn't give a clue as to which is the case currently, so it's probably less confusing to just omit it completely.