### PR TITLE
refactor(ast_tools): remove `LateCtx` abstraction

### DIFF
--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -4,9 +4,8 @@ use quote::{format_ident, quote};
 use syn::Ident;
 
 use crate::{
-    codegen::LateCtx,
     markers::CloneInAttribute,
-    schema::{EnumDef, GetIdent, StructDef, TypeDef},
+    schema::{EnumDef, GetIdent, Schema, StructDef, TypeDef},
 };
 
 use super::{define_derive, Derive};
@@ -20,7 +19,7 @@ impl Derive for DeriveCloneIn {
         "CloneIn"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         match &def {
             TypeDef::Enum(it) => derive_enum(it),
             TypeDef::Struct(it) => derive_struct(it),

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -3,8 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    codegen::LateCtx,
-    schema::{EnumDef, GetGenerics, StructDef, ToType, TypeDef},
+    schema::{EnumDef, GetGenerics, Schema, StructDef, ToType, TypeDef},
     util::ToIdent,
 };
 
@@ -28,7 +27,7 @@ impl Derive for DeriveContentEq {
         "ContentEq"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         let (other, body) = match &def {
             TypeDef::Enum(it) => derive_enum(it),
             TypeDef::Struct(it) => derive_struct(it),

--- a/tasks/ast_tools/src/derives/content_hash.rs
+++ b/tasks/ast_tools/src/derives/content_hash.rs
@@ -3,8 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    codegen::LateCtx,
-    schema::{EnumDef, GetGenerics, StructDef, ToType, TypeDef},
+    schema::{EnumDef, GetGenerics, Schema, StructDef, ToType, TypeDef},
     util::ToIdent,
 };
 
@@ -26,7 +25,7 @@ impl Derive for DeriveContentHash {
         "ContentHash"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         let (hasher, body) = match &def {
             TypeDef::Enum(it) => derive_enum(it),
             TypeDef::Struct(it) => derive_struct(it),

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -3,11 +3,10 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    codegen::LateCtx,
     markers::ESTreeStructTagMode,
     schema::{
         serialize::{enum_variant_name, get_always_flatten_structs, get_type_tag},
-        EnumDef, GetGenerics, GetIdent, StructDef, TypeDef,
+        EnumDef, GetGenerics, GetIdent, Schema, StructDef, TypeDef,
     },
 };
 
@@ -26,7 +25,7 @@ impl Derive for DeriveESTree {
         "estree".to_string()
     }
 
-    fn derive(&mut self, def: &TypeDef, ctx: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, schema: &Schema) -> TokenStream {
         if let TypeDef::Struct(def) = def {
             if def
                 .markers
@@ -41,7 +40,7 @@ impl Derive for DeriveESTree {
 
         let body = match def {
             TypeDef::Enum(def) => serialize_enum(def),
-            TypeDef::Struct(def) => serialize_struct(def, ctx),
+            TypeDef::Struct(def) => serialize_struct(def, schema),
         };
         let ident = def.ident();
 
@@ -65,7 +64,7 @@ impl Derive for DeriveESTree {
     }
 }
 
-fn serialize_struct(def: &StructDef, ctx: &LateCtx) -> TokenStream {
+fn serialize_struct(def: &StructDef, schema: &Schema) -> TokenStream {
     let ident = def.ident();
     // If type_tag is Some, we serialize it manually. If None, either one of
     // the fields is named r#type, or the struct does not need a "type" field.
@@ -90,7 +89,7 @@ fn serialize_struct(def: &StructDef, ctx: &LateCtx) -> TokenStream {
 
         let ident = field.ident().unwrap();
         let always_flatten = match field.typ.type_id() {
-            Some(id) => get_always_flatten_structs(ctx).contains(&id),
+            Some(id) => get_always_flatten_structs(schema).contains(&id),
             None => false,
         };
 

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -3,8 +3,7 @@ use quote::quote;
 use syn::Ident;
 
 use crate::{
-    codegen::LateCtx,
-    schema::{EnumDef, GetGenerics, StructDef, ToType, TypeDef},
+    schema::{EnumDef, GetGenerics, Schema, StructDef, ToType, TypeDef},
     util::{ToIdent, TypeWrapper},
 };
 
@@ -19,7 +18,7 @@ impl Derive for DeriveGetSpan {
         "GetSpan"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         let self_type = quote!(&self);
         let result_type = quote!(Span);
         let result_expr = quote!(self.span);
@@ -57,7 +56,7 @@ impl Derive for DeriveGetSpanMut {
         "GetSpanMut"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &LateCtx) -> TokenStream {
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         let self_type = quote!(&mut self);
         let result_type = quote!(&mut Span);
         let result_expr = quote!(&mut self.span);

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -3,9 +3,8 @@ use quote::quote;
 use syn::Type;
 
 use crate::{
-    codegen::LateCtx,
     output::{output_path, Output},
-    schema::{FieldDef, ToType, TypeDef},
+    schema::{FieldDef, Schema, ToType, TypeDef},
     util::ToIdent,
     Generator,
 };
@@ -17,10 +16,10 @@ pub struct AssertLayouts;
 define_generator!(AssertLayouts);
 
 impl Generator for AssertLayouts {
-    fn generate(&mut self, ctx: &LateCtx) -> Output {
-        let (assertions_64, assertions_32) = ctx
-            .schema()
-            .into_iter()
+    fn generate(&mut self, schema: &Schema) -> Output {
+        let (assertions_64, assertions_32) = schema
+            .defs
+            .iter()
             .map(|def| {
                 let typ = def.to_type_elide();
                 assert_type(&typ, def)

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -4,9 +4,8 @@ use quote::{format_ident, quote};
 use syn::{parse_quote, Arm, ImplItemFn, Variant};
 
 use crate::{
-    codegen::LateCtx,
     output::{output_path, Output},
-    schema::{GetIdent, ToType},
+    schema::{GetIdent, Schema, ToType},
     Generator,
 };
 
@@ -81,10 +80,10 @@ pub const BLACK_LIST: [&str; 61] = [
 ];
 
 impl Generator for AstKindGenerator {
-    fn generate(&mut self, ctx: &LateCtx) -> Output {
-        let have_kinds = ctx
-            .schema()
-            .into_iter()
+    fn generate(&mut self, schema: &Schema) -> Output {
+        let have_kinds = schema
+            .defs
+            .iter()
             .filter(|def| {
                 let is_visitable = def.visitable();
                 let is_blacklisted = BLACK_LIST.contains(&def.name());

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -1,4 +1,4 @@
-use crate::{codegen::LateCtx, output::Output, Result};
+use crate::{output::Output, Result, Schema};
 
 mod assert_layouts;
 mod ast_builder;
@@ -15,12 +15,12 @@ pub use visit::{VisitGenerator, VisitMutGenerator};
 pub trait Generator {
     // Methods defined by implementer
 
-    fn generate(&mut self, ctx: &LateCtx) -> Output;
+    fn generate(&mut self, schema: &Schema) -> Output;
 
     // Standard methods
 
-    fn output(&mut self, ctx: &LateCtx) -> Result<Vec<Output>> {
-        Ok(vec![self.generate(ctx)])
+    fn output(&mut self, schema: &Schema) -> Result<Vec<Output>> {
+        Ok(vec![self.generate(schema)])
     }
 }
 
@@ -28,13 +28,14 @@ macro_rules! define_generator {
     ($ident:ident $($lifetime:lifetime)?) => {
         const _: () = {
             use $crate::{
-                codegen::{LateCtx, Runner},
+                codegen::Runner,
                 output::Output,
+                schema::Schema,
                 Result,
             };
 
             impl $($lifetime)? Runner for $ident $($lifetime)? {
-                type Context = LateCtx;
+                type Context = Schema;
 
                 fn verb(&self) -> &'static str {
                     "Generate"
@@ -48,8 +49,8 @@ macro_rules! define_generator {
                     file!()
                 }
 
-                fn run(&mut self, ctx: &LateCtx) -> Result<Vec<Output>> {
-                    self.output(ctx)
+                fn run(&mut self, schema: &Schema) -> Result<Vec<Output>> {
+                    self.output(schema)
                 }
             }
         };

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -3,11 +3,10 @@ use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    codegen::LateCtx,
     output::Output,
     schema::{
         serialize::{enum_variant_name, get_always_flatten_structs, get_type_tag},
-        EnumDef, GetIdent, StructDef, TypeDef, TypeName,
+        EnumDef, GetIdent, Schema, StructDef, TypeDef, TypeName,
     },
     Generator, TypeId,
 };
@@ -21,12 +20,12 @@ pub struct TypescriptGenerator;
 define_generator!(TypescriptGenerator);
 
 impl Generator for TypescriptGenerator {
-    fn generate(&mut self, ctx: &LateCtx) -> Output {
+    fn generate(&mut self, schema: &Schema) -> Output {
         let mut code = String::new();
 
-        let always_flatten_structs = get_always_flatten_structs(ctx);
+        let always_flatten_structs = get_always_flatten_structs(schema);
 
-        for def in ctx.schema() {
+        for def in &schema.defs {
             if !def.generates_derive("ESTree") {
                 continue;
             }

--- a/tasks/ast_tools/src/schema/defs.rs
+++ b/tasks/ast_tools/src/schema/defs.rs
@@ -20,13 +20,6 @@ pub enum TypeDef {
 }
 
 impl TypeDef {
-    pub fn id(&self) -> TypeId {
-        match self {
-            TypeDef::Struct(def) => def.id,
-            TypeDef::Enum(def) => def.id,
-        }
-    }
-
     pub fn name(&self) -> &str {
         match self {
             TypeDef::Struct(def) => &def.name,

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -116,15 +116,6 @@ impl Schema {
     }
 }
 
-impl<'a> IntoIterator for &'a Schema {
-    type IntoIter = std::slice::Iter<'a, TypeDef>;
-    type Item = &'a TypeDef;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.defs.iter()
-    }
-}
-
 fn parse_struct_outer_markers(attrs: &Vec<Attribute>) -> Result<StructOuterMarkers> {
     Ok(StructOuterMarkers {
         scope: get_scope_attribute(attrs).transpose()?,

--- a/tasks/ast_tools/src/schema/serialize.rs
+++ b/tasks/ast_tools/src/schema/serialize.rs
@@ -1,7 +1,7 @@
 use convert_case::{Case, Casing};
 use rustc_hash::FxHashSet;
 
-use crate::{codegen::LateCtx, markers::ESTreeStructTagMode, schema::GetIdent, TypeId};
+use crate::{markers::ESTreeStructTagMode, schema::GetIdent, Schema, TypeId};
 
 use super::{EnumDef, StructDef, TypeDef, VariantDef};
 
@@ -36,9 +36,9 @@ pub fn get_type_tag(def: &StructDef) -> Option<String> {
 }
 
 /// Returns a HashSet of structs that have the #[estree(always_flatten)] attribute.
-pub fn get_always_flatten_structs(ctx: &LateCtx) -> FxHashSet<TypeId> {
+pub fn get_always_flatten_structs(schema: &Schema) -> FxHashSet<TypeId> {
     let mut set = FxHashSet::default();
-    for def in ctx.schema() {
+    for def in &schema.defs {
         if let TypeDef::Struct(def) = def {
             if def.markers.estree.as_ref().is_some_and(|e| e.always_flatten) {
                 set.insert(def.id);

--- a/tasks/ast_tools/src/util.rs
+++ b/tasks/ast_tools/src/util.rs
@@ -122,6 +122,7 @@ pub enum TypeWrapper {
     Box,
     Vec,
     Opt,
+    #[expect(dead_code)]
     VecBox,
     VecOpt,
     OptBox,


### PR DESCRIPTION
`LateCtx` is just a wrapper around `Schema`. Remove it and use `Schema` instead.