### PR TITLE
feat(editor/vscode): Support window/showMessage event

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -2,6 +2,8 @@ import { promises as fsPromises } from 'node:fs';
 
 import { commands, ExtensionContext, StatusBarAlignment, StatusBarItem, ThemeColor, window, workspace } from 'vscode';
 
+import { MessageType, ShowMessageNotification } from 'vscode-languageclient';
+
 import { Executable, LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 
 import { join } from 'node:path';
@@ -171,6 +173,25 @@ export async function activate(context: ExtensionContext) {
     serverOptions,
     clientOptions,
   );
+  client.onNotification(ShowMessageNotification.type, (params) => {
+    switch (params.type) {
+      case MessageType.Log:
+      case MessageType.Debug:
+        outputChannel.appendLine(params.message);
+        break;
+      case MessageType.Info:
+        window.showInformationMessage(params.message);
+        break;
+      case MessageType.Warning:
+        window.showWarningMessage(params.message);
+        break;
+      case MessageType.Error:
+        window.showErrorMessage(params.message);
+        break;
+      default:
+        outputChannel.appendLine(params.message);
+    }
+  });
 
   workspace.onDidDeleteFiles((event) => {
     event.files.forEach((fileUri) => {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -22,7 +22,7 @@
     "oxc"
   ],
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.95.0"
   },
   "sponsor": {
     "url": "https://github.com/sponsors/boshen"


### PR DESCRIPTION
Whenever the language server sends a `window/showMessage` event, VS Code will listen and display a notification or log a message based on the severity level of the message.

The language server doesn't currently send this event.  I'm going to follow up with a separate PR for that.

Ref https://github.com/oxc-project/oxc/issues/6988