### PR TITLE
feat(oxc_language_server): Publish a message when there are UnknownRules errors building the LinterBuilder

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -432,7 +432,7 @@ impl Tester {
         let linter = eslint_config
             .as_ref()
             .map_or_else(LinterBuilder::empty, |v| {
-                LinterBuilder::from_oxlintrc(true, Oxlintrc::deserialize(v).unwrap()).unwrap()
+                LinterBuilder::from_oxlintrc(true, Oxlintrc::deserialize(v).unwrap()).0
             })
             .with_fix(fix.into())
             .with_plugins(self.plugins)


### PR DESCRIPTION
I think this retains the current CLI behavior of exiting on unknown rules (that's still being discussed, but I figured I should just keep it the same here).  This modifies the language server to emit a message to editors which then display a notification within the editor.

Ref https://github.com/oxc-project/oxc/issues/6988