### PR TITLE
refactor(linter): remove unused CLI result types

### DIFF
--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -19,11 +19,6 @@ pub enum CliRunResult {
         error: String,
     },
     LintResult(LintResult),
-    FormatResult(FormatResult),
-    TypeCheckResult {
-        duration: Duration,
-        number_of_diagnostics: usize,
-    },
     PrintConfigResult {
         config_file: String,
     },
@@ -48,12 +43,6 @@ pub struct LintResult {
     pub deny_warnings: bool,
     /// Whether or not to print a summary of the results
     pub print_summary: bool,
-}
-
-#[derive(Debug)]
-pub struct FormatResult {
-    pub duration: Duration,
-    pub number_of_files: usize,
 }
 
 impl Termination for CliRunResult {
@@ -114,26 +103,6 @@ impl Termination for CliRunResult {
                 let exit_code =
                     u8::from((number_of_warnings > 0 && deny_warnings) || number_of_errors > 0);
                 ExitCode::from(exit_code)
-            }
-            Self::FormatResult(FormatResult { duration, number_of_files }) => {
-                let threads = rayon::current_num_threads();
-                let time = Self::get_execution_time(&duration);
-                let s = if number_of_files == 1 { "" } else { "s" };
-                println!(
-                    "Finished in {time} on {number_of_files} file{s} using {threads} threads."
-                );
-                ExitCode::from(0)
-            }
-            Self::TypeCheckResult { duration, number_of_diagnostics } => {
-                let time = Self::get_execution_time(&duration);
-                println!("Finished in {time}.");
-
-                if number_of_diagnostics > 0 {
-                    println!("Found {number_of_diagnostics} errors.");
-                    return ExitCode::from(1);
-                }
-
-                ExitCode::from(0)
             }
             Self::PrintConfigResult { config_file } => {
                 println!("{config_file}");


### PR DESCRIPTION
It doesn't seem like we should implement type checking or formatting in the `oxlint` binary. Plus, these are unused currently. So I removed them.