### PR TITLE
refactor(transformer/async-to-generator): move handling of `MethodDefinition`'s value to `exit_function`

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -130,14 +130,9 @@ impl<'a, 'ctx> Traverse<'a> for AsyncToGenerator<'a, 'ctx> {
         }
     }
 
-    fn exit_method_definition(
-        &mut self,
-        node: &mut MethodDefinition<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        let function = &mut node.value;
-        if function.r#async && !function.generator && !function.is_typescript_syntax() {
-            self.executor.transform_function_for_method_definition(function, ctx);
+    fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        if func.r#async && ctx.parent().is_method_definition() {
+            self.executor.transform_function_for_method_definition(func, ctx);
         }
     }
 }

--- a/crates/oxc_transformer/src/es2017/mod.rs
+++ b/crates/oxc_transformer/src/es2017/mod.rs
@@ -1,7 +1,7 @@
 mod async_to_generator;
 mod options;
 
-use oxc_ast::ast::{Expression, Statement};
+use oxc_ast::ast::{Expression, Function, Statement};
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::{es2017::async_to_generator::AsyncToGenerator, TransformCtx};
@@ -30,13 +30,9 @@ impl<'a, 'ctx> Traverse<'a> for ES2017<'a, 'ctx> {
         }
     }
 
-    fn exit_method_definition(
-        &mut self,
-        node: &mut oxc_ast::ast::MethodDefinition<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    fn exit_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.async_to_generator {
-            self.async_to_generator.exit_method_definition(node, ctx);
+            self.async_to_generator.exit_function(node, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -276,6 +276,7 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         }
         self.x1_jsx.exit_function(func, ctx);
         self.x2_es2018.exit_function(func, ctx);
+        self.x2_es2017.exit_function(func, ctx);
         self.x3_es2015.exit_function(func, ctx);
     }
 
@@ -333,7 +334,6 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
             typescript.exit_method_definition(def, ctx);
         }
         self.x2_es2018.exit_method_definition(def, ctx);
-        self.x2_es2017.exit_method_definition(def, ctx);
     }
 
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1672,7 +1672,15 @@ x Output mismatch
 x Output mismatch
 
 * regression/regression-2765/input.js
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(10): []
+rebuilt        : ScopeId(6): ["_this2"]
+Bindings mismatch:
+after transform: ScopeId(4): ["_this2", "c"]
+rebuilt        : ScopeId(7): ["c"]
+Symbol scope ID mismatch for "_this2":
+after transform: SymbolId(8): ScopeId(4)
+rebuilt        : SymbolId(6): ScopeId(6)
 
 
 # babel-plugin-transform-exponentiation-operator (3/4)


### PR DESCRIPTION
Part of #7074

We need to handle this before the `arrow_function` plugin inserts `_this = this` because, in the `async-to-generator` plugin, we will move the body to an inner generator function. However, we don't want `_this = this` moved to the inner generator function as well. So as long as we move first, and then insert, we can fix this problem.

The new semantic error is related to another tricky problem, I will fix it in another PR 