### PR TITLE
refactor(transformer/async-generator-functions): move handling of `MethodDefinition`'s value to `exit_function`

### DIFF
--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -164,22 +164,18 @@ impl<'a, 'ctx> Traverse<'a> for AsyncGeneratorFunctions<'a, 'ctx> {
         }
     }
 
-    fn exit_method_definition(
-        &mut self,
-        node: &mut MethodDefinition<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        let function = &mut node.value;
-        if function.r#async && function.generator && !function.is_typescript_syntax() {
-            self.executor.transform_function_for_method_definition(function, ctx);
-        }
-    }
-
     fn enter_function(&mut self, func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.stack.push(func.r#async && func.generator);
     }
 
-    fn exit_function(&mut self, _func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
+    fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        if func.r#async
+            && func.generator
+            && !func.is_typescript_syntax()
+            && matches!(ctx.parent(), Ancestor::MethodDefinitionValue(_))
+        {
+            self.executor.transform_function_for_method_definition(func, ctx);
+        }
         self.stack.pop();
     }
 }

--- a/crates/oxc_transformer/src/es2018/mod.rs
+++ b/crates/oxc_transformer/src/es2018/mod.rs
@@ -2,7 +2,7 @@ mod async_generator_functions;
 mod object_rest_spread;
 mod options;
 
-use oxc_ast::ast::{Expression, ForOfStatement, Function, MethodDefinition, Statement};
+use oxc_ast::ast::{Expression, ForOfStatement, Function, Statement};
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::context::TransformCtx;
@@ -53,16 +53,6 @@ impl<'a, 'ctx> Traverse<'a> for ES2018<'a, 'ctx> {
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.async_generator_functions {
             self.async_generator_functions.exit_statement(stmt, ctx);
-        }
-    }
-
-    fn exit_method_definition(
-        &mut self,
-        node: &mut MethodDefinition<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        if self.options.async_generator_functions {
-            self.async_generator_functions.exit_method_definition(node, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -333,7 +333,6 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.exit_method_definition(def, ctx);
         }
-        self.x2_es2018.exit_method_definition(def, ctx);
     }
 
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {


### PR DESCRIPTION
Part of #7074

I have mentioned the reason why I need to move this in https://github.com/oxc-project/oxc/pull/7105