### PR TITLE
feat(transformer): enable `ArrowFunctionConverter` in `async-to-generator` and `async-generator-functions` plugins

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -1,8 +1,6 @@
 //! Utility transforms which are in common between other transforms.
 
-use arrow_function_converter::{
-    ArrowFunctionConverter, ArrowFunctionConverterMode, ArrowFunctionConverterOptions,
-};
+use arrow_function_converter::ArrowFunctionConverter;
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -31,23 +29,12 @@ pub struct Common<'a, 'ctx> {
 
 impl<'a, 'ctx> Common<'a, 'ctx> {
     pub fn new(options: &TransformOptions, ctx: &'ctx TransformCtx<'a>) -> Self {
-        let arrow_function_converter_options = {
-            let mode = if options.env.es2015.arrow_function.is_some() {
-                ArrowFunctionConverterMode::Enabled
-            } else {
-                ArrowFunctionConverterMode::Disabled
-            };
-            ArrowFunctionConverterOptions { mode }
-        };
-
         Self {
             module_imports: ModuleImports::new(ctx),
             var_declarations: VarDeclarations::new(ctx),
             statement_injector: StatementInjector::new(ctx),
             top_level_statements: TopLevelStatements::new(ctx),
-            arrow_function_converter: ArrowFunctionConverter::new(
-                &arrow_function_converter_options,
-            ),
+            arrow_function_converter: ArrowFunctionConverter::new(options),
         }
     }
 }

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -131,7 +131,14 @@ impl<'a, 'ctx> Traverse<'a> for AsyncToGenerator<'a, 'ctx> {
     }
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
-        if func.r#async && matches!(ctx.parent(), Ancestor::MethodDefinitionValue(_)) {
+        if func.r#async
+            && !func.is_typescript_syntax()
+            && matches!(
+                ctx.parent(),
+                // `class A { async foo() {} }` | `({ async foo() {} })`
+                Ancestor::MethodDefinitionValue(_) | Ancestor::PropertyDefinitionValue(_)
+            )
+        {
             self.executor.transform_function_for_method_definition(func, ctx);
         }
     }

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -172,7 +172,11 @@ impl<'a, 'ctx> Traverse<'a> for AsyncGeneratorFunctions<'a, 'ctx> {
         if func.r#async
             && func.generator
             && !func.is_typescript_syntax()
-            && matches!(ctx.parent(), Ancestor::MethodDefinitionValue(_))
+            && matches!(
+                ctx.parent(),
+                // `class A { async foo() {} }` | `({ async foo() {} })`
+                Ancestor::MethodDefinitionValue(_) | Ancestor::ObjectPropertyValue(_)
+            )
         {
             self.executor.transform_function_for_method_definition(func, ctx);
         }

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1452,13 +1452,37 @@ x Output mismatch
 
 # babel-plugin-transform-async-generator-functions (15/19)
 * async-generators/class-method/input.js
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "_this"]
+rebuilt        : ScopeId(0): ["C"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(2): ["_this"]
+Symbol scope ID mismatch for "_this":
+after transform: SymbolId(1): ScopeId(0)
+rebuilt        : SymbolId(1): ScopeId(2)
 
 * async-generators/object-method/input.js
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(0): ["_this"]
+rebuilt        : ScopeId(0): []
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(1): ["_this"]
+Symbol scope ID mismatch for "_this":
+after transform: SymbolId(0): ScopeId(0)
+rebuilt        : SymbolId(0): ScopeId(1)
 
 * async-generators/static-method/input.js
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "_this"]
+rebuilt        : ScopeId(0): ["C"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(2): ["_this"]
+Symbol scope ID mismatch for "_this":
+after transform: SymbolId(1): ScopeId(0)
+rebuilt        : SymbolId(1): ScopeId(2)
 
 * nested/arrows-in-declaration/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -234,33 +234,3 @@ AssertionError: expected false to be true // Object.is equality
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[14/14]⎯
 
-
-⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
-AssertionError: expected [Function Object] to be [Function Bar] // Object.is equality
-
-- Expected
-+ Received
-
-- [Function Bar]
-+ [Function Object]
-
- ❯ fixtures/babel-preset-env-test-fixtures-plugins-integration-regression-7064-exec.test.js:13:30
-     11|    }).call(this);
-     12|    _asyncToGenerator(function* () {
-     13|     expect(this.constructor).toBe(Bar);
-       |                              ^
-     14|    })();
-     15|    _asyncToGenerator(function* () {
- ❯ asyncGeneratorStep ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17
- ❯ _next ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9
- ❯ ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7
- ❯ ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12
- ❯ Bar.test fixtures/babel-preset-env-test-fixtures-plugins-integration-regression-7064-exec.test.js:14:6
- ❯ fixtures/babel-preset-env-test-fixtures-plugins-integration-regression-7064-exec.test.js:20:12
- ❯ ../../node_modules/.pnpm/@vitest+runner@2.1.2/node_modules/@vitest/runner/dist/index.js:146:14
-
-This error originated in "fixtures/babel-preset-env-test-fixtures-plugins-integration-regression-7064-exec.test.js" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
-The latest test that might've caused the error is "fixtures/babel-preset-env-test-fixtures-plugins-integration-regression-7064-exec.test.js". It might mean one of the following:
-- The error was thrown, while Vitest was running this test.
-- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
-


### PR DESCRIPTION
Part of https://github.com/oxc-project/oxc/pull/7074

In async-to-generator and async-generator-functions plugins, we may need to transform the async arrow function to a regular generator function, now we can reuse the ability of the ArrowFunction plugin by enabling `ArrowFunctionConverter`.

I will fix semantic errors in the follow-up PR