### PR TITLE
fix(transformer/async_to_generator): fix checking if function is class method

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -131,7 +131,7 @@ impl<'a, 'ctx> Traverse<'a> for AsyncToGenerator<'a, 'ctx> {
     }
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
-        if func.r#async && ctx.parent().is_method_definition() {
+        if func.r#async && matches!(ctx.parent(), Ancestor::MethodDefinitionValue(_)) {
             self.executor.transform_function_for_method_definition(func, ctx);
         }
     }


### PR DESCRIPTION
Follow-on after #7105.

Correctly identify when a function is a method definition. `ctx.parent().is_method_definition()` would return `true` for this weird case where the function is the property key of the method, not the method itself:

```js
class C {
    [async function() {}]() {}
}
```

`matches!(ctx.parent(), Ancestor::MethodDefinitionValue(_))` only returns `true` if the function *is* a method definition. Of course, no-one would write such ridiculous code, but we may as well handle whatever is thrown at us.

It's also slightly more performant to check for one specific ancestor type, rather than:

https://github.com/oxc-project/oxc/blob/c2802e63fc0a43a7be3a4caf30d179db9eca6e5e/crates/oxc_traverse/src/generated/ancestor.rs#L1319-L1326