### PR TITLE
feat(transformer/arrow-function-converter): move scope to changed scope for `this_var` if scope have changed

### DIFF
--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 377/1078
+Passed: 381/1078
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -1450,40 +1450,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-async-generator-functions (15/19)
-* async-generators/class-method/input.js
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "_this"]
-rebuilt        : ScopeId(0): ["C"]
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(2): ["_this"]
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(0)
-rebuilt        : SymbolId(1): ScopeId(2)
-
-* async-generators/object-method/input.js
-Bindings mismatch:
-after transform: ScopeId(0): ["_this"]
-rebuilt        : ScopeId(0): []
-Bindings mismatch:
-after transform: ScopeId(2): []
-rebuilt        : ScopeId(1): ["_this"]
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(0): ScopeId(0)
-rebuilt        : SymbolId(0): ScopeId(1)
-
-* async-generators/static-method/input.js
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "_this"]
-rebuilt        : ScopeId(0): ["C"]
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(2): ["_this"]
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(0)
-rebuilt        : SymbolId(1): ScopeId(2)
-
+# babel-plugin-transform-async-generator-functions (18/19)
 * nested/arrows-in-declaration/input.js
 x Output mismatch
 
@@ -1652,7 +1619,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-async-to-generator (9/24)
+# babel-plugin-transform-async-to-generator (10/24)
 * assumption-ignoreFunctionLength-true/basic/input.mjs
 x Output mismatch
 
@@ -1694,17 +1661,6 @@ x Output mismatch
 
 * regression/in-uncompiled-class-fields/input.js
 x Output mismatch
-
-* regression/regression-2765/input.js
-Bindings mismatch:
-after transform: ScopeId(10): []
-rebuilt        : ScopeId(6): ["_this2"]
-Bindings mismatch:
-after transform: ScopeId(4): ["_this2", "c"]
-rebuilt        : ScopeId(7): ["c"]
-Symbol scope ID mismatch for "_this2":
-after transform: SymbolId(8): ScopeId(4)
-rebuilt        : SymbolId(6): ScopeId(6)
 
 
 # babel-plugin-transform-exponentiation-operator (3/4)


### PR DESCRIPTION
The scope can be moved or deleted, we need to check whether the scope id is the same as the container's scope id, if not, we need to move the `this_var` to the target scope id.