### PR TITLE
refactor(transformer): use `scope_id` etc methods

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -378,6 +378,10 @@ impl<'a> ArrowFunctionConverter<'a> {
         arrow_function_expr: ArrowFunctionExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
+        let scope_id = arrow_function_expr.scope_id();
+        let flags = ctx.scopes_mut().get_flags_mut(scope_id);
+        *flags &= !ScopeFlags::Arrow;
+
         let mut body = arrow_function_expr.body;
 
         if arrow_function_expr.expression {
@@ -388,10 +392,6 @@ impl<'a> ArrowFunctionConverter<'a> {
             let return_statement = ctx.ast.statement_return(stmt.span, Some(stmt.expression));
             body.statements.push(return_statement);
         }
-
-        let scope_id = arrow_function_expr.scope_id.get().unwrap();
-        let flags = ctx.scopes_mut().get_flags_mut(scope_id);
-        *flags &= !ScopeFlags::Arrow;
 
         Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
             FunctionType::FunctionExpression,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -254,7 +254,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             // so we need to move the id to the new scope.
             if let Some(id) = id.as_ref() {
                 Self::move_binding_identifier_to_target_scope(wrapper_scope_id, id, ctx);
-                let symbol_id = id.symbol_id.get().unwrap();
+                let symbol_id = id.symbol_id();
                 *ctx.symbols_mut().get_flags_mut(symbol_id) = SymbolFlags::FunctionScopedVariable;
             }
             (scope_id, wrapper_scope_id)
@@ -291,7 +291,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 let reference = ctx.create_bound_reference_id(
                     SPAN,
                     id.name.clone(),
-                    id.symbol_id.get().unwrap(),
+                    id.symbol_id(),
                     ReferenceFlags::Read,
                 );
                 let statement = Statement::FunctionDeclaration(caller_function);
@@ -403,7 +403,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         }
 
         let params = ctx.alloc(ctx.ast.move_formal_parameters(&mut arrow.params));
-        let generator_function_id = arrow.scope_id.get().unwrap();
+        let generator_function_id = arrow.scope_id();
         ctx.scopes_mut().get_flags_mut(generator_function_id).remove(ScopeFlags::Arrow);
         let function_name = Self::get_function_name_from_parent_variable_declarator(ctx);
 
@@ -727,7 +727,7 @@ impl<'a, 'ctx> Visit<'a> for BindingMover<'a, 'ctx> {
     /// Visits a binding identifier and moves it to the target scope.
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         let symbols = self.ctx.symbols();
-        let symbol_id = ident.symbol_id.get().unwrap();
+        let symbol_id = ident.symbol_id();
         let current_scope_id = symbols.get_scope_id(symbol_id);
         let scopes = self.ctx.scopes_mut();
         scopes.move_binding(current_scope_id, self.target_scope_id, ident.name.as_str());

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -58,7 +58,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
                 if block.body.is_empty() {
                     // If the block is empty, we don’t need to add it to the body;
                     // instead, we need to remove the useless scope.
-                    ctx.scopes_mut().delete_scope(block.scope_id.get().unwrap());
+                    ctx.scopes_mut().delete_scope(block.scope_id());
                 } else {
                     statements.push(ctx.ast.move_statement(stmt_body));
                 }
@@ -71,7 +71,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
             ctx.ast.move_expression(&mut stmt.right),
             &step_key,
             body,
-            stmt.scope_id.get().unwrap(),
+            stmt.scope_id(),
             ctx,
         )
     }

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -56,7 +56,7 @@ impl<'a> Traverse<'a> for OptionalCatchBinding {
 
         let binding = ctx.generate_uid(
             "unused",
-            clause.body.scope_id.get().unwrap(),
+            clause.body.scope_id(),
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );
         let binding_pattern = binding.create_binding_pattern(ctx);

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -138,7 +138,7 @@ impl ClassStaticBlock {
         block: &mut StaticBlock<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let scope_id = block.scope_id.get().unwrap();
+        let scope_id = block.scope_id();
 
         // If block contains only a single `ExpressionStatement`, no need to wrap in an IIFE.
         // `static { foo }` -> `foo`

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -186,16 +186,13 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let signature = match expr {
             Expression::FunctionExpression(func) => self.create_signature_call_expression(
-                func.scope_id.get().unwrap(),
+                func.scope_id(),
                 func.body.as_mut().unwrap(),
                 ctx,
             ),
             Expression::ArrowFunctionExpression(arrow) => {
-                let call_fn = self.create_signature_call_expression(
-                    arrow.scope_id.get().unwrap(),
-                    &mut arrow.body,
-                    ctx,
-                );
+                let call_fn =
+                    self.create_signature_call_expression(arrow.scope_id(), &mut arrow.body, ctx);
 
                 // If the signature is found, we will push a new statement to the arrow function body. So it's not an expression anymore.
                 if call_fn.is_some() {
@@ -263,7 +260,7 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
         }
 
         let Some((binding_identifier, mut arguments)) = self.create_signature_call_expression(
-            func.scope_id.get().unwrap(),
+            func.scope_id(),
             func.body.as_mut().unwrap(),
             ctx,
         ) else {
@@ -502,7 +499,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         let right = ctx.create_bound_reference_id(
             SPAN,
             id.name.clone(),
-            id.symbol_id.get().unwrap(),
+            id.symbol_id(),
             ReferenceFlags::Read,
         );
         let right = Expression::Identifier(ctx.alloc(right));
@@ -724,7 +721,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         let declarator = decl.declarations.first_mut().unwrap_or_else(|| unreachable!());
         let init = declarator.init.as_mut()?;
         let id = declarator.id.get_binding_identifier()?;
-        let symbol_id = id.symbol_id.get().unwrap();
+        let symbol_id = id.symbol_id();
 
         if !is_componentish_name(&id.name) {
             return None;

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::unused_self)]
 
-use std::cell::Cell;
-
 use rustc_hash::FxHashSet;
 
 use oxc_allocator::Vec as ArenaVec;
@@ -87,9 +85,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
                                 || self.type_identifier_names.contains(&specifier.exported.name())
                                 || matches!(
                                     &specifier.local, ModuleExportName::IdentifierReference(ident)
-                                    if ident.reference_id.get().is_some_and(|reference_id| {
-                                        ctx.symbols().get_reference(reference_id).is_type()
-                                    })
+                                    if ctx.symbols().get_reference(ident.reference_id()).is_type()
                                 ))
                         });
                         // Keep the export declaration if there are still specifiers after removing type exports
@@ -303,7 +299,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
                         self.assignments.push(Assignment {
                             span: id.span,
                             name: id.name.clone(),
-                            symbol_id: id.symbol_id.get().unwrap(),
+                            symbol_id: id.symbol_id(),
                         });
                     }
                 }
@@ -481,27 +477,18 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
     }
 
     fn enter_for_statement(&mut self, stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        Self::replace_for_statement_body_with_empty_block_if_ts(
-            &mut stmt.body,
-            &stmt.scope_id,
-            ctx,
-        );
+        let scope_id = stmt.scope_id();
+        Self::replace_for_statement_body_with_empty_block_if_ts(&mut stmt.body, scope_id, ctx);
     }
 
     fn enter_for_in_statement(&mut self, stmt: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        Self::replace_for_statement_body_with_empty_block_if_ts(
-            &mut stmt.body,
-            &stmt.scope_id,
-            ctx,
-        );
+        let scope_id = stmt.scope_id();
+        Self::replace_for_statement_body_with_empty_block_if_ts(&mut stmt.body, scope_id, ctx);
     }
 
     fn enter_for_of_statement(&mut self, stmt: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        Self::replace_for_statement_body_with_empty_block_if_ts(
-            &mut stmt.body,
-            &stmt.scope_id,
-            ctx,
-        );
+        let scope_id = stmt.scope_id();
+        Self::replace_for_statement_body_with_empty_block_if_ts(&mut stmt.body, scope_id, ctx);
     }
 
     fn enter_while_statement(&mut self, stmt: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -564,11 +551,10 @@ impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
 
     fn replace_for_statement_body_with_empty_block_if_ts(
         body: &mut Statement<'a>,
-        scope_id: &Cell<Option<ScopeId>>,
+        parent_scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let scope_id = scope_id.get().unwrap_or(ctx.current_scope_id());
-        Self::replace_with_empty_block_if_ts(body, scope_id, ctx);
+        Self::replace_with_empty_block_if_ts(body, parent_scope_id, ctx);
     }
 
     fn replace_with_empty_block_if_ts(

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -75,7 +75,7 @@ impl<'a> TypeScriptEnum<'a> {
         let is_not_top_scope = !ctx.scopes().get_flags(ctx.current_scope_id()).is_top();
 
         let enum_name = decl.id.name.clone();
-        let func_scope_id = decl.scope_id.get().unwrap();
+        let func_scope_id = decl.scope_id();
         let param_binding = ctx.generate_binding(
             enum_name.clone(),
             func_scope_id,
@@ -114,7 +114,7 @@ impl<'a> TypeScriptEnum<'a> {
             func_scope_id,
         ));
 
-        let var_symbol_id = decl.id.symbol_id.get().unwrap();
+        let var_symbol_id = decl.id.symbol_id();
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {
             // }({});
             let object_expr = ast.expression_object(SPAN, ast.vec(), None);

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -93,8 +93,7 @@ impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
         match type_name {
             TSTypeName::IdentifierReference(ident) => {
                 let ident = ident.clone();
-                let reference_id = ident.reference_id.get().unwrap();
-                let reference = ctx.symbols_mut().get_reference_mut(reference_id);
+                let reference = ctx.symbols_mut().get_reference_mut(ident.reference_id());
                 *reference.flags_mut() = ReferenceFlags::Read;
                 Expression::Identifier(ctx.alloc(ident))
             }


### PR DESCRIPTION
Utilize the methods added in #7127 in transformer.