### PR TITLE
refactor(traverse): use `symbol_id` etc methods

### DIFF
--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -50,9 +50,8 @@ impl<'a> BoundIdentifier<'a> {
     }
 
     /// Create `BoundIdentifier` from a `BindingIdentifier`
-    #[expect(clippy::missing_panics_doc)]
     pub fn from_binding_ident(ident: &BindingIdentifier<'a>) -> Self {
-        Self { name: ident.name.clone(), symbol_id: ident.symbol_id.get().unwrap() }
+        Self { name: ident.name.clone(), symbol_id: ident.symbol_id() }
     }
 
     /// Create `BindingIdentifier` for this binding

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -538,10 +538,7 @@ impl<'a> TraverseCtx<'a> {
         ident: &IdentifierReference<'a>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference =
-            self.symbols().get_reference(ident.reference_id.get().unwrap_or_else(|| {
-                unreachable!("IdentifierReference must have a reference_id");
-            }));
+        let reference = self.symbols().get_reference(ident.reference_id());
         let symbol_id = reference.symbol_id();
         self.create_reference_id(ident.span, ident.name.clone(), symbol_id, flags)
     }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -369,13 +369,13 @@ impl TraverseScoping {
     pub fn is_static(&self, expr: &Expression) -> bool {
         match expr {
             Expression::ThisExpression(_) | Expression::Super(_) => true,
-            Expression::Identifier(ident) => self
-                .symbols
-                .get_reference(ident.reference_id.get().unwrap())
-                .symbol_id()
-                .is_some_and(|symbol_id| {
-                    self.symbols.get_resolved_references(symbol_id).all(|r| !r.is_write())
-                }),
+            Expression::Identifier(ident) => {
+                self.symbols.get_reference(ident.reference_id()).symbol_id().is_some_and(
+                    |symbol_id| {
+                        self.symbols.get_resolved_references(symbol_id).all(|r| !r.is_write())
+                    },
+                )
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
Utilize the methods added in #7127 in `oxc_traverse`.