### PR TITLE
refactor(transformer/async-generator-functions): do not transform await expression where inside ArrowFunctionExpression

### DIFF
--- a/crates/oxc_transformer/src/es2018/mod.rs
+++ b/crates/oxc_transformer/src/es2018/mod.rs
@@ -62,12 +62,6 @@ impl<'a, 'ctx> Traverse<'a> for ES2018<'a, 'ctx> {
         }
     }
 
-    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
-        if self.options.async_generator_functions {
-            self.async_generator_functions.enter_function(node, ctx);
-        }
-    }
-
     fn exit_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.async_generator_functions {
             self.async_generator_functions.exit_function(node, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -266,7 +266,6 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
     }
 
     fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.x2_es2018.enter_function(func, ctx);
         self.common.enter_function(func, ctx);
     }
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,11 +1,12 @@
 commit: d20b314c
 
-Passed: 381/1078
+Passed: 382/1078
 
 # All Passed:
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-optional-catch-binding
+* babel-plugin-transform-async-generator-functions
 * babel-preset-react
 * babel-plugin-transform-react-display-name
 * babel-plugin-transform-react-jsx-self
@@ -1447,11 +1448,6 @@ x Output mismatch
 x Output mismatch
 
 * nullish-coalescing/transform-loose/input.js
-x Output mismatch
-
-
-# babel-plugin-transform-async-generator-functions (18/19)
-* nested/arrows-in-declaration/input.js
 x Output mismatch
 
 


### PR DESCRIPTION
The `await expr` should be transformed in AsyncToGenerator rather than AsyncGeneratorFunctions