### PR TITLE
fix(transformer/async-generator-functions): transform incorrectly for `for await` if it's in LabeledStatement

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 76/85
+Passed: 77/86
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/with-labeled-statement/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/with-labeled-statement/input.js
@@ -1,0 +1,10 @@
+async function* handleAsyncIterable(asyncIterable) {
+  outer: for await (const chunk of asyncIterable) {
+      for (;;) {
+          if (delimIndex === -1) {
+              // incomplete message, wait for more chunks
+              continue outer;
+          }
+      }
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/with-labeled-statement/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-generator-functions/test/fixtures/for-await/with-labeled-statement/output.js
@@ -1,0 +1,37 @@
+function handleAsyncIterable(_x) {
+  return _handleAsyncIterable.apply(this, arguments);
+}
+function _handleAsyncIterable() {
+  _handleAsyncIterable = babelHelpers.wrapAsyncGenerator(function* (asyncIterable) {
+    var _iteratorAbruptCompletion = false;
+    var _didIteratorError = false;
+    var _iteratorError;
+    try {
+      outer: for (var _iterator = babelHelpers.asyncIterator(asyncIterable), _step; _iteratorAbruptCompletion = !(_step = yield babelHelpers.awaitAsyncGenerator(_iterator.next())).done; _iteratorAbruptCompletion = false) {
+        const chunk = _step.value;
+        {
+          for (;;) {
+            if (delimIndex === -1) {
+              // incomplete message, wait for more chunks
+              continue outer;
+            }
+          }
+        }
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (_iteratorAbruptCompletion && _iterator.return != null) {
+          yield babelHelpers.awaitAsyncGenerator(_iterator.return());
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
+    }
+  });
+  return _handleAsyncIterable.apply(this, arguments);
+}


### PR DESCRIPTION
Found in https://github.com/oxc-project/monitor-oxc/actions/runs/11681867380/job/32527898715