### PR TITLE
feat(ast_tools): Add #[estree(append_to)], remove some custom serialization code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,9 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.35.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "oxc_index"

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -42,4 +42,5 @@ serialize = [
   "oxc_span/serialize",
   "oxc_syntax/serialize",
   "oxc_syntax/to_js_string",
+  "oxc_estree/serialize",
 ]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -805,12 +805,11 @@ pub use match_assignment_target_pattern;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(custom_serialize)]
 pub struct ArrayAssignmentTarget<'a> {
     pub span: Span,
     #[estree(type = "Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>")]
     pub elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
-    #[estree(skip)]
+    #[estree(append_to = "elements")]
     pub rest: Option<AssignmentTargetRest<'a>>,
     #[estree(skip)]
     pub trailing_comma: Option<Span>,
@@ -822,12 +821,11 @@ pub struct ArrayAssignmentTarget<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(custom_serialize)]
 pub struct ObjectAssignmentTarget<'a> {
     pub span: Span,
     #[estree(type = "Array<AssignmentTargetProperty | AssignmentTargetRest>")]
     pub properties: Vec<'a, AssignmentTargetProperty<'a>>,
-    #[estree(skip)]
+    #[estree(append_to = "properties")]
     pub rest: Option<AssignmentTargetRest<'a>>,
 }
 
@@ -1482,12 +1480,11 @@ pub struct AssignmentPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(custom_serialize)]
 pub struct ObjectPattern<'a> {
     pub span: Span,
     #[estree(type = "Array<BindingProperty | BindingRestElement>")]
     pub properties: Vec<'a, BindingProperty<'a>>,
-    #[estree(skip)]
+    #[estree(append_to = "properties")]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
 }
 
@@ -1506,12 +1503,11 @@ pub struct BindingProperty<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(custom_serialize)]
 pub struct ArrayPattern<'a> {
     pub span: Span,
     #[estree(type = "Array<BindingPattern | BindingRestElement | null>")]
     pub elements: Vec<'a, Option<BindingPattern<'a>>>,
-    #[estree(skip)]
+    #[estree(append_to = "elements")]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -707,6 +707,26 @@ impl<'a> Serialize for AssignmentTargetPattern<'a> {
     }
 }
 
+impl<'a> Serialize for ArrayAssignmentTarget<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "ArrayAssignmentTarget")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("elements", &oxc_estree::AppendTo(&self.elements, &self.rest))?;
+        map.end()
+    }
+}
+
+impl<'a> Serialize for ObjectAssignmentTarget<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "ObjectAssignmentTarget")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("properties", &oxc_estree::AppendTo(&self.properties, &self.rest))?;
+        map.end()
+    }
+}
+
 impl<'a> Serialize for AssignmentTargetRest<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
@@ -1311,6 +1331,16 @@ impl<'a> Serialize for AssignmentPattern<'a> {
     }
 }
 
+impl<'a> Serialize for ObjectPattern<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "ObjectPattern")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("properties", &oxc_estree::AppendTo(&self.properties, &self.rest))?;
+        map.end()
+    }
+}
+
 impl<'a> Serialize for BindingProperty<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
@@ -1320,6 +1350,16 @@ impl<'a> Serialize for BindingProperty<'a> {
         map.serialize_entry("value", &self.value)?;
         map.serialize_entry("shorthand", &self.shorthand)?;
         map.serialize_entry("computed", &self.computed)?;
+        map.end()
+    }
+}
+
+impl<'a> Serialize for ArrayPattern<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "ArrayPattern")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("elements", &oxc_estree::AppendTo(&self.elements, &self.rest))?;
         map.end()
     }
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -6,11 +6,9 @@ use serde::{
 };
 
 use crate::ast::{
-    ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
-    AssignmentTargetRest, BindingPattern, BindingPatternKind, BindingProperty, BindingRestElement,
-    Directive, Elision, FormalParameter, FormalParameterKind, FormalParameters, JSXElementName,
-    JSXIdentifier, JSXMemberExpressionObject, ObjectAssignmentTarget, ObjectPattern, Program,
-    RegExpFlags, Statement, StringLiteral, TSModuleBlock, TSTypeAnnotation,
+    BindingPatternKind, Directive, Elision, FormalParameter, FormalParameterKind, FormalParameters,
+    JSXElementName, JSXIdentifier, JSXMemberExpressionObject, Program, RegExpFlags, Statement,
+    StringLiteral, TSModuleBlock, TSTypeAnnotation,
 };
 
 pub struct EcmaFormatter;
@@ -59,82 +57,6 @@ impl Serialize for Elision {
     {
         serializer.serialize_none()
     }
-}
-
-/// Serialize `ArrayAssignmentTarget`, `ObjectAssignmentTarget`, `ObjectPattern`, `ArrayPattern`
-/// to be estree compatible, with `elements`/`properties` and `rest` fields combined.
-
-impl<'a> Serialize for ArrayAssignmentTarget<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let converted = SerArrayAssignmentTarget {
-            span: self.span,
-            elements: ElementsAndRest::new(&self.elements, &self.rest),
-        };
-        converted.serialize(serializer)
-    }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename = "ArrayAssignmentTarget", rename_all = "camelCase")]
-struct SerArrayAssignmentTarget<'a, 'b> {
-    #[serde(flatten)]
-    span: Span,
-    elements:
-        ElementsAndRest<'b, Option<AssignmentTargetMaybeDefault<'a>>, AssignmentTargetRest<'a>>,
-}
-
-impl<'a> Serialize for ObjectAssignmentTarget<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let converted = SerObjectAssignmentTarget {
-            span: self.span,
-            properties: ElementsAndRest::new(&self.properties, &self.rest),
-        };
-        converted.serialize(serializer)
-    }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename = "ObjectAssignmentTarget")]
-struct SerObjectAssignmentTarget<'a, 'b> {
-    #[serde(flatten)]
-    span: Span,
-    properties: ElementsAndRest<'b, AssignmentTargetProperty<'a>, AssignmentTargetRest<'a>>,
-}
-
-impl<'a> Serialize for ObjectPattern<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let converted = SerObjectPattern {
-            span: self.span,
-            properties: ElementsAndRest::new(&self.properties, &self.rest),
-        };
-        converted.serialize(serializer)
-    }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename = "ObjectPattern")]
-struct SerObjectPattern<'a, 'b> {
-    #[serde(flatten)]
-    span: Span,
-    properties: ElementsAndRest<'b, BindingProperty<'a>, Box<'a, BindingRestElement<'a>>>,
-}
-
-impl<'a> Serialize for ArrayPattern<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let converted = SerArrayPattern {
-            span: self.span,
-            elements: ElementsAndRest::new(&self.elements, &self.rest),
-        };
-        converted.serialize(serializer)
-    }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename = "ArrayPattern")]
-struct SerArrayPattern<'a, 'b> {
-    #[serde(flatten)]
-    span: Span,
-    elements: ElementsAndRest<'b, Option<BindingPattern<'a>>, Box<'a, BindingRestElement<'a>>>,
 }
 
 /// Serialize `FormalParameters`, to be estree compatible, with `items` and `rest` fields combined

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -13,6 +13,11 @@ rust-version.workspace = true
 description.workspace = true
 
 [dependencies]
+serde = { workspace = true, optional = true }
 
 [lints]
 workspace = true
+
+[features]
+default = []
+serialize = ["dep:serde"]

--- a/crates/oxc_estree/src/lib.rs
+++ b/crates/oxc_estree/src/lib.rs
@@ -1,3 +1,25 @@
+#[cfg(feature = "serialize")]
+use serde::ser::{Serialize, SerializeSeq, Serializer};
+
 /// Empty trait that will be used later for custom serialization and TypeScript
 /// generation for AST nodes.
 pub trait ESTree {}
+
+#[cfg(feature = "serialize")]
+pub struct AppendTo<'a, TVec, TChild>(pub &'a [TVec], pub &'a Option<TChild>);
+
+#[cfg(feature = "serialize")]
+impl<'b, TVec: Serialize, TChild: Serialize> Serialize for AppendTo<'b, TVec, TChild> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if let Some(child) = self.1 {
+            let mut seq = serializer.serialize_seq(Some(self.0.len() + 1))?;
+            for element in self.0 {
+                seq.serialize_element(element)?;
+            }
+            seq.serialize_element(child)?;
+            seq.end()
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -34,4 +34,9 @@ serde = { workspace = true, optional = true }
 
 [features]
 default = []
-serialize = ["dep:serde", "oxc_allocator/serialize", "oxc_span/serialize"]
+serialize = [
+  "dep:serde",
+  "oxc_allocator/serialize",
+  "oxc_span/serialize",
+  "oxc_estree/serialize",
+]

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -32,5 +32,5 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 default = []
-serialize = ["compact_str/serde", "dep:serde"]
+serialize = ["compact_str/serde", "dep:serde", "oxc_estree/serialize"]
 schemars = ["dep:schemars"]

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -41,7 +41,13 @@ wasm-bindgen = { workspace = true, optional = true }
 [features]
 default = []
 to_js_string = ["dep:ryu-js"]
-serialize = ["bitflags/serde", "dep:serde", "dep:wasm-bindgen", "oxc_index/serialize"]
+serialize = [
+  "bitflags/serde",
+  "dep:serde",
+  "dep:wasm-bindgen",
+  "oxc_index/serialize",
+  "oxc_estree/serialize",
+]
 
 [package.metadata.cargo-shear]
 # We use `oxc_ast_macros::CloneIn` which expands to use `oxc_allocator`.

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -384,11 +384,13 @@ export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTa
 export interface ArrayAssignmentTarget extends Span {
   type: 'ArrayAssignmentTarget';
   elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
+  rest: AssignmentTargetRest | null;
 }
 
 export interface ObjectAssignmentTarget extends Span {
   type: 'ObjectAssignmentTarget';
   properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
+  rest: AssignmentTargetRest | null;
 }
 
 export interface AssignmentTargetRest extends Span {
@@ -726,6 +728,7 @@ export interface AssignmentPattern extends Span {
 export interface ObjectPattern extends Span {
   type: 'ObjectPattern';
   properties: Array<BindingProperty | BindingRestElement>;
+  rest: BindingRestElement | null;
 }
 
 export interface BindingProperty extends Span {
@@ -739,6 +742,7 @@ export interface BindingProperty extends Span {
 export interface ArrayPattern extends Span {
   type: 'ArrayPattern';
   elements: Array<BindingPattern | BindingRestElement | null>;
+  rest: BindingRestElement | null;
 }
 
 export interface BindingRestElement extends Span {

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -211,6 +211,7 @@ pub struct ESTreeFieldAttribute {
     pub skip: bool,
     pub rename: Option<String>,
     pub typescript_type: Option<String>,
+    pub append_to: Option<String>,
 }
 
 impl Parse for ESTreeFieldAttribute {
@@ -219,6 +220,7 @@ impl Parse for ESTreeFieldAttribute {
         let mut skip = false;
         let mut rename = None;
         let mut typescript_type = None;
+        let mut append_to = None;
 
         loop {
             let is_type = input.peek(Token![type]);
@@ -257,6 +259,13 @@ impl Parse for ESTreeFieldAttribute {
                         "Duplicate estree(type)"
                     );
                 }
+                "append_to" => {
+                    input.parse::<Token![=]>()?;
+                    assert!(
+                        append_to.replace(input.parse::<LitStr>()?.value()).is_none(),
+                        "Duplicate estree(append_to)"
+                    );
+                }
                 arg => panic!("Unsupported #[estree(...)] argument: {arg}"),
             }
             let comma = input.peek(Token![,]);
@@ -266,7 +275,7 @@ impl Parse for ESTreeFieldAttribute {
                 break;
             }
         }
-        Ok(Self { flatten, skip, rename, typescript_type })
+        Ok(Self { flatten, skip, rename, typescript_type, append_to })
     }
 }
 


### PR DESCRIPTION
Removed custom logic for ObjectPattern, ArrayPattern, etc. in favor of a custom attribute macro `#[estree(append_to = "foo")]` as part of #6347