### PR TITLE
refactor(transformer/jsx-self): remove unused `&self` function params

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -610,7 +610,7 @@ impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
 
         // React.createElement's second argument
         if !is_fragment && is_classic {
-            if self.options.jsx_self_plugin && self.jsx_self.can_add_self_attribute(ctx) {
+            if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
                 if let Some(span) = self_attr_span {
                     self.jsx_self.report_error(span);
                 } else {
@@ -689,7 +689,7 @@ impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
                 }
 
                 // this
-                if self.options.jsx_self_plugin && self.jsx_self.can_add_self_attribute(ctx) {
+                if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
                     if let Some(span) = self_attr_span {
                         self.jsx_self.report_error(span);
                     } else {

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -63,8 +63,7 @@ impl<'a, 'ctx> JsxSelf<'a, 'ctx> {
         self.ctx.error(error);
     }
 
-    #[allow(clippy::unused_self)]
-    fn is_inside_constructor(&self, ctx: &TraverseCtx<'a>) -> bool {
+    fn is_inside_constructor(ctx: &TraverseCtx<'a>) -> bool {
         for scope_id in ctx.ancestor_scopes() {
             let flags = ctx.scopes().get_flags(scope_id);
             if flags.is_block() || flags.is_arrow() {
@@ -94,8 +93,8 @@ impl<'a, 'ctx> JsxSelf<'a, 'ctx> {
             .object_property_kind_object_property(SPAN, kind, key, value, None, false, false, false)
     }
 
-    pub fn can_add_self_attribute(&self, ctx: &TraverseCtx<'a>) -> bool {
-        !self.is_inside_constructor(ctx) || Self::has_no_super_class(ctx)
+    pub fn can_add_self_attribute(ctx: &TraverseCtx<'a>) -> bool {
+        !Self::is_inside_constructor(ctx) || Self::has_no_super_class(ctx)
     }
 
     /// `<div __self={this} />`

--- a/crates/oxc_transformer/src/jsx/mod.rs
+++ b/crates/oxc_transformer/src/jsx/mod.rs
@@ -16,6 +16,7 @@ use refresh::ReactRefresh;
 
 pub use display_name::ReactDisplayName;
 pub use jsx_impl::JsxImpl;
+use jsx_self::JsxSelf;
 pub use options::{JsxOptions, JsxRuntime, ReactRefreshOptions};
 
 pub(crate) use comments::update_options_with_comments;
@@ -103,7 +104,7 @@ impl<'a, 'ctx> Traverse<'a> for Jsx<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         if !self.enable_jsx_plugin {
-            if self.self_plugin && self.implementation.jsx_self.can_add_self_attribute(ctx) {
+            if self.self_plugin && JsxSelf::can_add_self_attribute(ctx) {
                 self.implementation.jsx_self.enter_jsx_opening_element(elem, ctx);
             }
             if self.source_plugin {


### PR DESCRIPTION
Small nit. Removing the unused `&self` param makes these function calls slightly cheaper.