### PR TITLE
refactor(transformer/async-generator-function): remove inactive `#[allow(clippy::unused_self)]` attrs

### DIFF
--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -177,7 +177,6 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
     }
 
     /// Transform `yield * argument` expression to `yield asyncGeneratorDelegate(asyncIterator(argument))`.
-    #[allow(clippy::unused_self)]
     fn transform_yield_expression(
         &self,
         expr: &mut YieldExpression<'a>,
@@ -199,7 +198,6 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
 
     /// Transforms `await expr` expression to `yield awaitAsyncGenerator(expr)`.
     /// Ignores top-level await expression.
-    #[allow(clippy::unused_self)]
     fn transform_await_expression(
         &self,
         expr: &mut AwaitExpression<'a>,


### PR DESCRIPTION
Follow-on after stack up to #7148. Remove 2 x `#[allow(clippy::unused_self)]` attrs where that lint isn't triggered because the functions do use their `&self` param.