### PR TITLE
style(transformer/arrow-functions): semicolon after return statements

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -386,14 +386,14 @@ impl<'a> ArrowFunctionConverter<'a> {
                         None
                     } else {
                         Some(func.scope_id().get().unwrap())
-                    }
+                    };
                 }
                 Ancestor::ArrowFunctionExpressionBody(func) => {
                     return if self.is_async_only() && !*func.r#async() {
                         None
                     } else {
                         Some(func.scope_id().get().unwrap())
-                    }
+                    };
                 }
                 // Function body
                 Ancestor::FunctionBody(func) => {
@@ -405,7 +405,7 @@ impl<'a> ArrowFunctionConverter<'a> {
                         Some(func.scope_id().get().unwrap())
                     } else {
                         None
-                    }
+                    };
                 }
                 _ => {}
             }


### PR DESCRIPTION
Follow-on after stack up to #7148. Style nit. End statements with semi-colons. Usually clippy demands this, not sure why it didn't here.