### PR TITLE
refactor(transformer/arrow-functions): pass `ArenaBox` as function param

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -277,7 +277,7 @@ impl<'a> Traverse<'a> for ArrowFunctionConverter<'a> {
                 unreachable!()
             };
 
-            *expr = Self::transform_arrow_function_expression(arrow_function_expr.unbox(), ctx);
+            *expr = Self::transform_arrow_function_expression(arrow_function_expr, ctx);
         }
     }
 }
@@ -414,9 +414,10 @@ impl<'a> ArrowFunctionConverter<'a> {
     }
 
     fn transform_arrow_function_expression(
-        arrow_function_expr: ArrowFunctionExpression<'a>,
+        arrow_function_expr: ArenaBox<'a, ArrowFunctionExpression<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
+        let arrow_function_expr = arrow_function_expr.unbox();
         let scope_id = arrow_function_expr.scope_id();
         let flags = ctx.scopes_mut().get_flags_mut(scope_id);
         *flags &= !ScopeFlags::Arrow;


### PR DESCRIPTION
Follow-on after stack up to #7148.

Small optimization. `ArrowFunctionExpression` is 56 bytes, whereas `ArenaBox<ArrowFunctionExpression>` is 8 bytes. So it's preferable to pass the `ArenaBox<ArrowFunctionExpression>` to `transform_arrow_function_expression` and call `unbox` on it there instead of unboxing *before* passing to the function.