### PR TITLE
refactor(transformer/async-generator-functions): use `clone` not `clone_in` on `LabelIdentifier`

### DIFF
--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -1,6 +1,6 @@
 //! This module is responsible for transforming `for await` to `for` statement
 
-use oxc_allocator::{CloneIn, Vec};
+use oxc_allocator::Vec;
 use oxc_ast::{ast::*, NONE};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::SPAN;
@@ -71,7 +71,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
             let for_statement = try_statement_block_body.pop().unwrap();
             try_statement_block_body.push(ctx.ast.statement_labeled(
                 SPAN,
-                label.clone_in(ctx.ast.allocator),
+                label.clone(),
                 for_statement,
             ));
         }


### PR DESCRIPTION
Follow-on after stack up to #7148.

Small optimization. `LabelIdentifier` is `Clone` so we can use `Clone::clone` to clone it, instead of `CloneIn::clone_in`.

The difference is that `clone_in` makes a 2nd copy of the `Atom`'s string in the arena, whereas `clone` creates a new `Atom` referencing the same string. This is an unfortunate shortcoming of `CloneIn` (https://github.com/oxc-project/backlog/issues/96), but the more we can avoid `CloneIn`, the better.