### PR TITLE
refactor(minifier): use `map` and `and_then` instead of let else

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -103,14 +103,11 @@ impl<'a> Traverse<'a> for PeepholeSubstituteAlternateSyntax {
                 }
             }
             Expression::CallExpression(call_expr) => {
-                if let Some(call_expr) =
+                if let Some(new_expr) =
                     Self::try_fold_literal_constructor_call_expression(call_expr, ctx)
+                        .or_else(|| Self::try_fold_simple_function_call(call_expr, ctx))
                 {
-                    *expr = call_expr;
-                    self.changed = true;
-                } else if let Some(call_expr) = Self::try_fold_simple_function_call(call_expr, ctx)
-                {
-                    *expr = call_expr;
+                    *expr = new_expr;
                     self.changed = true;
                 }
             }


### PR DESCRIPTION
For the test case, Closure Compiler doesn't handle this at all in the REPL! If it's necessary, I will turn it back.

This PR uses builtin `and_then` and `map` method, which is better instead of a lot of `if let Some`.