### PR TITLE
fix(editor/vscode): Update language client id to fix the resolution of the oxc.trace.server setting

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -9,7 +9,6 @@ import { Executable, LanguageClient, LanguageClientOptions, ServerOptions } from
 import { join } from 'node:path';
 import { ConfigService } from './config';
 
-const languageClientId = 'oxc-vscode';
 const languageClientName = 'oxc';
 const outputChannelName = 'Oxc';
 const traceOutputChannelName = 'Oxc (Trace)';
@@ -168,7 +167,6 @@ export async function activate(context: ExtensionContext) {
 
   // Create the language client and start the client.
   client = new LanguageClient(
-    languageClientId,
     languageClientName,
     serverOptions,
     clientOptions,


### PR DESCRIPTION
Currently `oxc-vscode.trace.server` needs to be used to enable trace logging for the language server.  This fixes it so that `oxc.trace.server` can be used.  I can't find any guidance on what should be used for the language client id.  The VS Code ESLint plugin uses "ESLint", so I think this change should be fine.

Ref https://github.com/oxc-project/oxc/issues/7136.