### PR TITLE
feat(editor/vscode): Replace existing output channel and trace output channel with a single LogOutputChannel

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -52,11 +52,6 @@
         "command": "oxc.showOutputChannel",
         "title": "Show Output Channel",
         "category": "Oxc"
-      },
-      {
-        "command": "oxc.showTraceOutputChannel",
-        "title": "Show Trace Output Channel",
-        "category": "Oxc"
       }
     ],
     "configuration": {


### PR DESCRIPTION
I don't think we need two separate channels for output.  This replaces the 2 existing channels with a single channel that allows configuring the log level.

Ref #7136