### PR TITLE
fix(transformer/async-generator-functions): only transform object method in exit_function

### DIFF
--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -145,11 +145,7 @@ impl<'a, 'ctx> Traverse<'a> for AsyncGeneratorFunctions<'a, 'ctx> {
         if func.r#async
             && func.generator
             && !func.is_typescript_syntax()
-            && matches!(
-                ctx.parent(),
-                // `class A { async foo() {} }` | `({ async foo() {} })`
-                Ancestor::MethodDefinitionValue(_) | Ancestor::ObjectPropertyValue(_)
-            )
+            && AsyncGeneratorExecutor::is_class_method_like_ancestor(ctx.parent())
         {
             self.executor.transform_function_for_method_definition(func, ctx);
         }


### PR DESCRIPTION
close: #7175