### PR TITLE
feat(transformer):  add ast changed hint in `InjectGlobalVariables`

### DIFF
--- a/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
@@ -3,34 +3,44 @@ use oxc_codegen::{CodeGenerator, CodegenOptions};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
-use oxc_transformer::{ReplaceGlobalDefines, ReplaceGlobalDefinesConfig};
+use oxc_transformer::{
+    ReplaceGlobalDefines, ReplaceGlobalDefinesConfig, ReplaceGlobalDefinesReturn,
+};
 
 use crate::codegen;
 
-pub(crate) fn test(source_text: &str, expected: &str, config: ReplaceGlobalDefinesConfig) {
+/// `semantic_info_changed` is used to assert that the semantic information has changed.
+pub(crate) fn test(
+    source_text: &str,
+    expected: &str,
+    config: ReplaceGlobalDefinesConfig,
+    expect_semantic_info_changed: bool,
+) {
     let source_type = SourceType::default();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
     let (symbols, scopes) =
         SemanticBuilder::new().build(&program).semantic.into_symbol_table_and_scope_tree();
-    let _ = ReplaceGlobalDefines::new(&allocator, config).build(symbols, scopes, &mut program);
+    let ReplaceGlobalDefinesReturn { changed, .. } =
+        ReplaceGlobalDefines::new(&allocator, config).build(symbols, scopes, &mut program);
     let result = CodeGenerator::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&program)
         .code;
     let expected = codegen(expected, source_type);
     assert_eq!(result, expected, "for source {source_text}");
+    assert_eq!(changed, expect_semantic_info_changed, "for source {source_text}");
 }
 
 fn test_same(source_text: &str, config: ReplaceGlobalDefinesConfig) {
-    test(source_text, source_text, config);
+    test(source_text, source_text, config, false);
 }
 
 #[test]
 fn simple() {
     let config = ReplaceGlobalDefinesConfig::new(&[("id", "text"), ("str", "'text'")]).unwrap();
-    test("id, str", "text, 'text'", config);
+    test("id, str", "text, 'text'", config, true);
 }
 
 #[test]
@@ -50,23 +60,23 @@ fn shadowed() {
 fn dot() {
     let config =
         ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "production")]).unwrap();
-    test("process.env.NODE_ENV", "production", config.clone());
-    test("process.env", "process.env", config.clone());
-    test("process.env.foo.bar", "process.env.foo.bar", config.clone());
-    test("process", "process", config);
+    test("process.env.NODE_ENV", "production", config.clone(), true);
+    test("process.env", "process.env", config.clone(), false);
+    test("process.env.foo.bar", "process.env.foo.bar", config.clone(), false);
+    test("process", "process", config, false);
 }
 
 #[test]
 fn dot_nested() {
     let config = ReplaceGlobalDefinesConfig::new(&[("process", "production")]).unwrap();
-    test("foo.process.NODE_ENV", "foo.process.NODE_ENV", config);
+    test("foo.process.NODE_ENV", "foo.process.NODE_ENV", config, false);
 }
 
 #[test]
 fn dot_with_postfix_wildcard() {
     let config = ReplaceGlobalDefinesConfig::new(&[("import.meta.env.*", "undefined")]).unwrap();
-    test("import.meta.env.result", "undefined", config.clone());
-    test("import.meta.env", "import.meta.env", config);
+    test("import.meta.env.result", "undefined", config.clone(), true);
+    test("import.meta.env", "import.meta.env", config, false);
 }
 
 #[test]
@@ -78,9 +88,9 @@ fn dot_with_postfix_mixed() {
         ("import.meta", "1"),
     ])
     .unwrap();
-    test("import.meta.env.result", "undefined", config.clone());
-    test("import.meta.env.result.many.nested", "undefined", config.clone());
-    test("import.meta.env", "env", config.clone());
-    test("import.meta.somethingelse", "metaProperty", config.clone());
-    test("import.meta", "1", config);
+    test("import.meta.env.result", "undefined", config.clone(), true);
+    test("import.meta.env.result.many.nested", "undefined", config.clone(), true);
+    test("import.meta.env", "env", config.clone(), true);
+    test("import.meta.somethingelse", "metaProperty", config.clone(), true);
+    test("import.meta", "1", config, true);
 }


### PR DESCRIPTION
here is a usage, https://github.com/rolldown/rolldown/blob/01197ec5548a091f8f1c1b6f112c1d30e883b0d9/crates/rolldown/src/utils/pre_process_ecma_ast.rs#L100-L106, 
this hint could avoid recreating semantic info, if the ast is not changed.