### PR TITLE
feat(transformer/babel): add support for trying to get the `Module` from `BabelPlugins`

### DIFF
--- a/crates/oxc_transformer/src/options/babel/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/mod.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 use crate::CompilerAssumptions;
 
 pub use self::env::{BabelEnvOptions, BabelModule, BabelTargets};
-use self::{plugins::BabelPlugins, presets::BabelPresets};
+pub(crate) use self::{plugins::BabelPlugins, presets::BabelPresets};
 
 /// Babel options
 ///

--- a/crates/oxc_transformer/src/options/babel/plugins.rs
+++ b/crates/oxc_transformer/src/options/babel/plugins.rs
@@ -38,6 +38,8 @@ pub struct BabelPlugins {
     pub react_jsx_self: bool,
     pub react_jsx_source: bool,
     pub react_display_name: bool,
+    // modules
+    pub modules_commonjs: bool,
     // regexp
     pub sticky_flag: bool,
     pub unicode_flag: bool,
@@ -100,6 +102,7 @@ impl TryFrom<PluginPresetEntries> for BabelPlugins {
                 "transform-react-display-name" => p.react_display_name = true,
                 "transform-react-jsx-self" => p.react_jsx_self = true,
                 "transform-react-jsx-source" => p.react_jsx_source = true,
+                "transform-modules-commonjs" => p.modules_commonjs = true,
                 "transform-sticky-regex" => p.sticky_flag = true,
                 "transform-unicode-regex" => p.unicode_flag = true,
                 "transform-dotall-regex" => p.dot_all_flag = true,

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -164,7 +164,9 @@ impl TryFrom<&BabelOptions> for TransformOptions {
 
         let env = options.presets.env.unwrap_or_default();
 
-        let module = options.presets.env.as_ref().map(|env| env.module).unwrap_or_default();
+        let module = Module::try_from(&options.plugins).unwrap_or_else(|_| {
+            options.presets.env.as_ref().map(|env| env.module).unwrap_or_default()
+        });
 
         let regexp = RegExpOptions {
             sticky_flag: env.regexp.sticky_flag || options.plugins.sticky_flag,

--- a/crates/oxc_transformer/src/options/module.rs
+++ b/crates/oxc_transformer/src/options/module.rs
@@ -1,6 +1,7 @@
 use oxc_diagnostics::Error;
 use serde::Deserialize;
 
+use super::babel::BabelPlugins;
 use crate::options::babel::BabelModule;
 
 /// Specify what module code is generated.
@@ -37,6 +38,17 @@ impl TryFrom<BabelModule> for Module {
             BabelModule::Commonjs => Ok(Self::CommonJS),
             BabelModule::Auto | BabelModule::Boolean(false) => Ok(Self::ESM),
             _ => Err(Error::msg(format!("{value:?} module is not implemented."))),
+        }
+    }
+}
+
+impl TryFrom<&BabelPlugins> for Module {
+    type Error = Error;
+    fn try_from(value: &BabelPlugins) -> Result<Self, Self::Error> {
+        if value.modules_commonjs {
+            Ok(Self::CommonJS)
+        } else {
+            Err(Error::msg("Doesn't find any transform-modules-* plugin."))
         }
     }
 }

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 316/626
+Passed: 316/633
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -460,7 +460,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-async-to-generator (11/24)
+# babel-plugin-transform-async-to-generator (11/28)
 * assumption-ignoreFunctionLength-true/basic/input.mjs
 x Output mismatch
 
@@ -486,6 +486,18 @@ x Output mismatch
 x Output mismatch
 
 * bluebird-coroutines/statement/input.js
+x Output mismatch
+
+* export-async/default-arrow-export/input.mjs
+x Output mismatch
+
+* export-async/default-export/input.mjs
+x Output mismatch
+
+* export-async/import-and-export/input.mjs
+x Output mismatch
+
+* export-async/lone-export/input.mjs
 x Output mismatch
 
 * regression/15978/input.js
@@ -560,7 +572,7 @@ rebuilt        : ScopeId(1): []
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (40/153)
+# babel-plugin-transform-typescript (40/155)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]
@@ -942,6 +954,17 @@ rebuilt        : ScopeId(0): []
    `----
 
 
+* exports/export=-to-cjs/input.ts
+
+  ! `export = <value>;` is only supported when compiling modules to CommonJS.
+  | Please consider using `export default <value>;`, or add @babel/plugin-
+  | transform-modules-commonjs to your Babel config.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/exports/export=-to-cjs/input.ts:1:1]
+ 1 | export = 0;
+   : ^^^^^^^^^^^
+   `----
+
+
 * exports/imported-types/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
@@ -1136,6 +1159,20 @@ rebuilt        : ScopeId(0): []
   | --allowSyntheticDefaultImports option, or add @babel/plugin-transform-
   | modules-commonjs to your Babel config.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-module/input.ts:1:1]
+ 1 | import lib = require("lib");
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 2 | lib();
+   `----
+
+
+* imports/import=-module-to-cjs/input.ts
+
+  ! `import lib = require(...);` is only supported when compiling modules
+  | to CommonJS.
+  | Please consider using `import lib from '...';` alongside Typescript's
+  | --allowSyntheticDefaultImports option, or add @babel/plugin-transform-
+  | modules-commonjs to your Babel config.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-module-to-cjs/input.ts:1:1]
  1 | import lib = require("lib");
    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 | lib();
@@ -2167,7 +2204,10 @@ after transform: ["T", "f"]
 rebuilt        : ["f"]
 
 
-# babel-plugin-transform-react-jsx (124/144)
+# babel-plugin-transform-react-jsx (124/145)
+* autoImport/after-polyfills-compiled-to-cjs/input.mjs
+x Output mismatch
+
 * pure/false-pragma-comment-automatic-runtime/input.js
 pragma and pragmaFrag cannot be set when runtime is automatic.
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: d20b314c
 
-Passed: 82/91
+Passed: 82/92
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -168,8 +168,11 @@ rebuilt        : SymbolId(2): []
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (31/33)
+# babel-plugin-transform-react-jsx (31/34)
 * refresh/does-not-transform-it-because-it-is-not-used-in-the-AST/input.jsx
+x Output mismatch
+
+* refresh/react-refresh/includes-custom-hooks-into-the-signatures-when-commonjs-target-is-used/input.jsx
 x Output mismatch
 
 * refresh/react-refresh/supports-typescript-namespace-syntax/input.tsx


### PR DESCRIPTION
When configuring a `transform-modules-commonjs` plugin in `options.json`, we should treat it as a `CommonJS` module