### PR TITLE
refactor(ast): remove `inherit_variants!` from `TSEnumMemberName`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -102,20 +102,13 @@ pub struct TSEnumMember<'a> {
     pub initializer: Option<Expression<'a>>,
 }
 
-inherit_variants! {
 /// TS Enum Member Name
-///
-/// Used in [`TSEnumMember`]. Inherits variants from [`Expression`]. See [`ast` module docs] for
-/// explanation of inheritance.
-///
-/// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub enum TSEnumMemberName<'a> {
-    StaticIdentifier(Box<'a, IdentifierName<'a>>) = 64,
-    StaticStringLiteral(Box<'a, StringLiteral<'a>>) = 65,
-}
+    StaticIdentifier(Box<'a, IdentifierName<'a>>) = 0,
+    StaticStringLiteral(Box<'a, StringLiteral<'a>>) = 1,
 }
 
 /// TypeScript Type Annotation


### PR DESCRIPTION
#7219 removed all variants of `TSEnumMemberName` except `IdentifierName` and `StringLiteral`. It no longer inherits variants from `Expression`, so we can remove the `inherit_variants!` macro wrapper.

The discriminants no longer need to avoid clashes with `Expression`'s, so they can start at 0.