### PR TITLE
fix(linter): react/exhaustive-deps update span for unknown deps diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/react_hooks/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react_hooks/exhaustive_deps.rs
@@ -226,7 +226,7 @@ impl Rule for ExhaustiveDeps {
             Argument::SpreadElement(_) => {
                 ctx.diagnostic(unknown_dependencies_diagnostic(
                     hook_name.as_str(),
-                    callback_node.span(),
+                    call_expr.callee.span(),
                 ));
                 None
             }
@@ -312,7 +312,7 @@ impl Rule for ExhaustiveDeps {
                     _ => {
                         ctx.diagnostic(unknown_dependencies_diagnostic(
                             hook_name.as_str(),
-                            callback_node.span(),
+                            call_expr.callee.span(),
                         ));
                         None
                     }

--- a/crates/oxc_linter/src/snapshots/exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/exhaustive_deps.snap
@@ -1953,12 +1953,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Either include it or remove the dependency array.
 
   ⚠ react_hooks(exhaustive-deps): React Hook useEffect received a function whose dependencies are unknown.
-   ╭─[exhaustive_deps.tsx:3:21]
- 2 │               const local = {};
- 3 │ ╭─▶           useEffect(debounce(() => {
- 4 │ │               console.log(local);
- 5 │ ╰─▶           }, delay), []);
- 6 │             }
+   ╭─[exhaustive_deps.tsx:3:11]
+ 2 │           const local = {};
+ 3 │           useEffect(debounce(() => {
+   ·           ─────────
+ 4 │             console.log(local);
    ╰────
   help: Pass an inline function instead.
 


### PR DESCRIPTION
Relates to #7246