### PR TITLE
refactor(ast)!: rename `TSEnumMemberName` enum variants

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -107,8 +107,8 @@ pub struct TSEnumMember<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub enum TSEnumMemberName<'a> {
-    StaticIdentifier(Box<'a, IdentifierName<'a>>) = 0,
-    StaticStringLiteral(Box<'a, StringLiteral<'a>>) = 1,
+    Identifier(Box<'a, IdentifierName<'a>>) = 0,
+    String(Box<'a, StringLiteral<'a>>) = 1,
 }
 
 /// TypeScript Type Annotation

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -14,8 +14,8 @@ impl<'a> TSEnumMemberName<'a> {
     /// Get the name of this enum member.
     pub fn static_name(&self) -> Atom<'a> {
         match self {
-            Self::StaticIdentifier(ident) => ident.name.clone(),
-            Self::StaticStringLiteral(lit) => lit.value.clone(),
+            Self::Identifier(ident) => ident.name.clone(),
+            Self::String(lit) => lit.value.clone(),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7745,7 +7745,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_enum_member(span, id, initializer), self.allocator)
     }
 
-    /// Build a [`TSEnumMemberName::StaticIdentifier`]
+    /// Build a [`TSEnumMemberName::Identifier`]
     ///
     /// This node contains an [`IdentifierName`] that will be stored in the memory arena.
     ///
@@ -7757,10 +7757,10 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        TSEnumMemberName::StaticIdentifier(self.alloc(self.identifier_name(span, name)))
+        TSEnumMemberName::Identifier(self.alloc(self.identifier_name(span, name)))
     }
 
-    /// Build a [`TSEnumMemberName::StaticStringLiteral`]
+    /// Build a [`TSEnumMemberName::String`]
     ///
     /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
     ///
@@ -7772,7 +7772,7 @@ impl<'a> AstBuilder<'a> {
     where
         A: IntoIn<'a, Atom<'a>>,
     {
-        TSEnumMemberName::StaticStringLiteral(self.alloc(self.string_literal(span, value)))
+        TSEnumMemberName::String(self.alloc(self.string_literal(span, value)))
     }
 
     /// Build a [`TSTypeAnnotation`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -2593,12 +2593,8 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSEnumMemberName<'old_alloc
     type Cloned = TSEnumMemberName<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::StaticIdentifier(it) => {
-                TSEnumMemberName::StaticIdentifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::StaticStringLiteral(it) => {
-                TSEnumMemberName::StaticStringLiteral(CloneIn::clone_in(it, allocator))
-            }
+            Self::Identifier(it) => TSEnumMemberName::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::String(it) => TSEnumMemberName::String(CloneIn::clone_in(it, allocator)),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2579,12 +2579,12 @@ impl<'a> ContentEq for TSEnumMember<'a> {
 impl<'a> ContentEq for TSEnumMemberName<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         match self {
-            Self::StaticIdentifier(it) => match other {
-                Self::StaticIdentifier(other) if ContentEq::content_eq(it, other) => true,
+            Self::Identifier(it) => match other {
+                Self::Identifier(other) if ContentEq::content_eq(it, other) => true,
                 _ => false,
             },
-            Self::StaticStringLiteral(it) => match other {
-                Self::StaticStringLiteral(other) if ContentEq::content_eq(it, other) => true,
+            Self::String(it) => match other {
+                Self::String(other) if ContentEq::content_eq(it, other) => true,
                 _ => false,
             },
         }

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -1416,8 +1416,8 @@ impl<'a> ContentHash for TSEnumMemberName<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&discriminant(self), state);
         match self {
-            Self::StaticIdentifier(it) => ContentHash::content_hash(it, state),
-            Self::StaticStringLiteral(it) => ContentHash::content_hash(it, state),
+            Self::Identifier(it) => ContentHash::content_hash(it, state),
+            Self::String(it) => ContentHash::content_hash(it, state),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1975,8 +1975,8 @@ impl<'a> Serialize for TSEnumMember<'a> {
 impl<'a> Serialize for TSEnumMemberName<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            TSEnumMemberName::StaticIdentifier(x) => Serialize::serialize(x, serializer),
-            TSEnumMemberName::StaticStringLiteral(x) => Serialize::serialize(x, serializer),
+            TSEnumMemberName::Identifier(x) => Serialize::serialize(x, serializer),
+            TSEnumMemberName::String(x) => Serialize::serialize(x, serializer),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -1272,8 +1272,8 @@ impl<'a> GetSpan for TSEnumMember<'a> {
 impl<'a> GetSpan for TSEnumMemberName<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::StaticStringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::String(it) => GetSpan::span(it.as_ref()),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -1272,8 +1272,8 @@ impl<'a> GetSpanMut for TSEnumMember<'a> {
 impl<'a> GetSpanMut for TSEnumMemberName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticStringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::String(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3806,8 +3806,8 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_enum_member_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMemberName<'a>) {
         match it {
-            TSEnumMemberName::StaticIdentifier(it) => visitor.visit_identifier_name(it),
-            TSEnumMemberName::StaticStringLiteral(it) => visitor.visit_string_literal(it),
+            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
         }
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -4024,8 +4024,8 @@ pub mod walk_mut {
         it: &mut TSEnumMemberName<'a>,
     ) {
         match it {
-            TSEnumMemberName::StaticIdentifier(it) => visitor.visit_identifier_name(it),
-            TSEnumMemberName::StaticStringLiteral(it) => visitor.visit_string_literal(it),
+            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
         }
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3607,8 +3607,8 @@ impl<'a> Gen for TSEnumDeclaration<'a> {
 impl<'a> Gen for TSEnumMember<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match &self.id {
-            TSEnumMemberName::StaticIdentifier(decl) => decl.print(p, ctx),
-            TSEnumMemberName::StaticStringLiteral(decl) => decl.print(p, ctx),
+            TSEnumMemberName::Identifier(decl) => decl.print(p, ctx),
+            TSEnumMemberName::String(decl) => decl.print(p, ctx),
         }
         if let Some(init) = &self.initializer {
             p.print_soft_space();

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -46,8 +46,8 @@ impl<'a> IsolatedDeclarations<'a> {
 
             if let Some(value) = &value {
                 let member_name = match &member.id {
-                    TSEnumMemberName::StaticIdentifier(id) => &id.name,
-                    TSEnumMemberName::StaticStringLiteral(str) => &str.value,
+                    TSEnumMemberName::Identifier(id) => &id.name,
+                    TSEnumMemberName::String(str) => &str.value,
                 };
                 prev_members.insert(member_name.clone(), value.clone());
             }

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -52,7 +52,7 @@ impl Rule for PreferEnumInitializers {
 
         for (index, member) in decl.members.iter().enumerate() {
             if member.initializer.is_none() {
-                if let TSEnumMemberName::StaticIdentifier(i) = &member.id {
+                if let TSEnumMemberName::Identifier(i) = &member.id {
                     ctx.diagnostic(prefer_enum_initializers_diagnostic(
                         i.name.as_str(),
                         index + 1,

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -64,12 +64,10 @@ impl<'a> ParserImpl<'a> {
         match self.cur_kind() {
             Kind::Str => {
                 let literal = self.parse_literal_string()?;
-                Ok(TSEnumMemberName::StaticStringLiteral(self.alloc(literal)))
+                Ok(TSEnumMemberName::String(self.alloc(literal)))
             }
             Kind::LBrack => match self.parse_computed_property_name()? {
-                Expression::StringLiteral(literal) => {
-                    Ok(TSEnumMemberName::StaticStringLiteral(literal))
-                }
+                Expression::StringLiteral(literal) => Ok(TSEnumMemberName::String(literal)),
                 Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
                     Ok(self.ast.ts_enum_member_name_string_literal(
                         template.span,
@@ -89,7 +87,7 @@ impl<'a> ParserImpl<'a> {
             }
             _ => {
                 let ident_name = self.parse_identifier_name()?;
-                Ok(TSEnumMemberName::StaticIdentifier(self.alloc(ident_name)))
+                Ok(TSEnumMemberName::Identifier(self.alloc(ident_name)))
             }
         }
     }

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1256,8 +1256,8 @@ impl<'a> Format<'a> for TSEnumMember<'a> {
 impl<'a> Format<'a> for TSEnumMemberName<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         match self {
-            TSEnumMemberName::StaticIdentifier(identifier) => identifier.format(p),
-            TSEnumMemberName::StaticStringLiteral(string_literal) => string_literal.format(p),
+            TSEnumMemberName::Identifier(identifier) => identifier.format(p),
+            TSEnumMemberName::String(string_literal) => string_literal.format(p),
         }
     }
 }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -193,8 +193,8 @@ impl<'a> TypeScriptEnum<'a> {
 
         for member in members.iter_mut() {
             let member_name: &Atom<'_> = match &member.id {
-                TSEnumMemberName::StaticIdentifier(id) => &id.name,
-                TSEnumMemberName::StaticStringLiteral(str) => &str.value,
+                TSEnumMemberName::Identifier(id) => &id.name,
+                TSEnumMemberName::String(str) => &str.value,
             };
 
             let init = if let Some(initializer) = &mut member.initializer {

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3715,10 +3715,10 @@ pub(crate) unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_ts_enum_member_name(&mut *node, ctx);
     match &mut *node {
-        TSEnumMemberName::StaticIdentifier(node) => {
+        TSEnumMemberName::Identifier(node) => {
             walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSEnumMemberName::StaticStringLiteral(node) => {
+        TSEnumMemberName::String(node) => {
             walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }
     }


### PR DESCRIPTION
Variants of `TSEnumMemberName` were previously only prefixed with `Static` to avoid naming conflicts with the variants inherited from `Expression` for non-static member names. #7219 removed the variants inherited from `Expression`, so all variants are now static. So we can shorten the names again (back to what they were before `inherit_variants!` was introduced).