### PR TITLE
fix(linter): move `exhaustive-deps` to `react`

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -240,6 +240,7 @@ mod jest {
 mod react {
     pub mod button_has_type;
     pub mod checked_requires_onchange_or_readonly;
+    pub mod exhaustive_deps;
     pub mod iframe_missing_sandbox;
     pub mod jsx_boolean_value;
     pub mod jsx_curly_brace_presence;
@@ -504,10 +505,6 @@ mod vitest {
 mod node {
     pub mod no_exports_assign;
     pub mod no_new_require;
-}
-
-mod react_hooks {
-    pub mod exhaustive_deps;
 }
 
 oxc_macros::declare_all_lint_rules! {
@@ -795,6 +792,7 @@ oxc_macros::declare_all_lint_rules! {
     promise::valid_params,
     react::button_has_type,
     react::checked_requires_onchange_or_readonly,
+    react::exhaustive_deps,
     react::iframe_missing_sandbox,
     react::jsx_boolean_value,
     react::jsx_curly_brace_presence,
@@ -806,8 +804,8 @@ oxc_macros::declare_all_lint_rules! {
     react::jsx_no_useless_fragment,
     react::jsx_props_no_spread_multi,
     react::no_children_prop,
-    react::no_danger,
     react::no_danger_with_children,
+    react::no_danger,
     react::no_direct_mutation_state,
     react::no_find_dom_node,
     react::no_is_mounted,
@@ -962,5 +960,4 @@ oxc_macros::declare_all_lint_rules! {
     vitest::prefer_to_be_object,
     vitest::prefer_to_be_truthy,
     vitest::require_local_test_context_for_concurrent_snapshots,
-    react_hooks::exhaustive_deps,
 }

--- a/crates/oxc_linter/src/snapshots/exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/exhaustive_deps.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.toString'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.toString'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo?.toString());
  4 │           }, []);
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo?.bar.baz);
  4 │           }, []);
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo?.bar?.baz);
  4 │           }, []);
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.toString'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.toString'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo?.bar.toString());
  4 │           }, []);
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, []);
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'setCount'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'setCount'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             return () => clearInterval(id);
   9 │           }, []);
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, []);
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, []);
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo does nothing when called with only one argument.
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useMemo does nothing when called with only one argument.
    ╭─[exhaustive_deps.tsx:2:25]
  1 │ function MyComponent(props) {
  2 │           const value = useMemo(() => { return 2*2; });
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass an array of dependencies?
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback does nothing when called with only one argument.
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback does nothing when called with only one argument.
    ╭─[exhaustive_deps.tsx:3:22]
  2 │           const value = useMemo(() => { return 2*2; });
  3 │           const fn = useCallback(() => { alert('foo'); });
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass an array of dependencies?
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo does nothing when called with only one argument.
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useMemo does nothing when called with only one argument.
    ╭─[exhaustive_deps.tsx:2:25]
  1 │ function MyComponent({ fn1, fn2 }) {
  2 │           const value = useMemo(fn1);
@@ -100,7 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass an array of dependencies?
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback does nothing when called with only one argument.
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback does nothing when called with only one argument.
    ╭─[exhaustive_deps.tsx:3:22]
  2 │           const value = useMemo(fn1);
  3 │           const fn = useCallback(fn2);
@@ -109,7 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass an array of dependencies?
 
-  ⚠ react_hooks(exhaustive-deps): React hook useEffect requires an effect callback.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React hook useEffect requires an effect callback.
    ╭─[exhaustive_deps.tsx:2:11]
  1 │ function MyComponent() {
  2 │           useEffect()
@@ -118,7 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass a callback to the hook?
 
-  ⚠ react_hooks(exhaustive-deps): React hook useLayoutEffect requires an effect callback.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React hook useLayoutEffect requires an effect callback.
    ╭─[exhaustive_deps.tsx:3:11]
  2 │           useEffect()
  3 │           useLayoutEffect()
@@ -127,7 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass a callback to the hook?
 
-  ⚠ react_hooks(exhaustive-deps): React hook useCallback requires an effect callback.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React hook useCallback requires an effect callback.
    ╭─[exhaustive_deps.tsx:4:11]
  3 │           useLayoutEffect()
  4 │           useCallback()
@@ -136,7 +136,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass a callback to the hook?
 
-  ⚠ react_hooks(exhaustive-deps): React hook useMemo requires an effect callback.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React hook useMemo requires an effect callback.
    ╭─[exhaustive_deps.tsx:5:11]
  4 │           useCallback()
  5 │           useMemo()
@@ -145,7 +145,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Did you forget to pass a callback to the hook?
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             }
  7 │           }, []);
@@ -154,7 +154,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             } finally {}
  7 │           }, []);
@@ -163,7 +163,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:8:14]
  7 │             inner();
  8 │           }, []);
@@ -172,7 +172,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local1'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local1'
    ╭─[exhaustive_deps.tsx:8:16]
  7 │               console.log(local2);
  8 │             }, []);
@@ -181,7 +181,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local2'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local2'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             console.log(local2);
  7 │           }, [local1]);
@@ -190,7 +190,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:7:15]
  6 │             console.log(local2);
  7 │           }, [local1]);
@@ -199,7 +199,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has unnecessary dependency: local2
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useMemo has unnecessary dependency: local2
    ╭─[exhaustive_deps.tsx:6:23]
  5 │             console.log(local1);
  6 │           }, [local1, local2]);
@@ -208,7 +208,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:6:15]
  5 │             console.log(local1);
  6 │           }, [local1, local2]);
@@ -217,7 +217,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:6:23]
  5 │             console.log(local1);
  6 │           }, [local1, local2]);
@@ -226,7 +226,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: local1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: local1.
    ╭─[exhaustive_deps.tsx:8:17]
  7 │               console.log(local2);
  8 │             }, [local1]);
@@ -235,7 +235,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'local2'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'local2'
    ╭─[exhaustive_deps.tsx:8:16]
  7 │               console.log(local2);
  8 │             }, [local1]);
@@ -244,7 +244,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(local);
  6 │           }, []);
@@ -253,7 +253,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): The literal is not a valid dependency because it never changes.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The literal is not a valid dependency because it never changes.
    ╭─[exhaustive_deps.tsx:6:22]
  5 │             console.log(local);
  6 │           }, [local, local]);
@@ -262,7 +262,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the literal from the array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:6:15]
  5 │             console.log(local);
  6 │           }, [local, local]);
@@ -271,7 +271,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: window.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: window.
    ╭─[exhaustive_deps.tsx:2:34]
  1 │ function MyComponent() {
  2 │           useCallback(() => {}, [window]);
@@ -280,7 +280,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: window
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: window
    ╭─[exhaustive_deps.tsx:2:34]
  1 │ function MyComponent() {
  2 │           useCallback(() => {}, [window]);
@@ -289,7 +289,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local
    ╭─[exhaustive_deps.tsx:3:34]
  2 │           let local = props.foo;
  3 │           useCallback(() => {}, [local]);
@@ -298,7 +298,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.listen'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.listen'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             return history.listen();
  4 │           }, []);
@@ -307,7 +307,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.foo.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.foo.bar'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             ];
  7 │           }, []);
@@ -316,7 +316,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'history.foo'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             ];
  6 │           }, []);
@@ -325,7 +325,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:2:32]
  1 │ function MyComponent() {
  2 │           useEffect(() => {}, ['foo']);
@@ -334,7 +334,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             console.log(foo, bar, baz);
  4 │           }, ['foo', 'bar']);
@@ -343,7 +343,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:22]
  3 │             console.log(foo, bar, baz);
  4 │           }, ['foo', 'bar']);
@@ -352,7 +352,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(foo, bar, baz);
  4 │           }, ['foo', 'bar']);
@@ -361,7 +361,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             console.log(foo, bar, baz);
  4 │           }, [42, false, null]);
@@ -370,7 +370,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:19]
  3 │             console.log(foo, bar, baz);
  4 │           }, [42, false, null]);
@@ -379,7 +379,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:26]
  3 │             console.log(foo, bar, baz);
  4 │           }, [42, false, null]);
@@ -388,7 +388,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(foo, bar, baz);
  4 │           }, [42, false, null]);
@@ -397,7 +397,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const dependencies = [];
  3 │           useEffect(() => {}, dependencies);
@@ -406,7 +406,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use an array literal as the second argument.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(local);
  6 │           }, dependencies);
@@ -415,7 +415,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use an array literal as the second argument.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:6:15]
  5 │             console.log(local);
  6 │           }, [...dependencies]);
@@ -424,7 +424,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(local);
  6 │           }, [...dependencies]);
@@ -433,7 +433,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:5:22]
  4 │             console.log(local);
  5 │           }, [local, ...dependencies]);
@@ -442,7 +442,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [computeCacheKey(local)]);
@@ -451,7 +451,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [computeCacheKey(local)]);
@@ -460,7 +460,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             console.log(props.items[0]);
  4 │           }, [props.items[0]]);
@@ -469,7 +469,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.items'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.items'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.items[0]);
  4 │           }, [props.items[0]]);
@@ -478,7 +478,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:28]
  3 │             console.log(props.items[0]);
  4 │           }, [props.items, props.items[0]]);
@@ -487,7 +487,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             console.log(items[0]);
  4 │           }, [items[0]]);
@@ -496,7 +496,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'items'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'items'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(items[0]);
  4 │           }, [items[0]]);
@@ -505,7 +505,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:4:22]
  3 │             console.log(items[0]);
  4 │           }, [items, items[0]]);
@@ -514,7 +514,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
    ╭─[exhaustive_deps.tsx:6:22]
  5 │             console.log(props.bar);
  6 │           }, [props, props.foo]);
@@ -523,7 +523,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.foo', and 'props.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.foo', and 'props.bar'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(props.bar);
  6 │           }, []);
@@ -532,7 +532,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [local.id]);
@@ -541,7 +541,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [local.id]);
@@ -550,7 +550,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [local.id]);
@@ -559,7 +559,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local
    ╭─[exhaustive_deps.tsx:5:25]
  4 │             console.log(local);
  5 │           }, [local.id, local]);
@@ -568,7 +568,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [local.id, local]);
@@ -577,7 +577,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:25]
  4 │             console.log(local);
  5 │           }, [local.id, local]);
@@ -586,7 +586,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar.baz'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo.bar.baz);
  4 │           }, []);
@@ -595,7 +595,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'color'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'color'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(color);
  6 │           }, [props.foo, props.foo.bar.baz]);
@@ -604,7 +604,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
    ╭─[exhaustive_deps.tsx:6:26]
  5 │             console.log(color);
  6 │           }, [props.foo, props.foo.bar.baz]);
@@ -613,7 +613,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
    ╭─[exhaustive_deps.tsx:4:34]
  3 │             console.log(props.foo.bar.baz);
  4 │           }, [props.foo.bar.baz, props.foo]);
@@ -622,7 +622,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.foo.bar.baz', and 'props.foo.fizz.bizz'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.foo.bar.baz', and 'props.foo.fizz.bizz'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(props.foo.fizz.bizz);
  5 │           }, []);
@@ -631,7 +631,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo.bar'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo.bar);
  4 │           }, [props.foo.bar.baz]);
@@ -640,7 +640,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             console.log(props.foo.bar);
  4 │           }, [props.foo.bar.baz]);
@@ -649,7 +649,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props', and 'props.hello'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props', and 'props.hello'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(props.hello);
  5 │           }, [props.foo.bar.baz]);
@@ -658,7 +658,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(props.hello);
  5 │           }, [props.foo.bar.baz]);
@@ -667,7 +667,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): The literal is not a valid dependency because it never changes.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The literal is not a valid dependency because it never changes.
    ╭─[exhaustive_deps.tsx:5:22]
  4 │             console.log(local);
  5 │           }, [local, local]);
@@ -676,7 +676,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the literal from the array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [local, local]);
@@ -692,7 +692,7 @@ source: crates/oxc_linter/src/tester.rs
    ·          ─
    ╰────
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local1
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local1
    ╭─[exhaustive_deps.tsx:3:34]
  2 │           const local1 = {};
  3 │           useCallback(() => {}, [local1]);
@@ -701,7 +701,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:34]
  2 │           const local1 = {};
  3 │           useCallback(() => {}, [local1]);
@@ -710,7 +710,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo);
  4 │           }, []);
@@ -719,7 +719,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', and 'props.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', and 'props.bar'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(props.bar);
  5 │           }, []);
@@ -728,7 +728,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'e', 'd', and 'f'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'e', 'd', and 'f'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, [c, a, g]);
@@ -737,7 +737,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'e', 'd', and 'f'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'e', 'd', and 'f'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, [a, c, g]);
@@ -746,7 +746,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'a', 'c', 'e', 'd', 'g', and 'f'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'a', 'c', 'e', 'd', 'g', and 'f'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, []);
@@ -755,7 +755,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', 'local', and 'props.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', 'local', and 'props.bar'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             console.log(local);
  7 │           }, []);
@@ -764,7 +764,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             console.log(local);
  7 │           }, [props]);
@@ -773,7 +773,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             console.log(props.foo);
  4 │           }, []);
@@ -782,7 +782,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             console.log(props.foo);
  7 │           }, []);
@@ -791,7 +791,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'props.foo'
     ╭─[exhaustive_deps.tsx:10:14]
   9 │             console.log(props.foo);
  10 │           }, []);
@@ -800,7 +800,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
     ╭─[exhaustive_deps.tsx:13:14]
  12 │             console.log(props.foo);
  13 │           }, []);
@@ -809,7 +809,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
     ╭─[exhaustive_deps.tsx:16:14]
  15 │             console.log(props.foo);
  16 │           }, []);
@@ -818,7 +818,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'props.foo'
     ╭─[exhaustive_deps.tsx:19:14]
  18 │             console.log(props.foo);
  19 │           }, []);
@@ -827,7 +827,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             console.log(props.foo);
  7 │           }, []);
@@ -836,7 +836,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
     ╭─[exhaustive_deps.tsx:10:14]
   9 │             console.log(props.foo);
  10 │           }, []);
@@ -845,7 +845,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [a ? local : b]);
@@ -854,7 +854,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [a ? local : b]);
@@ -863,7 +863,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(local);
  5 │           }, [a && local]);
@@ -872,7 +872,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [a && local]);
@@ -881,7 +881,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:2:32]
  1 │ function MyComponent(props) {
  2 │           useEffect(() => {}, [props?.attribute.method()]);
@@ -890,7 +890,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a complex expression in the dependency array.
    ╭─[exhaustive_deps.tsx:2:32]
  1 │ function MyComponent(props) {
  2 │           useEffect(() => {}, [props.method()]);
@@ -899,7 +899,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'state'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'state'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             setState(state + 1);
  7 │           }, []);
@@ -908,7 +908,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'state'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'state'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             setState(state + 1);
  7 │           }, [ref]);
@@ -917,7 +917,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.someOtherRefs.current.innerHTML', and 'props.color'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.someOtherRefs.current.innerHTML', and 'props.color'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             fetch(props.color);
   9 │           }, []);
@@ -926,7 +926,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
     ╭─[exhaustive_deps.tsx:9:29]
   8 │             fetch(props.color);
   9 │           }, [ref1.current, ref2.current, props.someOtherRefs, props.color]);
@@ -935,7 +935,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
     ╭─[exhaustive_deps.tsx:9:15]
   8 │             fetch(props.color);
   9 │           }, [ref1.current, ref2.current, props.someOtherRefs, props.color]);
@@ -944,7 +944,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
     ╭─[exhaustive_deps.tsx:9:30]
   8 │             fetch(props.color);
   9 │           }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
@@ -953,7 +953,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
     ╭─[exhaustive_deps.tsx:9:15]
   8 │             fetch(props.color);
   9 │           }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
@@ -962,7 +962,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(ref.current);
  5 │           }, [ref.current]);
@@ -971,7 +971,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
    ╭─[exhaustive_deps.tsx:7:29]
  6 │             ref2.current.scrollTop = 0;
  7 │           }, [ref1.current, ref2.current, activeTab]);
@@ -980,7 +980,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
    ╭─[exhaustive_deps.tsx:7:15]
  6 │             ref2.current.scrollTop = 0;
  7 │           }, [ref1.current, ref2.current, activeTab]);
@@ -989,7 +989,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref2.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref2.
    ╭─[exhaustive_deps.tsx:7:29]
  6 │             ref2.current.scrollTop = initY;
  7 │           }, [ref1.current, ref2.current, activeTab, initY]);
@@ -998,7 +998,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref1.
    ╭─[exhaustive_deps.tsx:7:15]
  6 │             ref2.current.scrollTop = initY;
  7 │           }, [ref1.current, ref2.current, activeTab, initY]);
@@ -1007,7 +1007,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: activeTab
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: activeTab
    ╭─[exhaustive_deps.tsx:7:43]
  6 │             ref2.current.scrollTop = initY;
  7 │           }, [ref1.current, ref2.current, activeTab, initY]);
@@ -1016,7 +1016,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(ref.current);
  5 │           }, [ref.current, ref]);
@@ -1025,7 +1025,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useImperativeHandle has a missing dependency: 'props.hello'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useImperativeHandle has a missing dependency: 'props.hello'
    ╭─[exhaustive_deps.tsx:6:15]
  5 │             }
  6 │           }), [])
@@ -1034,7 +1034,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.onChange'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.onChange'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             }
  6 │           }, []);
@@ -1043,7 +1043,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.onChange'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.onChange'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             }
  6 │           }, []);
@@ -1052,7 +1052,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onPause', and 'props.onPlay'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onPause', and 'props.onPlay'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             }
   9 │           }, []);
@@ -1061,7 +1061,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo.onChange'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo.onChange'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             }
  6 │           }, []);
@@ -1070,7 +1070,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props.foo.onChange'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props.foo.onChange'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             }
  7 │           }, []);
@@ -1079,7 +1079,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'skillsCount', 'props.toggleEditMode', and 'props.isEditMode'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'skillsCount', 'props.toggleEditMode', and 'props.isEditMode'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             }
  7 │           }, []);
@@ -1088,7 +1088,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             props.onChange();
  5 │           }, []);
@@ -1097,7 +1097,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.onChange', and 'props'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             externalCall(props);
  5 │           }, []);
@@ -1106,7 +1106,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'value', 'value2', 'value4', 'asyncValue', and 'value3'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'value', 'value2', 'value4', 'asyncValue', and 'value3'
     ╭─[exhaustive_deps.tsx:19:14]
  18 │             });
  19 │           }, []);
@@ -1115,7 +1115,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'asyncValue'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'asyncValue'
     ╭─[exhaustive_deps.tsx:15:14]
  14 │             });
  15 │           }, [value, value2, value3]);
@@ -1124,7 +1124,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:6:26]
  5 │             myRef.current.addEventListener('mousemove', handleMove);
  6 │             return () => myRef.current.removeEventListener('mousemove', handleMove);
@@ -1133,7 +1133,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:6:26]
  5 │             myRef?.current?.addEventListener('mousemove', handleMove);
  6 │             return () => myRef?.current?.removeEventListener('mousemove', handleMove);
@@ -1142,7 +1142,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:6:26]
  5 │             myRef.current.addEventListener('mousemove', handleMove);
  6 │             return () => myRef.current.removeEventListener('mousemove', handleMove);
@@ -1151,7 +1151,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:5:26]
  4 │             myRef.current.addEventListener('mousemove', handleMove);
  5 │             return () => myRef.current.removeEventListener('mousemove', handleMove);
@@ -1160,7 +1160,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:8:17]
  7 │               setTimeout(() => {
  8 │                 myRef.current.removeEventListener('mousemove', handleMouse);
@@ -1169,7 +1169,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
     ╭─[exhaustive_deps.tsx:9:17]
   8 │                 myRef.current.removeEventListener('mousemove', handleMouse);
   9 │                 myRef.current.removeEventListener('mousein', handleMouse);
@@ -1178,7 +1178,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): The ref's value `.current` is accessed directly in the effect cleanup function.
    ╭─[exhaustive_deps.tsx:8:19]
  7 │                 setTimeout(() => {
  8 │                   myRef.current.removeEventListener('mousemove', handleMove);
@@ -1187,7 +1187,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The ref value will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by react, copy it to a variable inside the effect and use that variable in the cleanup function.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local4'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local4'
     ╭─[exhaustive_deps.tsx:11:14]
  10 │             console.log(local4);
  11 │           }, [local1, local3]);
@@ -1196,7 +1196,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: window.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: window.
    ╭─[exhaustive_deps.tsx:4:15]
  3 │             window.scrollTo(0, 0);
  4 │           }, [window]);
@@ -1205,7 +1205,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(MutableStore.hello);
  5 │           }, [MutableStore.hello]);
@@ -1214,7 +1214,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1223,7 +1223,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1232,7 +1232,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: global.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: global.
     ╭─[exhaustive_deps.tsx:10:63]
   9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1241,7 +1241,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1250,7 +1250,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1259,7 +1259,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1268,7 +1268,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: global.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: global.
     ╭─[exhaustive_deps.tsx:10:63]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1277,7 +1277,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1286,7 +1286,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1295,7 +1295,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1304,7 +1304,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: global.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: global.
     ╭─[exhaustive_deps.tsx:10:63]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1313,7 +1313,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
     ╭─[exhaustive_deps.tsx:10:43]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1322,7 +1322,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
     ╭─[exhaustive_deps.tsx:10:57]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1331,7 +1331,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1340,7 +1340,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1349,7 +1349,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
     ╭─[exhaustive_deps.tsx:10:63]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1358,7 +1358,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: x
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: x
     ╭─[exhaustive_deps.tsx:10:54]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1367,7 +1367,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1376,7 +1376,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:62]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1385,7 +1385,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1394,7 +1394,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: global.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: global.
     ╭─[exhaustive_deps.tsx:10:65]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1403,7 +1403,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
     ╭─[exhaustive_deps.tsx:10:45]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1412,7 +1412,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
     ╭─[exhaustive_deps.tsx:10:59]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1421,7 +1421,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
     ╭─[exhaustive_deps.tsx:10:62]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1430,7 +1430,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
     ╭─[exhaustive_deps.tsx:10:17]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1439,7 +1439,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
     ╭─[exhaustive_deps.tsx:10:65]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1448,7 +1448,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: x
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: x
     ╭─[exhaustive_deps.tsx:10:56]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1457,7 +1457,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:62]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1466,7 +1466,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
     ╭─[exhaustive_deps.tsx:21:14]
  20 │             return Store.subscribe(handleNext1);
  21 │           }, []);
@@ -1475,7 +1475,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
     ╭─[exhaustive_deps.tsx:24:14]
  23 │             return Store.subscribe(handleNext2);
  24 │           }, []);
@@ -1484,7 +1484,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
     ╭─[exhaustive_deps.tsx:27:14]
  26 │             return Store.subscribe(handleNext3);
  27 │           }, []);
@@ -1493,7 +1493,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
     ╭─[exhaustive_deps.tsx:24:14]
  23 │             return Store.subscribe(handleNext1);
  24 │           }, []);
@@ -1502,7 +1502,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
     ╭─[exhaustive_deps.tsx:27:14]
  26 │             return Store.subscribe(handleNext2);
  27 │           }, []);
@@ -1511,7 +1511,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
     ╭─[exhaustive_deps.tsx:30:14]
  29 │             return Store.subscribe(handleNext3);
  30 │           }, []);
@@ -1520,7 +1520,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'handleNext1'
     ╭─[exhaustive_deps.tsx:24:14]
  23 │             return Store.subscribe(handleNext1);
  24 │           }, []);
@@ -1529,7 +1529,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a missing dependency: 'handleNext2'
     ╭─[exhaustive_deps.tsx:27:14]
  26 │             return Store.subscribe(handleNext2);
  27 │           }, []);
@@ -1538,7 +1538,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a missing dependency: 'handleNext3'
     ╭─[exhaustive_deps.tsx:30:14]
  29 │             return Store.subscribe(handleNext3);
  30 │           }, []);
@@ -1547,7 +1547,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:15]
   9 │             return Store.subscribe(handleNext);
  10 │           }, [handleNext]);
@@ -1556,7 +1556,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:15]
   9 │             return Store.subscribe(handleNext);
  10 │           }, [handleNext]);
@@ -1565,7 +1565,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:10:15]
   9 │             return Store.subscribe(handleNext);
  10 │           }, [handleNext]);
@@ -1574,7 +1574,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:13:15]
  12 │             return Store.subscribe(handleNext1);
  13 │           }, [handleNext1]);
@@ -1583,7 +1583,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:16:15]
  15 │             return Store.subscribe(handleNext2);
  16 │           }, [handleNext2]);
@@ -1592,7 +1592,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:19:15]
  18 │             return Store.subscribe(handleNext3);
  19 │           }, [handleNext3]);
@@ -1601,7 +1601,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:14:15]
  13 │             return Store.subscribe(() => handleNext1());
  14 │           }, [handleNext1]);
@@ -1610,7 +1610,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:18:15]
  17 │             return Store.subscribe(() => handleNext2());
  18 │           }, [handleNext2]);
@@ -1619,7 +1619,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:22:15]
  21 │             return Store.subscribe(() => handleNext3());
  22 │           }, [handleNext3]);
@@ -1628,7 +1628,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:14:15]
  13 │             return Store.subscribe(() => handleNext1());
  14 │           }, [handleNext1]);
@@ -1637,7 +1637,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:18:15]
  17 │             return Store.subscribe(() => handleNext2());
  18 │           }, [handleNext2]);
@@ -1646,7 +1646,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:22:15]
  21 │             return Store.subscribe(() => handleNext3());
  22 │           }, [handleNext3]);
@@ -1655,7 +1655,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:11:15]
  10 │             return Store.subscribe(handleNext2);
  11 │           }, [handleNext1, handleNext2]);
@@ -1664,7 +1664,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:11:28]
  10 │             return Store.subscribe(handleNext2);
  11 │           }, [handleNext1, handleNext2]);
@@ -1673,7 +1673,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:15:15]
  14 │             return Store.subscribe(handleNext2);
  15 │           }, [handleNext1, handleNext2]);
@@ -1682,7 +1682,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:15:28]
  14 │             return Store.subscribe(handleNext2);
  15 │           }, [handleNext1, handleNext2]);
@@ -1691,7 +1691,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:12:15]
  11 │             return Store.subscribe(handleNext);
  12 │           }, [handleNext]);
@@ -1700,7 +1700,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:13:15]
  12 │             return Store.subscribe(handleNext);
  13 │           }, [handleNext]);
@@ -1709,7 +1709,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'count'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'count'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             return () => clearInterval(id);
   9 │           }, []);
@@ -1718,7 +1718,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'increment', and 'count'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'increment', and 'count'
     ╭─[exhaustive_deps.tsx:10:14]
   9 │             return () => clearInterval(id);
  10 │           }, []);
@@ -1727,7 +1727,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
     ╭─[exhaustive_deps.tsx:10:14]
   9 │             return () => clearInterval(id);
  10 │           }, []);
@@ -1736,7 +1736,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
     ╭─[exhaustive_deps.tsx:10:14]
   9 │             return () => clearInterval(id);
  10 │           }, []);
@@ -1745,7 +1745,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
     ╭─[exhaustive_deps.tsx:13:14]
  12 │             return () => clearInterval(id);
  13 │           }, []);
@@ -1754,7 +1754,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
     ╭─[exhaustive_deps.tsx:13:15]
  12 │             return () => clearInterval(id);
  13 │           }, [increment]);
@@ -1763,7 +1763,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'increment'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             return () => clearInterval(id);
   9 │           }, []);
@@ -1772,7 +1772,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'tick'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'tick'
     ╭─[exhaustive_deps.tsx:13:14]
  12 │             return () => clearInterval(id);
  13 │           }, []);
@@ -1781,7 +1781,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'podcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'podcasts'
    ╭─[exhaustive_deps.tsx:4:14]
  3 │             alert(podcasts);
  4 │           }, []);
@@ -1790,7 +1790,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             fetchPodcasts(id).then(setPodcasts);
  5 │           }, [id]);
@@ -1799,7 +1799,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             fetchPodcasts(id).then(setPodcasts);
  5 │           }, [id]);
@@ -1808,7 +1808,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'fetchPodcasts2', and 'fetchPodcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'fetchPodcasts2', and 'fetchPodcasts'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             });
   9 │           }, [id]);
@@ -1817,7 +1817,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             fetchPodcasts(id).then(setPodcasts);
  6 │           }, [id]);
@@ -1826,7 +1826,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'fetchPodcasts'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             fetchPodcasts?.(id).then(setPodcasts);
  6 │           }, [id]);
@@ -1835,7 +1835,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
    ╭─[exhaustive_deps.tsx:3:11]
  2 │           const [state, setState] = useState(0);
  3 │           useEffect(() => {
@@ -1844,7 +1844,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider adding an empty list of dependencies to make it clear which values are intended to be stable.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
    ╭─[exhaustive_deps.tsx:3:11]
  2 │           const [data, setData] = useState(0);
  3 │           useEffect(() => {
@@ -1853,7 +1853,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider adding an empty list of dependencies to make it clear which values are intended to be stable.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
    ╭─[exhaustive_deps.tsx:3:11]
  2 │           const [data, setData] = useState(0);
  3 │           useEffect(() => {
@@ -1862,7 +1862,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider adding an empty list of dependencies to make it clear which values are intended to be stable.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect contains a call to setState. Without a list of dependencies, this can lead to an infinite chain of updates.
    ╭─[exhaustive_deps.tsx:3:11]
  2 │           const [state, setState] = useState(0);
  3 │           useEffect(() => {
@@ -1871,7 +1871,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider adding an empty list of dependencies to make it clear which values are intended to be stable.
 
-  ⚠ react_hooks(exhaustive-deps): Effect callbacks are synchronous to prevent race conditions.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): Effect callbacks are synchronous to prevent race conditions.
    ╭─[exhaustive_deps.tsx:2:21]
  1 │ function Thing() {
  2 │           useEffect(async () => {}, []);
@@ -1880,7 +1880,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider putting the asynchronous code inside a function and calling it from the effect.
 
-  ⚠ react_hooks(exhaustive-deps): Effect callbacks are synchronous to prevent race conditions.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): Effect callbacks are synchronous to prevent race conditions.
    ╭─[exhaustive_deps.tsx:2:21]
  1 │ function Thing() {
  2 │           useEffect(async () => {});
@@ -1889,7 +1889,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider putting the asynchronous code inside a function and calling it from the effect.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:31]
  5 │           }
  6 │           useEffect(myEffect, []);
@@ -1898,7 +1898,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:31]
  5 │           };
  6 │           useEffect(myEffect, []);
@@ -1907,7 +1907,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:31]
  5 │           };
  6 │           useEffect(myEffect, []);
@@ -1916,7 +1916,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'otherThing'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'otherThing'
     ╭─[exhaustive_deps.tsx:9:31]
   8 │           };
   9 │           useEffect(myEffect, []);
@@ -1925,7 +1925,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
    ╭─[exhaustive_deps.tsx:7:31]
  6 │ 
  7 │           useEffect(myEffect, []);
@@ -1934,7 +1934,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
    ╭─[exhaustive_deps.tsx:6:31]
  5 │           }, delay);
  6 │           useEffect(myEffect, [local]);
@@ -1943,7 +1943,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'myEffect'
    ╭─[exhaustive_deps.tsx:2:31]
  1 │ function MyComponent({myEffect}) {
  2 │           useEffect(myEffect, []);
@@ -1952,16 +1952,17 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect received a function whose dependencies are unknown.
-   ╭─[exhaustive_deps.tsx:3:11]
- 2 │           const local = {};
- 3 │           useEffect(debounce(() => {
-   ·           ─────────
- 4 │             console.log(local);
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect received a function whose dependencies are unknown.
+   ╭─[exhaustive_deps.tsx:3:21]
+ 2 │               const local = {};
+ 3 │ ╭─▶           useEffect(debounce(() => {
+ 4 │ │               console.log(local);
+ 5 │ ╰─▶           }, delay), []);
+ 6 │             }
    ╰────
   help: Pass an inline function instead.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, []);
@@ -1970,7 +1971,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'foo.bar.baz', and 'props.foo.bar.baz'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'foo.bar.baz', and 'props.foo.bar.baz'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             props.foo.bar.baz = 1;
  6 │           }, []);
@@ -1979,7 +1980,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = {};
  3 │           useMemo(() => foo, [foo]);
@@ -1988,7 +1989,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = [];
  3 │           useMemo(() => foo, [foo]);
@@ -1997,7 +1998,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = () => {};
  3 │           useMemo(() => foo, [foo]);
@@ -2006,7 +2007,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = function bar(){};
  3 │           useMemo(() => foo, [foo]);
@@ -2015,7 +2016,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = class {};
  3 │           useMemo(() => foo, [foo]);
@@ -2024,7 +2025,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = true ? {} : 'fine';
  3 │           useMemo(() => foo, [foo]);
@@ -2033,7 +2034,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = bar || {};
  3 │           useMemo(() => foo, [foo]);
@@ -2042,7 +2043,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = bar ?? {};
  3 │           useMemo(() => foo, [foo]);
@@ -2051,7 +2052,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = bar && {};
  3 │           useMemo(() => foo, [foo]);
@@ -2060,7 +2061,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           const foo = bar ? baz ? {} : null : null;
  3 │           useMemo(() => foo, [foo]);
@@ -2069,7 +2070,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           let foo = {};
  3 │           useMemo(() => foo, [foo]);
@@ -2078,7 +2079,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:3:31]
  2 │           var foo = {};
  3 │           useMemo(() => foo, [foo]);
@@ -2087,7 +2088,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2096,7 +2097,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2105,7 +2106,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2114,7 +2115,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useImperativeHandle has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useImperativeHandle has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:8:14]
  7 │             },
  8 │             [foo]
@@ -2123,7 +2124,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2132,7 +2133,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:6:15]
  5 │             console.log(foo);
  6 │           }, [foo]);
@@ -2141,7 +2142,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2150,7 +2151,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2159,7 +2160,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2168,7 +2169,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2177,7 +2178,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2186,7 +2187,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2195,7 +2196,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useMemo has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(new Bar());
  5 │           }, [Bar]);
@@ -2204,7 +2205,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useLayoutEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(foo);
  5 │           }, [foo]);
@@ -2213,7 +2214,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ react_hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a dependency array that changes every render.
    ╭─[exhaustive_deps.tsx:8:15]
  7 │             console.log(foo);
  8 │           }, [foo]);


### PR DESCRIPTION
@Boshen lemme know if this is incorrect, but i noticed that `rules-of-hooks` lives inside `react` not `react-hooks`

https://github.com/oxc-project/oxc/blob/1f2a6c666f55df21a6cc2409eb93482b4e57d50f/crates/oxc_linter/src/config/rules.rs#L291-L292

https://github.com/oxc-project/oxc/blob/1f2a6c666f55df21a6cc2409eb93482b4e57d50f/crates/oxc_linter/src/options/filter.rs#L254