### PR TITLE
fix(linter): revert unmatched rule error

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -244,9 +244,6 @@ mod test {
         let options = lint_command().run_inner(new_args.as_slice()).unwrap();
         match LintRunner::new(options).run() {
             CliRunResult::LintResult(lint_result) => lint_result,
-            CliRunResult::LintError { error } => {
-                panic!("{error}")
-            }
             other => panic!("{other:?}"),
         }
     }

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -7,21 +7,10 @@ use std::{
 #[derive(Debug)]
 pub enum CliRunResult {
     None,
-    InvalidOptions {
-        message: String,
-    },
-    PathNotFound {
-        paths: Vec<PathBuf>,
-    },
-    /// Indicates that there was an error trying to run the linter and it was
-    /// not able to complete linting successfully.
-    LintError {
-        error: String,
-    },
+    InvalidOptions { message: String },
+    PathNotFound { paths: Vec<PathBuf> },
     LintResult(LintResult),
-    PrintConfigResult {
-        config_file: String,
-    },
+    PrintConfigResult { config_file: String },
 }
 
 /// A summary of a complete linter run.
@@ -56,10 +45,6 @@ impl Termination for CliRunResult {
             }
             Self::PathNotFound { paths } => {
                 println!("Path {paths:?} does not exist.");
-                ExitCode::from(1)
-            }
-            Self::LintError { error } => {
-                eprintln!("Error: {error}");
                 ExitCode::from(1)
             }
             Self::LintResult(LintResult {

--- a/crates/oxc_linter/src/builder.rs
+++ b/crates/oxc_linter/src/builder.rs
@@ -3,7 +3,6 @@ use std::{
     fmt,
 };
 
-use oxc_diagnostics::{Error, OxcDiagnostic};
 use oxc_span::CompactStr;
 use rustc_hash::FxHashSet;
 
@@ -100,20 +99,6 @@ impl LinterBuilder {
         {
             let all_rules = builder.cache.borrow();
             oxlintrc_rules.override_rules(&mut builder.rules, all_rules.as_slice());
-        }
-
-        #[expect(clippy::print_stderr)]
-        if !oxlintrc_rules.unknown_rules.is_empty() {
-            let rules = oxlintrc_rules
-                .unknown_rules
-                .iter()
-                .map(|r| r.full_name())
-                .collect::<Vec<_>>()
-                .join("\n");
-            let error = Error::from(OxcDiagnostic::warn(format!(
-                "The following rules do not match the currently supported rules:\n{rules}"
-            )));
-            eprintln!("{error:?}");
         }
 
         builder


### PR DESCRIPTION
- related to https://github.com/oxc-project/oxc/issues/6988

This is causing a lot of errors currently such as https://github.com/oxc-project/oxc/issues/7233. I think we need to handle rule names more robustly first:

- https://github.com/oxc-project/oxc/issues/7240
- https://github.com/oxc-project/oxc/issues/7082
- https://github.com/oxc-project/oxc/discussions/7242

then, I think we can revisit this and maybe implement it as an actual lint plugin too?  https://github.com/oxc-project/oxc/discussions/7086