### PR TITLE
refactor(linter): temporarily remove unknown rules checking

### DIFF
--- a/crates/oxc_linter/src/builder.rs
+++ b/crates/oxc_linter/src/builder.rs
@@ -82,7 +82,7 @@ impl LinterBuilder {
     /// match any recognized rules.
     pub fn from_oxlintrc(start_empty: bool, oxlintrc: Oxlintrc) -> Self {
         // TODO: monorepo config merging, plugin-based extends, etc.
-        let Oxlintrc { plugins, settings, env, globals, categories, rules: mut oxlintrc_rules } =
+        let Oxlintrc { plugins, settings, env, globals, categories, rules: oxlintrc_rules } =
             oxlintrc;
 
         let config = LintConfig { plugins, settings, env, globals };

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -101,7 +101,7 @@ mod test {
     fn test_vitest_rule_replace() {
         let fixture_path: std::path::PathBuf =
             env::current_dir().unwrap().join("fixtures/eslint_config_vitest_replace.json");
-        let mut config = Oxlintrc::from_file(&fixture_path).unwrap();
+        let config = Oxlintrc::from_file(&fixture_path).unwrap();
         let mut set = FxHashSet::default();
         config.rules.override_rules(&mut set, &RULES);
 


### PR DESCRIPTION
I had intended to leave this in until we could rework some of the rule/plugin name resolution code, however this is causing issues with merging https://github.com/oxc-project/oxc/pull/6974. The mutability of `self` is difficult to resolve in that PR without more drastic changes. Since this isn't currently helping us out, I am simply removing the code for now until we can revisit this.