### PR TITLE
feat(ast): serialize StringLiterals to ESTree without `raw`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -65,6 +65,7 @@ pub struct NumericLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw?: undefined")]
 pub struct StringLiteral<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -33,11 +33,7 @@ impl<'a> Serialize for NumericLiteral<'a> {
 
 impl<'a> Serialize for StringLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "StringLiteral")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
     }
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -20,8 +20,9 @@ export interface NumericLiteral extends Span {
 }
 
 export interface StringLiteral extends Span {
-  type: 'StringLiteral';
+  type: 'Literal';
   value: string;
+  raw?: undefined;
 }
 
 export interface BigIntLiteral extends Span {


### PR DESCRIPTION
#7211 alternative. Makes the `raw` field on estree literals optional.