### PR TITLE
feat(traverse): introduce `MaybeBoundIdentifier`

### DIFF
--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -18,10 +18,12 @@ use crate::{
 
 mod ancestry;
 mod bound_identifier;
+mod maybe_bound_identifier;
 mod scoping;
 use ancestry::PopToken;
 pub use ancestry::TraverseAncestry;
 pub use bound_identifier::BoundIdentifier;
+pub use maybe_bound_identifier::MaybeBoundIdentifier;
 pub use scoping::TraverseScoping;
 
 /// Traverse context.

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -66,7 +66,9 @@ use oxc_semantic::{ScopeTree, SymbolTable};
 
 pub mod ast_operations;
 mod context;
-pub use context::{BoundIdentifier, TraverseAncestry, TraverseCtx, TraverseScoping};
+pub use context::{
+    BoundIdentifier, MaybeBoundIdentifier, TraverseAncestry, TraverseCtx, TraverseScoping,
+};
 
 mod generated {
     pub mod ancestor;


### PR DESCRIPTION
`MaybeBoundIdentifier` is similar to `BoundIdentifier`, but can be used where the identifier may or may not have have a `SymbolId` (may or may not be bound).

Typical usage:

```rs
// Create `MaybeBoundIdentifier` from an existing `IdentifierReference`
let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);

// Generate `IdentifierReference`s and insert them into AST
assign_expr.left = binding.create_write_target(ctx);
assign_expr.right = binding.create_read_expression(ctx);
```