### PR TITLE
refactor(ast): move `StringLiteral` definition higher up

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -59,6 +59,21 @@ pub struct NumericLiteral<'a> {
     pub base: NumberBase,
 }
 
+/// String literal
+///
+/// <https://tc39.es/ecma262/#sec-literals-string-literals>
+#[ast(visit)]
+#[derive(Debug, Clone)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+pub struct StringLiteral<'a> {
+    /// Node location in source code
+    pub span: Span,
+    /// The value of the string.
+    ///
+    /// Any escape sequences in the raw code are unescaped.
+    pub value: Atom<'a>,
+}
+
 /// BigInt literal
 #[ast(visit)]
 #[derive(Debug, Clone)]
@@ -126,21 +141,6 @@ pub enum RegExpPattern<'a> {
     /// A parsed pattern. Read [Pattern] for more details.
     /// Pattern was parsed and found to be valid.
     Pattern(Box<'a, Pattern<'a>>) = 2,
-}
-
-/// String literal
-///
-/// <https://tc39.es/ecma262/#sec-literals-string-literals>
-#[ast(visit)]
-#[derive(Debug, Clone)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-pub struct StringLiteral<'a> {
-    /// Node location in source code
-    pub span: Span,
-    /// The value of the string.
-    ///
-    /// Any escape sequences in the raw code are unescaped.
-    pub value: Atom<'a>,
 }
 
 bitflags! {

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -25,6 +25,11 @@ const _: () = {
     assert!(offset_of!(NumericLiteral, raw) == 16usize);
     assert!(offset_of!(NumericLiteral, base) == 32usize);
 
+    assert!(size_of::<StringLiteral>() == 24usize);
+    assert!(align_of::<StringLiteral>() == 8usize);
+    assert!(offset_of!(StringLiteral, span) == 0usize);
+    assert!(offset_of!(StringLiteral, value) == 8usize);
+
     assert!(size_of::<BigIntLiteral>() == 32usize);
     assert!(align_of::<BigIntLiteral>() == 8usize);
     assert!(offset_of!(BigIntLiteral, span) == 0usize);
@@ -44,11 +49,6 @@ const _: () = {
 
     assert!(size_of::<RegExpPattern>() == 24usize);
     assert!(align_of::<RegExpPattern>() == 8usize);
-
-    assert!(size_of::<StringLiteral>() == 24usize);
-    assert!(align_of::<StringLiteral>() == 8usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
 
     assert!(size_of::<Program>() == 160usize);
     assert!(align_of::<Program>() == 8usize);
@@ -1581,6 +1581,11 @@ const _: () = {
     assert!(offset_of!(NumericLiteral, raw) == 16usize);
     assert!(offset_of!(NumericLiteral, base) == 24usize);
 
+    assert!(size_of::<StringLiteral>() == 16usize);
+    assert!(align_of::<StringLiteral>() == 4usize);
+    assert!(offset_of!(StringLiteral, span) == 0usize);
+    assert!(offset_of!(StringLiteral, value) == 8usize);
+
     assert!(size_of::<BigIntLiteral>() == 20usize);
     assert!(align_of::<BigIntLiteral>() == 4usize);
     assert!(offset_of!(BigIntLiteral, span) == 0usize);
@@ -1600,11 +1605,6 @@ const _: () = {
 
     assert!(size_of::<RegExpPattern>() == 12usize);
     assert!(align_of::<RegExpPattern>() == 4usize);
-
-    assert!(size_of::<StringLiteral>() == 16usize);
-    assert!(align_of::<StringLiteral>() == 4usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
 
     assert!(size_of::<Program>() == 88usize);
     assert!(align_of::<Program>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -116,6 +116,36 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
     }
 
+    /// Build a [`StringLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: Node location in source code
+    /// - value: The value of the string.
+    #[inline]
+    pub fn string_literal<A>(self, span: Span, value: A) -> StringLiteral<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        StringLiteral { span, value: value.into_in(self.allocator) }
+    }
+
+    /// Build a [`StringLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: Node location in source code
+    /// - value: The value of the string.
+    #[inline]
+    pub fn alloc_string_literal<A>(self, span: Span, value: A) -> Box<'a, StringLiteral<'a>>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        Box::new_in(self.string_literal(span, value), self.allocator)
+    }
+
     /// Build a [`BigIntLiteral`].
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_big_int_literal`] instead.
@@ -188,36 +218,6 @@ impl<'a> AstBuilder<'a> {
         S: IntoIn<'a, &'a str>,
     {
         Box::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
-    }
-
-    /// Build a [`StringLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
-    ///
-    /// ## Parameters
-    /// - span: Node location in source code
-    /// - value: The value of the string.
-    #[inline]
-    pub fn string_literal<A>(self, span: Span, value: A) -> StringLiteral<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        StringLiteral { span, value: value.into_in(self.allocator) }
-    }
-
-    /// Build a [`StringLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
-    ///
-    /// ## Parameters
-    /// - span: Node location in source code
-    /// - value: The value of the string.
-    #[inline]
-    pub fn alloc_string_literal<A>(self, span: Span, value: A) -> Box<'a, StringLiteral<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.string_literal(span, value), self.allocator)
     }
 
     /// Build a [`Program`].

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -13,9 +13,9 @@ pub enum AstType {
     BooleanLiteral,
     NullLiteral,
     NumericLiteral,
+    StringLiteral,
     BigIntLiteral,
     RegExpLiteral,
-    StringLiteral,
     Program,
     IdentifierName,
     IdentifierReference,
@@ -183,9 +183,9 @@ pub enum AstKind<'a> {
     BooleanLiteral(&'a BooleanLiteral),
     NullLiteral(&'a NullLiteral),
     NumericLiteral(&'a NumericLiteral<'a>),
+    StringLiteral(&'a StringLiteral<'a>),
     BigIntLiteral(&'a BigIntLiteral<'a>),
     RegExpLiteral(&'a RegExpLiteral<'a>),
-    StringLiteral(&'a StringLiteral<'a>),
     Program(&'a Program<'a>),
     IdentifierName(&'a IdentifierName<'a>),
     IdentifierReference(&'a IdentifierReference<'a>),
@@ -354,9 +354,9 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::BooleanLiteral(it) => it.span(),
             Self::NullLiteral(it) => it.span(),
             Self::NumericLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
             Self::BigIntLiteral(it) => it.span(),
             Self::RegExpLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
             Self::Program(it) => it.span(),
             Self::IdentifierName(it) => it.span(),
             Self::IdentifierReference(it) => it.span(),
@@ -549,6 +549,15 @@ impl<'a> AstKind<'a> {
     }
 
     #[inline]
+    pub fn as_string_literal(self) -> Option<&'a StringLiteral<'a>> {
+        if let Self::StringLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     pub fn as_big_int_literal(self) -> Option<&'a BigIntLiteral<'a>> {
         if let Self::BigIntLiteral(v) = self {
             Some(v)
@@ -560,15 +569,6 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_reg_exp_literal(self) -> Option<&'a RegExpLiteral<'a>> {
         if let Self::RegExpLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_string_literal(self) -> Option<&'a StringLiteral<'a>> {
-        if let Self::StringLiteral(v) = self {
             Some(v)
         } else {
             None

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -44,6 +44,16 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'old_alloc> 
     }
 }
 
+impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StringLiteral<'old_alloc> {
+    type Cloned = StringLiteral<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        StringLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
+    }
+}
+
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'old_alloc> {
     type Cloned = BigIntLiteral<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
@@ -83,16 +93,6 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'old_alloc> {
             Self::Raw(it) => RegExpPattern::Raw(CloneIn::clone_in(it, allocator)),
             Self::Invalid(it) => RegExpPattern::Invalid(CloneIn::clone_in(it, allocator)),
             Self::Pattern(it) => RegExpPattern::Pattern(CloneIn::clone_in(it, allocator)),
-        }
-    }
-}
-
-impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for StringLiteral<'old_alloc> {
-    type Cloned = StringLiteral<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StringLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -35,6 +35,12 @@ impl<'a> ContentEq for NumericLiteral<'a> {
     }
 }
 
+impl<'a> ContentEq for StringLiteral<'a> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
 impl<'a> ContentEq for BigIntLiteral<'a> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.raw, &other.raw)
@@ -72,12 +78,6 @@ impl<'a> ContentEq for RegExpPattern<'a> {
                 _ => false,
             },
         }
-    }
-}
-
-impl<'a> ContentEq for StringLiteral<'a> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_hash.rs
+++ b/crates/oxc_ast/src/generated/derive_content_hash.rs
@@ -23,6 +23,12 @@ impl ContentHash for BooleanLiteral {
     }
 }
 
+impl<'a> ContentHash for StringLiteral<'a> {
+    fn content_hash<H: Hasher>(&self, state: &mut H) {
+        ContentHash::content_hash(&self.value, state);
+    }
+}
+
 impl<'a> ContentHash for BigIntLiteral<'a> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&self.raw, state);
@@ -52,12 +58,6 @@ impl<'a> ContentHash for RegExpPattern<'a> {
             Self::Invalid(it) => ContentHash::content_hash(it, state),
             Self::Pattern(it) => ContentHash::content_hash(it, state),
         }
-    }
-}
-
-impl<'a> ContentHash for StringLiteral<'a> {
-    fn content_hash<H: Hasher>(&self, state: &mut H) {
-        ContentHash::content_hash(&self.value, state);
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -31,6 +31,16 @@ impl<'a> Serialize for NumericLiteral<'a> {
     }
 }
 
+impl<'a> Serialize for StringLiteral<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "StringLiteral")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("value", &self.value)?;
+        map.end()
+    }
+}
+
 impl<'a> Serialize for BigIntLiteral<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
@@ -59,16 +69,6 @@ impl<'a> Serialize for RegExpPattern<'a> {
             RegExpPattern::Invalid(x) => Serialize::serialize(x, serializer),
             RegExpPattern::Pattern(x) => Serialize::serialize(x, serializer),
         }
-    }
-}
-
-impl<'a> Serialize for StringLiteral<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "StringLiteral")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -34,6 +34,13 @@ impl<'a> GetSpan for NumericLiteral<'a> {
     }
 }
 
+impl<'a> GetSpan for StringLiteral<'a> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 impl<'a> GetSpan for BigIntLiteral<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -42,13 +49,6 @@ impl<'a> GetSpan for BigIntLiteral<'a> {
 }
 
 impl<'a> GetSpan for RegExpLiteral<'a> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl<'a> GetSpan for StringLiteral<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -34,6 +34,13 @@ impl<'a> GetSpanMut for NumericLiteral<'a> {
     }
 }
 
+impl<'a> GetSpanMut for StringLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpanMut for BigIntLiteral<'a> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
@@ -42,13 +49,6 @@ impl<'a> GetSpanMut for BigIntLiteral<'a> {
 }
 
 impl<'a> GetSpanMut for RegExpLiteral<'a> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl<'a> GetSpanMut for StringLiteral<'a> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
         &mut self.span

--- a/crates/oxc_traverse/src/generated/traverse.rs
+++ b/crates/oxc_traverse/src/generated/traverse.rs
@@ -1495,6 +1495,11 @@ pub trait Traverse<'a> {
     fn exit_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
+    fn enter_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
     fn enter_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
     fn exit_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
@@ -1503,11 +1508,6 @@ pub trait Traverse<'a> {
     fn enter_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
     fn exit_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_this_parameter(

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3606,6 +3606,15 @@ pub(crate) unsafe fn walk_numeric_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_numeric_literal(&mut *node, ctx);
 }
 
+pub(crate) unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut StringLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_string_literal(&mut *node, ctx);
+    traverser.exit_string_literal(&mut *node, ctx);
+}
+
 pub(crate) unsafe fn walk_big_int_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BigIntLiteral<'a>,
@@ -3622,15 +3631,6 @@ pub(crate) unsafe fn walk_reg_exp_literal<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_reg_exp_literal(&mut *node, ctx);
     traverser.exit_reg_exp_literal(&mut *node, ctx);
-}
-
-pub(crate) unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
-    traverser: &mut Tr,
-    node: *mut StringLiteral<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) {
-    traverser.enter_string_literal(&mut *node, ctx);
-    traverser.exit_string_literal(&mut *node, ctx);
 }
 
 pub(crate) unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -19,6 +19,11 @@ export interface NumericLiteral extends Span {
   raw: string;
 }
 
+export interface StringLiteral extends Span {
+  type: 'StringLiteral';
+  value: string;
+}
+
 export interface BigIntLiteral extends Span {
   type: 'Literal';
   raw: string;
@@ -39,11 +44,6 @@ export interface RegExp {
 }
 
 export type RegExpPattern = string | string | Pattern;
-
-export interface StringLiteral extends Span {
-  type: 'StringLiteral';
-  value: string;
-}
 
 export interface Program extends Span {
   type: 'Program';


### PR DESCRIPTION
Pure refactor. `StringLiteral` definition was sandwiched in the middle of RegExp-related code. Move it higher up in `literal.rs`.

All the rest of the diff is just re-ordering generated code.