### PR TITLE
chore(linter): add allowReject option to `unicorn/no-useless-promise-resolve-reject`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -66,7 +66,7 @@ impl Rule for NoUselessPromiseResolveReject {
         let allow_reject = config
             .and_then(|c| c.get("allowReject"))
             .and_then(serde_json::Value::as_bool)
-            .map_or(false, |v| v);
+            .unwrap_or_default();
 
         Self(Box::new(NoUselessPromiseResolveRejectOptions { allow_reject }))
     }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -600,11 +600,15 @@ fn test() {
         (r"function then() { return Promise.reject() }", None),
         (r"doThing(function(x) { return Promise.reject(x) })", None),
         (r"doThing().then(function() { return })", None),
-        // TODO: support `allow_reject` option
-        // "doThing().then(function() { return Promise.reject(4) })",
+        (
+            "doThing().then(function() { return Promise.reject(4) })",
+            Some(serde_json::json!([{ "allowReject": true }])),
+        ),
         (r"doThing().then((function() { return Promise.resolve(4) }).toString())", None),
-        // TODO: support `allow_reject` option
-        // "doThing().then(() => Promise.reject(4))",
+        (
+            "doThing().then(() => Promise.reject(4))",
+            Some(serde_json::json!([{ "allowReject": true }])),
+        ),
         (r"doThing().then(function() { return a() })", None),
         (r"doThing().then(function() { return Promise.a() })", None),
         (r"doThing().then(() => { return a() })", None),


### PR DESCRIPTION
followup to #7232.

I'll keep this draft until #7232 is merged.