### PR TITLE
refactor(semantic): remove duplicated code

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -409,11 +409,8 @@ impl<'a> Binder<'a> for TSModuleDeclaration<'a> {
             SymbolFlags::None,
         );
 
-        // do not bind `global` for `declare global { ... }`
-        if !self.kind.is_global() {
-            if let TSModuleDeclarationName::Identifier(id) = &self.id {
-                id.symbol_id.set(Some(symbol_id));
-            }
+        if let TSModuleDeclarationName::Identifier(id) = &self.id {
+            id.symbol_id.set(Some(symbol_id));
         }
     }
 }


### PR DESCRIPTION
`if matches!(self.kind, TSModuleDeclarationKind::Global)` at top of function already performed this check, no need to check it again.