### PR TITLE
refactor(semantic): shorten code

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -395,7 +395,7 @@ impl<'a> Binder<'a> for TSEnumMember<'a> {
 impl<'a> Binder<'a> for TSModuleDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         // do not bind `global` for `declare global { ... }`
-        if matches!(self.kind, TSModuleDeclarationKind::Global) {
+        if self.kind == TSModuleDeclarationKind::Global {
             return;
         }
 


### PR DESCRIPTION
Tiny refactor. No need for `matches!` here.