### PR TITLE
fix(tasks): cargo clippy error on rust 1.82.0

### DIFF
--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -108,20 +108,19 @@ fn typescript_struct(def: &StructDef, always_flatten_structs: &FxHashSet<TypeId>
 
         let ident = field.ident().unwrap();
         if let Some(append_after) = append_to.get(&ident.to_string()) {
-            let after_type = if let Some(ty) =
-                &append_after.markers.derive_attributes.estree.typescript_type
-            {
-                ty.clone()
-            } else {
-                let typ = append_after.typ.name();
-                if let TypeName::Opt(inner) = typ {
-                    type_to_string(inner)
+            let after_type =
+                if let Some(ty) = &append_after.markers.derive_attributes.estree.typescript_type {
+                    ty.clone()
                 } else {
-                    panic!(
+                    let typ = append_after.typ.name();
+                    if let TypeName::Opt(inner) = typ {
+                        type_to_string(inner)
+                    } else {
+                        panic!(
                         "expected field labeled with append_to to be Option<...>, but found {typ}"
                     );
-                }
-            };
+                    }
+                };
             if let Some(inner) = ty.strip_prefix("Array<") {
                 ty = format!("Array<{after_type} | {inner}");
             } else {

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -108,15 +108,18 @@ fn typescript_struct(def: &StructDef, always_flatten_structs: &FxHashSet<TypeId>
 
         let ident = field.ident().unwrap();
         if let Some(append_after) = append_to.get(&ident.to_string()) {
-            let after_type = match &append_after.markers.derive_attributes.estree.typescript_type {
-                Some(ty) => ty.clone(),
-                None => {
-                    let typ = append_after.typ.name();
-                    if let TypeName::Opt(inner) = typ {
-                        type_to_string(inner)
-                    } else {
-                        panic!("expected field labeled with append_to to be Option<...>, but found {typ}");
-                    }
+            let after_type = if let Some(ty) =
+                &append_after.markers.derive_attributes.estree.typescript_type
+            {
+                ty.clone()
+            } else {
+                let typ = append_after.typ.name();
+                if let TypeName::Opt(inner) = typ {
+                    type_to_string(inner)
+                } else {
+                    panic!(
+                        "expected field labeled with append_to to be Option<...>, but found {typ}"
+                    );
                 }
             };
             if let Some(inner) = ty.strip_prefix("Array<") {

--- a/tasks/ast_tools/src/layout.rs
+++ b/tasks/ast_tools/src/layout.rs
@@ -160,10 +160,10 @@ impl Layout {
 /// For `n` bigger than `16`, Or if it's not a power of 2 number
 fn max_val_of_bytes(n: usize) -> u128 {
     match n {
-        1 => u8::MAX as u128,
-        2 => u16::MAX as u128,
-        4 => u32::MAX as u128,
-        8 => u64::MAX as u128,
+        1 => u128::from(u8::MAX),
+        2 => u128::from(u16::MAX),
+        4 => u128::from(u32::MAX),
+        8 => u128::from(u64::MAX),
         16 => u128::MAX,
         _ => panic!("We do not support `n` bigger than 16 bytes."),
     }


### PR DESCRIPTION
I mentioned this clippy issue in the discord help channel. The problem seems to be related to using the stable rust toolchain, but when I switched to version `1.81.0`, the issue was resolved. 

However, some of the clippy suggestions might still be worth considering and could be adopted.