### PR TITLE
style(ast_tools): fix wonky formatting

### DIFF
--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -108,19 +108,20 @@ fn typescript_struct(def: &StructDef, always_flatten_structs: &FxHashSet<TypeId>
 
         let ident = field.ident().unwrap();
         if let Some(append_after) = append_to.get(&ident.to_string()) {
-            let after_type =
-                if let Some(ty) = &append_after.markers.derive_attributes.estree.typescript_type {
-                    ty.clone()
+            let ts_type = &append_after.markers.derive_attributes.estree.typescript_type;
+            let after_type = if let Some(ty) = ts_type {
+                ty.clone()
+            } else {
+                let typ = append_after.typ.name();
+                if let TypeName::Opt(inner) = typ {
+                    type_to_string(inner)
                 } else {
-                    let typ = append_after.typ.name();
-                    if let TypeName::Opt(inner) = typ {
-                        type_to_string(inner)
-                    } else {
-                        panic!(
+                    panic!(
                         "expected field labeled with append_to to be Option<...>, but found {typ}"
                     );
-                    }
-                };
+                }
+            };
+
             if let Some(inner) = ty.strip_prefix("Array<") {
                 ty = format!("Array<{after_type} | {inner}");
             } else {


### PR DESCRIPTION
Follow-on after #7283. Pure refactor. `rustfmt` was malfunctioning on this code for some reason. Alter the code slightly so it formats it nicely.