### PR TITLE
fix(justfile): make submodules work on windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S just --justfile
 
-set windows-shell := ["pwsh", "-NoLogo", "-Command"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 set shell := ["bash", "-cu"]
 
 _default:

--- a/justfile
+++ b/justfile
@@ -192,18 +192,17 @@ new-vitest-rule name:
 new-security-rule name:
     cargo run -p rulegen {{name}} security
 
+[unix]
 clone-submodule dir url sha:
-  just git-init-if-not-exist {{dir}}
-  cd {{dir}} && git remote add origin {{url}}
+  cd {{dir}} || git init {{dir}}
+  cd {{dir}} && git remote add origin {{url}} || true
   cd {{dir}} && git fetch --depth=1 origin {{sha}} && git reset --hard {{sha}}
 
-[unix]
-git-init-if-not-exist dir:
-  cd {{dir}} || git init {{dir}}
-
 [windows]
-git-init-if-not-exist dir:
-  if (Test-Path {{ dir }}) {cd {{ dir }}} else {git init {{dir}}}
+clone-submodule dir url sha:
+  if (-not (Test-Path {{dir}}/.git)) { git init {{dir}} }
+  cd {{dir}} ; if ((git remote) -notcontains 'origin') { git remote add origin {{url}} } else { git remote set-url origin {{url}} }
+  cd {{dir}} ; git fetch --depth=1 origin {{sha}} ; git reset --hard {{sha}}
 
 website path:
   cargo run -p website -- linter-rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules


### PR DESCRIPTION
Related to #7290, closes #7296 

By default, `Windows` encounters the following issue unless the user installs `PowerShell 7` (pwsh).

```bash
error: Recipe `submodules` could not be run because just could not find the shell: program not found
error: Recipe `init` could not be run because just could not find the shell: program not found
```

Furthermore, I have found a better way to solve this problem.