### PR TITLE
fix(minifier): do not compare bigint with object

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -362,14 +362,14 @@ impl<'a, 'b> PeepholeFoldConstants {
                 }
             }
 
-            if matches!(left, ValueType::String | ValueType::Number)
+            if matches!(left, ValueType::String | ValueType::Number | ValueType::BigInt)
                 && matches!(right, ValueType::Object)
             {
                 return None;
             }
 
             if matches!(left, ValueType::Object)
-                && matches!(right, ValueType::String | ValueType::Number)
+                && matches!(right, ValueType::String | ValueType::Number | ValueType::BigInt)
             {
                 return None;
             }
@@ -871,6 +871,13 @@ mod test {
         test("'1' != 1n", "false");
         test("'1' === 1n", "false");
         test("'1' !== 1n", "true");
+    }
+
+    #[test]
+    fn test_object_bigint_comparison() {
+        test_same("{ valueOf: function() { return 0n; } } != 0n");
+        test_same("0n != { valueOf: function() { return 0n; } }");
+        test_same("0n != { toString: function() { return '0'; } }");
     }
 
     #[test]

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -18,7 +18,7 @@ use crate::{node_util::Ctx, CompressorPass};
 pub struct PeepholeSubstituteAlternateSyntax {
     /// Do not compress syntaxes that are hard to analyze inside the fixed loop.
     /// e.g. Do not compress `undefined -> void 0`, `true` -> `!0`.
-    /// Opposite of `late` in Closure Compier.
+    /// Opposite of `late` in Closure Compiler.
     in_fixed_loop: bool,
 
     // states

--- a/tasks/coverage/snapshots/runtime.snap
+++ b/tasks/coverage/snapshots/runtime.snap
@@ -2,7 +2,7 @@ commit: 06454619
 
 runtime Summary:
 AST Parsed     : 18055/18055 (100.00%)
-Positive Passed: 17796/18055 (98.57%)
+Positive Passed: 17798/18055 (98.58%)
 tasks/coverage/test262/test/language/arguments-object/async-gen-meth-args-trailing-comma-multiple.js
 transform error: Test262Error: Expected SameValue(«0», «2») to be true
 
@@ -446,12 +446,6 @@ transform error: Test262Error: Expected a TypeError to be thrown but no exceptio
 
 tasks/coverage/test262/test/language/expressions/class/heritage-async-arrow-function.js
 transform error: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
-
-tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-object.js
-minify error: Test262Error: The result of (0n != {valueOf: function() {return 0n;}}) is false Expected SameValue(«true», «false») to be true
-
-tasks/coverage/test262/test/language/expressions/equals/bigint-and-object.js
-minify error: Test262Error: The result of (0n == {valueOf: function() {return 0n;}}) is true Expected SameValue(«false», «true») to be true
 
 tasks/coverage/test262/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
 transform error: Test262Error: (-1n) ** -1n throws RangeError Expected a RangeError but got a TypeError


### PR DESCRIPTION
@Boshen, could you please update the snap of runtime and commit to this PR? I want to see the effects after the unit tests are added.