### PR TITLE
fix(tools): `just test-transform` run conformance only once

### DIFF
--- a/justfile
+++ b/justfile
@@ -128,8 +128,7 @@ autoinherit:
 
 # Test Transform
 test-transform *args='':
-  cargo run -p oxc_transform_conformance -- {{args}}
-  cargo run -p oxc_transform_conformance -- --exec  {{args}}
+  cargo run -p oxc_transform_conformance -- --exec {{args}}
 
 # Install wasm-pack
 install-wasm:


### PR DESCRIPTION
`--exec` flag also runs the non-exec tests, so it's not required to run it twice.