### PR TITLE
chore(justfile): add `pnpm install` to init

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,10 +11,12 @@ alias c := conformance
 alias f := fix
 alias new-typescript-rule := new-ts-rule
 
+# Make sure you have cargo-binstall installed.
+# You can download the pre-compiled binary from <https://github.com/cargo-bins/cargo-binstall#installation>
+# or install via `cargo install cargo-binstall`
 # Initialize the project by installing all the necessary tools.
 init:
   # Rust related init
-  cargo install cargo-binstall
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint -y
   # Node.js related init
   pnpm install

--- a/justfile
+++ b/justfile
@@ -11,12 +11,13 @@ alias c := conformance
 alias f := fix
 alias new-typescript-rule := new-ts-rule
 
-# Make sure you have cargo-binstall installed.
-# You can download the pre-compiled binary from <https://github.com/cargo-bins/cargo-binstall#installation>
-# or install via `cargo install cargo-binstall`
 # Initialize the project by installing all the necessary tools.
 init:
+  # Rust related init
+  cargo install cargo-binstall
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint -y
+  # Node.js related init
+  pnpm install
 
 # When ready, run the same CI commands
 ready:


### PR DESCRIPTION
Recently, due to some issues, I had to re-clone the oxc project multiple times. After running `just init`, I always had to run `pnpm install` separately. We could include `pnpm install` to init command to streamline the process. In addition, I propose to include `cargo-binstall` in the init command.

I'm not sure if we should include the `submodules` command in the init command, as it is generally unnecessary for most users unless they are working on specific projects like the minifier.