### PR TITLE
chore(doc): replace main/master to tag/commit to make the url always accessible

### DIFF
--- a/crates/oxc/src/napi/parse.rs
+++ b/crates/oxc/src/napi/parse.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 
 /// Babel Parser Options
 ///
-/// <https://github.com/babel/babel/blob/main/packages/babel-parser/typings/babel-parser.d.ts>
+/// <https://github.com/babel/babel/blob/v7.26.2/packages/babel-parser/typings/babel-parser.d.ts>
 #[napi(object)]
 #[derive(Default)]
 pub struct ParserOptions {

--- a/crates/oxc/src/napi/transform.rs
+++ b/crates/oxc/src/napi/transform.rs
@@ -1,4 +1,4 @@
-// NOTE: Types must be aligned with [@types/babel__core](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/babel__core/index.d.ts).
+// NOTE: Types must be aligned with [@types/babel__core](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b5dc32740d9b45d11cff9b025896dd333c795b39/types/babel__core/index.d.ts).
 
 #![allow(rustdoc::bare_urls)]
 
@@ -241,7 +241,7 @@ pub struct JsxOptions {
 
     /// Enable React Fast Refresh .
     ///
-    /// Conforms to the implementation in {@link https://github.com/facebook/react/tree/main/packages/react-refresh}
+    /// Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
     ///
     /// @default false
     pub refresh: Option<Either<bool, ReactRefreshOptions>>,

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -1,6 +1,6 @@
 //! Arena Box.
 //!
-//! Originally based on [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/master/crates/ast/src/arena.rs)
+//! Originally based on [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/24004745a8ed4939fc0dc7332bfd1268ac52285f/crates/ast/src/arena.rs)
 
 use std::{
     self,

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -1,6 +1,6 @@
 //! Arena Vec.
 //!
-//! Originally based on [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/master/crates/ast/src/arena.rs)
+//! Originally based on [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/24004745a8ed4939fc0dc7332bfd1268ac52285f/crates/ast/src/arena.rs)
 
 use std::{
     self,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2414,7 +2414,7 @@ pub enum ExportDefaultDeclarationKind<'a> {
 /// Supports:
 ///   * `import {"\0 any unicode" as foo} from ""`
 ///   * `export {foo as "\0 any unicode"}`
-/// * es2022: <https://github.com/estree/estree/blob/master/es2022.md#modules>
+/// * es2022: <https://github.com/estree/estree/blob/e6015c4c63118634749001b1cd1c3f7a0388f16e/es2022.md#modules>
 /// * <https://github.com/tc39/ecma262/pull/2154>
 #[ast(visit)]
 #[derive(Debug, Clone)]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1,6 +1,6 @@
 //! TypeScript Definitions
 //!
-//! - [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec)
+//! - [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec)
 //! - [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
 #![allow(missing_docs)] // FIXME
 

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -1,6 +1,6 @@
 //! TypeScript Definitions
 //!
-//! [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec)
+//! [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec)
 //! [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
 #![warn(missing_docs)]
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -5,7 +5,7 @@
 //!
 //! See:
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
-//! * [rustc visitor](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/visit.rs)
+//! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
 #![allow(
     unused_variables,

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -5,7 +5,7 @@
 //!
 //! See:
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
-//! * [rustc visitor](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/visit.rs)
+//! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
 #![allow(
     unused_variables,

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -34,7 +34,7 @@
 //! [`oxc_parser`]: <https://docs.rs/oxc_parser>
 //! [`Parser`]: <https://docs.rs/oxc_parser/latest/oxc_parser/struct.Parser.html>
 //! [estree]: <https://github.com/estree/estree>
-//! [typescript-eslint]: <https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec>
+//! [typescript-eslint]: <https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec>
 //! [ECMAScript spec]: <https://tc39.es/ecma262/>
 //! [tsc]: <https://github.com/microsoft/TypeScript>
 //! [`Traverse`]: <https://github.com/oxc-project/oxc/tree/main/crates/oxc_traverse>

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -39,7 +39,7 @@ impl<'a> Codegen<'a> {
 
     /// `#__PURE__` Notation Specification
     ///
-    /// <https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md>
+    /// <https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/c14f7e197cb225c9eee877143536665ce3150712/pure-notation-spec.md>
     fn is_annotation_comment(&self, comment: &Comment) -> bool {
         let s = comment.content_span().source_text(self.source_text).trim_start();
         if let Some(s) = s.strip_prefix(['@', '#']) {

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -67,7 +67,7 @@ impl<'a> Gen for Directive<'a> {
         p.print_indent();
         // A Use Strict Directive may not contain an EscapeSequence or LineContinuation.
         // So here should print original `directive` value, the `expression` value is escaped str.
-        // See https://github.com/babel/babel/blob/main/packages/babel-generator/src/generators/base.ts#L64
+        // See https://github.com/babel/babel/blob/v7.26.2/packages/babel-generator/src/generators/base.ts#L64
         p.wrap_quote(|p, _| {
             p.print_str(self.directive.as_str());
         });

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -1,7 +1,7 @@
 //! Oxc Codegen
 //!
 //! Code adapted from
-//! * [esbuild](https://github.com/evanw/esbuild/blob/main/internal/js_printer/js_printer.go)
+//! * [esbuild](https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_printer/js_printer.go)
 #![warn(missing_docs)]
 
 mod binary_expr_visitor;

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -1,6 +1,6 @@
 //! Tests ported from `esbuild`
-//! * <https://github.com/evanw/esbuild/blob/main/internal/js_printer/js_printer_test.go>
-//! * <https://github.com/evanw/esbuild/blob/main/internal/js_parser/js_parser_test.go>
+//! * <https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_printer/js_printer_test.go>
+//! * <https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_parser/js_parser_test.go>
 
 use crate::tester::{test, test_minify};
 

--- a/crates/oxc_codegen/tests/integration/pure_comments.rs
+++ b/crates/oxc_codegen/tests/integration/pure_comments.rs
@@ -133,7 +133,7 @@ const defineSSRCustomElement = () => {
         const Component = // #__PURE__
         React.forwardRef((props, ref) => {});
         ",
-        // Copy from <https://github.com/rolldown-rs/rolldown/blob/main/crates/rolldown/tests/esbuild/dce/remove_unused_pure_comment_calls/entry.js>
+        // Copy from <https://github.com/rolldown-rs/rolldown/blob/v0.14.0/crates/rolldown/tests/esbuild/dce/remove_unused_pure_comment_calls/entry.js>
         "
         function bar() {}
         let bare = foo(bar);

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -59,7 +59,7 @@ fn shorthand() {
     test("let { x } = y", "let { x } = y;\n");
     test("({ x: (x) })", "({ x });\n");
     test("({ x } = y)", "({x} = y);\n");
-    // https://github.com/tc39/test262/blob/main/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
+    // https://github.com/tc39/test262/blob/05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
     test("var obj = { __proto__, __proto__, };", "var obj = {\n\t__proto__,\n\t__proto__\n};\n");
     test("var obj = { __proto__: __proto__, };", "var obj = { __proto__: __proto__ };\n");
 }

--- a/crates/oxc_diagnostics/src/reporter/json.rs
+++ b/crates/oxc_diagnostics/src/reporter/json.rs
@@ -27,7 +27,7 @@ impl DiagnosticReporter for JsonReporter {
     }
 }
 
-/// <https://github.com/fregante/eslint-formatters/tree/main/packages/eslint-formatter-json>
+/// <https://github.com/fregante/eslint-formatters/tree/ae1fd9748596447d1fd09625c33d9e7ba9a3d06d/packages/eslint-formatter-json>
 #[allow(clippy::print_stdout)]
 fn format_json(diagnostics: &mut Vec<Error>) {
     let handler = JSONReportHandler::new();

--- a/crates/oxc_diagnostics/src/reporter/unix.rs
+++ b/crates/oxc_diagnostics/src/reporter/unix.rs
@@ -37,7 +37,7 @@ impl DiagnosticReporter for UnixReporter {
     }
 }
 
-/// <https://github.com/fregante/eslint-formatters/tree/main/packages/eslint-formatter-unix>
+/// <https://github.com/fregante/eslint-formatters/tree/ae1fd9748596447d1fd09625c33d9e7ba9a3d06d/packages/eslint-formatter-unix>
 fn format_unix(diagnostic: &Error) -> String {
     let Info { line, column, filename, message, severity, rule_id } = Info::new(diagnostic);
     let severity = match severity {

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -3,7 +3,7 @@
 //! References:
 //! * <https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-rc/#isolated-declarations>
 //! * <https://www.typescriptlang.org/tsconfig#isolatedDeclarations>
-//! * <https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformers/declarations.ts>
+//! * <https://github.com/microsoft/TypeScript/blob/v5.6.3/src/compiler/transformers/declarations.ts>
 
 mod class;
 mod declaration;

--- a/crates/oxc_isolated_declarations/tests/deno/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/deno/mod.rs
@@ -1,4 +1,4 @@
-//! Copy from <https://github.com/denoland/deno_graph/blob/main/src/fast_check/transform_dts.rs#L932-#L1532>
+//! Copy from <https://github.com/denoland/deno_graph/blob/0.84.0/src/fast_check/transform_dts.rs#L932-#L1532>
 //! Make some changes to conform to the Isolated Declarations output
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::default_true;
 
-// <https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/settings.md>
+// <https://github.com/gajus/eslint-plugin-jsdoc/blob/v50.5.0/docs/settings.md>
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct JSDocPluginSettings {
@@ -123,7 +123,7 @@ impl JSDocPluginSettings {
                 Some(Cow::Borrowed(message))
             }
             _ => {
-                // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/settings.md#default-preferred-aliases
+                // https://github.com/gajus/eslint-plugin-jsdoc/blob/v50.5.0/docs/settings.md#default-preferred-aliases
                 let aliased_name = match original_name {
                     "virtual" => "abstract",
                     "extends" => "augments",

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -457,7 +457,7 @@ impl<'a> CompositeFix<'a> {
     // }
 
     /// Gets one fix from the fixes. If we retrieve multiple fixes, this merges those into one.
-    /// <https://github.com/eslint/eslint/blob/main/lib/linter/report-translator.js#L181-L203>
+    /// <https://github.com/eslint/eslint/blob/v9.9.1/lib/linter/report-translator.js#L181-L203>
     pub fn normalize_fixes(self, source_text: &str) -> Fix<'a> {
         match self {
             CompositeFix::Single(fix) => fix,
@@ -472,7 +472,7 @@ impl<'a> CompositeFix<'a> {
     /// 2. contains overlapped ranges
     /// 3. contains negative ranges (span.start > span.end)
     ///
-    /// <https://github.com/eslint/eslint/blob/main/lib/linter/report-translator.js#L147-L179>
+    /// <https://github.com/eslint/eslint/blob/v9.9.1/lib/linter/report-translator.js#L147-L179>
     fn merge_fixes(fixes: Vec<Fix<'a>>, source_text: &str) -> Fix<'a> {
         let mut fixes = fixes;
         if fixes.is_empty() {

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -11,7 +11,7 @@ use crate::LintContext;
 
 /// Produces [`RuleFix`] instances. Inspired by ESLint's [`RuleFixer`].
 ///
-/// [`RuleFixer`]: https://github.com/eslint/eslint/blob/main/lib/linter/rule-fixer.js
+/// [`RuleFixer`]: https://github.com/eslint/eslint/blob/v9.9.1/lib/linter/rule-fixer.js
 #[derive(Clone, Copy)]
 #[must_use]
 pub struct RuleFixer<'c, 'a: 'c> {
@@ -671,7 +671,7 @@ mod test {
     }
 
     // Remain test caces picked from eslint
-    // <https://github.com/eslint/eslint/blob/main/tests/lib/linter/report-translator.js>
+    // <https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/linter/report-translator.js>
     // 1. Combining autofixes
     #[test]
     fn merge_fixes_into_one() {

--- a/crates/oxc_linter/src/globals.rs
+++ b/crates/oxc_linter/src/globals.rs
@@ -70,7 +70,7 @@ pub const VALID_ARIA_PROPS: phf::Set<&'static str> = phf_set! {
 
 /// set of valid ARIA role definitions
 /// Reference: <https://www.w3.org/TR/wai-aria/#role_definitions>
-/// Reference: <https://github.com/A11yance/aria-query/blob/main/src/rolesMap.js>
+/// Reference: <https://github.com/A11yance/aria-query/blob/v5.3.2/src/rolesMap.js>
 pub const VALID_ARIA_ROLES: phf::Set<&'static str> = phf_set! {
   "alert",
   "alertdialog",
@@ -355,7 +355,7 @@ pub const HTML_TAG: phf::Set<&'static str> = phf_set! {
 /// if it's not reserved, then it can have aria-* roles, states, and properties
 /// Reference: <https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_12>
 /// Reference: <https://www.w3.org/TR/html-aria/#rules-wd>
-/// Reference: <https://github.com/A11yance/aria-query/blob/main/src/domMap.js>
+/// Reference: <https://github.com/A11yance/aria-query/blob/v5.3.2/src/domMap.js>
 pub const RESERVED_HTML_TAG: phf::Set<&'static str> = phf_set! {
     "base",
     "col",

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -132,7 +132,7 @@ impl Rule for ArrayCallbackReturn {
     }
 }
 
-/// Code ported from [eslint](https://github.com/eslint/eslint/blob/main/lib/rules/array-callback-return.js)
+/// Code ported from [eslint](https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/array-callback-return.js)
 /// We're currently on a `Function` or `ArrowFunctionExpression`, findout if it is an argument
 /// to the target array methods we're interested in.
 pub fn get_array_method_name<'a>(

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn test() {
         // test cases taken from eslint. See:
-        // https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-control-regex.js
+        // https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/no-control-regex.js
         Tester::new(
             NoControlRegex::NAME,
             vec![

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -1,5 +1,5 @@
 use memchr::memchr2;
-// Ported from https://github.com/eslint/eslint/blob/main/lib/rules/no-empty-character-class.js
+// Ported from https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/no-empty-character-class.js
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -1,4 +1,4 @@
-// Ported from https://github.com/eslint/eslint/tree/main/lib/rules/no-eval.js
+// Ported from https://github.com/eslint/eslint/tree/v9.9.1/lib/rules/no-eval.js
 use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -164,7 +164,7 @@ impl Rule for NoObjCalls {
 #[test]
 fn test() {
     use crate::tester::Tester;
-    // see: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-obj-calls.js
+    // see: https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/no-obj-calls.js
 
     let pass = vec![
         ("const m = Math;", None),

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -179,7 +179,7 @@ fn check_character(
              * it only needs to be escaped in character classes if it's at the beginning of the character class. To
              * account for this, consider it to be a valid escape character outside of character classes, and filter
              * out '^' characters that appear at the start of a character class.
-             * (From ESLint source: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-escape.js)
+             * (From ESLint source: https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/no-useless-escape.js)
              */
             if class.span.start + 1 == span.start {
                 return None;
@@ -216,7 +216,7 @@ fn check_character(
              * class, and is not at either edge of the character class. To account for this, don't consider '-'
              * characters to be valid in general, and filter out '-' characters that appear in the middle of a
              * character class.
-             * (From ESLint source: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-escape.js)
+             * (From ESLint source: https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/no-useless-escape.js)
              */
             if class.span.start + 1 != span.start && span.end != class.span.end - 1 {
                 return None;

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -17,9 +17,9 @@ fn no_var_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoVar;
 
-// doc: https://github.com/eslint/eslint/blob/main/docs/src/rules/no-var.md
-// code: https://github.com/eslint/eslint/blob/main/lib/rules/no-var.js
-// test: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-var.js
+// doc: https://github.com/eslint/eslint/blob/v9.9.1/docs/src/rules/no-var.md
+// code: https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/no-var.js
+// test: https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/no-var.js
 
 declare_oxc_lint!(
     /// ### What it does

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -31,9 +31,9 @@ pub struct Radix {
     radix_type: RadixType,
 }
 
-// doc: https://github.com/eslint/eslint/blob/main/docs/src/rules/radix.md
-// code: https://github.com/eslint/eslint/blob/main/lib/rules/radix.js
-// test: https://github.com/eslint/eslint/blob/main/tests/lib/rules/radix.js
+// doc: https://github.com/eslint/eslint/blob/v9.9.1/docs/src/rules/radix.md
+// code: https://github.com/eslint/eslint/blob/v9.9.1/lib/rules/radix.js
+// test: https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/radix.js
 
 declare_oxc_lint!(
     /// ### What it does

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -11,7 +11,7 @@ fn default_diagnostic(imported_name: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/default.md>
 #[derive(Debug, Default, Clone)]
 pub struct Default;
 

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -13,7 +13,7 @@ fn no_named_export(module_name: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/export.md>
 #[derive(Debug, Default, Clone)]
 pub struct Export;
 

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -95,7 +95,7 @@ fn is_relative_path(path: &str) -> bool {
     path.starts_with("./")
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/first.md>
 impl Rule for First {
     fn from_configuration(value: serde_json::Value) -> Self {
         let obj = value.get(0);

--- a/crates/oxc_linter/src/rules/import/import_no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/import_no_namespace.rs
@@ -82,7 +82,7 @@ declare_oxc_lint!(
     pending  // TODO: fixer
 );
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-namespace.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-namespace.md>
 impl Rule for ImportNoNamespace {
     fn from_configuration(value: serde_json::Value) -> Self {
         let obj = value.get(0);

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -16,7 +16,7 @@ fn max_dependencies_diagnostic<S: Into<Cow<'static, str>>>(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/max-dependencies.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/max-dependencies.md>
 #[derive(Debug, Default, Clone)]
 pub struct MaxDependencies(Box<MaxDependenciesConfig>);
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -11,7 +11,7 @@ fn named_diagnostic(imported_name: &str, module_name: &str, span: Span) -> OxcDi
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/named.md>
 #[derive(Debug, Default, Clone)]
 pub struct Named;
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -42,7 +42,7 @@ fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone)]
 pub struct Namespace {
     allow_computed: bool,

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
     restriction
 );
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-amd.md>
 impl Rule for NoAmd {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // not in top level

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -128,7 +128,7 @@ fn is_conditional(parent_node: &AstNode, ctx: &LintContext) -> bool {
         is_conditional(parent, ctx)
     }
 }
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-commonjs.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-commonjs.md>
 impl Rule for NoCommonjs {
     fn from_configuration(value: serde_json::Value) -> Self {
         let obj = value.get(0);

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -18,7 +18,7 @@ fn no_cycle_diagnostic(span: Span, paths: &str) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-cycle.md>
 #[derive(Debug, Clone)]
 pub struct NoCycle {
     /// maximum dependency depth to traverse

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -12,7 +12,7 @@ use crate::{
 // #[diagnostic(severity(warning), help(""))]
 // struct NoDeprecatedDiagnostic(CompactStr, #[label] pub Span);
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-deprecated.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-deprecated.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoDeprecated;
 

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -32,7 +32,7 @@ where
         .with_help("Merge these imports into a single import statement")
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-duplicates.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoDuplicates {
     prefer_inline: bool,

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -15,7 +15,7 @@ fn no_named_as_default_diagnostic(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoNamedAsDefault;
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -22,7 +22,7 @@ fn no_named_as_default_member_dignostic(
         .with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-named-as-default-member.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoNamedAsDefaultMember;
 

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -10,7 +10,7 @@ fn no_exports_found(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No exports found").with_label(span)
 }
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unused-modules.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-unused-modules.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedModules {
     missing_exports: bool,

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     restriction
 );
 
-/// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/unambiguous.md>
+/// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
     fn run_once(&self, ctx: &LintContext<'_>) {
         if ctx.semantic().module_record().not_esm {

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -158,7 +158,7 @@ declare_oxc_lint!(
     /// Decides whether to use `test` or `it` within a `describe` scope.
     ///
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/consistent-test-it.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -68,7 +68,7 @@ declare_oxc_lint!(
     /// test('should assert something', () => {});
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/expect-expect.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/expect-expect.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// expect(a).toThrowError();
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-alias-methods.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-alias-methods.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     /// // test.skip('foo', () => {});
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-commented-out-tests.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-conditional-expect.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-disabled-tests.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
     /// `();
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-focused-tests.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
     ///  });
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-identical-title.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -14,7 +14,7 @@ fn no_jasmine_globals_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnost
     OxcDiagnostic::warn(format!("{x0:?}")).with_help(format!("{x1:?}")).with_label(span2)
 }
 
-/// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md>
+/// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-jasmine-globals.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoJasmineGlobals;
 

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -13,7 +13,7 @@ fn no_mocks_import_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md>
+/// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-mocks-import.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoMocksImport;
 

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -22,7 +22,7 @@ fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md>
+/// <https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/docs/rules/no-standalone-expect.md>
 #[derive(Debug, Default, Clone)]
 pub struct NoStandaloneExpect(Box<NoStandaloneExpectConfig>);
 

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     /// xdescribe('foo'); // invalid
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-test-prefixes.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -128,7 +128,7 @@ declare_oxc_lint!(
     /// ```
     ///
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/prefer-hooks-in-order.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -58,7 +58,7 @@ declare_oxc_lint!(
     /// }));
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-describe-callback.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/valid-describe-callback.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -68,7 +68,7 @@ declare_oxc_lint!(
     /// expect(Promise.resolve('Hi!')).resolves.toBe('Hi!');
     /// ```
     ///
-    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-expect.md),
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/docs/rules/valid-expect.md),
     /// to use it, add the following configuration to your `.eslintrc.json`:
     ///
     /// ```json

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ### Resources
-    /// - [eslint-plugin-jsx-a11y/lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/lang.md)
+    /// - [eslint-plugin-jsx-a11y/lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/docs/rules/lang.md)
     /// - [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
     Lang,
     correctness

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -100,7 +100,7 @@ impl Rule for RoleSupportsAriaProps {
     }
 }
 
-/// ref: <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/getImplicitRole.js>
+/// ref: <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/getImplicitRole.js>
 fn get_implicit_role<'a>(
     node: &'a JSXOpeningElement<'a>,
     element_type: &str,

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     correctness
 );
 
-// Keep in sync with next.js polyfills file : https://github.com/vercel/next.js/blob/master/packages/next-polyfill-nomodule/src/index.js
+// Keep in sync with next.js polyfills file : https://github.com/vercel/next.js/blob/v15.0.2/packages/next-polyfill-nomodule/src/index.js
 const NEXT_POLYFILLED_FEATURES: Set<&'static str> = phf_set! {
     "Array.prototype.@@iterator",
     "Array.prototype.at",

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -365,7 +365,7 @@ fn test() {
             }
         }
         ",
-        // source: https://github.com/biomejs/biome/blob/main/crates/biome_js_analyze/tests/specs/performance/noAccumulatingSpread/valid.jsonc#L3C1-L23C52
+        // source: https://github.com/biomejs/biome/blob/cli/v1.9.4/crates/biome_js_analyze/tests/specs/performance/noAccumulatingSpread/valid.jsonc#L3C1-L23C52
         "foo.reduce((acc, bar) => {acc.push(bar); return acc;}, [])",
         "foo.reduceRight((acc, bar) => {acc.push(bar); return acc;}, [])",
         // Array - Allow spreading the item into the accumulator
@@ -420,7 +420,7 @@ fn test() {
             let temp = { ...acc, x }
             return temp
         }, {})",
-        // source https://github.com/biomejs/biome/blob/main/crates/biome_js_analyze/tests/specs/performance/noAccumulatingSpread/invalid.jsonc#L2-L32
+        // source https://github.com/biomejs/biome/blob/cli/v1.9.4/crates/biome_js_analyze/tests/specs/performance/noAccumulatingSpread/invalid.jsonc#L2-L32
         // Array - Arrow return
         "foo.reduce((acc, bar) => [...acc, bar], [])",
         "foo.reduceRight((acc, bar) => [...acc, bar], [])",

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -22,9 +22,9 @@ fn no_direct_mutation_state_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoDirectMutationState;
 
-// code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-direct-mutation-state.js
-// doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
-// test: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/no-direct-mutation-state.js
+// code: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.2/lib/rules/no-direct-mutation-state.js
+// doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.2/docs/rules/no-direct-mutation-state.md
+// test: https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.2/tests/lib/rules/no-direct-mutation-state.js
 
 declare_oxc_lint!(
     /// ### What it does

--- a/crates/oxc_linter/src/rules/security/api_keys/mod.rs
+++ b/crates/oxc_linter/src/rules/security/api_keys/mod.rs
@@ -72,7 +72,7 @@ declare_oxc_lint!(
     /// One possible alternative is to store secrets in a secure secrets manager
     /// (such as [AWS
     /// KMS](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/),
-    /// [HashiCorp Vault](https://github.com/nodevault/node-vault/tree/master),
+    /// [HashiCorp Vault](https://github.com/nodevault/node-vault/tree/v0.10.2),
     /// [Pangea](https://pangea.cloud/docs/sdk/js/vault#retrieve), etc.) and
     /// request them when your application starts (e.g. a Docker container, an
     /// EC2).

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -88,7 +88,7 @@ fn throw(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Throwing an error is a side-effect").with_label(span)
 }
 
-/// <https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/master/src/rules/no-side-effects-in-initialization.ts>
+/// <https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/v1.12.2/src/rules/no-side-effects-in-initialization.ts>
 #[derive(Debug, Default, Clone)]
 pub struct NoSideEffectsInInitialization(Box<NoSideEffectsInInitiallizationOptions>);
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -47,7 +47,7 @@ impl Deref for ConsistentTypeImports {
     }
 }
 
-/// <https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
+/// <https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx>
 #[derive(Default, Debug, Clone)]
 pub struct ConsistentTypeImportsConfig {
     disallow_type_annotations: DisallowTypeAnnotations,

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -60,7 +60,7 @@ pub fn get_string_literal_prop_value<'a>(item: &'a JSXAttributeItem<'_>) -> Opti
     get_prop_value(item).and_then(JSXAttributeValue::as_string_literal).map(|s| s.value.as_str())
 }
 
-// ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/isHiddenFromScreenReader.js
+// ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/isHiddenFromScreenReader.js
 pub fn is_hidden_from_screen_reader<'a>(
     ctx: &LintContext<'a>,
     node: &JSXOpeningElement<'a>,
@@ -91,7 +91,7 @@ pub fn is_hidden_from_screen_reader<'a>(
     })
 }
 
-// ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/hasAccessibleChild.js
+// ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/hasAccessibleChild.js
 pub fn object_has_accessible_child<'a>(ctx: &LintContext<'a>, node: &JSXElement<'a>) -> bool {
     node.children.iter().any(|child| match child {
         JSXChild::Text(text) => !text.value.is_empty(),
@@ -206,7 +206,7 @@ pub fn get_parent_component<'a, 'b>(
 
 /// Resolve element type(name) using jsx-a11y settings
 /// ref:
-/// <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/util/getElementType.js>
+/// <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/getElementType.js>
 pub fn get_element_type<'c, 'a>(
     context: &'c LintContext<'a>,
     element: &JSXOpeningElement<'a>,

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -39,7 +39,7 @@ pub fn is_empty_stmt(stmt: &Statement) -> bool {
     }
 }
 
-// ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/utils/array-or-object-prototype-property.js
+// ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v56.0.0/rules/utils/array-or-object-prototype-property.js
 pub fn is_prototype_property(
     member_expr: &MemberExpression,
     property: &str,

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -14,7 +14,7 @@ pub struct MangleOptions {
 /// # Name Mangler / Symbol Minification
 ///
 /// See:
-///   * [esbuild](https://github.com/evanw/esbuild/blob/main/docs/architecture.md#symbol-minification)
+///   * [esbuild](https://github.com/evanw/esbuild/blob/v0.24.0/docs/architecture.md#symbol-minification)
 ///
 /// This algorithm is targeted for better gzip compression.
 ///

--- a/crates/oxc_minifier/README.md
+++ b/crates/oxc_minifier/README.md
@@ -20,4 +20,4 @@ The compressor is responsible for rewriting statements and expressions for minim
 
 ## Terser Tests
 
-The fixtures are copied from https://github.com/terser/terser/tree/master/test/compress
+The fixtures are copied from https://github.com/terser/terser/tree/v5.9.0/test/compress

--- a/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
+++ b/crates/oxc_minifier/src/ast_passes/collapse_variable_declarations.rs
@@ -7,7 +7,7 @@ use crate::CompressorPass;
 /// Collapse variable declarations.
 ///
 /// `var a; var b = 1; var c = 2` => `var a, b = 1; c = 2`
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/CollapseVariableDeclarations.java>
 pub struct CollapseVariableDeclarations {
     changed: bool,
 }
@@ -108,7 +108,7 @@ impl<'a> CollapseVariableDeclarations {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/CollapseVariableDeclarationsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
+++ b/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
@@ -5,7 +5,7 @@ use crate::CompressorPass;
 
 /// Tries to chain assignments together.
 ///
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/ExploitAssigns.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/ExploitAssigns.java>
 pub struct ExploitAssigns {
     changed: bool,
 }
@@ -29,7 +29,7 @@ impl ExploitAssigns {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/ExploitAssignsTest.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/ExploitAssignsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -14,7 +14,7 @@ use crate::{node_util::Ctx, CompressorPass};
 
 /// Constant Folding
 ///
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeFoldConstants.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeFoldConstants.java>
 pub struct PeepholeFoldConstants {
     changed: bool,
 }
@@ -449,7 +449,7 @@ impl<'a, 'b> PeepholeFoldConstants {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/PeepholeFoldConstantsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;
@@ -1151,7 +1151,7 @@ mod test {
         test("1 << -1", "1<<-1");
         test("1 >> 32", "1>>32");
 
-        // Regression on #6161, ported from <https://github.com/tc39/test262/blob/main/test/language/expressions/unsigned-right-shift/S9.6_A2.2.js>.
+        // Regression on #6161, ported from <https://github.com/tc39/test262/blob/05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d/test/language/expressions/unsigned-right-shift/S9.6_A2.2.js>.
         test("-2147483647 >>> 0", "2147483649");
         test("-2147483648 >>> 0", "2147483648");
         test("-2147483649 >>> 0", "2147483647");

--- a/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
@@ -9,7 +9,7 @@ use crate::CompressorPass;
 /// Also rewrites conditional statements as expressions by replacing them
 /// with `? :` and short-circuit binary operators.
 ///
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeMinimizeConditions.java>
 pub struct PeepholeMinimizeConditions {
     changed: bool,
 }
@@ -58,7 +58,7 @@ impl<'a> PeepholeMinimizeConditions {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeMinimizeConditionsTest.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/PeepholeMinimizeConditionsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
@@ -12,7 +12,7 @@ use crate::{keep_var::KeepVar, CompressorPass};
 /// Terser option: `dead_code: true`.
 ///
 /// See `KeepVar` at the end of this file for `var` hoisting logic.
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeRemoveDeadCode.java>
 pub struct PeepholeRemoveDeadCode {
     changed: bool,
 }
@@ -417,7 +417,7 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
     }
 }
 
-/// <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/PeepholeRemoveDeadCodeTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
@@ -9,7 +9,7 @@ use oxc_traverse::{Traverse, TraverseCtx};
 use crate::{node_util::Ctx, CompressorPass};
 
 /// Minimize With Known Methods
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java>
 pub struct PeepholeReplaceKnownMethods {
     changed: bool,
 }
@@ -269,7 +269,7 @@ impl PeepholeReplaceKnownMethods {
     }
 }
 
-/// Port from: <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeReplaceKnownMethodsTest.java>
+/// Port from: <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/PeepholeReplaceKnownMethodsTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -14,7 +14,7 @@ use crate::{node_util::Ctx, CompressorPass};
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
 /// with literals, and simplifying returns.
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntax.java>
 pub struct PeepholeSubstituteAlternateSyntax {
     /// Do not compress syntaxes that are hard to analyze inside the fixed loop.
     /// e.g. Do not compress `undefined -> void 0`, `true` -> `!0`.
@@ -566,7 +566,7 @@ impl<'a, 'b> PeepholeSubstituteAlternateSyntax {
     }
 }
 
-/// Port from <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java>
+/// Port from <https://github.com/google/closure-compiler/blob/v20240609/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java>
 #[cfg(test)]
 mod test {
     use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
+++ b/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
@@ -10,7 +10,7 @@ use crate::CompressorPass;
 ///
 /// Tries to fuse all the statements in a block into a one statement by using COMMAs or statements.
 ///
-/// <https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/StatementFusion.java>
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/StatementFusion.java>
 pub struct StatementFusion {
     changed: bool,
 }

--- a/crates/oxc_minifier/tests/ast_passes/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/ast_passes/dead_code_elimination.rs
@@ -155,7 +155,7 @@ fn dce_var_hoisting() {
     );
 }
 
-// https://github.com/terser/terser/blob/master/test/compress/dead-code.js
+// https://github.com/terser/terser/blob/v5.9.0/test/compress/dead-code.js
 #[test]
 fn dce_from_terser() {
     test(

--- a/crates/oxc_module_lexer/tests/integration/esm.rs
+++ b/crates/oxc_module_lexer/tests/integration/esm.rs
@@ -1,4 +1,4 @@
-//! <https://github.com/guybedford/es-module-lexer/blob/main/test/_unit.cjs>
+//! <https://github.com/guybedford/es-module-lexer/blob/1.5.4/test/_unit.cjs>
 
 use oxc_allocator::Allocator;
 use oxc_module_lexer::ImportType;

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -48,7 +48,7 @@ impl<'a> ParserImpl<'a> {
 
             // Section 11.2.1 Directive Prologue
             // The only way to get a correct directive is to parse the statement first and check if it is a string literal.
-            // All other method are flawed, see test cases in [babel](https://github.com/babel/babel/blob/main/packages/babel-parser/test/fixtures/core/categorized/not-directive/input.js)
+            // All other method are flawed, see test cases in [babel](https://github.com/babel/babel/blob/v7.26.2/packages/babel-parser/test/fixtures/core/categorized/not-directive/input.js)
             if expecting_directives {
                 if let Statement::ExpressionStatement(expr) = &stmt {
                     if let Expression::StringLiteral(string) = &expr.expression {

--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -15,7 +15,7 @@ pub(super) unsafe fn handle_byte(byte: u8, lexer: &mut Lexer) -> Kind {
 type ByteHandler = unsafe fn(&mut Lexer<'_>) -> Kind;
 
 /// Lookup table mapping any incoming byte to a handler function defined below.
-/// <https://github.com/ratel-rust/ratel-core/blob/master/ratel/src/lexer/mod.rs>
+/// <https://github.com/ratel-rust/ratel-core/blob/v0.7.0/ratel/src/lexer/mod.rs>
 #[rustfmt::skip]
 static BYTE_HANDLERS: [ByteHandler; 256] = [
 //  0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F    //

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -3,9 +3,9 @@
 
 //! An Ecma-262 Lexer / Tokenizer
 //! Prior Arts:
-//!     * [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/master/crates/parser/src)
-//!     * [rome](https://github.com/rome/tools/tree/main/crates/rome_js_parser/src/lexer)
-//!     * [rustc](https://github.com/rust-lang/rust/blob/master/compiler/rustc_lexer/src)
+//!     * [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/24004745a8ed4939fc0dc7332bfd1268ac52285f/crates/parser/src)
+//!     * [rome](https://github.com/rome/tools/tree/lsp/v0.28.0/crates/rome_js_parser/src/lexer)
+//!     * [rustc](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_lexer/src)
 //!     * [v8](https://v8.dev/blog/scanner)
 
 mod byte_handlers;

--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -1,6 +1,6 @@
 //! Parsing utilities for converting Javascript numbers to Rust f64.
 //! Code copied originally from
-//! [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/master/crates/parser/src/numeric_value.rs)
+//! [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/24004745a8ed4939fc0dc7332bfd1268ac52285f/crates/parser/src/numeric_value.rs)
 //! but iterated on since.
 
 use std::borrow::Cow;

--- a/crates/oxc_prettier/README.md
+++ b/crates/oxc_prettier/README.md
@@ -7,4 +7,4 @@ Create a `test.js` and run the example `just example prettier` from `crates/oxc_
 - [x] Have the basic infrastructure ready for contribution
 - [x] Implement a test runner in Rust which extracts the snapshots and do a comparison over it
 - [x] Establish a way to pass all the tests by manually porting code
-- [ ] Pass as many tests as possible in https://github.com/prettier/prettier/tree/main/tests/format/js
+- [ ] Pass as many tests as possible in https://github.com/prettier/prettier/tree/3.3.3/tests/format/js

--- a/crates/oxc_prettier/src/doc.rs
+++ b/crates/oxc_prettier/src/doc.rs
@@ -1,7 +1,7 @@
 //! Prettier IR
 //!
 //! References:
-//! * <https://github.com/prettier/prettier/blob/main/commands.md>
+//! * <https://github.com/prettier/prettier/blob/3.3.3/commands.md>
 
 use std::fmt;
 
@@ -218,7 +218,7 @@ impl<'a> fmt::Display for Doc<'a> {
     }
 }
 
-// https://github.com/prettier/prettier/blob/main/src/document/debug.js
+// https://github.com/prettier/prettier/blob/3.3.3/src/document/debug.js
 fn print_doc_to_debug(doc: &Doc<'_>) -> std::string::String {
     use std::string::String;
     let mut string = String::new();

--- a/crates/oxc_prettier/src/format/call_arguments.rs
+++ b/crates/oxc_prettier/src/format/call_arguments.rs
@@ -178,7 +178,7 @@ pub fn print_call_arguments<'a>(
     Doc::Group(Group::new(parts).with_break(should_break))
 }
 
-/// * Reference <https://github.com/prettier/prettier/blob/main/src/language-js/print/call-arguments.js#L247-L272>
+/// * Reference <https://github.com/prettier/prettier/blob/3.3.3/src/language-js/print/call-arguments.js#L247-L272>
 fn should_expand_first_arg<'a>(arguments: &Vec<'a, Argument<'a>>) -> bool {
     if arguments.len() != 2 {
         return false;

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1,7 +1,7 @@
 //! Formatting logic
 //!
 //! References:
-//! * <https://github.com/prettier/prettier/blob/main/src/language-js/print/estree.js>
+//! * <https://github.com/prettier/prettier/blob/3.3.3/src/language-js/print/estree.js>
 
 #![allow(unused_variables)]
 
@@ -1789,7 +1789,7 @@ impl<'a> Format<'a> for NullLiteral {
 impl<'a> Format<'a> for NumericLiteral<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         wrap!(p, self, NumericLiteral, {
-            // See https://github.com/prettier/prettier/blob/main/src/utils/print-number.js
+            // See https://github.com/prettier/prettier/blob/3.3.3/src/utils/print-number.js
             // Perf: the regexes from prettier code above are ported to manual search for performance reasons.
             let mut string = self.span.source_text(p.source_text).cow_to_ascii_lowercase();
 

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Prettier<'a> {
     options: PrettierOptions,
 
     /// The stack of AST Nodes
-    /// See <https://github.com/prettier/prettier/blob/main/src/common/ast-path.js>
+    /// See <https://github.com/prettier/prettier/blob/3.3.3/src/common/ast-path.js>
     stack: Vec<AstKind<'a>>,
 
     group_id_builder: GroupIdBuilder,

--- a/crates/oxc_prettier/src/needs_parens.rs
+++ b/crates/oxc_prettier/src/needs_parens.rs
@@ -1,6 +1,6 @@
 //! Direct port of needs-parens for adding or removing parentheses.
 //!
-//! See <https://github.com/prettier/prettier/blob/main/src/language-js/needs-parens.js>
+//! See <https://github.com/prettier/prettier/blob/3.3.3/src/language-js/needs-parens.js>
 
 #![allow(
     clippy::unused_self,

--- a/crates/oxc_prettier/src/options.rs
+++ b/crates/oxc_prettier/src/options.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 ///
 /// References
 /// * <https://prettier.io/docs/en/options>
-/// * <https://github.com/prettier/prettier/blob/main/src/main/core-options.evaluate.js>
-/// * <https://github.com/prettier/prettier/blob/main/src/language-js/options.js>
+/// * <https://github.com/prettier/prettier/blob/3.3.3/src/main/core-options.evaluate.js>
+/// * <https://github.com/prettier/prettier/blob/3.3.3/src/language-js/options.js>
 #[derive(Debug, Clone, Copy)]
 pub struct PrettierOptions {
     /* Global Options */

--- a/crates/oxc_prettier/src/printer/mod.rs
+++ b/crates/oxc_prettier/src/printer/mod.rs
@@ -1,7 +1,7 @@
 //! [Doc] Printer
 //!
 //! References:
-//! * <https://github.com/prettier/prettier/blob/main/src/document/printer.js>
+//! * <https://github.com/prettier/prettier/blob/3.3.3/src/document/printer.js>
 
 mod command;
 
@@ -440,7 +440,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Reference:
-    /// * <https://github.com/prettier/prettier/blob/main/src/document/utils.js#L156-L185>
+    /// * <https://github.com/prettier/prettier/blob/3.3.3/src/document/utils.js#L156-L185>
     pub fn propagate_breaks(doc: &mut Doc<'_>) -> bool {
         let check_array = |arr: &mut oxc_allocator::Vec<'_, Doc<'_>>| {
             arr.iter_mut().rev().any(|doc| Self::propagate_breaks(doc))

--- a/crates/oxc_sourcemap/src/decode.rs
+++ b/crates/oxc_sourcemap/src/decode.rs
@@ -1,11 +1,11 @@
-/// Port from https://github.com/getsentry/rust-sourcemap/blob/master/src/decoder.rs
+/// Port from https://github.com/getsentry/rust-sourcemap/blob/9.1.0/src/decoder.rs
 /// It is a helper for decode vlq soucemap string to `SourceMap`.
 use std::sync::Arc;
 
 use crate::error::{Error, Result};
 use crate::{SourceMap, Token};
 
-/// See <https://github.com/tc39/source-map/blob/main/source-map-rev3.md>.
+/// See <https://github.com/tc39/source-map/blob/1930e58ffabefe54038f7455759042c6e3dd590e/source-map-rev3.md>.
 #[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct JSONSourceMap {

--- a/crates/oxc_sourcemap/src/encode.rs
+++ b/crates/oxc_sourcemap/src/encode.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use rayon::prelude::*;
 
 use crate::JSONSourceMap;
-/// Port from https://github.com/getsentry/rust-sourcemap/blob/master/src/encoder.rs
+/// Port from https://github.com/getsentry/rust-sourcemap/blob/9.1.0/src/encoder.rs
 /// It is a helper for encode `SourceMap` to vlq sourcemap string, but here some different.
 /// - Quote `source_content` at parallel.
 /// - If you using `ConcatSourceMapBuilder`, serialize `tokens` to vlq `mappings` at parallel.

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -31,7 +31,7 @@
 //! helperName(...arguments);
 //! ```
 //!
-//! Based on [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-runtime).
+//! Based on [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-runtime).
 //!
 //! ### External ([`HelperLoaderMode::External`])
 //!
@@ -43,7 +43,7 @@
 //! babelHelpers.helperName(...arguments);
 //! ```
 //!
-//! Based on [@babel/plugin-external-helpers](https://github.com/babel/babel/tree/main/packages/babel-plugin-external-helpers).
+//! Based on [@babel/plugin-external-helpers](https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-external-helpers).
 //!
 //! ### Inline ([`HelperLoaderMode::Inline`])
 //!
@@ -58,7 +58,7 @@
 //! helperName(...arguments);
 //! ```
 //!
-//! Based on [@babel/helper](https://github.com/babel/babel/tree/main/packages/babel-helpers).
+//! Based on [@babel/helper](https://github.com/babel/babel/tree/v7.26.2/packages/babel-helpers).
 //!
 //! ## Implementation
 //!

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -30,7 +30,7 @@
 //! > NOTE: Using `import` or `require` is determined by [`TransformCtx::source_type`].
 //!
 //! Based on `@babel/helper-module-imports`
-//! <https://github.com/nicolo-ribaudo/babel/tree/main/packages/babel-helper-module-imports>
+//! <https://github.com/nicolo-ribaudo/babel/tree/v7.25.8/packages/babel-helper-module-imports>
 
 use std::cell::RefCell;
 

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -122,7 +122,7 @@
 //!
 //! ## References:
 //!
-//! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-arrow-functions>
+//! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-arrow-functions>
 //! * Arrow function specification: <https://tc39.es/ecma262/#sec-arrow-function-definitions>
 
 use serde::Deserialize;

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -27,8 +27,8 @@
 //! ## References:
 //!
 //! * Babel plugin implementation:
-//!   <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-exponentiation-operator>
-//!   <https://github.com/babel/babel/tree/main/packages/babel-helper-builder-binary-assignment-operator-visitor>
+//!   <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-exponentiation-operator>
+//!   <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-binary-assignment-operator-visitor>
 //! * Exponentiation operator TC39 proposal: <https://github.com/tc39/proposal-exponentiation-operator>
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -48,7 +48,7 @@
 //!
 //! Reference:
 //! * Babel docs: <https://babeljs.io/docs/en/babel-plugin-transform-async-to-generator>
-//! * Babel implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-async-to-generator>
+//! * Babel implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-async-to-generator>
 //! * Async / Await TC39 proposal: <https://github.com/tc39/proposal-async-await>
 
 use std::mem;

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -61,7 +61,7 @@
 //!
 //! Reference:
 //! * Babel docs: <https://babeljs.io/docs/en/babel-plugin-transform-async-generator-functions>
-//! * Babel implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-async-generator-functions>
+//! * Babel implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-async-generator-functions>
 //! * Async Iteration TC39 proposal: <https://github.com/tc39/proposal-async-iteration>
 
 mod for_await;

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -23,7 +23,7 @@
 //! Implementation based on [@babel/plugin-transform-object-rest-spread](https://babeljs.io/docs/babel-plugin-transform-object-rest-spread).
 //!
 //! ## References:
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-object-rest-spread>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
 use serde::Deserialize;

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -30,7 +30,7 @@
 //! Implementation based on [@babel/plugin-transform-optional-catch-binding](https://babel.dev/docs/babel-plugin-transform-optional-catch-binding).
 //!
 //! ## References:
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-optional-catch-binding>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-optional-catch-binding>
 //! * Optional catch binding TC39 proposal: <https://github.com/tc39/proposal-optional-catch-binding>
 
 use oxc_ast::ast::*;

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -25,7 +25,7 @@
 //! Implementation based on [@babel/plugin-transform-nullish-coalescing-operator](https://babeljs.io/docs/babel-plugin-transform-nullish-coalescing-operator).
 //!
 //! ## References:
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-nullish-coalescing-operator>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-nullish-coalescing-operator>
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
 use oxc_allocator::Box as ArenaBox;

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -51,7 +51,7 @@
 //! Implementation based on [@babel/plugin-transform-logical-assignment-operators](https://babel.dev/docs/babel-plugin-transform-logical-assignment-operators).
 //!
 //! ## References:
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-logical-assignment-operators>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-logical-assignment-operators>
 //! * Logical Assignment TC39 proposal: <https://github.com/tc39/proposal-logical-assignment>
 
 use oxc_allocator::CloneIn;

--- a/crates/oxc_transformer/src/es2022/class_properties.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties.rs
@@ -57,9 +57,9 @@
 //!
 //! ## References:
 //! * Babel plugin implementation:
-//!   * <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-class-properties>
-//!   * <https://github.com/babel/babel/blob/main/packages/babel-helper-create-class-features-plugin/src/index.ts>
-//!   * <https://github.com/babel/babel/blob/main/packages/babel-helper-create-class-features-plugin/src/fields.ts>
+//!   * <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-class-properties>
+//!   * <https://github.com/babel/babel/blob/v7.26.2/packages/babel-helper-create-class-features-plugin/src/index.ts>
+//!   * <https://github.com/babel/babel/blob/v7.26.2/packages/babel-helper-create-class-features-plugin/src/fields.ts>
 //! * Class properties TC39 proposal: <https://github.com/tc39/proposal-class-fields>
 
 use serde::Deserialize;

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -36,7 +36,7 @@
 //! Implementation based on [@babel/plugin-transform-class-static-block](https://babel.dev/docs/babel-plugin-transform-class-static-block).
 //!
 //! ## References:
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-class-static-block>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-class-static-block>
 //! * Class static initialization blocks TC39 proposal: <https://github.com/tc39/proposal-class-static-block>
 
 use itoa::Buffer as ItoaBuffer;

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -43,7 +43,7 @@
 //!
 //! ## References:
 //!
-//! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-display-name/src/index.ts>
+//! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-display-name/src/index.ts>
 
 use oxc_ast::ast::*;
 use oxc_span::{Atom, SPAN};

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -86,7 +86,7 @@
 //!
 //! ## References:
 //!
-//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-helper-builder-react-jsx>
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::{ast::*, AstBuilder, NONE};

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -26,7 +26,7 @@
 //!
 //! ## References:
 //!
-//! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-jsx-self/src/index.ts>
+//! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-self/src/index.ts>
 
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -31,7 +31,7 @@
 //!
 //! ## References:
 //!
-//! * Babel plugin implementation: <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
+//! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
 use ropey::Rope;
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -99,7 +99,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
 /// References:
 ///
 /// * <https://github.com/facebook/react/issues/16604#issuecomment-528663101>
-/// * <https://github.com/facebook/react/blob/main/packages/react-refresh/src/ReactFreshBabelPlugin.js>
+/// * <https://github.com/facebook/react/blob/v18.3.1/packages/react-refresh/src/ReactFreshBabelPlugin.js>
 pub struct ReactRefresh<'a, 'ctx> {
     refresh_reg: RefreshIdentifierResolver<'a>,
     refresh_sig: RefreshIdentifierResolver<'a>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -3,7 +3,7 @@
 //! References:
 //! * <https://www.typescriptlang.org/tsconfig#target>
 //! * <https://babel.dev/docs/presets>
-//! * <https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformer.ts>
+//! * <https://github.com/microsoft/TypeScript/blob/v5.6.3/src/compiler/transformer.ts>
 
 use std::path::Path;
 

--- a/crates/oxc_transformer/tests/integrations/plugins/inject_global_variables.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/inject_global_variables.rs
@@ -1,6 +1,6 @@
 //! References
 //!
-//! * <https://github.com/rollup/plugins/tree/master/packages/inject/test>
+//! * <https://github.com/rollup/plugins/tree/pluginutils-v5.1.3/packages/inject/test>
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{CodeGenerator, CodegenOptions};

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -102,7 +102,7 @@ export interface ParseResult {
 /**
  * Babel Parser Options
  *
- * <https://github.com/babel/babel/blob/main/packages/babel-parser/typings/babel-parser.d.ts>
+ * <https://github.com/babel/babel/blob/v7.26.2/packages/babel-parser/typings/babel-parser.d.ts>
  */
 export interface ParserOptions {
   sourceType?: 'script' | 'module' | 'unambiguous' | undefined

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -127,7 +127,7 @@ export interface JsxOptions {
   /**
    * Enable React Fast Refresh .
    *
-   * Conforms to the implementation in {@link https://github.com/facebook/react/tree/main/packages/react-refresh}
+   * Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
    *
    * @default false
    */

--- a/npm/oxc-parser/scripts/generate-packages.mjs
+++ b/npm/oxc-parser/scripts/generate-packages.mjs
@@ -1,4 +1,4 @@
-// Code copied from [Rome](https://github.com/rome/tools/blob/main/npm/rome/scripts/generate-packages.mjs)
+// Code copied from [Rome](https://github.com/rome/tools/blob/lsp/v0.28.0/npm/rome/scripts/generate-packages.mjs)
 
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';

--- a/npm/oxc-transform/scripts/generate-packages.mjs
+++ b/npm/oxc-transform/scripts/generate-packages.mjs
@@ -1,4 +1,4 @@
-// Code copied from [Rome](https://github.com/rome/tools/blob/main/npm/rome/scripts/generate-packages.mjs)
+// Code copied from [Rome](https://github.com/rome/tools/blob/lsp/v0.28.0/npm/rome/scripts/generate-packages.mjs)
 
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';

--- a/npm/oxlint/scripts/generate-packages.mjs
+++ b/npm/oxlint/scripts/generate-packages.mjs
@@ -1,4 +1,4 @@
-// Code copied from [Rome](https://github.com/rome/tools/blob/main/npm/rome/scripts/generate-packages.mjs)
+// Code copied from [Rome](https://github.com/rome/tools/blob/lsp/v0.28.0/npm/rome/scripts/generate-packages.mjs)
 
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -74,7 +74,7 @@ fn generate_visit(is_mut: bool, schema: &Schema) -> TokenStream {
         //!
         //! See:
         //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
-        //! * [rustc visitor](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/visit.rs)
+        //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
         //!@@line_break
         #![allow(

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -19,7 +19,7 @@ impl TestFiles {
         }
     }
 
-    /// These are kept in sync with <https://github.com/privatenumber/minification-benchmarks/tree/master>
+    /// These are kept in sync with <https://github.com/privatenumber/minification-benchmarks/tree/d8d54ceeb206d318fa288b152904adf715b076b2>
     /// for checking against minification size in `tasks/minsize/minsize.snap`.
     pub fn minifier() -> Self {
         Self {

--- a/tasks/compat_data/README.md
+++ b/tasks/compat_data/README.md
@@ -2,7 +2,7 @@
 
 Get engine compatibility Data from https://github.com/compat-table/compat-table/
 
-Code extracted from https://github.com/babel/babel/tree/main/packages/babel-compat-data
+Code extracted from https://github.com/babel/babel/tree/v7.26.2/packages/babel-compat-data
 
 ## Adding a new feature
 

--- a/tasks/compat_data/build.js
+++ b/tasks/compat_data/build.js
@@ -1,5 +1,5 @@
-// https://github.com/babel/babel/blob/main/packages/babel-compat-data/scripts/build-data.js
-// https://github.com/babel/babel/blob/main/packages/babel-compat-data/scripts/utils-build-data.js
+// https://github.com/babel/babel/blob/v7.26.2/packages/babel-compat-data/scripts/build-data.js
+// https://github.com/babel/babel/blob/v7.26.2/packages/babel-compat-data/scripts/utils-build-data.js
 
 const fs = require('node:fs');
 const envs = require('./compat-table/environments');

--- a/tasks/compat_data/chromium-to-electron.js
+++ b/tasks/compat_data/chromium-to-electron.js
@@ -1,4 +1,4 @@
-// https://github.com/babel/babel/blob/main/packages/babel-compat-data/scripts/chromium-to-electron.js
+// https://github.com/babel/babel/blob/v7.26.2/packages/babel-compat-data/scripts/chromium-to-electron.js
 
 const chromiumVersions = require('./chromium-versions');
 const chromiumVersionList = Object.keys(chromiumVersions);

--- a/tasks/compat_data/chromium-versions.js
+++ b/tasks/compat_data/chromium-versions.js
@@ -1,4 +1,4 @@
-// https://github.com/Kilian/electron-to-chromium/blob/master/chromium-versions.js
+// https://github.com/Kilian/electron-to-chromium/blob/v1.5.60/chromium-versions.js
 
 module.exports = {
   '39': '0.20',

--- a/tasks/compat_data/es-features.js
+++ b/tasks/compat_data/es-features.js
@@ -1,5 +1,5 @@
-// https://github.com/babel/babel/blob/main/packages/babel-compat-data/scripts/data/plugin-features.js
-// https://github.com/evanw/esbuild/blob/main/compat-table/src/index.ts
+// https://github.com/babel/babel/blob/v7.26.2/packages/babel-compat-data/scripts/data/plugin-features.js
+// https://github.com/evanw/esbuild/blob/v0.24.0/compat-table/src/index.ts
 
 const f = (es) => (item) => {
   item.es = es;

--- a/tasks/coverage/misc/fail/oxc-2394.ts
+++ b/tasks/coverage/misc/fail/oxc-2394.ts
@@ -1,4 +1,4 @@
-// copy from https://github.com/microsoft/TypeScript/blob/main/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmitErrors.ts#L72
+// copy from https://github.com/microsoft/TypeScript/blob/v5.6.3/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmitErrors.ts#L72
 
 // @filename: /node_modules/pkg/import.d.ts
 export interface ImportInterface {}

--- a/tasks/coverage/src/runtime/runtime.js
+++ b/tasks/coverage/src/runtime/runtime.js
@@ -1,4 +1,4 @@
-// https://github.com/evanw/esbuild/blob/main/scripts/test262.js
+// https://github.com/evanw/esbuild/blob/v0.24.0/scripts/test262.js
 //
 import fs from 'node:fs';
 import { createServer } from 'node:http';

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -286,7 +286,7 @@ pub trait Case: Sized + Sync + Send + UnwindSafe {
 
     /// Mark strict mode as always strict
     ///
-    /// See <https://github.com/tc39/test262/blob/main/INTERPRETING.md#strict-mode>
+    /// See <https://github.com/tc39/test262/blob/05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d/INTERPRETING.md#strict-mode>
     fn always_strict(&self) -> bool {
         false
     }

--- a/tasks/coverage/src/test262/mod.rs
+++ b/tasks/coverage/src/test262/mod.rs
@@ -116,7 +116,7 @@ impl Case for Test262Case {
     // each test must be executed twice: once in ECMAScript's non-strict mode, and again in ECMAScript's strict mode.
     // To run in strict mode, the test contents must be modified prior to execution--
     // a "use strict" directive must be inserted as the initial character sequence of the file
-    // https://github.com/tc39/test262/blob/main/INTERPRETING.md#strict-mode
+    // https://github.com/tc39/test262/blob/05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d/INTERPRETING.md#strict-mode
     fn run(&mut self) {
         let flags = &self.meta.flags;
         let source_type = SourceType::cjs();

--- a/tasks/coverage/src/typescript/transpile_runner.rs
+++ b/tasks/coverage/src/typescript/transpile_runner.rs
@@ -1,4 +1,4 @@
-//! <https://github.com/microsoft/TypeScript/blob/main/src/testRunner/transpileRunner.ts>
+//! <https://github.com/microsoft/TypeScript/blob/v5.6.3/src/testRunner/transpileRunner.ts>
 
 use std::path::{Path, PathBuf};
 

--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -9,59 +9,59 @@ const { Linter } = require('eslint');
 // - rule.meta.docs.recommended
 // Some plugins have the recommended flag in rule itself, but some plugins have it in config.
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/index.ts
+// https://github.com/typescript-eslint/typescript-eslint/blob/v8.9.0/packages/eslint-plugin/src/index.ts
 const {
   rules: pluginTypeScriptAllRules,
   configs: pluginTypeScriptConfigs,
 } = require('@typescript-eslint/eslint-plugin');
-// https://github.com/eslint-community/eslint-plugin-n/blob/master/lib/index.js
+// https://github.com/eslint-community/eslint-plugin-n/blob/v17.13.2/lib/index.js
 const { rules: pluginNAllRules } = require('eslint-plugin-n');
-// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/index.js
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v56.0.0/index.js
 const {
   rules: pluginUnicornAllRules,
   configs: pluginUnicornConfigs,
 } = require('eslint-plugin-unicorn');
-// https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js
+// https://github.com/gajus/eslint-plugin-jsdoc/blob/v50.5.0/src/index.js
 const {
   // @ts-expect-error: Module has no exported member
   rules: pluginJSDocAllRules,
   // @ts-expect-error: Module has no exported member
   configs: pluginJSDocConfigs,
 } = require('eslint-plugin-jsdoc');
-// https://github.com/import-js/eslint-plugin-import/blob/main/src/index.js
+// https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/src/index.js
 const {
   rules: pluginImportAllRules,
   configs: pluginImportConfigs,
 } = require('eslint-plugin-import');
-// https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/index.js
+// https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/index.js
 const {
   rules: pluginJSXA11yAllRules,
   configs: pluginJSXA11yConfigs,
 } = require('eslint-plugin-jsx-a11y');
-// https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts
+// https://github.com/jest-community/eslint-plugin-jest/blob/v28.9.0/src/index.ts
 const {
   rules: pluginJestAllRules,
   configs: pluginJestConfigs,
 } = require('eslint-plugin-jest');
-// https://github.com/jsx-eslint/eslint-plugin-react/blob/master/index.js
+// https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.2/index.js
 const { rules: pluginReactAllRules } = require('eslint-plugin-react');
-// https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js
+// https://github.com/facebook/react/blob/v18.3.1/packages/eslint-plugin-react-hooks/src/index.js
 const {
   rules: pluginReactHooksAllRules,
 } = require('eslint-plugin-react-hooks');
-// https://github.com/cvazac/eslint-plugin-react-perf/blob/master/index.js
+// https://github.com/cvazac/eslint-plugin-react-perf/blob/9bfa930661a23218f5460ebd39d35d76ccdb5724/index.js
 const {
   rules: pluginReactPerfAllRules,
   configs: pluginReactPerfConfigs,
 } = require('eslint-plugin-react-perf');
 // https://github.com/vercel/next.js/blob/canary/packages/eslint-plugin-next/src/index.ts
 const { rules: pluginNextAllRules } = require('@next/eslint-plugin-next');
-// https://github.com/eslint-community/eslint-plugin-promise/blob/main/index.js
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.1.0/index.js
 const {
   rules: pluginPromiseRules,
   configs: pluginPromiseConfigs,
 } = require('eslint-plugin-promise');
-// https://github.com/veritem/eslint-plugin-vitest/blob/main/src/index.ts
+// https://github.com/veritem/eslint-plugin-vitest/blob/v1.1.9/src/index.ts
 const {
   rules: pluginVitestRules,
   configs: pluginVitestConfigs,

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/README.md
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/react-refresh/README.md
@@ -1,3 +1,3 @@
-The tests of this directory are copied from the (react-refresh)[https://github.com/facebook/react/blob/main/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js], and did some style, import order, and other minor changes to made them work with our transformer.
+The tests of this directory are copied from the (react-refresh)[https://github.com/facebook/react/blob/v18.3.1/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js], and did some style, import order, and other minor changes to made them work with our transformer.
 
 NOTE: This directory only add tests copied from the upstream, so that we can distinguish the source of the test


### PR DESCRIPTION
Fix #7291

The match relationship is :

```
 {
    "oxc-project/oxc": "main",
    "cvazac/eslint-plugin-react-perf": "9bfa930661a23218f5460ebd39d35d76ccdb5724",
    "DefinitelyTyped/DefinitelyTyped": "b5dc32740d9b45d11cff9b025896dd333c795b39",
    "estree/estree": "e6015c4c63118634749001b1cd1c3f7a0388f16e",
    "fregante/eslint-formatters": "ae1fd9748596447d1fd09625c33d9e7ba9a3d06d",
    "javascript-compiler-hints/compiler-notations-spec": "c14f7e197cb225c9eee877143536665ce3150712",
    "mozilla-spidermonkey/jsparagus": "24004745a8ed4939fc0dc7332bfd1268ac52285f",
    "privatenumber/minification-benchmarks": "d8d54ceeb206d318fa288b152904adf715b076b2",
    "tc39/source-map": "1930e58ffabefe54038f7455759042c6e3dd590e",
    "tc39/test262": "05c45a4c430ab6fee3e0c7f0d47d8a30d8876a6d",
    "biomejs/biome": "cli/v1.9.4",
    "eslint-community/eslint-plugin-promise": "v7.1.0",
    "eslint-community/eslint-plugin-n": "v17.13.2",
    "rollup/plugins": "pluginutils-v5.1.3",
    "rome/tools": "lsp/v0.28.0",
    "A11yance/aria-query": "v5.3.2",
    "babel/babel": "v7.26.2",
    "denoland/deno_graph": "0.84.0",
    "eslint/eslint": "v9.9.1",
    "evanw/esbuild": "v0.24.0",
    "facebook/react": "v18.3.1",
    "gajus/eslint-plugin-jsdoc": "v50.5.0",
    "getsentry/rust-sourcemap": "9.1.0",
    "google/closure-compiler": "v20240609",
    "guybedford/es-module-lexer": "1.5.4",
    "import-js/eslint-plugin-import": "v2.29.1",
    "jest-community/eslint-plugin-jest": "v28.9.0",
    "jsx-eslint/eslint-plugin-jsx-a11y": "v6.9.0",
    "jsx-eslint/eslint-plugin-react": "v7.37.2",
    "Kilian/electron-to-chromium": "v1.5.60",
    "lukastaegert/eslint-plugin-tree-shaking": "v1.12.2",
    "microsoft/TypeScript": "v5.6.3",
    "nicolo-ribaudo/babel": "v7.25.8",
    "nodevault/node-vault": "v0.10.2",
    "prettier/prettier": "3.3.3",
    "ratel-rust/ratel-core": "v0.7.0",
    "rolldown-rs/rolldown": "v0.14.0",
    "rust-lang/rust": "1.82.0",
    "sindresorhus/eslint-plugin-unicorn": "v56.0.0",
    "terser/terser": "v5.9.0",
    "typescript-eslint/typescript-eslint": "v8.9.0",
    "vercel/next.js": "v15.0.2",
    "veritem/eslint-plugin-vitest": "v1.1.9",
}

```