### PR TITLE
refactor(traverse)!: rename `TraverseCtx` methods for creating `IdentifierReference`s

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -277,8 +277,12 @@ impl<'a> HelperLoaderStore<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
         let symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), HELPER_VAR);
-        let ident =
-            ctx.create_reference_id(SPAN, Atom::from(HELPER_VAR), symbol_id, ReferenceFlags::Read);
+        let ident = ctx.create_ident_reference(
+            SPAN,
+            Atom::from(HELPER_VAR),
+            symbol_id,
+            ReferenceFlags::Read,
+        );
         let object = Expression::Identifier(ctx.alloc(ident));
         let property = ctx.ast.identifier_name(SPAN, Atom::from(helper.name()));
         Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -227,7 +227,7 @@ impl<'a> ModuleImportsStore<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let var_kind = VariableDeclarationKind::Var;
-        let ident = ctx.create_reference_id(
+        let ident = ctx.create_ident_reference(
             SPAN,
             Atom::from("require"),
             require_symbol_id,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -310,7 +310,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 let id = caller_function.id.as_ref().unwrap();
                 // If the function has an id, then we need to return the id.
                 // `function foo() { ... }` -> `function foo() {} return foo;`
-                let reference = ctx.create_bound_reference_id(
+                let reference = ctx.create_bound_ident_reference(
                     SPAN,
                     id.name.clone(),
                     id.symbol_id(),
@@ -597,8 +597,12 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), "arguments");
-        let arguments_ident =
-            ctx.create_reference_id(SPAN, Atom::from("arguments"), symbol_id, ReferenceFlags::Read);
+        let arguments_ident = ctx.create_ident_reference(
+            SPAN,
+            Atom::from("arguments"),
+            symbol_id,
+            ReferenceFlags::Read,
+        );
         let arguments_ident = Argument::Identifier(ctx.alloc(arguments_ident));
 
         // (this, arguments)

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -142,7 +142,7 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
 
     fn object_assign(symbol_id: Option<SymbolId>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         let ident =
-            ctx.create_reference_id(SPAN, Atom::from("Object"), symbol_id, ReferenceFlags::Read);
+            ctx.create_ident_reference(SPAN, Atom::from("Object"), symbol_id, ReferenceFlags::Read);
         let object = Expression::Identifier(ctx.alloc(ident));
         let property = ctx.ast.identifier_name(SPAN, Atom::from("assign"));
         Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -134,7 +134,7 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         let symbol_id = reference.symbol_id();
         let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
 
-        let ident = ctx.create_reference_id(
+        let ident = ctx.create_ident_reference(
             SPAN,
             ident.name.clone(),
             symbol_id,

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -336,7 +336,7 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
                             binding_name.as_str(),
                         )
                         .map(|symbol_id| {
-                            let ident = ctx.create_bound_reference_id(
+                            let ident = ctx.create_bound_ident_reference(
                                 SPAN,
                                 binding_name,
                                 symbol_id,
@@ -496,7 +496,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let left = self.create_registration(id.name.clone(), ReferenceFlags::Write, ctx);
-        let right = ctx.create_bound_reference_id(
+        let right = ctx.create_bound_ident_reference(
             SPAN,
             id.name.clone(),
             id.symbol_id(),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -180,7 +180,7 @@ impl<'a, 'ctx> Traverse<'a> for RegExp<'a, 'ctx> {
 
         let callee = {
             let symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), "RegExp");
-            let ident = ctx.create_reference_id(
+            let ident = ctx.create_ident_reference(
                 SPAN,
                 Atom::from("RegExp"),
                 symbol_id,

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -122,7 +122,7 @@ impl<'a> TypeScriptEnum<'a> {
         } else {
             // }(Foo || {});
             let op = LogicalOperator::Or;
-            let left = ctx.create_bound_reference_id(
+            let left = ctx.create_bound_ident_reference(
                 decl.id.span,
                 enum_name.clone(),
                 var_symbol_id,
@@ -138,7 +138,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         if is_already_declared {
             let op = AssignmentOperator::Assign;
-            let left = ctx.create_bound_reference_id(
+            let left = ctx.create_bound_ident_reference(
                 decl.id.span,
                 enum_name.clone(),
                 var_symbol_id,

--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -236,7 +236,7 @@ impl<'a> BoundIdentifier<'a> {
         flags: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, flags)
+        ctx.create_bound_ident_reference(span, self.name.clone(), self.symbol_id, flags)
     }
 
     /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`

--- a/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
@@ -218,7 +218,7 @@ impl<'a> MaybeBoundIdentifier<'a> {
         flags: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_reference_id(span, self.name.clone(), self.symbol_id, flags)
+        ctx.create_ident_reference(span, self.name.clone(), self.symbol_id, flags)
     }
 
     /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -434,7 +434,7 @@ impl<'a> TraverseCtx<'a> {
     }
 
     /// Create an `IdentifierReference` bound to a `SymbolId`.
-    pub fn create_bound_reference_id(
+    pub fn create_bound_ident_reference(
         &mut self,
         span: Span,
         name: Atom<'a>,
@@ -458,7 +458,7 @@ impl<'a> TraverseCtx<'a> {
     }
 
     /// Create an unbound `IdentifierReference`.
-    pub fn create_unbound_reference_id(
+    pub fn create_unbound_ident_reference(
         &mut self,
         span: Span,
         name: Atom<'a>,
@@ -486,9 +486,9 @@ impl<'a> TraverseCtx<'a> {
 
     /// Create an `IdentifierReference` optionally bound to a `SymbolId`.
     ///
-    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_reference_id`
-    /// or `TraverseCtx::create_unbound_reference_id`.
-    pub fn create_reference_id(
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_ident_reference`
+    /// or `TraverseCtx::create_unbound_ident_reference`.
+    pub fn create_ident_reference(
         &mut self,
         span: Span,
         name: Atom<'a>,
@@ -496,9 +496,9 @@ impl<'a> TraverseCtx<'a> {
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         if let Some(symbol_id) = symbol_id {
-            self.create_bound_reference_id(span, name, symbol_id, flags)
+            self.create_bound_ident_reference(span, name, symbol_id, flags)
         } else {
-            self.create_unbound_reference_id(span, name, flags)
+            self.create_unbound_ident_reference(span, name, flags)
         }
     }
 


### PR DESCRIPTION
`create_reference_id` was a confusing name, as it doesn't return a `ReferenceId`. Rename these methods to more clearly represent what they do.