### PR TITLE
fix(linter)!: override plugins array when passed in config file

### DIFF
--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -142,29 +142,28 @@ mod test {
     #[test]
     fn test_oxlintrc_de_plugins_empty_array() {
         let config: Oxlintrc = serde_json::from_value(json!({ "plugins": [] })).unwrap();
+        assert_eq!(config.plugins, LintPlugins::empty());
+    }
+
+    #[test]
+    fn test_oxlintrc_empty_config_plugins() {
+        let config: Oxlintrc = serde_json::from_str(r"{}").unwrap();
         assert_eq!(config.plugins, LintPlugins::default());
     }
 
     #[test]
-    fn test_oxlintrc_de_plugins_enabled_by_default() {
-        // NOTE(@DonIsaac): creating a Value with `json!` then deserializing it with serde_json::from_value
-        // Errs with "invalid type: string \"eslint\", expected a borrowed string" and I can't
-        // figure out why. This seems to work. Why???
-        let configs = [
-            r#"{ "plugins": ["eslint"] }"#,
-            r#"{ "plugins": ["oxc"] }"#,
-            r#"{ "plugins": ["deepscan"] }"#, // alias for oxc
-        ];
-        // ^ these plugins are enabled by default already
-        for oxlintrc in configs {
-            let config: Oxlintrc = serde_json::from_str(oxlintrc).unwrap();
-            assert_eq!(config.plugins, LintPlugins::default());
-        }
-    }
+    fn test_oxlintrc_specifying_plugins_will_override() {
+        let config: Oxlintrc = serde_json::from_str(r#"{ "plugins": ["react", "oxc"] }"#).unwrap();
+        assert_eq!(config.plugins, LintPlugins::REACT.union(LintPlugins::OXC));
+        let config: Oxlintrc =
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
+        assert_eq!(config.plugins, LintPlugins::TYPESCRIPT.union(LintPlugins::UNICORN));
+        let config: Oxlintrc =
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "security"] }"#).unwrap();
+        assert_eq!(config.plugins, LintPlugins::all());
 
-    #[test]
-    fn test_oxlintrc_de_plugins_new() {
-        let config: Oxlintrc = serde_json::from_str(r#"{ "plugins": ["import"] }"#).unwrap();
-        assert_eq!(config.plugins, LintPlugins::default().union(LintPlugins::IMPORT));
+        let config: Oxlintrc =
+            serde_json::from_str(r#"{ "plugins": ["typescript", "@typescript-eslint"] }"#).unwrap();
+        assert_eq!(config.plugins, LintPlugins::TYPESCRIPT);
     }
 }

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -178,7 +178,7 @@ impl<'de> Deserialize<'de> for LintPlugins {
             where
                 A: de::SeqAccess<'de>,
             {
-                let mut plugins = LintPlugins::default();
+                let mut plugins = LintPlugins::empty();
                 loop {
                     // serde_json::from_str will provide an &str, while
                     // serde_json::from_value provides a String. The former is


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/6896

When the `plugins` config property is specified, it will overwrite the default plugins array. This allows the plugins list to be easily customized and allows for disabling default plugins at the same time as enabling non-default ones.

- example: `{ "plugins": [] }` will enable no plugins.
- example: `{ }` will enable default plugins.
- example: `{ "plugins": ["typescript", "import"] }` will enable only the import and typescript plugins.