### PR TITLE
refactor(transformer): helper loader methods take `Span`

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -73,7 +73,7 @@ use serde::Deserialize;
 use oxc_allocator::{String as ArenaString, Vec as ArenaVec};
 use oxc_ast::ast::{Argument, CallExpression, Expression, TSTypeParameterInstantiation};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
-use oxc_span::{Atom, SPAN};
+use oxc_span::{Atom, Span, SPAN};
 use oxc_traverse::{BoundIdentifier, TraverseCtx};
 
 use crate::TransformCtx;
@@ -183,12 +183,13 @@ impl<'a> TransformCtx<'a> {
     pub fn helper_call(
         &self,
         helper: Helper,
+        span: Span,
         arguments: ArenaVec<'a, Argument<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> CallExpression<'a> {
         let callee = self.helper_load(helper, ctx);
         ctx.ast.call_expression(
-            SPAN,
+            span,
             callee,
             None::<TSTypeParameterInstantiation<'a>>,
             arguments,
@@ -200,12 +201,13 @@ impl<'a> TransformCtx<'a> {
     pub fn helper_call_expr(
         &self,
         helper: Helper,
+        span: Span,
         arguments: ArenaVec<'a, Argument<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let callee = self.helper_load(helper, ctx);
         ctx.ast.expression_call(
-            SPAN,
+            span,
             callee,
             None::<TSTypeParameterInstantiation<'a>>,
             arguments,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -639,7 +639,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         let mut function = Self::create_function(None, params, body, scope_id, ctx);
         function.generator = true;
         let arguments = ctx.ast.vec1(Argument::FunctionExpression(function));
-        self.ctx.helper_call_expr(self.helper, arguments, ctx)
+        self.ctx.helper_call_expr(self.helper, SPAN, arguments, ctx)
     }
 
     /// Creates a helper declaration statement for async-to-generator transformation.

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -150,6 +150,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
         let iterator = ctx.ast.move_expression(&mut stmt.right);
         let iterator = self.ctx.helper_call_expr(
             Helper::AsyncIterator,
+            SPAN,
             ctx.ast.vec1(Argument::from(iterator)),
             ctx,
         );

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -166,9 +166,11 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
         expr.argument.as_mut().map(|argument| {
             let argument = Argument::from(ctx.ast.move_expression(argument));
             let arguments = ctx.ast.vec1(argument);
-            let mut argument = self.ctx.helper_call_expr(Helper::AsyncIterator, arguments, ctx);
+            let mut argument =
+                self.ctx.helper_call_expr(Helper::AsyncIterator, SPAN, arguments, ctx);
             let arguments = ctx.ast.vec1(Argument::from(argument));
-            argument = self.ctx.helper_call_expr(Helper::AsyncGeneratorDelegate, arguments, ctx);
+            argument =
+                self.ctx.helper_call_expr(Helper::AsyncGeneratorDelegate, SPAN, arguments, ctx);
             ctx.ast.expression_yield(SPAN, expr.delegate, Some(argument))
         })
     }
@@ -199,7 +201,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
 
         let mut argument = ctx.ast.move_expression(&mut expr.argument);
         let arguments = ctx.ast.vec1(Argument::from(argument));
-        argument = self.ctx.helper_call_expr(Helper::AwaitAsyncGenerator, arguments, ctx);
+        argument = self.ctx.helper_call_expr(Helper::AwaitAsyncGenerator, SPAN, arguments, ctx);
 
         Some(ctx.ast.expression_yield(SPAN, false, Some(argument)))
     }


### PR DESCRIPTION
`TransformCtx::helper_call` and `TransformCtx::helper_call_expr` take a `Span`. Sometimes the helper call replaces some original code, and should have the same span as the original code.