### PR TITLE
perf(transformer/arrow-function): create super method binding names lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,7 @@ name = "oxc_transformer"
 version = "0.36.0"
 dependencies = [
  "base64",
+ "compact_str",
  "cow-utils",
  "dashmap 6.1.0",
  "indexmap",

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -35,6 +35,7 @@ oxc_syntax = { workspace = true, features = ["to_js_string"] }
 oxc_traverse = { workspace = true }
 
 base64 = { workspace = true }
+compact_str = { workspace = true }
 cow-utils = { workspace = true }
 dashmap = { workspace = true }
 indexmap = { workspace = true }


### PR DESCRIPTION
Key `super` getter/setter hash map with original property name `&str`, instead of generated binding name. This allows a couple of improvements:

* Generate binding names for `super` getters/setters lazily, only when they're created, rather than every time you encounter a `super`.
* Don't allocate strings into arena which are never used as part of AST. Use `CompactString` for building those strings instead.
