### PR TITLE
test(transformer/async-to-generator): failing test for nested supers

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 90/100
+Passed: 90/101
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -8,12 +8,16 @@ Passed: 90/100
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
 * babel-plugin-transform-object-rest-spread
-* babel-plugin-transform-async-to-generator
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
 * babel-plugin-transform-react-jsx-source
 * regexp
+
+
+# babel-plugin-transform-async-to-generator (14/15)
+* super/nested/input.js
+x Output mismatch
 
 
 # babel-plugin-transform-typescript (2/9)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/nested/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/nested/input.js
@@ -1,0 +1,15 @@
+const outer = {
+  value: 0,
+  async method() {
+    () => super.value;
+
+    const inner = {
+      value: 0,
+      async method() {
+        () => super.value;
+      }
+    };
+
+    () => super.value;
+  }
+};

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/nested/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/nested/output.js
@@ -1,0 +1,22 @@
+const outer = {
+  value: 0,
+  method() {
+    var _superprop_getValue = () => super.value;
+
+    return babelHelpers.asyncToGenerator(function* () {
+      () => _superprop_getValue();
+
+      const inner = {
+        value: 0,
+        method() {
+          var _superprop_getValue2 = () => super.value;
+          return babelHelpers.asyncToGenerator(function* () {
+            () => _superprop_getValue2();
+          })();
+        }
+      };
+
+      () => _superprop_getValue();
+    })();
+  }
+};


### PR DESCRIPTION
Failing test for async-to-generator transform.

When exiting a function which has `super` bindings, need to restore previous state of `super_methods`. It probably needs to be a stack. But not sure if `renamed_arguments_symbol_ids` needs to be a stack too? I don't really understand this transform, so am not attempting to fix myself.

[Babel REPL](https://babeljs.io/repl#?browsers=ie%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBCCuUCmAnGBeGBvAUDGAbgIYA28SAXDAAwA0eMREAnmMDALZJQAWIAJgAoAlNgb4RGAHwwI8AA6oAdMTJIA3DnExQkWAEswYVBjH5zhUuSp1t-Jq3ZdeAybgsXJ6GXMUoVVhp2MAC-2iGa2l4-Csqq5Jr4YRE4QA&debug=false&forceAllTransforms=false&modules=commonjs&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=true&targets=&version=7.26.2&externalPlugins=%40babel%2Fplugin-external-helpers%407.25.9%2C%40babel%2Fplugin-transform-async-to-generator%407.25.9&assumptions=%7B%7D)