### PR TITLE
refactor(transformer/arrow-functions): use `IndexMap` for `super` getter/setters

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/assign/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/super/assign/output.js
@@ -1,13 +1,13 @@
 const Obj = {
   value: 0,
   method() {
-    var _superprop_getObject = () => super.object,
-    _superprop_set = (_prop, _value) => super[_prop] = _value,
-    _superprop_setValue = _value2 => super.value = _value2;
+    var _superprop_setValue = (_value) => (super.value = _value),
+      _superprop_set = (_prop, _value2) => (super[_prop] = _value2),
+      _superprop_getObject = () => super.object;
     return babelHelpers.asyncToGenerator(function* () {
       _superprop_setValue(true);
       () => {
-        _superprop_set('value', true);
+        _superprop_set("value", true);
         _superprop_getObject().value = true;
       };
     })();


### PR DESCRIPTION
Generate getter/setter declarations in same order as Babel by using `IndexMap` instead of `HashMap` to store `super` getter/setter method details.