### PR TITLE
perf(transformer/arrow-function): reduce string comparisons

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -857,7 +857,7 @@ impl<'a> ArrowFunctionConverter<'a> {
 
     /// Whether to transform the `arguments` identifier.
     fn should_transform_arguments_identifier(&self, name: &str, ctx: &mut TraverseCtx<'a>) -> bool {
-        self.is_async_only() && name == "arguments" && Self::is_affected_arguments_identifier(ctx)
+        self.is_async_only() && Self::is_affected_arguments_identifier(ctx) && name == "arguments"
     }
 
     /// Check if the `arguments` identifier is affected by the transformation.


### PR DESCRIPTION
Experiment. Try avoiding string comparisons in most cases for `IdentifierReference`s and `BindingIdentifier`s. Not sure if this will be faster or not.