### PR TITLE
docs(website): Link to specific ref when generating website docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -207,6 +207,6 @@ clone-submodule dir url sha:
   cd {{dir}} ; git fetch --depth=1 origin {{sha}} ; git reset --hard {{sha}}
 
 website path:
-  cargo run -p website -- linter-rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules
+  cargo run -p website -- linter-rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules --git-ref $(git rev-parse HEAD)
   cargo run -p website -- linter-cli > {{path}}/src/docs/guide/usage/linter/generated-cli.md
   cargo run -p website -- linter-schema-markdown > {{path}}/src/docs/guide/usage/linter/generated-config.md


### PR DESCRIPTION
Currently the website links to main which is subject to change without an update to the website.  This updates the website to link to the specific commit that was used when the website was published.

Feel free to cleanup anything in this PR.