### PR TITLE
refactor(codegen): do not print unnecessary parentheses if both sides use the same logical operator

### DIFF
--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -174,8 +174,8 @@ fn conditional() {
 fn coalesce() {
     test_minify("a ?? b", "a??b;");
     test_minify("a ?? b ?? c ?? d", "a??b??c??d;");
-    test_minify("a ?? (b ?? (c ?? d))", "a??(b??(c??d));");
-    test_minify("(a ?? (b ?? (c ?? d)))", "a??(b??(c??d));");
+    test_minify("a ?? (b ?? (c ?? d))", "a??b??c??d;");
+    test_minify("(a ?? (b ?? (c ?? d)))", "a??b??c??d;");
     test_minify("a, b ?? c", "a,b??c;");
     test_minify("(a, b) ?? c", "(a,b)??c;");
     test_minify("a, b ?? c, d", "a,b??c,d;");
@@ -188,8 +188,8 @@ fn coalesce() {
 #[test]
 fn logical_or() {
     test_minify("a || b || c", "a||b||c;");
-    test_minify("(a || (b || c)) || d", "a||(b||c)||d;");
-    test_minify("a || (b || (c || d))", "a||(b||(c||d));");
+    test_minify("(a || (b || c)) || d", "a||b||c||d;");
+    test_minify("a || (b || (c || d))", "a||b||c||d;");
     test_minify("a || b && c", "a||b&&c;");
     test_minify("(a || b) && c", "(a||b)&&c;");
     test_minify("a, b || c, d", "a,b||c,d;");
@@ -201,7 +201,7 @@ fn logical_or() {
 #[test]
 fn logical_and() {
     test_minify("a && b && c", "a&&b&&c;");
-    test_minify("a && ((b && c) && d)", "a&&(b&&c&&d);");
+    test_minify("a && ((b && c) && d)", "a&&b&&c&&d;");
     test_minify("((a && b) && c) && d", "a&&b&&c&&d;");
     test_minify("(a || b) && (c || d)", "(a||b)&&(c||d);");
     test_minify("a, b && c, d", "a,b&&c,d;");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -10,17 +10,17 @@ Original   | Minified   | esbuild    | Gzip       | esbuild
 
 544.10 kB  | 73.48 kB   | 72.48 kB   | 26.12 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 276.49 kB  | 270.13 kB  | 91.15 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 276.48 kB  | 270.13 kB  | 91.15 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 467.60 kB  | 458.89 kB  | 126.74 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 467.59 kB  | 458.89 kB  | 126.73 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 662.86 kB  | 646.76 kB  | 164.00 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 741.57 kB  | 724.14 kB  | 181.45 kB  | 181.07 kB  | victory.js
+2.14 MB    | 741.55 kB  | 724.14 kB  | 181.45 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.02 MB    | 1.01 MB    | 332.01 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.39 MB    | 2.31 MB    | 496.10 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.56 MB    | 3.49 MB    | 911.23 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.56 MB    | 3.49 MB    | 911.24 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
As shown by the changing tests, we don't need to print parentheses for them. 

### Comparison
In [esbuild](https://esbuild.github.io/try/#dAAwLjI0LjAAAGEgPz8gKGIgPz8gKGMgPz8gZCkpOwooYSA/PyAoYiA/PyAoYyA/PyBkKSkpOwooYSB8fCAoYiB8fCBjKSkgfHwgZDsKYSB8fCAoYiB8fCAoYyB8fCBkKSk7CmEgJiYgKChiICYmIGMpICYmIGQp), it will print parentheses as-is, in [SWC](https://play.swc.rs/?version=1.9.2&code=H4sIAAAAAAAAA0tUsLdX0EgCk8kgMkVT05pLIxGLMES8pgYkDiSTNTVBVIo1F5IgUDFIDKQ2UUFNTUEDKAykkjVBZIomAGEbiHtuAAAA&config=H4sIAAAAAAAAA1VQzW7DIAy%2B9ykin6tlyrHXTb3ttCdA1GmpACPbSIuqvPuAJml6w9%2Bv8ePQdXAXC6fuUZ5lSIYFeZsLIlNU81cQ0CmhWHZJ4biyKpVSztiQ%2BUmAGr6iVhPK8DkMsOJsoozEYd%2BQBb9xdBHPxF%2FeiJwd%2BossuVsVo7G68xXIhUSsv5TZYi27qSY59T1K%2BJBbn56W48vAOaoLTWuyUjDqLCz0%2FPYDTyRVNxovyw4QXHTjtF%2FdUiglIu%2FCKjXx6jf%2FYc1v6RDokhu5HL0etq5U0gLFu8BLuTZu6eDkZ7W3s8%2F%2FYy0r4MUBAAA%3D), we have the same output now