### PR TITLE
perf(transformer/arrow-functions): inline hot visitors

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -120,6 +120,8 @@ impl<'a, 'ctx> Traverse<'a> for Common<'a, 'ctx> {
         self.arrow_function_converter.exit_expression(expr, ctx);
     }
 
+    // `#[inline]` because this is a hot path and `arrow_function_converter`'s function is small
+    #[inline]
     fn enter_binding_identifier(
         &mut self,
         node: &mut BindingIdentifier<'a>,
@@ -128,6 +130,8 @@ impl<'a, 'ctx> Traverse<'a> for Common<'a, 'ctx> {
         self.arrow_function_converter.enter_binding_identifier(node, ctx);
     }
 
+    // `#[inline]` because this is a hot path and `arrow_function_converter`'s function is small
+    #[inline]
     fn enter_identifier_reference(
         &mut self,
         node: &mut IdentifierReference<'a>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -191,6 +191,8 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         self.x2_es2020.enter_big_int_literal(node, ctx);
     }
 
+    // `#[inline]` because this is a hot path and function at end of chain in `common` transform is small
+    #[inline]
     fn enter_binding_identifier(
         &mut self,
         node: &mut BindingIdentifier<'a>,
@@ -199,6 +201,8 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         self.common.enter_binding_identifier(node, ctx);
     }
 
+    // `#[inline]` because this is a hot path and function at end of chain in `common` transform is small
+    #[inline]
     fn enter_identifier_reference(
         &mut self,
         node: &mut IdentifierReference<'a>,


### PR DESCRIPTION
Follow-on after #7322. Add more `#[inline]` attrs to make absolutely sure these methods are inlined.