### PR TITLE
perf(transformer): use `AstBuilder::vec_from_array`

### DIFF
--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -261,24 +261,22 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
                 Some(ctx.ast.for_statement_init_variable_declaration(
                     SPAN,
                     VariableDeclarationKind::Var,
-                    {
-                        let mut items = ctx.ast.vec_with_capacity(2);
-                        items.push(ctx.ast.variable_declarator(
+                    ctx.ast.vec_from_array([
+                        ctx.ast.variable_declarator(
                             SPAN,
                             VariableDeclarationKind::Var,
                             iterator_key.create_binding_pattern(ctx),
                             Some(iterator),
                             false,
-                        ));
-                        items.push(ctx.ast.variable_declarator(
+                        ),
+                        ctx.ast.variable_declarator(
                             SPAN,
                             VariableDeclarationKind::Var,
                             step_key.create_binding_pattern(ctx),
                             None,
                             false,
-                        ));
-                        items
-                    },
+                        ),
+                    ]),
                     false,
                 )),
                 Some(ctx.ast.expression_assignment(
@@ -371,9 +369,8 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
                 {
                     ctx.ast.block_statement_with_scope_id(
                         SPAN,
-                        {
-                            let mut items = ctx.ast.vec_with_capacity(2);
-                            items.push(ctx.ast.statement_expression(
+                        ctx.ast.vec_from_array([
+                            ctx.ast.statement_expression(
                                 SPAN,
                                 ctx.ast.expression_assignment(
                                     SPAN,
@@ -381,8 +378,8 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
                                     iterator_had_error_key.create_write_target(ctx),
                                     ctx.ast.expression_boolean_literal(SPAN, true),
                                 ),
-                            ));
-                            items.push(ctx.ast.statement_expression(
+                            ),
+                            ctx.ast.statement_expression(
                                 SPAN,
                                 ctx.ast.expression_assignment(
                                     SPAN,
@@ -390,9 +387,8 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
                                     iterator_error_key.create_write_target(ctx),
                                     err_ident.create_read_expression(ctx),
                                 ),
-                            ));
-                            items
-                        },
+                            ),
+                        ]),
                         block_scope_id,
                     )
                 },

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -176,10 +176,7 @@ impl<'a, 'ctx> JsxSource<'a, 'ctx> {
                 .object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
         };
 
-        let mut properties = ctx.ast.vec_with_capacity(3);
-        properties.push(filename);
-        properties.push(line_number);
-        properties.push(column_number);
+        let properties = ctx.ast.vec_from_array([filename, line_number, column_number]);
         ctx.ast.expression_object(SPAN, properties, None)
     }
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -164,11 +164,12 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
             ));
 
             let callee = self.refresh_reg.to_expression(ctx);
-            let mut arguments = ctx.ast.vec_with_capacity(2);
-            arguments.push(Argument::from(binding.create_read_expression(ctx)));
-            arguments.push(Argument::from(
-                ctx.ast.expression_string_literal(SPAN, ctx.ast.atom(&persistent_id)),
-            ));
+            let arguments = ctx.ast.vec_from_array([
+                Argument::from(binding.create_read_expression(ctx)),
+                Argument::from(
+                    ctx.ast.expression_string_literal(SPAN, ctx.ast.atom(&persistent_id)),
+                ),
+            ]);
             new_statements.push(ctx.ast.statement_expression(
                 SPAN,
                 ctx.ast.expression_call(SPAN, callee, NONE, arguments, false),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -183,12 +183,10 @@ impl<'a, 'ctx> Traverse<'a> for RegExp<'a, 'ctx> {
             ctx.create_ident_expr(SPAN, Atom::from("RegExp"), symbol_id, ReferenceFlags::read())
         };
 
-        let mut arguments = ctx.ast.vec_with_capacity(2);
-        arguments.push(Argument::from(ctx.ast.expression_string_literal(SPAN, pattern_source)));
-
-        let flags_str = flags.to_string();
-        let flags_str = Argument::from(ctx.ast.expression_string_literal(SPAN, flags_str));
-        arguments.push(flags_str);
+        let arguments = ctx.ast.vec_from_array([
+            Argument::from(ctx.ast.expression_string_literal(SPAN, pattern_source)),
+            Argument::from(ctx.ast.expression_string_literal(SPAN, flags.to_string())),
+        ]);
 
         *expr = ctx.ast.expression_new(regexp.span, callee, arguments, NONE);
     }

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -491,12 +491,10 @@ impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
             assignments.push(Self::create_assignment_statement(name.clone(), id.name.clone(), ctx));
         });
 
-        let mut stmts = ctx.ast.vec_with_capacity(2);
-        stmts.push(Statement::VariableDeclaration(var_decl));
-        stmts.push(
+        ctx.ast.vec_from_array([
+            Statement::VariableDeclaration(var_decl),
             ctx.ast.statement_expression(SPAN, ctx.ast.expression_sequence(SPAN, assignments)),
-        );
-        stmts
+        ])
     }
 }
 


### PR DESCRIPTION
Use `AstBuilder::vec_from_array` introduced in #7331 in the transformer, in place of creating a `Vec` with `Vec::with_capacity` and then pushing values to it.