### PR TITLE
perf(ast): `AstBuilder::vec1` use `Vec::from_array_in`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -56,9 +56,7 @@ impl<'a> AstBuilder<'a> {
     /// Create a new arena-allocated [`Vec`] initialized with a single element.
     #[inline]
     pub fn vec1<T>(self, value: T) -> Vec<'a, T> {
-        let mut vec = self.vec_with_capacity(1);
-        vec.push(value);
-        vec
+        self.vec_from_array([value])
     }
 
     /// Collect an iterator into a new arena-allocated [`Vec`].


### PR DESCRIPTION
`AstBuilder::vec1` can use `Vec::from_array_in` rather than creating a `Vec` and then pushing to it. This should optimize better.