### PR TITLE
refactor(ast)!: remove `impl GetAddress for Function`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1011,16 +1011,6 @@ impl<'a> Function<'a> {
     }
 }
 
-// FIXME: This is a workaround for we can't get current address by `TraverseCtx`,
-// we will remove this once we support `TraverseCtx::current_address`.
-// See: <https://github.com/oxc-project/oxc/pull/6881#discussion_r1816560516>
-impl GetAddress for Function<'_> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self)
-    }
-}
-
 impl<'a> FormalParameters<'a> {
     /// Number of parameters bound in this parameter list.
     pub fn parameters_count(&self) -> usize {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -2,7 +2,7 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use rustc_hash::FxHashMap;
 use sha1::{Digest, Sha1};
 
-use oxc_allocator::{CloneIn, GetAddress, Vec as ArenaVec};
+use oxc_allocator::{Address, CloneIn, GetAddress, Vec as ArenaVec};
 use oxc_ast::{ast::*, match_expression, AstBuilder, NONE};
 use oxc_semantic::{Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{Atom, GetSpan, SPAN};
@@ -289,8 +289,9 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
             // which is a `Statement::ExportDefaultDeclaration`
             Ancestor::ExportDefaultDeclarationDeclaration(decl) => decl.address(),
             // Otherwise just a `function Foo() {}`
-            // which is a `Statement::FunctionDeclaration`
-            _ => func.address(),
+            // which is a `Statement::FunctionDeclaration`.
+            // `Function` is always stored in a `Box`, so has a stable memory address.
+            _ => Address::from_ptr(func),
         };
         self.ctx.statement_injector.insert_after(&address, statement);
     }


### PR DESCRIPTION
`impl GetAddress for Function` was added as a hack, in the absence of another way to get the `Address` of a `&Function` (https://github.com/oxc-project/backlog/issues/140).

Remove it, and use `Address:from_ptr` instead in JSX Refresh transform, which is only place using it.