### PR TITLE
fix(semantic): Set all exported declaration variables with the `SymbolFlags::Export` flag

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+use oxc_ecmascript::BoundNames;
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{ast::*, AstKind, Visit};
@@ -579,6 +580,12 @@ impl<'a> SemanticBuilder<'a> {
                             self.add_export_flag_to_identifier(name.as_str());
                         }
                     }
+                }
+
+                if let Some(decl) = &decl.declaration {
+                    decl.bound_names(&mut |ident| {
+                        self.add_export_flag_to_identifier(ident.name.as_str());
+                    });
                 }
             }
         }

--- a/crates/oxc_semantic/tests/integration/modules.rs
+++ b/crates/oxc_semantic/tests/integration/modules.rs
@@ -258,3 +258,14 @@ fn test_import_type() {
         .contains_flags(SymbolFlags::TypeImport)
         .test();
 }
+
+#[test]
+fn test_multiple_export_var() {
+    let test = SemanticTester::js(
+        "
+    export const x = 1, y = 2;
+    ",
+    );
+    test.has_some_symbol("x").contains_flags(SymbolFlags::Export).test();
+    test.has_some_symbol("y").contains_flags(SymbolFlags::Export).test();
+}

--- a/crates/oxc_semantic/tests/integration/modules.rs
+++ b/crates/oxc_semantic/tests/integration/modules.rs
@@ -263,9 +263,11 @@ fn test_import_type() {
 fn test_multiple_export_var() {
     let test = SemanticTester::js(
         "
-    export const x = 1, y = 2;
+    export var x = 1, y = 2, [z] = [3], { a: b } = { a: 4 };
     ",
     );
     test.has_some_symbol("x").contains_flags(SymbolFlags::Export).test();
     test.has_some_symbol("y").contains_flags(SymbolFlags::Export).test();
+    test.has_some_symbol("z").contains_flags(SymbolFlags::Export).test();
+    test.has_some_symbol("b").contains_flags(SymbolFlags::Export).test();
 }


### PR DESCRIPTION
- Closes: #7338