### PR TITLE
perf(syntax): reorder operator enum variants

### DIFF
--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -44,16 +44,16 @@ impl<'alloc> CloneIn<'alloc> for AssignmentOperator {
             Self::Multiplication => AssignmentOperator::Multiplication,
             Self::Division => AssignmentOperator::Division,
             Self::Remainder => AssignmentOperator::Remainder,
+            Self::Exponential => AssignmentOperator::Exponential,
             Self::ShiftLeft => AssignmentOperator::ShiftLeft,
             Self::ShiftRight => AssignmentOperator::ShiftRight,
             Self::ShiftRightZeroFill => AssignmentOperator::ShiftRightZeroFill,
             Self::BitwiseOR => AssignmentOperator::BitwiseOR,
             Self::BitwiseXOR => AssignmentOperator::BitwiseXOR,
             Self::BitwiseAnd => AssignmentOperator::BitwiseAnd,
-            Self::LogicalAnd => AssignmentOperator::LogicalAnd,
             Self::LogicalOr => AssignmentOperator::LogicalOr,
+            Self::LogicalAnd => AssignmentOperator::LogicalAnd,
             Self::LogicalNullish => AssignmentOperator::LogicalNullish,
-            Self::Exponential => AssignmentOperator::Exponential,
         }
     }
 }
@@ -70,20 +70,20 @@ impl<'alloc> CloneIn<'alloc> for BinaryOperator {
             Self::LessEqualThan => BinaryOperator::LessEqualThan,
             Self::GreaterThan => BinaryOperator::GreaterThan,
             Self::GreaterEqualThan => BinaryOperator::GreaterEqualThan,
-            Self::ShiftLeft => BinaryOperator::ShiftLeft,
-            Self::ShiftRight => BinaryOperator::ShiftRight,
-            Self::ShiftRightZeroFill => BinaryOperator::ShiftRightZeroFill,
             Self::Addition => BinaryOperator::Addition,
             Self::Subtraction => BinaryOperator::Subtraction,
             Self::Multiplication => BinaryOperator::Multiplication,
             Self::Division => BinaryOperator::Division,
             Self::Remainder => BinaryOperator::Remainder,
+            Self::Exponential => BinaryOperator::Exponential,
+            Self::ShiftLeft => BinaryOperator::ShiftLeft,
+            Self::ShiftRight => BinaryOperator::ShiftRight,
+            Self::ShiftRightZeroFill => BinaryOperator::ShiftRightZeroFill,
             Self::BitwiseOR => BinaryOperator::BitwiseOR,
             Self::BitwiseXOR => BinaryOperator::BitwiseXOR,
             Self::BitwiseAnd => BinaryOperator::BitwiseAnd,
             Self::In => BinaryOperator::In,
             Self::Instanceof => BinaryOperator::Instanceof,
-            Self::Exponential => BinaryOperator::Exponential,
         }
     }
 }
@@ -103,8 +103,8 @@ impl<'alloc> CloneIn<'alloc> for UnaryOperator {
     type Cloned = UnaryOperator;
     fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
         match self {
-            Self::UnaryNegation => UnaryOperator::UnaryNegation,
             Self::UnaryPlus => UnaryOperator::UnaryPlus,
+            Self::UnaryNegation => UnaryOperator::UnaryNegation,
             Self::LogicalNot => UnaryOperator::LogicalNot,
             Self::BitwiseNot => UnaryOperator::BitwiseNot,
             Self::Typeof => UnaryOperator::Typeof,

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -28,35 +28,35 @@ impl Serialize for AssignmentOperator {
             AssignmentOperator::Remainder => {
                 serializer.serialize_unit_variant("AssignmentOperator", 5u32, "%=")
             }
+            AssignmentOperator::Exponential => {
+                serializer.serialize_unit_variant("AssignmentOperator", 6u32, "**=")
+            }
             AssignmentOperator::ShiftLeft => {
-                serializer.serialize_unit_variant("AssignmentOperator", 6u32, "<<=")
+                serializer.serialize_unit_variant("AssignmentOperator", 7u32, "<<=")
             }
             AssignmentOperator::ShiftRight => {
-                serializer.serialize_unit_variant("AssignmentOperator", 7u32, ">>=")
+                serializer.serialize_unit_variant("AssignmentOperator", 8u32, ">>=")
             }
             AssignmentOperator::ShiftRightZeroFill => {
-                serializer.serialize_unit_variant("AssignmentOperator", 8u32, ">>>=")
+                serializer.serialize_unit_variant("AssignmentOperator", 9u32, ">>>=")
             }
             AssignmentOperator::BitwiseOR => {
-                serializer.serialize_unit_variant("AssignmentOperator", 9u32, "|=")
+                serializer.serialize_unit_variant("AssignmentOperator", 10u32, "|=")
             }
             AssignmentOperator::BitwiseXOR => {
-                serializer.serialize_unit_variant("AssignmentOperator", 10u32, "^=")
+                serializer.serialize_unit_variant("AssignmentOperator", 11u32, "^=")
             }
             AssignmentOperator::BitwiseAnd => {
-                serializer.serialize_unit_variant("AssignmentOperator", 11u32, "&=")
-            }
-            AssignmentOperator::LogicalAnd => {
-                serializer.serialize_unit_variant("AssignmentOperator", 12u32, "&&=")
+                serializer.serialize_unit_variant("AssignmentOperator", 12u32, "&=")
             }
             AssignmentOperator::LogicalOr => {
                 serializer.serialize_unit_variant("AssignmentOperator", 13u32, "||=")
             }
-            AssignmentOperator::LogicalNullish => {
-                serializer.serialize_unit_variant("AssignmentOperator", 14u32, "??=")
+            AssignmentOperator::LogicalAnd => {
+                serializer.serialize_unit_variant("AssignmentOperator", 14u32, "&&=")
             }
-            AssignmentOperator::Exponential => {
-                serializer.serialize_unit_variant("AssignmentOperator", 15u32, "**=")
+            AssignmentOperator::LogicalNullish => {
+                serializer.serialize_unit_variant("AssignmentOperator", 15u32, "??=")
             }
         }
     }
@@ -89,45 +89,45 @@ impl Serialize for BinaryOperator {
             BinaryOperator::GreaterEqualThan => {
                 serializer.serialize_unit_variant("BinaryOperator", 7u32, ">=")
             }
-            BinaryOperator::ShiftLeft => {
-                serializer.serialize_unit_variant("BinaryOperator", 8u32, "<<")
-            }
-            BinaryOperator::ShiftRight => {
-                serializer.serialize_unit_variant("BinaryOperator", 9u32, ">>")
-            }
-            BinaryOperator::ShiftRightZeroFill => {
-                serializer.serialize_unit_variant("BinaryOperator", 10u32, ">>>")
-            }
             BinaryOperator::Addition => {
-                serializer.serialize_unit_variant("BinaryOperator", 11u32, "+")
+                serializer.serialize_unit_variant("BinaryOperator", 8u32, "+")
             }
             BinaryOperator::Subtraction => {
-                serializer.serialize_unit_variant("BinaryOperator", 12u32, "-")
+                serializer.serialize_unit_variant("BinaryOperator", 9u32, "-")
             }
             BinaryOperator::Multiplication => {
-                serializer.serialize_unit_variant("BinaryOperator", 13u32, "*")
+                serializer.serialize_unit_variant("BinaryOperator", 10u32, "*")
             }
             BinaryOperator::Division => {
-                serializer.serialize_unit_variant("BinaryOperator", 14u32, "/")
+                serializer.serialize_unit_variant("BinaryOperator", 11u32, "/")
             }
             BinaryOperator::Remainder => {
-                serializer.serialize_unit_variant("BinaryOperator", 15u32, "%")
-            }
-            BinaryOperator::BitwiseOR => {
-                serializer.serialize_unit_variant("BinaryOperator", 16u32, "|")
-            }
-            BinaryOperator::BitwiseXOR => {
-                serializer.serialize_unit_variant("BinaryOperator", 17u32, "^")
-            }
-            BinaryOperator::BitwiseAnd => {
-                serializer.serialize_unit_variant("BinaryOperator", 18u32, "&")
-            }
-            BinaryOperator::In => serializer.serialize_unit_variant("BinaryOperator", 19u32, "in"),
-            BinaryOperator::Instanceof => {
-                serializer.serialize_unit_variant("BinaryOperator", 20u32, "instanceof")
+                serializer.serialize_unit_variant("BinaryOperator", 12u32, "%")
             }
             BinaryOperator::Exponential => {
-                serializer.serialize_unit_variant("BinaryOperator", 21u32, "**")
+                serializer.serialize_unit_variant("BinaryOperator", 13u32, "**")
+            }
+            BinaryOperator::ShiftLeft => {
+                serializer.serialize_unit_variant("BinaryOperator", 14u32, "<<")
+            }
+            BinaryOperator::ShiftRight => {
+                serializer.serialize_unit_variant("BinaryOperator", 15u32, ">>")
+            }
+            BinaryOperator::ShiftRightZeroFill => {
+                serializer.serialize_unit_variant("BinaryOperator", 16u32, ">>>")
+            }
+            BinaryOperator::BitwiseOR => {
+                serializer.serialize_unit_variant("BinaryOperator", 17u32, "|")
+            }
+            BinaryOperator::BitwiseXOR => {
+                serializer.serialize_unit_variant("BinaryOperator", 18u32, "^")
+            }
+            BinaryOperator::BitwiseAnd => {
+                serializer.serialize_unit_variant("BinaryOperator", 19u32, "&")
+            }
+            BinaryOperator::In => serializer.serialize_unit_variant("BinaryOperator", 20u32, "in"),
+            BinaryOperator::Instanceof => {
+                serializer.serialize_unit_variant("BinaryOperator", 21u32, "instanceof")
             }
         }
     }
@@ -150,11 +150,11 @@ impl Serialize for LogicalOperator {
 impl Serialize for UnaryOperator {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match *self {
-            UnaryOperator::UnaryNegation => {
-                serializer.serialize_unit_variant("UnaryOperator", 0u32, "-")
-            }
             UnaryOperator::UnaryPlus => {
-                serializer.serialize_unit_variant("UnaryOperator", 1u32, "+")
+                serializer.serialize_unit_variant("UnaryOperator", 0u32, "+")
+            }
+            UnaryOperator::UnaryNegation => {
+                serializer.serialize_unit_variant("UnaryOperator", 1u32, "-")
             }
             UnaryOperator::LogicalNot => {
                 serializer.serialize_unit_variant("UnaryOperator", 2u32, "!")

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -37,42 +37,42 @@ pub enum AssignmentOperator {
     /// `%=`
     #[estree(rename = "%=")]
     Remainder = 5,
+    /// `**=`
+    #[estree(rename = "**=")]
+    Exponential = 6,
     /// `<<=`
     #[estree(rename = "<<=")]
-    ShiftLeft = 6,
+    ShiftLeft = 7,
     /// `>>=`
     #[estree(rename = ">>=")]
-    ShiftRight = 7,
+    ShiftRight = 8,
     /// `>>>=`
     #[estree(rename = ">>>=")]
-    ShiftRightZeroFill = 8,
+    ShiftRightZeroFill = 9,
     /// `|=`
     #[estree(rename = "|=")]
-    BitwiseOR = 9,
+    BitwiseOR = 10,
     /// `^=`
     #[estree(rename = "^=")]
-    BitwiseXOR = 10,
+    BitwiseXOR = 11,
     /// `&=`
     #[estree(rename = "&=")]
-    BitwiseAnd = 11,
-    /// `&&=`
-    #[estree(rename = "&&=")]
-    LogicalAnd = 12,
+    BitwiseAnd = 12,
     /// `||=`
     #[estree(rename = "||=")]
     LogicalOr = 13,
+    /// `&&=`
+    #[estree(rename = "&&=")]
+    LogicalAnd = 14,
     /// `??=`
     #[estree(rename = "??=")]
-    LogicalNullish = 14,
-    /// `**=`
-    #[estree(rename = "**=")]
-    Exponential = 15,
+    LogicalNullish = 15,
 }
 
 impl AssignmentOperator {
     /// Returns `true` for '||=`, `&&=`, and `??=`.
     pub fn is_logical(self) -> bool {
-        matches!(self, Self::LogicalAnd | Self::LogicalOr | Self::LogicalNullish)
+        matches!(self, Self::LogicalOr | Self::LogicalAnd | Self::LogicalNullish)
     }
 
     /// Returns `true` for `+=`, `-=`, `*=`, `/=`, `%=`, and `**=`.
@@ -90,16 +90,16 @@ impl AssignmentOperator {
     pub fn is_bitwise(self) -> bool {
         matches!(
             self,
-            Self::BitwiseOR | Self::BitwiseXOR | Self::BitwiseAnd
-            | Self::ShiftLeft | Self::ShiftRight | Self::ShiftRightZeroFill
+            Self::ShiftLeft | Self::ShiftRight | Self::ShiftRightZeroFill
+            | Self::BitwiseOR | Self::BitwiseXOR | Self::BitwiseAnd
         )
     }
 
     /// Get [`LogicalOperator`] corresponding to this [`AssignmentOperator`].
     pub fn to_logical_operator(self) -> Option<LogicalOperator> {
         match self {
-            Self::LogicalAnd => Some(LogicalOperator::And),
             Self::LogicalOr => Some(LogicalOperator::Or),
+            Self::LogicalAnd => Some(LogicalOperator::And),
             Self::LogicalNullish => Some(LogicalOperator::Coalesce),
             _ => None,
         }
@@ -113,13 +113,13 @@ impl AssignmentOperator {
             Self::Multiplication => Some(BinaryOperator::Multiplication),
             Self::Division => Some(BinaryOperator::Division),
             Self::Remainder => Some(BinaryOperator::Remainder),
+            Self::Exponential => Some(BinaryOperator::Exponential),
             Self::ShiftLeft => Some(BinaryOperator::ShiftLeft),
             Self::ShiftRight => Some(BinaryOperator::ShiftRight),
             Self::ShiftRightZeroFill => Some(BinaryOperator::ShiftRightZeroFill),
             Self::BitwiseOR => Some(BinaryOperator::BitwiseOR),
             Self::BitwiseXOR => Some(BinaryOperator::BitwiseXOR),
             Self::BitwiseAnd => Some(BinaryOperator::BitwiseAnd),
-            Self::Exponential => Some(BinaryOperator::Exponential),
             _ => None,
         }
     }
@@ -135,16 +135,16 @@ impl AssignmentOperator {
             Self::Multiplication => "*=",
             Self::Division => "/=",
             Self::Remainder => "%=",
+            Self::Exponential => "**=",
             Self::ShiftLeft => "<<=",
             Self::ShiftRight => ">>=",
             Self::ShiftRightZeroFill => ">>>=",
             Self::BitwiseOR => "|=",
             Self::BitwiseXOR => "^=",
             Self::BitwiseAnd => "&=",
-            Self::LogicalAnd => "&&=",
             Self::LogicalOr => "||=",
+            Self::LogicalAnd => "&&=",
             Self::LogicalNullish => "??=",
-            Self::Exponential => "**=",
         }
     }
 }
@@ -182,48 +182,48 @@ pub enum BinaryOperator {
     /// `>=`
     #[estree(rename = ">=")]
     GreaterEqualThan = 7,
-    /// `<<`
-    #[estree(rename = "<<")]
-    ShiftLeft = 8,
-    /// `>>`
-    #[estree(rename = ">>")]
-    ShiftRight = 9,
-    /// `>>>`
-    #[estree(rename = ">>>")]
-    ShiftRightZeroFill = 10,
     /// `+`
     #[estree(rename = "+")]
-    Addition = 11,
+    Addition = 8,
     /// `-`
     #[estree(rename = "-")]
-    Subtraction = 12,
+    Subtraction = 9,
     /// `*`
     #[estree(rename = "*")]
-    Multiplication = 13,
+    Multiplication = 10,
     /// `/`
     #[estree(rename = "/")]
-    Division = 14,
+    Division = 11,
     /// `%`
     #[estree(rename = "%")]
-    Remainder = 15,
-    /// `|`
-    #[estree(rename = "|")]
-    BitwiseOR = 16,
-    /// `^`
-    #[estree(rename = "^")]
-    BitwiseXOR = 17,
-    /// `&`
-    #[estree(rename = "&")]
-    BitwiseAnd = 18,
-    /// `in`
-    #[estree(rename = "in")]
-    In = 19,
-    /// `instanceof`
-    #[estree(rename = "instanceof")]
-    Instanceof = 20,
+    Remainder = 12,
     /// `**`
     #[estree(rename = "**")]
-    Exponential = 21,
+    Exponential = 13,
+    /// `<<`
+    #[estree(rename = "<<")]
+    ShiftLeft = 14,
+    /// `>>`
+    #[estree(rename = ">>")]
+    ShiftRight = 15,
+    /// `>>>`
+    #[estree(rename = ">>>")]
+    ShiftRightZeroFill = 16,
+    /// `|`
+    #[estree(rename = "|")]
+    BitwiseOR = 17,
+    /// `^`
+    #[estree(rename = "^")]
+    BitwiseXOR = 18,
+    /// `&`
+    #[estree(rename = "&")]
+    BitwiseAnd = 19,
+    /// `in`
+    #[estree(rename = "in")]
+    In = 20,
+    /// `instanceof`
+    #[estree(rename = "instanceof")]
+    Instanceof = 21,
 }
 
 impl BinaryOperator {
@@ -262,7 +262,7 @@ impl BinaryOperator {
 
     /// Returns `true` if this is an [`In`](BinaryOperator::In) operator.
     pub fn is_in(self) -> bool {
-        matches!(self, Self::In)
+        self == Self::In
     }
 
     /// Returns `true` for any bitwise operator
@@ -321,20 +321,20 @@ impl BinaryOperator {
             Self::LessEqualThan => "<=",
             Self::GreaterThan => ">",
             Self::GreaterEqualThan => ">=",
-            Self::ShiftLeft => "<<",
-            Self::ShiftRight => ">>",
-            Self::ShiftRightZeroFill => ">>>",
             Self::Addition => "+",
             Self::Subtraction => "-",
             Self::Multiplication => "*",
             Self::Division => "/",
             Self::Remainder => "%",
+            Self::Exponential => "**",
+            Self::ShiftLeft => "<<",
+            Self::ShiftRight => ">>",
+            Self::ShiftRightZeroFill => ">>>",
             Self::BitwiseOR => "|",
             Self::BitwiseXOR => "^",
             Self::BitwiseAnd => "&",
             Self::In => "in",
             Self::Instanceof => "instanceof",
-            Self::Exponential => "**",
         }
     }
 
@@ -444,12 +444,12 @@ impl GetPrecedence for LogicalOperator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[generate_derive(CloneIn, ContentEq, ContentHash, ESTree)]
 pub enum UnaryOperator {
-    /// `-`
-    #[estree(rename = "-")]
-    UnaryNegation = 0,
     /// `+`
     #[estree(rename = "+")]
-    UnaryPlus = 1,
+    UnaryPlus = 0,
+    /// `-`
+    #[estree(rename = "-")]
+    UnaryNegation = 1,
     /// `!`
     #[estree(rename = "!")]
     LogicalNot = 2,
@@ -470,24 +470,24 @@ pub enum UnaryOperator {
 impl UnaryOperator {
     /// Returns `true` if this operator is a unary arithmetic operator.
     pub fn is_arithmetic(self) -> bool {
-        matches!(self, Self::UnaryNegation | Self::UnaryPlus)
+        matches!(self, Self::UnaryPlus | Self::UnaryNegation)
     }
 
     /// Returns `true` if this operator is a [`LogicalNot`].
     ///
     /// [`LogicalNot`]: UnaryOperator::LogicalNot
     pub fn is_not(self) -> bool {
-        matches!(self, Self::LogicalNot)
+        self == Self::LogicalNot
     }
 
     /// Returns `true` if this operator is a bitwise operator.
     pub fn is_bitwise(self) -> bool {
-        matches!(self, Self::BitwiseNot)
+        self == Self::BitwiseNot
     }
 
     /// Returns `true` if this is the [`void`](UnaryOperator::Void) operator.
     pub fn is_void(self) -> bool {
-        matches!(self, Self::Void)
+        self == Self::Void
     }
 
     /// Returns `true` if this operator is a keyword instead of punctuation.
@@ -498,8 +498,8 @@ impl UnaryOperator {
     /// Get the string representation of this operator as it appears in source code.
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::UnaryNegation => "-",
             Self::UnaryPlus => "+",
+            Self::UnaryNegation => "-",
             Self::LogicalNot => "!",
             Self::BitwiseNot => "~",
             Self::Typeof => "typeof",

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1714,16 +1714,16 @@ export type AssignmentOperator =
   | '*='
   | '/='
   | '%='
+  | '**='
   | '<<='
   | '>>='
   | '>>>='
   | '|='
   | '^='
   | '&='
-  | '&&='
   | '||='
-  | '??='
-  | '**=';
+  | '&&='
+  | '??=';
 
 export type BinaryOperator =
   | '=='
@@ -1734,24 +1734,24 @@ export type BinaryOperator =
   | '<='
   | '>'
   | '>='
-  | '<<'
-  | '>>'
-  | '>>>'
   | '+'
   | '-'
   | '*'
   | '/'
   | '%'
+  | '**'
+  | '<<'
+  | '>>'
+  | '>>>'
   | '|'
   | '^'
   | '&'
   | 'in'
-  | 'instanceof'
-  | '**';
+  | 'instanceof';
 
 export type LogicalOperator = '||' | '&&' | '??';
 
-export type UnaryOperator = '-' | '+' | '!' | '~' | 'typeof' | 'void' | 'delete';
+export type UnaryOperator = '+' | '-' | '!' | '~' | 'typeof' | 'void' | 'delete';
 
 export type UpdateOperator = '++' | '--';
 


### PR DESCRIPTION
Re-order enum variants of `AssignmentOperator`, `BinaryOperator` and `UnaryOperator`.

* `Exponential` moved to after `Remainder` (so with the rest of the arithmetic operators).
* `Shift*` operators follow arithmetic operators.
* `AssignmentOperator::Bitwise*` ops moved to before `Logical*` ops (so all ops which correspond to `BinaryOperator`s are together).
* `*Or` always before `*And`.
* Plus/Addition always before Minus/Subtraction.

The purpose is to make the various methods on these types maximally efficient:

1. Group together variants so that `AssignmentOperator::is_*` methods can be executed with the minimum number of operations (essentially `variant - min <= max`).
2. Align the variants of `AssignmentOperator` and `BinaryOperator` so that conversion methods added in #7350 become very cheap too (essentially `if variant - min <= max { Some(variant + offset) } else { None }`).
