### PR TITLE
feat(oxlint): add `cwd` property to `LintRunner`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -68,6 +68,11 @@ pub struct BasicOptions {
     /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,
+    
+    /// The working directory where oxlint should be executed
+    /// defaults to `env::current_dir()`
+    #[bpaf(long("working-dir"), hide_usage)]
+    pub working_dir: Option<PathBuf>,
 }
 
 // This is formatted according to

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -68,11 +68,6 @@ pub struct BasicOptions {
     /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,
-
-    /// The working directory where oxlint should be executed
-    /// appends the path to the current work directory
-    #[bpaf(long("working-dir"), argument("./package/sub-package"), hide_usage)]
-    pub working_dir: Option<PathBuf>,
 }
 
 // This is formatted according to

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -68,10 +68,10 @@ pub struct BasicOptions {
     /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,
-    
+
     /// The working directory where oxlint should be executed
-    /// defaults to `env::current_dir()`
-    #[bpaf(long("working-dir"), hide_usage)]
+    /// appends the path to the current work directory
+    #[bpaf(long("working-dir"), argument("./package/sub-package"), hide_usage)]
     pub working_dir: Option<PathBuf>,
 }
 

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -52,16 +52,19 @@ impl Runner for LintRunner {
         let now = Instant::now();
 
         let mut cwd = env::current_dir().expect("Failed to get current working directory");
-        
+
         // append the working directory paths
         if let Some(working_dir) = basic_options.working_dir {
             cwd.push(working_dir);
 
-            paths = paths.into_iter().map(|x| {
-                let mut new = cwd.clone();
-                new.push(x);
-                new
-            }).collect()
+            paths = paths
+                .into_iter()
+                .map(|x| {
+                    let mut new = cwd.clone();
+                    new.push(x);
+                    new
+                })
+                .collect()
         }
 
         // The ignore crate whitelists explicit paths, but priority

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -179,6 +179,7 @@ impl Runner for LintRunner {
 }
 
 impl LintRunner {
+    #[must_use]
     pub fn with_cwd(mut self, cwd: PathBuf) -> Self {
         self.cwd = cwd;
         self
@@ -244,7 +245,7 @@ impl LintRunner {
 
 #[cfg(all(test, not(target_os = "windows")))]
 mod test {
-    use std::{env, path::PathBuf};
+    use std::env;
 
     use super::LintRunner;
     use crate::cli::{lint_command, CliRunResult, LintResult, Runner};
@@ -267,7 +268,7 @@ mod test {
         let mut current_cwd = env::current_dir().unwrap();
         current_cwd.push(cwd);
 
-        match LintRunner::new(options).with_cwd(PathBuf::from(current_cwd)).run() {
+        match LintRunner::new(options).with_cwd(current_cwd).run() {
             CliRunResult::LintResult(lint_result) => lint_result,
             other => panic!("{other:?}"),
         }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -60,11 +60,11 @@ impl Runner for LintRunner {
             paths = paths
                 .into_iter()
                 .map(|x| {
-                    let mut new = cwd.clone();
-                    new.push(x);
-                    new
+                    let mut path_with_cwd = cwd.clone();
+                    path_with_cwd.push(x);
+                    path_with_cwd
                 })
-                .collect()
+                .collect();
         }
 
         // The ignore crate whitelists explicit paths, but priority

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -1,6 +1,7 @@
 ---
 source: tasks/website/src/linter/cli.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Usage
  **`oxlint`** \[**`-c`**=_`<./oxlintrc.json>`_\] \[_`PATH`_\]...
@@ -12,6 +13,8 @@ expression: snapshot
 * tries to be compatible with the ESLint v8's format
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
   TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
+- **`    --working-dir`**=_`<./package/sub-package>`_ &mdash; 
+  The working directory where oxlint should be executed appends the path to the current work directory
 
 
 

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -13,8 +13,6 @@ snapshot_kind: text
 * tries to be compatible with the ESLint v8's format
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
   TypeScript `tsconfig.json` path for reading path alias and project references for import plugin
-- **`    --working-dir`**=_`<./package/sub-package>`_ &mdash; 
-  The working directory where oxlint should be executed appends the path to the current work directory
 
 
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -1,6 +1,7 @@
 ---
 source: tasks/website/src/linter/cli.rs
 expression: snapshot
+snapshot_kind: text
 ---
 Usage: [-c=<./oxlintrc.json>] [PATH]...
 
@@ -10,6 +11,8 @@ Basic Configuration
                               * tries to be compatible with the ESLint v8's format
         --tsconfig=<./tsconfig.json>  TypeScript `tsconfig.json` path for reading path alias and
                               project references for import plugin
+        --working-dir=<./package/sub-package>  The working directory where oxlint should be executed
+                              appends the path to the current work directory
 
 Allowing / Denying Multiple Lints
    Accumulate rules and categories from left to right on the command-line.

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -11,8 +11,6 @@ Basic Configuration
                               * tries to be compatible with the ESLint v8's format
         --tsconfig=<./tsconfig.json>  TypeScript `tsconfig.json` path for reading path alias and
                               project references for import plugin
-        --working-dir=<./package/sub-package>  The working directory where oxlint should be executed
-                              appends the path to the current work directory
 
 Allowing / Denying Multiple Lints
    Accumulate rules and categories from left to right on the command-line.


### PR DESCRIPTION
allows to use multiple `LintRunner` in one file targeting multiple directory.
The current problem is for the test in #7348 we can not change `env::current_dir`,  
so as a workaround I introduce a new property :) 

See more info here: https://discord.com/channels/1079625926024900739/1117322804291964931/1308179827576016897