### PR TITLE
fix(codegen): do not print parenthesis for `in` expression in ArrowFunctionExpression

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1623,7 +1623,7 @@ impl<'a> GenExpr for ArrowFunctionExpression<'a> {
             if self.expression {
                 if let Some(Statement::ExpressionStatement(stmt)) = &self.body.statements.first() {
                     p.start_of_arrow_expr = p.code_len();
-                    stmt.expression.print_expr(p, Precedence::Comma, ctx.and_forbid_in(true));
+                    stmt.expression.print_expr(p, Precedence::Comma, ctx);
                 }
             } else {
                 self.body.print(p, ctx);

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -294,3 +294,10 @@ fn in_expr_in_sequence_in_for_loop_init() {
         "for ((\"hidden\" in a) && (m = a.hidden), r = 0; s > r; r++) {}\n",
     );
 }
+
+#[test]
+fn in_expr_in_arrow_function_expression() {
+    test("() => ('foo' in bar)", "() => \"foo\" in bar;\n");
+    test("() => 'foo' in bar", "() => \"foo\" in bar;\n");
+    test("() => { ('foo' in bar) }", "() => {\n\t\"foo\" in bar;\n};\n");
+}


### PR DESCRIPTION
Please check out [esbuild](https://esbuild.github.io/try/#dAAwLjI0LjAAACgpID0+ICIiIGluIHt9)