### PR TITLE
chore: add tab and url check to changed files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,10 @@
+# https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
 trim_trailing_whitespace = true
+end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,8 @@ version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -221,6 +223,14 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "changed_file_check"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "regex",
+]
 
 [[package]]
 name = "ciborium"
@@ -700,6 +710,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1112,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1149,32 @@ checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1376,6 +1450,24 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "outref"
@@ -2302,6 +2394,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -3233,6 +3331,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ env_logger = { version = "0.11.5", default-features = false }
 fast-glob = "0.4.0"
 flate2 = "1.0.34"
 futures = "0.3.31"
+git2 = "0.19.0"
 glob = "0.3.1"
 globset = "0.4.15"
 handlebars = "6.1.0"

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -317,7 +317,7 @@ fn test_value_used_as_type() {
     .test();
 
     // T is a value that gets shadowed by a type. When `T` is referenced within
-    // a value context, the root `const T` should be the symbol recoreded in the
+    // a value context, the root `const T` should be the symbol recorded in the
     // reference.
     let tester = SemanticTester::ts(
         "

--- a/tasks/changed_file_check/Cargo.toml
+++ b/tasks/changed_file_check/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "changed_file_check"
+version = "0.1.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
+
+[dependencies]
+git2.workspace = true
+regex.workspace = true
+
+[lints]
+workspace = true

--- a/tasks/changed_file_check/src/lib.rs
+++ b/tasks/changed_file_check/src/lib.rs
@@ -1,0 +1,92 @@
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::File,
+        io::{self, BufRead},
+        path::{Path, PathBuf},
+    };
+
+    use git2::Repository;
+
+    fn repo_path() -> PathBuf {
+        // The test file is executed {root}/tasks/changed_file_check
+        let current_path = std::env::current_dir().unwrap();
+
+        // So the repo path is {root}/tasks/changed_file_check/../..
+        current_path.parent().unwrap().parent().unwrap().to_path_buf()
+    }
+
+    fn git_diff_new_files<P: AsRef<Path>>(repo_path: P) -> Vec<PathBuf> {
+        let repo = match Repository::init(repo_path.as_ref()) {
+            Ok(repo) => repo,
+            Err(e) => panic!("failed to init: {}", e),
+        };
+
+        let main_branch_tree = repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_tree()
+            .unwrap();
+
+        let diff = repo.diff_tree_to_workdir(Some(&main_branch_tree), None).unwrap();
+
+        let mut result = vec![];
+
+        for delta in diff.deltas() {
+            let tmp = delta.new_file().path().unwrap();
+            result.push(repo_path.as_ref().join(tmp));
+        }
+
+        result
+    }
+
+    fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(filename)?;
+        Ok(io::BufReader::new(file).lines())
+    }
+    use regex::Regex;
+
+    #[test]
+    fn no_master_or_main_branch_for_git_url() {
+        let github_main_like_url_pattern =
+            Regex::new(r"https://github.com/.*?/.*?/(tree|blob)/(master|main)").unwrap();
+
+        let files = git_diff_new_files(repo_path());
+
+        // Read file content and check whether it contains tabs
+        for ref file in files {
+            let lines = read_lines(file).unwrap();
+
+            lines.enumerate().for_each(|(line_number, line)| {
+                assert!(
+                    !github_main_like_url_pattern.is_match(&line.unwrap()),
+                    "A github url associated with main/master branch is found in file: '{}:{}', please use a tag or branch to ensure the link is stable",
+                    file.display(),
+                    line_number
+                );
+            })
+        }
+    }
+
+    #[test]
+    fn no_tab_used_in_repo() {
+        let files = git_diff_new_files(repo_path());
+        // Read file content and check whether it contains tabs
+        for ref file in files {
+            let lines = read_lines(file).unwrap();
+
+            lines.enumerate().for_each(|(line_number, line)| {
+                assert!(
+                    !line.unwrap().contains('\t'),
+                    "there is a tab found in file: '{}: {}'",
+                    file.display(),
+                    line_number
+                );
+            })
+        }
+    }
+}


### PR DESCRIPTION
fix #7299

follow #7337

This PR tried to add a way to check the changed files
- If it's a git url, it should not refer to master/main branch
- There should be no tab used in the repo

And also copy .editorconfig from RA, to help to unify the code style