### PR TITLE
feat(traverse): implement `GatherNodeParts` for member expression types

### DIFF
--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -218,18 +218,36 @@ impl<'a> GatherNodeParts<'a> for MemberExpression<'a> {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         match self {
             MemberExpression::ComputedMemberExpression(expr) => {
-                expr.object.gather(f);
-                expr.expression.gather(f);
+                expr.gather(f);
             }
             MemberExpression::StaticMemberExpression(expr) => {
-                expr.object.gather(f);
-                expr.property.gather(f);
+                expr.gather(f);
             }
             MemberExpression::PrivateFieldExpression(expr) => {
-                expr.object.gather(f);
-                expr.field.gather(f);
+                expr.gather(f);
             }
         }
+    }
+}
+
+impl<'a> GatherNodeParts<'a> for ComputedMemberExpression<'a> {
+    fn gather<F: FnMut(&str)>(&self, f: &mut F) {
+        self.object.gather(f);
+        self.expression.gather(f);
+    }
+}
+
+impl<'a> GatherNodeParts<'a> for StaticMemberExpression<'a> {
+    fn gather<F: FnMut(&str)>(&self, f: &mut F) {
+        self.object.gather(f);
+        self.property.gather(f);
+    }
+}
+
+impl<'a> GatherNodeParts<'a> for PrivateFieldExpression<'a> {
+    fn gather<F: FnMut(&str)>(&self, f: &mut F) {
+        self.object.gather(f);
+        self.field.gather(f);
     }
 }
 


### PR DESCRIPTION
`GatherNodeParts` was missing support for these types as entry points for collection.