### PR TITLE
docs(linter): import/first options

### DIFF
--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -72,7 +72,7 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
-    /// with `"absolute-import"`:
+    /// with `"absolute-first"`:
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js


### PR DESCRIPTION
Fix the docs for [import-first](https://oxc.rs/docs/guide/usage/linter/rules/import/first.html#import-first) which mentions the option `"absolute-import"` rather than `"absolute-first"`