### PR TITLE
fix(linter/no-array-index-key): compile error due to it uses a renamed API

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -121,7 +121,7 @@ fn check_react_clone_element<'a>(
 }
 
 fn find_index_param_name<'a>(node: &'a AstNode, ctx: &'a LintContext) -> Option<&'a str> {
-    for ancestor in ctx.nodes().iter_parents(node.id()).skip(1) {
+    for ancestor in ctx.nodes().ancestors(node.id()).skip(1) {
         if let AstKind::CallExpression(call_expr) = ancestor.kind() {
             let Expression::StaticMemberExpression(expr) = &call_expr.callee else {
                 return None;


### PR DESCRIPTION
Fix: https://github.com/oxc-project/oxc/pull/6960#issuecomment-2490754348