### PR TITLE
fix(tasks/lint_rules): map prefix `node` to `n`

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -26,13 +26,16 @@ const readAllImplementedRuleNames = async () => {
     }
 
     if (found) {
-      const prefixedName = line
+      let prefixedName = line
         .replaceAll(',', '')
         .replaceAll('::', '/')
         .replaceAll('_', '-');
 
       // Ignore no reference rules
       if (prefixedName.startsWith('oxc/')) continue;
+      if (prefixedName.startsWith('node/')) {
+        prefixedName = prefixedName.replace(/^node/, 'n');
+      }
 
       rules.add(prefixedName);
     }


### PR DESCRIPTION
The `eslint-plugin-n` page is not showing any rules implemented.