### PR TITLE
test(transformer): add `--debug` option to transform conformance

### DIFF
--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -24,6 +24,7 @@ fn test() {
 
 #[derive(Default, Clone)]
 pub struct TestRunnerOptions {
+    pub debug: bool,
     pub filter: Option<String>,
     pub exec: bool,
 }

--- a/tasks/transform_conformance/src/main.rs
+++ b/tasks/transform_conformance/src/main.rs
@@ -5,6 +5,7 @@ fn main() {
     let mut args = Arguments::from_env();
 
     let options = TestRunnerOptions {
+        debug: args.contains("--debug"),
         filter: args.opt_value_from_str("--filter").unwrap(),
         exec: args.contains("--exec"),
     };

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -191,6 +191,10 @@ impl TestCase {
     }
 
     pub fn test(&mut self, options: &TestRunnerOptions) {
+        if options.debug {
+            println!("{}", self.path.to_string_lossy());
+        }
+
         let filtered = options.filter.is_some();
         match self.kind {
             TestCaseKind::Conformance => self.test_conformance(filtered),


### PR DESCRIPTION
Add `--debug` command line option for transformer conformance runner, same as for `cargo coverage`. It prints the paths of test fixtures before running them.