### PR TITLE
chore: make editor respect space as indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,10 @@
+# https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
 trim_trailing_whitespace = true
+end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
#7337

Copy editrconfig from rust-analyzer

Tab is causing some trouble, and it seems a better choice to unify indent style

This is part work of #7362, split it to make meaningful change merged quickly