### PR TITLE
fix(linter): make `overrides` globs relative to config path

### DIFF
--- a/apps/oxlint/fixtures/overrides/directories-config.json
+++ b/apps/oxlint/fixtures/overrides/directories-config.json
@@ -1,0 +1,19 @@
+{
+  "rules": {
+    "no-debugger": "off"
+  },
+  "overrides": [
+    {
+      "files": ["lib/*.{js,ts}", "src/*"],
+      "rules": {
+        "no-debugger": "error"
+      }
+    },
+    {
+      "files": ["**/tests/*"],
+      "rules": {
+        "no-debugger": "warn"
+      }
+    }
+  ]
+}

--- a/apps/oxlint/fixtures/overrides/lib/index.ts
+++ b/apps/oxlint/fixtures/overrides/lib/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/overrides/lib/tests/index.js
+++ b/apps/oxlint/fixtures/overrides/lib/tests/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/overrides/src/oxlint.js
+++ b/apps/oxlint/fixtures/overrides/src/oxlint.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/overrides/src/tests/index.js
+++ b/apps/oxlint/fixtures/overrides/src/tests/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -695,4 +695,13 @@ mod test {
         assert_eq!(result.number_of_warnings, 0);
         assert_eq!(result.number_of_errors, 1);
     }
+
+    #[test]
+    fn test_overrides_directories() {
+        let result =
+            test(&["-c", "fixtures/overrides/directories-config.json", "fixtures/overrides"]);
+        assert_eq!(result.number_of_files, 7);
+        assert_eq!(result.number_of_warnings, 2);
+        assert_eq!(result.number_of_errors, 2);
+    }
 }

--- a/crates/oxc_linter/src/builder.rs
+++ b/crates/oxc_linter/src/builder.rs
@@ -94,9 +94,10 @@ impl LinterBuilder {
             categories,
             rules: oxlintrc_rules,
             overrides,
+            path,
         } = oxlintrc;
 
-        let config = LintConfig { plugins, settings, env, globals };
+        let config = LintConfig { plugins, settings, env, globals, path: Some(path) };
         let options = LintOptions::default();
         let rules =
             if start_empty { FxHashSet::default() } else { Self::warn_correctness(plugins) };

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -8,6 +8,8 @@ mod plugins;
 mod rules;
 mod settings;
 
+use std::path::PathBuf;
+
 pub(crate) use self::flat::ResolvedLinterState;
 pub use self::{
     env::OxlintEnv,
@@ -29,6 +31,8 @@ pub(crate) struct LintConfig {
     pub(crate) env: OxlintEnv,
     /// Enabled or disabled specific global variables.
     pub(crate) globals: OxlintGlobals,
+    /// Absolute path to the configuration file (may be `None` if there is no file).
+    pub(crate) path: Option<PathBuf>,
 }
 
 impl From<Oxlintrc> for LintConfig {
@@ -38,6 +42,7 @@ impl From<Oxlintrc> for LintConfig {
             settings: config.settings,
             env: config.env,
             globals: config.globals,
+            path: Some(config.path),
         }
     }
 }
@@ -58,6 +63,7 @@ mod test {
         let fixture_path = env::current_dir().unwrap().join("fixtures/eslint_config.json");
         let config = Oxlintrc::from_file(&fixture_path).unwrap();
         assert!(!config.rules.is_empty());
+        assert!(config.path.ends_with("fixtures/eslint_config.json"));
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -154,6 +154,26 @@ impl JsonSchema for GlobSet {
 
 mod test {
     #[test]
+    fn test_globset() {
+        use super::*;
+        use serde_json::{from_value, json};
+
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx",],
+        }))
+        .unwrap();
+        assert!(config.files.globs.is_match("/some/path/foo.tsx"));
+        assert!(!config.files.globs.is_match("/some/path/foo.ts"));
+
+        let config: OxlintOverride = from_value(json!({
+            "files": ["lib/*.ts",],
+        }))
+        .unwrap();
+        assert!(config.files.globs.is_match("lib/foo.ts"));
+        assert!(!config.files.globs.is_match("src/foo.ts"));
+    }
+
+    #[test]
     fn test_parsing_plugins() {
         use super::*;
         use serde_json::{from_value, json};


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/7365

currently, we are matching globs on the absolute path to the file, which means that in order to properly match, all globs would need to start with `**/`. this is not consistent with the behavior in ESLint, which is defined here:  https://eslint.org/docs/v8.x/use/configure/configuration-files#how-do-overrides-work

> **The patterns are applied against the file path relative to the directory of the config file.** For example, if your config file has the path `/Users/john/workspace/any-project/.eslintrc.js` and the file you want to lint has the path `/Users/john/workspace/any-project/lib/util.js`, then the pattern provided in `.eslintrc.js` is executed against the relative path `lib/util.js`.

This PR adds the ability to store the path to the configuration file along with the configuration data, so that we can later use it to resolve the relative paths of the files in the overrides section.

I'm not exactly sure if this will still make sense with nested configuration files, but I think it makes sense to store a path to each configuration file, alongside where the overrides are stored.