### PR TITLE
refactor(transformer/logic-assignment): shorten code

### DIFF
--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -296,7 +296,7 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         match expr {
             Expression::Identifier(ident) => {
                 let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);
-                binding.create_spanned_expression(ident.span, ReferenceFlags::Read, ctx)
+                binding.create_spanned_read_expression(ident.span, ctx)
             }
             _ => expr.clone_in(ctx.ast.allocator),
         }


### PR DESCRIPTION
Use `create_spanned_read_expression` instead of `create_spanned_expression`, as it's shorter than specifying `ReferenceFlags` manually.