### PR TITLE
feat(oxc_transformer): ReplaceGlobalDefinesPlugin for ComputedMemberExpr

### DIFF
--- a/crates/oxc_transformer/src/plugins/inject_global_variables.rs
+++ b/crates/oxc_transformer/src/plugins/inject_global_variables.rs
@@ -8,7 +8,10 @@ use oxc_semantic::{ScopeTree, SymbolTable};
 use oxc_span::{CompactStr, SPAN};
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 
-use super::replace_global_defines::{DotDefine, ReplaceGlobalDefines};
+use super::{
+    replace_global_defines::{DotDefine, ReplaceGlobalDefines},
+    DotDefineMemberExpression,
+};
 
 #[derive(Debug, Clone)]
 pub struct InjectGlobalVariablesConfig {
@@ -233,7 +236,11 @@ impl<'a> InjectGlobalVariables<'a> {
     fn replace_dot_defines(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Expression::StaticMemberExpression(member) = expr {
             for DotDefineState { dot_define, value_atom } in &mut self.dot_defines {
-                if ReplaceGlobalDefines::is_dot_define(ctx.symbols(), dot_define, member) {
+                if ReplaceGlobalDefines::is_dot_define(
+                    ctx.symbols(),
+                    dot_define,
+                    DotDefineMemberExpression::StaticMemberExpression(member),
+                ) {
                     // If this is first replacement made for this dot define,
                     // create `Atom` for replacement, and record in `replaced_dot_defines`
                     let value_atom = value_atom.get_or_insert_with(|| {

--- a/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
@@ -53,13 +53,18 @@ fn dot() {
     test("process.env.NODE_ENV", "production", config.clone());
     test("process.env", "process.env", config.clone());
     test("process.env.foo.bar", "process.env.foo.bar", config.clone());
-    test("process", "process", config);
+    test("process", "process", config.clone());
+
+    // computed member expression
+    test("process['env'].NODE_ENV", "production", config.clone());
 }
 
 #[test]
 fn dot_nested() {
     let config = ReplaceGlobalDefinesConfig::new(&[("process", "production")]).unwrap();
-    test("foo.process.NODE_ENV", "foo.process.NODE_ENV", config);
+    test("foo.process.NODE_ENV", "foo.process.NODE_ENV", config.clone());
+    // computed member expression
+    test("foo['process'].NODE_ENV", "foo['process'].NODE_ENV", config);
 }
 
 #[test]


### PR DESCRIPTION
support replace `test['foo']` like `ComputedMemberExpr`, since they are static either, 
e.g.: 
https://hyrious.me/esbuild-repl/?version=0.23.0&b=e%00entry.js%00console.log%28a%5B%27b%27%5D.c%29&b=%00file.js%00&b=%00file2.js%00&o=%7B%0A++treeShaking%3A+true%2C%0A%0AglobalName%3A+%22global%22%2C%0A%22bundle%22%3A+false%2C%0Aformat%3A+%22esm%22%2C%0Adefine%3A+%7B%0A++%22a.b.c%22%3A+%22foo%22%0A%7D%0A%7D