### PR TITLE
refactor(ast_tools): remove `tsify` helper attr from `Ast` derive macro

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -85,10 +85,7 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// The only purpose is to allow the occurrence of helper attributes used with the `tasks/ast_tools`.
 ///
 /// Read [`macro@ast`] for further details.
-#[proc_macro_derive(
-    Ast,
-    attributes(scope, visit, span, generate_derive, clone_in, estree, tsify, ts)
-)]
+#[proc_macro_derive(Ast, attributes(scope, visit, span, generate_derive, clone_in, estree, ts))]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()
 }


### PR DESCRIPTION
We no longer use this attr.