### PR TITLE
fix(language-server): fix panic by building scope tree child ids

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -274,6 +274,7 @@ impl IsolatedLintHandler {
 
             let semantic_ret = SemanticBuilder::new()
                 .with_cfg(true)
+                .with_scope_tree_child_ids(true)
                 .with_check_syntax_error(true)
                 .build(&ret.program);
 


### PR DESCRIPTION
closes #7434

i couldn't test this. but what's happening is semaitc is being build without scope child ids. When exhaustive_deps tries to access it its an empty vec - hence the panic