### PR TITLE
fix(vscode)!: use `.oxlintrc.json` as default value for `oxc.configPath`

### DIFF
--- a/editors/vscode/client/Config.ts
+++ b/editors/vscode/client/Config.ts
@@ -19,7 +19,7 @@ export class Config implements ConfigInterface {
     this._runTrigger = conf.get<Trigger>('lint.run') || 'onType';
     this._enable = conf.get<boolean>('enable') ?? true;
     this._trace = conf.get<TraceLevel>('trace.server') || 'off';
-    this._configPath = conf.get<string>('configPath') || '.eslintrc';
+    this._configPath = conf.get<string>('configPath') || '.oxlintrc.json';
     this._binPath = conf.get<string>('path.server');
   }
 
@@ -124,7 +124,7 @@ interface ConfigInterface {
    *
    * `oxc.configPath`
    *
-   * @default ".eslintrc"
+   * @default ".oxlintrc.json"
    */
   configPath: string;
   /**

--- a/editors/vscode/client/config.spec.ts
+++ b/editors/vscode/client/config.spec.ts
@@ -16,7 +16,7 @@ suite('Config', () => {
     strictEqual(config.runTrigger, 'onType');
     strictEqual(config.enable, true);
     strictEqual(config.trace, 'off');
-    strictEqual(config.configPath, '.eslintrc');
+    strictEqual(config.configPath, '.oxlintrc.json');
     strictEqual(config.binPath, '');
   });
 

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -142,8 +142,7 @@ export async function activate(context: ExtensionContext) {
     synchronize: {
       // Notify the server about file config changes in the workspace
       fileEvents: [
-        workspace.createFileSystemWatcher('**/.eslintr{c,c.json}'),
-        workspace.createFileSystemWatcher('**/.oxlint{.json,rc.json,rc}'),
+        workspace.createFileSystemWatcher('**/.oxlint{.json,rc.json}'),
         workspace.createFileSystemWatcher('**/oxlint{.json,rc.json}'),
       ],
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -92,7 +92,7 @@
         "oxc.configPath": {
           "type": "string",
           "scope": "window",
-          "default": ".eslintrc",
+          "default": ".oxlintrc.json",
           "description": "Path to ESlint configuration."
         },
         "oxc.path.server": {
@@ -108,8 +108,7 @@
           "oxlintrc.json",
           "oxlint.json",
           ".oxlintrc.json",
-          ".oxlint.json",
-          ".oxlintrc"
+          ".oxlint.json"
         ],
         "url": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json"
       }
@@ -121,8 +120,7 @@
           "oxlintrc.json",
           "oxlint.json",
           ".oxlintrc.json",
-          ".oxlint.json",
-          ".oxlintrc"
+          ".oxlint.json"
         ]
       }
     ]


### PR DESCRIPTION
**BREAKING CHANGE**:  VSCode-Client does not watch for `eslint` configuration files. Default value for `oxc.configPath` is now `.oxlintrc.json` instead of `.eslintrc`