### PR TITLE
feat(language_server)!: add capability `diagnosticProvider`

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -8,6 +8,9 @@ This crate provides an [LSP](https://microsoft.github.io/language-server-protoco
 - Workspace
   - [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFoldersServerCapabilities): `true`
   - File Operations: `false`
+- [Diagnostic Provider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics)
+  - `interFileDependencies`: `false`
+  - `workspaceDiagnostics`: `false`
 - [Code Actions Provider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind):
   - `quickfix`
 
@@ -34,19 +37,19 @@ The server will revalidate the diagnostics for all open files and send one or mo
 
 #### [textDocument/didOpen](https://microsoft.github.io/language-server-protocol/specification#textDocument_didOpen)
 
-The server will validate the file content and send a [textDocument/publishDiagnostics](#textdocumentpublishdiagnostics) request to the client.
-
-#### [textDocument/didSave](https://microsoft.github.io/language-server-protocol/specification#textDocument_didSave)
-
-When the configuration `run` is set to `onSave`, the server will validate the file content and send a [textDocument/publishDiagnostics](#textdocumentpublishdiagnostics) request to the client.
+It will save the reference internal.
 
 #### [textDocument/didChange](https://microsoft.github.io/language-server-protocol/specification#textDocument_didChange)
 
-When the configuration `run` is set to `onType`, the server will validate the file content and send a [textDocument/publishDiagnostics](#textdocumentpublishdiagnostics) request to the client.
+It will update the reference internal.
 
 #### [textDocument/didClose](https://microsoft.github.io/language-server-protocol/specification#textDocument_didClose)
 
 It will remove the reference internal.
+
+#### [textDocument/diagnostic](https://microsoft.github.io/language-server-protocol/specification#textDocument_diagnostic)
+
+Returns all Diagnostics for the requested file
 
 #### [textDocument/codeAction](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction)
 

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -38,13 +38,7 @@ struct Backend {
     options: Mutex<Options>,
     gitignore_glob: Mutex<Vec<Gitignore>>,
 }
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, PartialOrd, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
-enum Run {
-    OnSave,
-    #[default]
-    OnType,
-}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct Options {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -152,6 +152,20 @@ export async function activate(context: ExtensionContext) {
     },
     outputChannel,
     traceOutputChannel: outputChannel,
+    diagnosticPullOptions: {
+      onChange: true,
+      onSave: true,
+      onTabs: false,
+      filter: (_, mode) => {
+        if (mode === 'onType' && configService.config.runTrigger !== 'onType') {
+          return true;
+        } else if (mode === 'onSave' && configService.config.runTrigger !== 'onSave') {
+          return true;
+        }
+
+        return !configService.config.enable
+      }
+    }
   };
 
   // Create the language client and start the client.

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -163,9 +163,9 @@ export async function activate(context: ExtensionContext) {
           return true;
         }
 
-        return !configService.config.enable
-      }
-    }
+        return !configService.config.enable;
+      },
+    },
   };
 
   // Create the language client and start the client.


### PR DESCRIPTION
The current implementation checks on onChange / onSave. There they will respect the `run` option. 
This is not optimal because the client is sending events, which will be ignored by the server.

This implementation uses the feature, that the client requests diagnostics from the server. 
> Diagnostics are currently published by the server to the client using a notification. This model has the advantage that for workspace wide diagnostics the server has the freedom to compute them at a server preferred point in time. On the other hand the approach has the disadvantage that the server can’t prioritize the computation for the file in which the user types or which are visible in the editor. Inferring the client’s UI state from the [textDocument/didOpen](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen) and [textDocument/didChange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange) notifications might lead to false positives since these notifications are ownership transfer notifications.
> 
> The specification therefore introduces the concept of diagnostic pull requests to give a client more control over the documents for which diagnostics should be computed and at which point in time.

_https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics_

