### PR TITLE
fix(language_server): revalidate files when `configPath` has changed

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -151,8 +151,18 @@ impl LanguageServer for Backend {
                 options
             };
 
-        debug!("{:?}", &changed_options.get_lint_level());
-        if changed_options.get_lint_level() == SyntheticRunLevel::Disable {
+        let current_option = &self.options.lock().await.clone();
+
+        debug!("
+        configuration changed:
+        incoming: {changed_options:?}
+        current: {current_option:?}
+        ");
+
+        if current_option.get_lint_level() != changed_options.get_lint_level()
+            && changed_options.get_lint_level() == SyntheticRunLevel::Disable
+        {
+            debug!("lint level change detected {:?}", &changed_options.get_lint_level());
             // clear all exists diagnostics when linter is disabled
             let opened_files = self.diagnostics_report_map.iter().map(|k| k.key().to_string());
             let cleared_diagnostics = opened_files
@@ -170,7 +180,19 @@ impl LanguageServer for Backend {
                 .collect::<Vec<_>>();
             self.publish_all_diagnostics(&cleared_diagnostics).await;
         }
-        *self.options.lock().await = changed_options;
+
+        *self.options.lock().await = changed_options.clone();
+
+        // revalidate the config and alle open files, when lint level is not disabled and the config path is changed
+        if changed_options.get_lint_level() != SyntheticRunLevel::Disable
+            && changed_options
+                .get_config_path()
+                .is_some_and(|path| path.to_str().unwrap() != current_option.config_path)
+        {
+            info!("config path change detected {:?}", &changed_options.get_config_path());
+            self.init_linter_config().await;
+            self.revalidate_open_files().await;
+        }
     }
 
     async fn did_change_watched_files(&self, _params: DidChangeWatchedFilesParams) {

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -153,11 +153,13 @@ impl LanguageServer for Backend {
 
         let current_option = &self.options.lock().await.clone();
 
-        debug!("
+        debug!(
+            "
         configuration changed:
         incoming: {changed_options:?}
         current: {current_option:?}
-        ");
+        "
+        );
 
         if current_option.get_lint_level() != changed_options.get_lint_level()
             && changed_options.get_lint_level() == SyntheticRunLevel::Disable

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -185,7 +185,7 @@ impl LanguageServer for Backend {
 
         *self.options.lock().await = changed_options.clone();
 
-        // revalidate the config and alle open files, when lint level is not disabled and the config path is changed
+        // revalidate the config and all open files, when lint level is not disabled and the config path is changed
         if changed_options.get_lint_level() != SyntheticRunLevel::Disable
             && changed_options
                 .get_config_path()


### PR DESCRIPTION
closes #7446 
![revalidate-files-when-config-changes](https://github.com/user-attachments/assets/a5f4a612-9e0d-4f14-932c-f3b9b956a24a)
