### PR TITLE
ci(dev): fix `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.{js,mjs,cjs,jsx,ts,tsx,json,yml}]
+indent_size = 2


### PR DESCRIPTION
#7401 set indent to 4 spaces in `.editorconfig`. But our convention is 2 spaces for JS, YAML and JSON files. Update `.editorconfig` to reflect this.