### PR TITLE
refactor(ast_tools): move `prelude` above `derive` in `Derive`s

### DIFF
--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -19,19 +19,19 @@ impl Derive for DeriveCloneIn {
         "CloneIn"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
-        match &def {
-            TypeDef::Enum(it) => derive_enum(it),
-            TypeDef::Struct(it) => derive_struct(it),
-        }
-    }
-
     fn prelude() -> TokenStream {
         quote! {
             #![allow(clippy::default_trait_access)]
 
             ///@@line_break
             use oxc_allocator::{Allocator, CloneIn};
+        }
+    }
+
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
+        match &def {
+            TypeDef::Enum(it) => derive_enum(it),
+            TypeDef::Struct(it) => derive_struct(it),
         }
     }
 }

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -27,15 +27,6 @@ impl Derive for DeriveContentEq {
         "ContentEq"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
-        let (other, body) = match &def {
-            TypeDef::Enum(it) => derive_enum(it),
-            TypeDef::Struct(it) => derive_struct(it),
-        };
-
-        impl_content_eq(def, other, &body)
-    }
-
     fn prelude() -> TokenStream {
         quote! {
             // NOTE: writing long match expressions formats better than using `matches` macro.
@@ -44,6 +35,15 @@ impl Derive for DeriveContentEq {
             ///@@line_break
             use oxc_span::cmp::ContentEq;
         }
+    }
+
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
+        let (other, body) = match &def {
+            TypeDef::Enum(it) => derive_enum(it),
+            TypeDef::Struct(it) => derive_struct(it),
+        };
+
+        impl_content_eq(def, other, &body)
     }
 }
 

--- a/tasks/ast_tools/src/derives/content_hash.rs
+++ b/tasks/ast_tools/src/derives/content_hash.rs
@@ -25,15 +25,6 @@ impl Derive for DeriveContentHash {
         "ContentHash"
     }
 
-    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
-        let (hasher, body) = match &def {
-            TypeDef::Enum(it) => derive_enum(it),
-            TypeDef::Struct(it) => derive_struct(it),
-        };
-
-        impl_content_hash(def, hasher, &body)
-    }
-
     fn prelude() -> TokenStream {
         quote! {
             #![allow(clippy::match_same_arms)]
@@ -44,6 +35,15 @@ impl Derive for DeriveContentHash {
             ///@@line_break
             use oxc_span::hash::ContentHash;
         }
+    }
+
+    fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
+        let (hasher, body) = match &def {
+            TypeDef::Enum(it) => derive_enum(it),
+            TypeDef::Struct(it) => derive_struct(it),
+        };
+
+        impl_content_hash(def, hasher, &body)
     }
 }
 

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -26,6 +26,15 @@ impl Derive for DeriveESTree {
         "estree".to_string()
     }
 
+    fn prelude() -> TokenStream {
+        quote! {
+            #![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+
+            ///@@line_break
+            use serde::{Serialize, Serializer, ser::SerializeMap};
+        }
+    }
+
     fn derive(&mut self, def: &TypeDef, schema: &Schema) -> TokenStream {
         if let TypeDef::Struct(def) = def {
             if def
@@ -52,15 +61,6 @@ impl Derive for DeriveESTree {
                     #body
                 }
             }
-        }
-    }
-
-    fn prelude() -> TokenStream {
-        quote! {
-            #![allow(unused_imports, unused_mut, clippy::match_same_arms)]
-
-            ///@@line_break
-            use serde::{Serialize, Serializer, ser::SerializeMap};
         }
     }
 }

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -18,6 +18,15 @@ impl Derive for DeriveGetSpan {
         "GetSpan"
     }
 
+    fn prelude() -> TokenStream {
+        quote! {
+            #![allow(clippy::match_same_arms)]
+
+            ///@@line_break
+            use oxc_span::{Span, GetSpan};
+        }
+    }
+
     fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
         let self_type = quote!(&self);
         let result_type = quote!(Span);
@@ -36,15 +45,6 @@ impl Derive for DeriveGetSpan {
             reference,
         )
     }
-
-    fn prelude() -> TokenStream {
-        quote! {
-            #![allow(clippy::match_same_arms)]
-
-            ///@@line_break
-            use oxc_span::{Span, GetSpan};
-        }
-    }
 }
 
 pub struct DeriveGetSpanMut;
@@ -54,6 +54,15 @@ define_derive!(DeriveGetSpanMut);
 impl Derive for DeriveGetSpanMut {
     fn trait_name() -> &'static str {
         "GetSpanMut"
+    }
+
+    fn prelude() -> TokenStream {
+        quote! {
+            #![allow(clippy::match_same_arms)]
+
+            ///@@line_break
+            use oxc_span::{Span, GetSpanMut};
+        }
     }
 
     fn derive(&mut self, def: &TypeDef, _: &Schema) -> TokenStream {
@@ -73,15 +82,6 @@ impl Derive for DeriveGetSpanMut {
             unbox,
             reference,
         )
-    }
-
-    fn prelude() -> TokenStream {
-        quote! {
-            #![allow(clippy::match_same_arms)]
-
-            ///@@line_break
-            use oxc_span::{Span, GetSpanMut};
-        }
     }
 }
 

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -32,11 +32,11 @@ pub trait Derive {
         Self::trait_name().to_case(Case::Snake)
     }
 
-    fn derive(&mut self, def: &TypeDef, schema: &Schema) -> TokenStream;
-
     fn prelude() -> TokenStream {
         TokenStream::default()
     }
+
+    fn derive(&mut self, def: &TypeDef, schema: &Schema) -> TokenStream;
 
     // Standard methods
 


### PR DESCRIPTION
Pure refactor. Prelude is printed first, so it makes sense to define it first.