### PR TITLE
feat(ast): derive `GetAddress` on all enum types

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -15,6 +15,8 @@ src:
   - 'crates/oxc_ast/src/generated/derive_clone_in.rs'
   - 'crates/oxc_regular_expression/src/generated/derive_clone_in.rs'
   - 'crates/oxc_syntax/src/generated/derive_clone_in.rs'
+  - 'crates/oxc_ast/src/generated/derive_get_address.rs'
+  - 'crates/oxc_regular_expression/src/generated/derive_get_address.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span_mut.rs'
   - 'crates/oxc_ast/src/generated/derive_content_eq.rs'

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -6,7 +6,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Box, CloneIn, Vec};
+use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, GetSpan, GetSpanMut, SourceType, Span};
@@ -53,7 +53,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum Expression<'a> {
     /// See [`BooleanLiteral`] for AST node details.
     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
@@ -346,7 +346,7 @@ pub struct ObjectExpression<'a> {
 /// Represents a property in an object literal.
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ObjectPropertyKind<'a> {
     /// `a: 1` in `const obj = { a: 1 };`
     ObjectProperty(Box<'a, ObjectProperty<'a>>) = 0,
@@ -378,7 +378,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum PropertyKey<'a> {
     /// `a` in `const obj = { a: 1 }; obj.a;`
     StaticIdentifier(Box<'a, IdentifierName<'a>>) = 64,
@@ -462,7 +462,7 @@ pub struct TemplateElementValue<'a> {
 /// <https://tc39.es/ecma262/#prod-MemberExpression>
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum MemberExpression<'a> {
     /// `ar[0]` in `const ar = [1, 2]; ar[0];`
     ComputedMemberExpression(Box<'a, ComputedMemberExpression<'a>>) = 48,
@@ -605,7 +605,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum Argument<'a> {
     /// `...[1, 2]` in `const arr = [...[1, 2]];`
     SpreadElement(Box<'a, SpreadElement<'a>>) = 64,
@@ -713,7 +713,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum AssignmentTarget<'a> {
     // `SimpleAssignmentTarget` variants added here by `inherit_variants!` macro
     @inherit SimpleAssignmentTarget
@@ -730,7 +730,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum SimpleAssignmentTarget<'a> {
     AssignmentTargetIdentifier(Box<'a, IdentifierReference<'a>>) = 0,
     TSAsExpression(Box<'a, TSAsExpression<'a>>) = 1,
@@ -783,7 +783,7 @@ pub use match_simple_assignment_target;
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum AssignmentTargetPattern<'a> {
     ArrayAssignmentTarget(Box<'a, ArrayAssignmentTarget<'a>>) = 8,
     ObjectAssignmentTarget(Box<'a, ObjectAssignmentTarget<'a>>) = 9,
@@ -847,7 +847,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum AssignmentTargetMaybeDefault<'a> {
     AssignmentTargetWithDefault(Box<'a, AssignmentTargetWithDefault<'a>>) = 16,
     // `AssignmentTarget` variants added here by `inherit_variants!` macro
@@ -866,7 +866,7 @@ pub struct AssignmentTargetWithDefault<'a> {
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum AssignmentTargetProperty<'a> {
     AssignmentTargetPropertyIdentifier(Box<'a, AssignmentTargetPropertyIdentifier<'a>>) = 0,
     AssignmentTargetPropertyProperty(Box<'a, AssignmentTargetPropertyProperty<'a>>) = 1,
@@ -947,7 +947,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ChainElement<'a> {
     CallExpression(Box<'a, CallExpression<'a>>) = 0,
     /// `foo?.baz!` or `foo?.[bar]!`
@@ -977,7 +977,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum Statement<'a> {
     // Statements
     BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
@@ -1048,7 +1048,7 @@ pub struct BlockStatement<'a> {
 /// Declarations and the Variable Statement
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum Declaration<'a> {
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 32,
     #[visit(args(flags = ScopeFlags::Function))]
@@ -1197,7 +1197,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ForStatementInit<'a> {
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 64,
     // `Expression` variants added here by `inherit_variants!` macro
@@ -1228,7 +1228,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ForStatementLeft<'a> {
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 16,
     // `AssignmentTarget` variants added here by `inherit_variants!` macro
@@ -1451,7 +1451,7 @@ pub struct BindingPattern<'a> {
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum BindingPatternKind<'a> {
     /// `const a = 1`
     BindingIdentifier(Box<'a, BindingIdentifier<'a>>) = 0,
@@ -1855,7 +1855,7 @@ pub struct ClassBody<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ClassElement<'a> {
     StaticBlock(Box<'a, StaticBlock<'a>>) = 0,
     /// Class Methods
@@ -2086,7 +2086,7 @@ pub struct StaticBlock<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ModuleDeclaration<'a> {
     /// `import hello from './world.js';`
     /// `import * as t from './world.js';`
@@ -2208,7 +2208,7 @@ pub struct ImportDeclaration<'a> {
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ImportDeclarationSpecifier<'a> {
     /// import {imported} from "source"
     /// import {imported as local} from "source"
@@ -2398,7 +2398,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum ExportDefaultDeclarationKind<'a> {
     #[visit(args(flags = ScopeFlags::Function))]
     FunctionDeclaration(Box<'a, Function<'a>>) = 64,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -4,7 +4,7 @@
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
 // Read [`macro@oxc_ast_macros::ast`] for more information.
 
-use oxc_allocator::{Box, CloneIn, Vec};
+use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, GetSpan, GetSpanMut, Span};
@@ -146,7 +146,7 @@ pub struct JSXClosingFragment {
 /// JSX Element Name
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash)]
 pub enum JSXElementName<'a> {
     /// `<div />`
     Identifier(Box<'a, JSXIdentifier<'a>>) = 0,
@@ -224,7 +224,7 @@ pub struct JSXMemberExpression<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash)]
 pub enum JSXMemberExpressionObject<'a> {
     /// `<Apple.Orange />`
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,
@@ -303,7 +303,7 @@ pub struct JSXEmptyExpression {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum JSXAttributeItem<'a> {
     /// A `key="value"` attribute
     Attribute(Box<'a, JSXAttribute<'a>>) = 0,
@@ -370,7 +370,7 @@ pub struct JSXSpreadAttribute<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum JSXAttributeName<'a> {
     /// An attribute name without a namespace prefix, e.g. `foo` in `foo="bar"`.
     Identifier(Box<'a, JSXIdentifier<'a>>) = 0,
@@ -398,7 +398,7 @@ pub enum JSXAttributeName<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum JSXAttributeValue<'a> {
     /// `<Component foo="bar" />`
     StringLiteral(Box<'a, StringLiteral<'a>>) = 0,
@@ -432,7 +432,7 @@ pub struct JSXIdentifier<'a> {
 /// Part of a [`JSXElement`].
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum JSXChild<'a> {
     /// `<Foo>Some Text</Foo>`
     Text(Box<'a, JSXText<'a>>) = 0,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -10,7 +10,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Box, CloneIn, Vec};
+use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, GetSpan, GetSpanMut, Span};
@@ -105,7 +105,7 @@ pub struct TSEnumMember<'a> {
 /// TS Enum Member Name
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSEnumMemberName<'a> {
     Identifier(Box<'a, IdentifierName<'a>>) = 0,
     String(Box<'a, StringLiteral<'a>>) = 1,
@@ -158,7 +158,7 @@ pub struct TSLiteralType<'a> {
 /// A literal in a [`TSLiteralType`].
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSLiteral<'a> {
     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
     NullLiteral(Box<'a, NullLiteral>) = 1,
@@ -183,7 +183,7 @@ pub enum TSLiteral<'a> {
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSType<'a> {
     // Keyword
     TSAnyKeyword(Box<'a, TSAnyKeyword>) = 0,
@@ -512,7 +512,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSTupleElement<'a> {
     // Discriminants start at 64, so that `TSTupleElement::is_ts_type` is a single
     // bitwise AND operation on the discriminant (`discriminant & 63 != 0`).
@@ -732,7 +732,7 @@ pub struct TSTypeReference<'a> {
 ///     NamespaceName . IdentifierReference
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSTypeName<'a> {
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,
     QualifiedName(Box<'a, TSQualifiedName<'a>>) = 1,
@@ -943,7 +943,7 @@ pub struct TSPropertySignature<'a> {
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSSignature<'a> {
     TSIndexSignature(Box<'a, TSIndexSignature<'a>>) = 0,
     TSPropertySignature(Box<'a, TSPropertySignature<'a>>) = 1,
@@ -1206,7 +1206,7 @@ pub enum TSModuleDeclarationName<'a> {
 
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSModuleDeclarationBody<'a> {
     TSModuleDeclaration(Box<'a, TSModuleDeclaration<'a>>) = 0,
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>) = 1,
@@ -1280,7 +1280,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSTypeQueryExprName<'a> {
     TSImportType(Box<'a, TSImportType<'a>>) = 2,
     // `TSTypeName` variants added here by `inherit_variants!` macro
@@ -1532,7 +1532,7 @@ inherit_variants! {
 /// [`ast` module docs]: `super`
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ContentHash, ESTree)]
 pub enum TSModuleReference<'a> {
     ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>) = 2,
     // `TSTypeName` variants added here by `inherit_variants!` macro

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -2,7 +2,7 @@
 #![warn(missing_docs)]
 use std::{borrow::Cow, fmt};
 
-use oxc_allocator::{Address, Box, FromIn, GetAddress, Vec};
+use oxc_allocator::{Box, FromIn, Vec};
 use oxc_span::{Atom, GetSpan, Span};
 use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags, symbol::SymbolId};
 
@@ -734,47 +734,6 @@ impl<'a> FromIn<'a, Expression<'a>> for Statement<'a> {
             ExpressionStatement { span: expression.span(), expression },
             allocator,
         ))
-    }
-}
-
-impl<'a> GetAddress for Statement<'a> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Statement::BlockStatement(s) => s.address(),
-            Statement::BreakStatement(s) => s.address(),
-            Statement::ContinueStatement(s) => s.address(),
-            Statement::DebuggerStatement(s) => s.address(),
-            Statement::DoWhileStatement(s) => s.address(),
-            Statement::EmptyStatement(s) => s.address(),
-            Statement::ExpressionStatement(s) => s.address(),
-            Statement::ForInStatement(s) => s.address(),
-            Statement::ForOfStatement(s) => s.address(),
-            Statement::ForStatement(s) => s.address(),
-            Statement::IfStatement(s) => s.address(),
-            Statement::LabeledStatement(s) => s.address(),
-            Statement::ReturnStatement(s) => s.address(),
-            Statement::SwitchStatement(s) => s.address(),
-            Statement::ThrowStatement(s) => s.address(),
-            Statement::TryStatement(s) => s.address(),
-            Statement::WhileStatement(s) => s.address(),
-            Statement::WithStatement(s) => s.address(),
-            Statement::VariableDeclaration(s) => s.address(),
-            Statement::FunctionDeclaration(s) => s.address(),
-            Statement::ClassDeclaration(s) => s.address(),
-            Statement::TSTypeAliasDeclaration(s) => s.address(),
-            Statement::TSInterfaceDeclaration(s) => s.address(),
-            Statement::TSEnumDeclaration(s) => s.address(),
-            Statement::TSModuleDeclaration(s) => s.address(),
-            Statement::TSImportEqualsDeclaration(s) => s.address(),
-            Statement::ImportDeclaration(s) => s.address(),
-            Statement::ExportAllDeclaration(s) => s.address(),
-            Statement::ExportDefaultDeclaration(s) => s.address(),
-            Statement::ExportNamedDeclaration(s) => s.address(),
-            Statement::TSExportAssignment(s) => s.address(),
-            Statement::TSNamespaceExportDeclaration(s) => s.address(),
-        }
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -1,0 +1,784 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_address.rs`
+
+#![allow(clippy::match_same_arms)]
+
+use oxc_allocator::{Address, GetAddress};
+
+use crate::ast::js::*;
+
+use crate::ast::jsx::*;
+
+use crate::ast::ts::*;
+
+impl<'a> GetAddress for Expression<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::MetaProperty(it) => GetAddress::address(it),
+            Self::Super(it) => GetAddress::address(it),
+            Self::ArrayExpression(it) => GetAddress::address(it),
+            Self::ArrowFunctionExpression(it) => GetAddress::address(it),
+            Self::AssignmentExpression(it) => GetAddress::address(it),
+            Self::AwaitExpression(it) => GetAddress::address(it),
+            Self::BinaryExpression(it) => GetAddress::address(it),
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::ChainExpression(it) => GetAddress::address(it),
+            Self::ClassExpression(it) => GetAddress::address(it),
+            Self::ConditionalExpression(it) => GetAddress::address(it),
+            Self::FunctionExpression(it) => GetAddress::address(it),
+            Self::ImportExpression(it) => GetAddress::address(it),
+            Self::LogicalExpression(it) => GetAddress::address(it),
+            Self::NewExpression(it) => GetAddress::address(it),
+            Self::ObjectExpression(it) => GetAddress::address(it),
+            Self::ParenthesizedExpression(it) => GetAddress::address(it),
+            Self::SequenceExpression(it) => GetAddress::address(it),
+            Self::TaggedTemplateExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+            Self::UpdateExpression(it) => GetAddress::address(it),
+            Self::YieldExpression(it) => GetAddress::address(it),
+            Self::PrivateInExpression(it) => GetAddress::address(it),
+            Self::JSXElement(it) => GetAddress::address(it),
+            Self::JSXFragment(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ObjectPropertyKind<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ObjectProperty(it) => GetAddress::address(it),
+            Self::SpreadProperty(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for PropertyKey<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::StaticIdentifier(it) => GetAddress::address(it),
+            Self::PrivateIdentifier(it) => GetAddress::address(it),
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::MetaProperty(it) => GetAddress::address(it),
+            Self::Super(it) => GetAddress::address(it),
+            Self::ArrayExpression(it) => GetAddress::address(it),
+            Self::ArrowFunctionExpression(it) => GetAddress::address(it),
+            Self::AssignmentExpression(it) => GetAddress::address(it),
+            Self::AwaitExpression(it) => GetAddress::address(it),
+            Self::BinaryExpression(it) => GetAddress::address(it),
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::ChainExpression(it) => GetAddress::address(it),
+            Self::ClassExpression(it) => GetAddress::address(it),
+            Self::ConditionalExpression(it) => GetAddress::address(it),
+            Self::FunctionExpression(it) => GetAddress::address(it),
+            Self::ImportExpression(it) => GetAddress::address(it),
+            Self::LogicalExpression(it) => GetAddress::address(it),
+            Self::NewExpression(it) => GetAddress::address(it),
+            Self::ObjectExpression(it) => GetAddress::address(it),
+            Self::ParenthesizedExpression(it) => GetAddress::address(it),
+            Self::SequenceExpression(it) => GetAddress::address(it),
+            Self::TaggedTemplateExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+            Self::UpdateExpression(it) => GetAddress::address(it),
+            Self::YieldExpression(it) => GetAddress::address(it),
+            Self::PrivateInExpression(it) => GetAddress::address(it),
+            Self::JSXElement(it) => GetAddress::address(it),
+            Self::JSXFragment(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for MemberExpression<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for Argument<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::SpreadElement(it) => GetAddress::address(it),
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::MetaProperty(it) => GetAddress::address(it),
+            Self::Super(it) => GetAddress::address(it),
+            Self::ArrayExpression(it) => GetAddress::address(it),
+            Self::ArrowFunctionExpression(it) => GetAddress::address(it),
+            Self::AssignmentExpression(it) => GetAddress::address(it),
+            Self::AwaitExpression(it) => GetAddress::address(it),
+            Self::BinaryExpression(it) => GetAddress::address(it),
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::ChainExpression(it) => GetAddress::address(it),
+            Self::ClassExpression(it) => GetAddress::address(it),
+            Self::ConditionalExpression(it) => GetAddress::address(it),
+            Self::FunctionExpression(it) => GetAddress::address(it),
+            Self::ImportExpression(it) => GetAddress::address(it),
+            Self::LogicalExpression(it) => GetAddress::address(it),
+            Self::NewExpression(it) => GetAddress::address(it),
+            Self::ObjectExpression(it) => GetAddress::address(it),
+            Self::ParenthesizedExpression(it) => GetAddress::address(it),
+            Self::SequenceExpression(it) => GetAddress::address(it),
+            Self::TaggedTemplateExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+            Self::UpdateExpression(it) => GetAddress::address(it),
+            Self::YieldExpression(it) => GetAddress::address(it),
+            Self::PrivateInExpression(it) => GetAddress::address(it),
+            Self::JSXElement(it) => GetAddress::address(it),
+            Self::JSXFragment(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for AssignmentTarget<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+            Self::ArrayAssignmentTarget(it) => GetAddress::address(it),
+            Self::ObjectAssignmentTarget(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for SimpleAssignmentTarget<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for AssignmentTargetPattern<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ArrayAssignmentTarget(it) => GetAddress::address(it),
+            Self::ObjectAssignmentTarget(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for AssignmentTargetMaybeDefault<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::AssignmentTargetWithDefault(it) => GetAddress::address(it),
+            Self::AssignmentTargetIdentifier(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+            Self::ArrayAssignmentTarget(it) => GetAddress::address(it),
+            Self::ObjectAssignmentTarget(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for AssignmentTargetProperty<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::AssignmentTargetPropertyIdentifier(it) => GetAddress::address(it),
+            Self::AssignmentTargetPropertyProperty(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ChainElement<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for Statement<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::BlockStatement(it) => GetAddress::address(it),
+            Self::BreakStatement(it) => GetAddress::address(it),
+            Self::ContinueStatement(it) => GetAddress::address(it),
+            Self::DebuggerStatement(it) => GetAddress::address(it),
+            Self::DoWhileStatement(it) => GetAddress::address(it),
+            Self::EmptyStatement(it) => GetAddress::address(it),
+            Self::ExpressionStatement(it) => GetAddress::address(it),
+            Self::ForInStatement(it) => GetAddress::address(it),
+            Self::ForOfStatement(it) => GetAddress::address(it),
+            Self::ForStatement(it) => GetAddress::address(it),
+            Self::IfStatement(it) => GetAddress::address(it),
+            Self::LabeledStatement(it) => GetAddress::address(it),
+            Self::ReturnStatement(it) => GetAddress::address(it),
+            Self::SwitchStatement(it) => GetAddress::address(it),
+            Self::ThrowStatement(it) => GetAddress::address(it),
+            Self::TryStatement(it) => GetAddress::address(it),
+            Self::WhileStatement(it) => GetAddress::address(it),
+            Self::WithStatement(it) => GetAddress::address(it),
+            Self::VariableDeclaration(it) => GetAddress::address(it),
+            Self::FunctionDeclaration(it) => GetAddress::address(it),
+            Self::ClassDeclaration(it) => GetAddress::address(it),
+            Self::TSTypeAliasDeclaration(it) => GetAddress::address(it),
+            Self::TSInterfaceDeclaration(it) => GetAddress::address(it),
+            Self::TSEnumDeclaration(it) => GetAddress::address(it),
+            Self::TSModuleDeclaration(it) => GetAddress::address(it),
+            Self::TSImportEqualsDeclaration(it) => GetAddress::address(it),
+            Self::ImportDeclaration(it) => GetAddress::address(it),
+            Self::ExportAllDeclaration(it) => GetAddress::address(it),
+            Self::ExportDefaultDeclaration(it) => GetAddress::address(it),
+            Self::ExportNamedDeclaration(it) => GetAddress::address(it),
+            Self::TSExportAssignment(it) => GetAddress::address(it),
+            Self::TSNamespaceExportDeclaration(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for Declaration<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::VariableDeclaration(it) => GetAddress::address(it),
+            Self::FunctionDeclaration(it) => GetAddress::address(it),
+            Self::ClassDeclaration(it) => GetAddress::address(it),
+            Self::TSTypeAliasDeclaration(it) => GetAddress::address(it),
+            Self::TSInterfaceDeclaration(it) => GetAddress::address(it),
+            Self::TSEnumDeclaration(it) => GetAddress::address(it),
+            Self::TSModuleDeclaration(it) => GetAddress::address(it),
+            Self::TSImportEqualsDeclaration(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ForStatementInit<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::VariableDeclaration(it) => GetAddress::address(it),
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::MetaProperty(it) => GetAddress::address(it),
+            Self::Super(it) => GetAddress::address(it),
+            Self::ArrayExpression(it) => GetAddress::address(it),
+            Self::ArrowFunctionExpression(it) => GetAddress::address(it),
+            Self::AssignmentExpression(it) => GetAddress::address(it),
+            Self::AwaitExpression(it) => GetAddress::address(it),
+            Self::BinaryExpression(it) => GetAddress::address(it),
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::ChainExpression(it) => GetAddress::address(it),
+            Self::ClassExpression(it) => GetAddress::address(it),
+            Self::ConditionalExpression(it) => GetAddress::address(it),
+            Self::FunctionExpression(it) => GetAddress::address(it),
+            Self::ImportExpression(it) => GetAddress::address(it),
+            Self::LogicalExpression(it) => GetAddress::address(it),
+            Self::NewExpression(it) => GetAddress::address(it),
+            Self::ObjectExpression(it) => GetAddress::address(it),
+            Self::ParenthesizedExpression(it) => GetAddress::address(it),
+            Self::SequenceExpression(it) => GetAddress::address(it),
+            Self::TaggedTemplateExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+            Self::UpdateExpression(it) => GetAddress::address(it),
+            Self::YieldExpression(it) => GetAddress::address(it),
+            Self::PrivateInExpression(it) => GetAddress::address(it),
+            Self::JSXElement(it) => GetAddress::address(it),
+            Self::JSXFragment(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ForStatementLeft<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::VariableDeclaration(it) => GetAddress::address(it),
+            Self::AssignmentTargetIdentifier(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+            Self::ArrayAssignmentTarget(it) => GetAddress::address(it),
+            Self::ObjectAssignmentTarget(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for BindingPatternKind<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::BindingIdentifier(it) => GetAddress::address(it),
+            Self::ObjectPattern(it) => GetAddress::address(it),
+            Self::ArrayPattern(it) => GetAddress::address(it),
+            Self::AssignmentPattern(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ClassElement<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::StaticBlock(it) => GetAddress::address(it),
+            Self::MethodDefinition(it) => GetAddress::address(it),
+            Self::PropertyDefinition(it) => GetAddress::address(it),
+            Self::AccessorProperty(it) => GetAddress::address(it),
+            Self::TSIndexSignature(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ModuleDeclaration<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ImportDeclaration(it) => GetAddress::address(it),
+            Self::ExportAllDeclaration(it) => GetAddress::address(it),
+            Self::ExportDefaultDeclaration(it) => GetAddress::address(it),
+            Self::ExportNamedDeclaration(it) => GetAddress::address(it),
+            Self::TSExportAssignment(it) => GetAddress::address(it),
+            Self::TSNamespaceExportDeclaration(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ImportDeclarationSpecifier<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ImportSpecifier(it) => GetAddress::address(it),
+            Self::ImportDefaultSpecifier(it) => GetAddress::address(it),
+            Self::ImportNamespaceSpecifier(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for ExportDefaultDeclarationKind<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::FunctionDeclaration(it) => GetAddress::address(it),
+            Self::ClassDeclaration(it) => GetAddress::address(it),
+            Self::TSInterfaceDeclaration(it) => GetAddress::address(it),
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::MetaProperty(it) => GetAddress::address(it),
+            Self::Super(it) => GetAddress::address(it),
+            Self::ArrayExpression(it) => GetAddress::address(it),
+            Self::ArrowFunctionExpression(it) => GetAddress::address(it),
+            Self::AssignmentExpression(it) => GetAddress::address(it),
+            Self::AwaitExpression(it) => GetAddress::address(it),
+            Self::BinaryExpression(it) => GetAddress::address(it),
+            Self::CallExpression(it) => GetAddress::address(it),
+            Self::ChainExpression(it) => GetAddress::address(it),
+            Self::ClassExpression(it) => GetAddress::address(it),
+            Self::ConditionalExpression(it) => GetAddress::address(it),
+            Self::FunctionExpression(it) => GetAddress::address(it),
+            Self::ImportExpression(it) => GetAddress::address(it),
+            Self::LogicalExpression(it) => GetAddress::address(it),
+            Self::NewExpression(it) => GetAddress::address(it),
+            Self::ObjectExpression(it) => GetAddress::address(it),
+            Self::ParenthesizedExpression(it) => GetAddress::address(it),
+            Self::SequenceExpression(it) => GetAddress::address(it),
+            Self::TaggedTemplateExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+            Self::UpdateExpression(it) => GetAddress::address(it),
+            Self::YieldExpression(it) => GetAddress::address(it),
+            Self::PrivateInExpression(it) => GetAddress::address(it),
+            Self::JSXElement(it) => GetAddress::address(it),
+            Self::JSXFragment(it) => GetAddress::address(it),
+            Self::TSAsExpression(it) => GetAddress::address(it),
+            Self::TSSatisfiesExpression(it) => GetAddress::address(it),
+            Self::TSTypeAssertion(it) => GetAddress::address(it),
+            Self::TSNonNullExpression(it) => GetAddress::address(it),
+            Self::TSInstantiationExpression(it) => GetAddress::address(it),
+            Self::ComputedMemberExpression(it) => GetAddress::address(it),
+            Self::StaticMemberExpression(it) => GetAddress::address(it),
+            Self::PrivateFieldExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSEnumMemberName<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::String(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSLiteral<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::BooleanLiteral(it) => GetAddress::address(it),
+            Self::NullLiteral(it) => GetAddress::address(it),
+            Self::NumericLiteral(it) => GetAddress::address(it),
+            Self::BigIntLiteral(it) => GetAddress::address(it),
+            Self::RegExpLiteral(it) => GetAddress::address(it),
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::TemplateLiteral(it) => GetAddress::address(it),
+            Self::UnaryExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSType<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::TSAnyKeyword(it) => GetAddress::address(it),
+            Self::TSBigIntKeyword(it) => GetAddress::address(it),
+            Self::TSBooleanKeyword(it) => GetAddress::address(it),
+            Self::TSIntrinsicKeyword(it) => GetAddress::address(it),
+            Self::TSNeverKeyword(it) => GetAddress::address(it),
+            Self::TSNullKeyword(it) => GetAddress::address(it),
+            Self::TSNumberKeyword(it) => GetAddress::address(it),
+            Self::TSObjectKeyword(it) => GetAddress::address(it),
+            Self::TSStringKeyword(it) => GetAddress::address(it),
+            Self::TSSymbolKeyword(it) => GetAddress::address(it),
+            Self::TSUndefinedKeyword(it) => GetAddress::address(it),
+            Self::TSUnknownKeyword(it) => GetAddress::address(it),
+            Self::TSVoidKeyword(it) => GetAddress::address(it),
+            Self::TSArrayType(it) => GetAddress::address(it),
+            Self::TSConditionalType(it) => GetAddress::address(it),
+            Self::TSConstructorType(it) => GetAddress::address(it),
+            Self::TSFunctionType(it) => GetAddress::address(it),
+            Self::TSImportType(it) => GetAddress::address(it),
+            Self::TSIndexedAccessType(it) => GetAddress::address(it),
+            Self::TSInferType(it) => GetAddress::address(it),
+            Self::TSIntersectionType(it) => GetAddress::address(it),
+            Self::TSLiteralType(it) => GetAddress::address(it),
+            Self::TSMappedType(it) => GetAddress::address(it),
+            Self::TSNamedTupleMember(it) => GetAddress::address(it),
+            Self::TSQualifiedName(it) => GetAddress::address(it),
+            Self::TSTemplateLiteralType(it) => GetAddress::address(it),
+            Self::TSThisType(it) => GetAddress::address(it),
+            Self::TSTupleType(it) => GetAddress::address(it),
+            Self::TSTypeLiteral(it) => GetAddress::address(it),
+            Self::TSTypeOperatorType(it) => GetAddress::address(it),
+            Self::TSTypePredicate(it) => GetAddress::address(it),
+            Self::TSTypeQuery(it) => GetAddress::address(it),
+            Self::TSTypeReference(it) => GetAddress::address(it),
+            Self::TSUnionType(it) => GetAddress::address(it),
+            Self::TSParenthesizedType(it) => GetAddress::address(it),
+            Self::JSDocNullableType(it) => GetAddress::address(it),
+            Self::JSDocNonNullableType(it) => GetAddress::address(it),
+            Self::JSDocUnknownType(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSTupleElement<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::TSOptionalType(it) => GetAddress::address(it),
+            Self::TSRestType(it) => GetAddress::address(it),
+            Self::TSAnyKeyword(it) => GetAddress::address(it),
+            Self::TSBigIntKeyword(it) => GetAddress::address(it),
+            Self::TSBooleanKeyword(it) => GetAddress::address(it),
+            Self::TSIntrinsicKeyword(it) => GetAddress::address(it),
+            Self::TSNeverKeyword(it) => GetAddress::address(it),
+            Self::TSNullKeyword(it) => GetAddress::address(it),
+            Self::TSNumberKeyword(it) => GetAddress::address(it),
+            Self::TSObjectKeyword(it) => GetAddress::address(it),
+            Self::TSStringKeyword(it) => GetAddress::address(it),
+            Self::TSSymbolKeyword(it) => GetAddress::address(it),
+            Self::TSUndefinedKeyword(it) => GetAddress::address(it),
+            Self::TSUnknownKeyword(it) => GetAddress::address(it),
+            Self::TSVoidKeyword(it) => GetAddress::address(it),
+            Self::TSArrayType(it) => GetAddress::address(it),
+            Self::TSConditionalType(it) => GetAddress::address(it),
+            Self::TSConstructorType(it) => GetAddress::address(it),
+            Self::TSFunctionType(it) => GetAddress::address(it),
+            Self::TSImportType(it) => GetAddress::address(it),
+            Self::TSIndexedAccessType(it) => GetAddress::address(it),
+            Self::TSInferType(it) => GetAddress::address(it),
+            Self::TSIntersectionType(it) => GetAddress::address(it),
+            Self::TSLiteralType(it) => GetAddress::address(it),
+            Self::TSMappedType(it) => GetAddress::address(it),
+            Self::TSNamedTupleMember(it) => GetAddress::address(it),
+            Self::TSQualifiedName(it) => GetAddress::address(it),
+            Self::TSTemplateLiteralType(it) => GetAddress::address(it),
+            Self::TSThisType(it) => GetAddress::address(it),
+            Self::TSTupleType(it) => GetAddress::address(it),
+            Self::TSTypeLiteral(it) => GetAddress::address(it),
+            Self::TSTypeOperatorType(it) => GetAddress::address(it),
+            Self::TSTypePredicate(it) => GetAddress::address(it),
+            Self::TSTypeQuery(it) => GetAddress::address(it),
+            Self::TSTypeReference(it) => GetAddress::address(it),
+            Self::TSUnionType(it) => GetAddress::address(it),
+            Self::TSParenthesizedType(it) => GetAddress::address(it),
+            Self::JSDocNullableType(it) => GetAddress::address(it),
+            Self::JSDocNonNullableType(it) => GetAddress::address(it),
+            Self::JSDocUnknownType(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSTypeName<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::QualifiedName(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSSignature<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::TSIndexSignature(it) => GetAddress::address(it),
+            Self::TSPropertySignature(it) => GetAddress::address(it),
+            Self::TSCallSignatureDeclaration(it) => GetAddress::address(it),
+            Self::TSConstructSignatureDeclaration(it) => GetAddress::address(it),
+            Self::TSMethodSignature(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSModuleDeclarationBody<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::TSModuleDeclaration(it) => GetAddress::address(it),
+            Self::TSModuleBlock(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSTypeQueryExprName<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::TSImportType(it) => GetAddress::address(it),
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::QualifiedName(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for TSModuleReference<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::ExternalModuleReference(it) => GetAddress::address(it),
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::QualifiedName(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXElementName<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::NamespacedName(it) => GetAddress::address(it),
+            Self::MemberExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXMemberExpressionObject<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::MemberExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXAttributeItem<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Attribute(it) => GetAddress::address(it),
+            Self::SpreadAttribute(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXAttributeName<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::NamespacedName(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXAttributeValue<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::ExpressionContainer(it) => GetAddress::address(it),
+            Self::Element(it) => GetAddress::address(it),
+            Self::Fragment(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl<'a> GetAddress for JSXChild<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Text(it) => GetAddress::address(it),
+            Self::Element(it) => GetAddress::address(it),
+            Self::Fragment(it) => GetAddress::address(it),
+            Self::ExpressionContainer(it) => GetAddress::address(it),
+            Self::Spread(it) => GetAddress::address(it),
+        }
+    }
+}

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -65,6 +65,7 @@ mod generated {
     pub mod derive_content_hash;
     #[cfg(feature = "serialize")]
     pub mod derive_estree;
+    pub mod derive_get_address;
     pub mod derive_get_span;
     pub mod derive_get_span_mut;
     pub mod get_id;

--- a/crates/oxc_ast_macros/src/ast.rs
+++ b/crates/oxc_ast_macros/src/ast.rs
@@ -77,6 +77,8 @@ fn abs_trait(
         (quote!(::oxc_span::GetSpan), TokenStream::default())
     } else if ident == "GetSpanMut" {
         (quote!(::oxc_span::GetSpanMut), TokenStream::default())
+    } else if ident == "GetAddress" {
+        (quote!(::oxc_allocator::GetAddress), TokenStream::default())
     } else if ident == "ContentEq" {
         (quote!(::oxc_span::cmp::ContentEq), TokenStream::default())
     } else if ident == "ContentHash" {

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, CloneIn, Vec};
+use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{cmp::ContentEq, hash::ContentHash, Atom, GetSpan, Span};
@@ -229,7 +229,7 @@ pub enum CharacterClassContentsKind {
 
 #[ast]
 #[derive(Debug)]
-#[generate_derive(CloneIn, ContentEq, ContentHash, ESTree)]
+#[generate_derive(CloneIn, ContentEq, ContentHash, GetAddress, ESTree)]
 pub enum CharacterClassContents<'a> {
     CharacterClassRange(Box<'a, CharacterClassRange>) = 0,
     CharacterClassEscape(Box<'a, CharacterClassEscape>) = 1,

--- a/crates/oxc_regular_expression/src/generated/derive_get_address.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_get_address.rs
@@ -1,0 +1,23 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_address.rs`
+
+#![allow(clippy::match_same_arms)]
+
+use oxc_allocator::{Address, GetAddress};
+
+use crate::ast::*;
+
+impl<'a> GetAddress for CharacterClassContents<'a> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::CharacterClassRange(it) => GetAddress::address(it),
+            Self::CharacterClassEscape(it) => GetAddress::address(it),
+            Self::UnicodePropertyEscape(it) => GetAddress::address(it),
+            Self::Character(it) => GetAddress::address(it),
+            Self::NestedCharacterClass(it) => GetAddress::address(it),
+            Self::ClassStringDisjunction(it) => GetAddress::address(it),
+        }
+    }
+}

--- a/tasks/ast_tools/src/derives/get_address.rs
+++ b/tasks/ast_tools/src/derives/get_address.rs
@@ -1,0 +1,63 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{
+    schema::{EnumDef, Schema, ToType, TypeDef},
+    util::TypeWrapper,
+};
+
+use super::{define_derive, Derive};
+
+pub struct DeriveGetAddress;
+
+define_derive!(DeriveGetAddress);
+
+impl Derive for DeriveGetAddress {
+    fn trait_name() -> &'static str {
+        "GetAddress"
+    }
+
+    fn prelude() -> TokenStream {
+        quote! {
+            #![allow(clippy::match_same_arms)]
+
+            ///@@line_break
+            use oxc_allocator::{Address, GetAddress};
+        }
+    }
+
+    fn derive(&mut self, def: &TypeDef, _schema: &Schema) -> TokenStream {
+        if let TypeDef::Enum(enum_def) = def {
+            derive_enum(enum_def)
+        } else {
+            panic!("`GetAddress` can only be implemented with `#[generate_derive]` on enums");
+        }
+    }
+}
+
+fn derive_enum(def: &EnumDef) -> TokenStream {
+    let target_type = def.to_type();
+
+    let matches = def.all_variants().map(|variant| {
+        assert!(
+            variant.fields.len() == 1
+                && variant.fields[0].typ.analysis().wrapper == TypeWrapper::Box,
+            "`GetAddress` can only be derived on enums where all variants are boxed"
+        );
+
+        let ident = variant.ident();
+        quote!(Self::#ident(it) => GetAddress::address(it))
+    });
+
+    quote! {
+        impl<'a> GetAddress for #target_type {
+            ///@ `#[inline]` because compiler should boil this down to a single assembly instruction
+            #[inline]
+            fn address(&self) -> Address {
+                match self {
+                    #(#matches),*
+                }
+            }
+        }
+    }
+}

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -15,12 +15,14 @@ mod clone_in;
 mod content_eq;
 mod content_hash;
 mod estree;
+mod get_address;
 mod get_span;
 
 pub use clone_in::DeriveCloneIn;
 pub use content_eq::DeriveContentEq;
 pub use content_hash::DeriveContentHash;
 pub use estree::DeriveESTree;
+pub use get_address::DeriveGetAddress;
 pub use get_span::{DeriveGetSpan, DeriveGetSpanMut};
 
 pub trait Derive {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -18,8 +18,8 @@ mod schema;
 mod util;
 
 use derives::{
-    DeriveCloneIn, DeriveContentEq, DeriveContentHash, DeriveESTree, DeriveGetSpan,
-    DeriveGetSpanMut,
+    DeriveCloneIn, DeriveContentEq, DeriveContentHash, DeriveESTree, DeriveGetAddress,
+    DeriveGetSpan, DeriveGetSpanMut,
 };
 use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, Generator, GetIdGenerator,
@@ -76,6 +76,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .pass(Linker)
         .pass(CalcLayout)
         .generate(DeriveCloneIn)
+        .generate(DeriveGetAddress)
         .generate(DeriveGetSpan)
         .generate(DeriveGetSpanMut)
         .generate(DeriveContentEq)


### PR DESCRIPTION
Implement `GetAddress` on all AST enums where all variants are boxed. Part of #7339.
