### PR TITLE
fix(transformer/class-properties): stop searching for `super()` in `TSModuleBlock`s

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -333,6 +333,9 @@ impl<'a, 'c> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, 'c> {
     fn visit_static_block(&mut self, _block: &mut StaticBlock) {}
 
     #[inline]
+    fn visit_ts_module_block(&mut self, _block: &mut TSModuleBlock<'a>) {}
+
+    #[inline]
     fn visit_property_definition(&mut self, prop: &mut PropertyDefinition<'a>) {
         // `super()` in computed key of property or method refers to super binding of parent class.
         // So visit computed `key`, but not `value`.
@@ -585,6 +588,9 @@ impl<'a, 'c> VisitMut<'a> for ConstructorBodyInitsInserter<'a, 'c> {
 
     #[inline]
     fn visit_static_block(&mut self, _block: &mut StaticBlock) {}
+
+    #[inline]
+    fn visit_ts_module_block(&mut self, _block: &mut TSModuleBlock<'a>) {}
 
     #[inline]
     fn visit_property_definition(&mut self, prop: &mut PropertyDefinition<'a>) {


### PR DESCRIPTION
Fix edge case in class static properties transform. When transforming `super()` in class constructor, stop searching when hit a `TSModuleBlock`. `TSModuleBlock` is essentially a function, so `super()` there is invalid.