### PR TITLE
refactor(transformer/class-properties): placeholder method for transforming private field assignment patterns

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -302,10 +302,16 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
                 // TODO: `transform_tagged_template_expression` is no-op at present
                 self.transform_tagged_template_expression(expr, ctx);
             }
-            // TODO: `[object.#prop] = value`
-            // TODO: `({x: object.#prop} = value)`
             _ => {}
         }
+    }
+
+    fn enter_assignment_target(
+        &mut self,
+        target: &mut AssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.transform_assignment_target(target, ctx);
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {


### PR DESCRIPTION
Add a no-op placeholder method for transforming private fields as `AssignmentPattern`s. e.g. `[object.#prop] = []`.

Implementation will be added later.