### PR TITLE
test(transformer): fix fixtures updating script

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@babel/plugin-transform-arrow-functions':
         specifier: ^7.25.9
         version: 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-class-properties':
         specifier: ^7.25.9
         version: 7.25.9(@babel/core@7.26.0)
@@ -270,6 +273,12 @@ packages:
     resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-remap-async-to-generator@7.25.9':
+    resolution: {integrity: sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-replace-supers@7.25.9':
     resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
     engines: {node: '>=6.9.0'}
@@ -290,6 +299,10 @@ packages:
 
   '@babel/helper-validator-option@7.25.9':
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-wrap-function@7.25.9':
+    resolution: {integrity: sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.26.0':
@@ -321,6 +334,12 @@ packages:
 
   '@babel/plugin-transform-arrow-functions@7.25.9':
     resolution: {integrity: sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-async-to-generator@7.25.9':
+    resolution: {integrity: sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3168,6 +3187,15 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.25.9': {}
 
+  '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-wrap-function': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -3189,6 +3217,14 @@ snapshots:
   '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helper-wrap-function@7.25.9':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helpers@7.26.0':
     dependencies:
@@ -3222,6 +3258,15 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.26.0)':
     dependencies:

--- a/tasks/transform_conformance/package.json
+++ b/tasks/transform_conformance/package.json
@@ -11,6 +11,7 @@
     "@babel/plugin-external-helpers": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@babel/plugin-transform-arrow-functions": "^7.25.9",
+    "@babel/plugin-transform-async-to-generator": "^7.25.9",
     "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-transform-class-static-block": "^7.26.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.25.9",

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 406/846
+Passed: 413/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (79/264)
+# babel-plugin-transform-class-properties (86/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -817,12 +817,6 @@ Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
-* public/non-block-arrow-func/input.mjs
-x Output mismatch
-
-* public/regression-T2983/input.mjs
-x Output mismatch
-
 * public/regression-T7364/input.mjs
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(7)]
@@ -855,9 +849,6 @@ rebuilt        : ScopeId(9): Some(ScopeId(8))
 * public/static-class-binding/input.js
 x Output mismatch
 
-* public/static-export/input.mjs
-x Output mismatch
-
 * public/static-infer-name/input.js
 x Output mismatch
 
@@ -886,12 +877,6 @@ x Output mismatch
 x Output mismatch
 
 * public-loose/foobar/input.js
-x Output mismatch
-
-* public-loose/non-block-arrow-func/input.mjs
-x Output mismatch
-
-* public-loose/regression-T2983/input.mjs
 x Output mismatch
 
 * public-loose/regression-T7364/input.mjs
@@ -924,9 +909,6 @@ after transform: ScopeId(6): Some(ScopeId(5))
 rebuilt        : ScopeId(9): Some(ScopeId(8))
 
 * public-loose/static-class-binding/input.js
-x Output mismatch
-
-* public-loose/static-export/input.mjs
 x Output mismatch
 
 * public-loose/static-infer-name/input.js
@@ -969,9 +951,6 @@ rebuilt        : SymbolId(2): ScopeId(0)
 Symbol scope ID mismatch for "_bar":
 after transform: SymbolId(4): ScopeId(2)
 rebuilt        : SymbolId(3): ScopeId(0)
-
-* regression/T2983/input.mjs
-x Output mismatch
 
 * regression/T7364/input.mjs
 Scope children mismatch:


### PR DESCRIPTION
Script to update fixtures for class properties transform was failing to transform fixtures where output is `output.mjs` (instead of `output.js`). This PR fixes that.