### PR TITLE
refactor(linter, syntax): introduce type alias `FxDashMap`

### DIFF
--- a/crates/oxc_linter/src/config/flat.rs
+++ b/crates/oxc_linter/src/config/flat.rs
@@ -15,6 +15,7 @@ use dashmap::DashMap;
 use rustc_hash::FxBuildHasher;
 
 type AppliedOverrideHash = u64;
+type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
 
 // TODO: support `categories` et. al. in overrides.
 #[derive(Debug)]
@@ -41,7 +42,7 @@ pub struct ConfigStore {
     // with nested configs.
     /// Resolved override cache. The key is a hash of each override's ID that matched the list of
     /// file globs in order to avoid re-allocating the same set of rules multiple times.
-    cache: DashMap<AppliedOverrideHash, ResolvedLinterState, FxBuildHasher>,
+    cache: FxDashMap<AppliedOverrideHash, ResolvedLinterState>,
     /// "root" level configuration. In the future this may just be the first entry in `overrides`.
     base: ResolvedLinterState,
     /// Config deltas applied to `base`.
@@ -64,7 +65,7 @@ impl ConfigStore {
         // could end up needing (overrides.len() ** 2) capacity. I don't really want to
         // pre-allocate that much space unconditionally. Better to re-alloc if we end up needing
         // it.
-        let cache = DashMap::with_capacity_and_hasher(overrides.len(), FxBuildHasher);
+        let cache = FxDashMap::with_capacity_and_hasher(overrides.len(), FxBuildHasher);
 
         Self { cache, base, overrides }
     }

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -1,11 +1,13 @@
 //! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
 #![allow(missing_docs)] // fixme
 
-use std::{fmt, hash::BuildHasherDefault, path::PathBuf, sync::Arc};
+use std::{fmt, path::PathBuf, sync::Arc};
 
 use dashmap::DashMap;
 use oxc_span::{CompactStr, Span};
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
+type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
 
 /// ESM Module Record
 ///
@@ -41,7 +43,7 @@ pub struct ModuleRecord {
     ///
     /// Note that Oxc does not support cross-file analysis, so this map will be empty after
     /// [`ModuleRecord`] is created. You must link the module records yourself.
-    pub loaded_modules: DashMap<CompactStr, Arc<ModuleRecord>, BuildHasherDefault<FxHasher>>,
+    pub loaded_modules: FxDashMap<CompactStr, Arc<ModuleRecord>>,
 
     /// `[[ImportEntries]]`
     ///


### PR DESCRIPTION
Pure refactor. Introduce a type alias `FxDashMap<K, V>` for `DashMap<K, V, FxBuildHasher>`. This makes the code using it clearer.