### PR TITLE
refactor(semantic, transformer): simplify `FxIndexMap` type aliases

### DIFF
--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -1,7 +1,7 @@
-use std::{hash::BuildHasherDefault, mem};
+use std::mem;
 
 use indexmap::IndexMap;
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use oxc_index::IndexVec;
 use oxc_span::CompactStr;
@@ -10,7 +10,7 @@ pub use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 use crate::{symbol::SymbolId, NodeId};
 
-type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 pub(crate) type Bindings = FxIndexMap<CompactStr, SymbolId>;
 pub type UnresolvedReferences = FxHashMap<CompactStr, Vec<ReferenceId>>;

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -87,11 +87,9 @@
 //! The Implementation based on
 //! <https://github.com/babel/babel/blob/d20b314c14533ab86351ecf6ca6b7296b66a57b3/packages/babel-traverse/src/path/conversion.ts#L170-L247>
 
-use std::hash::BuildHasherDefault;
-
 use compact_str::CompactString;
 use indexmap::IndexMap;
-use rustc_hash::{FxHashSet, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::{ast::*, NONE};
@@ -106,7 +104,7 @@ use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, TraverseCtx};
 
 use crate::EnvOptions;
 
-type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 /// Mode for arrow function conversion
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -139,10 +139,8 @@
 //!   * <https://github.com/babel/babel/blob/v7.26.2/packages/babel-helper-create-class-features-plugin/src/fields.ts>
 //! * Class properties TC39 proposal: <https://github.com/tc39/proposal-class-fields>
 
-use std::hash::BuildHasherDefault;
-
 use indexmap::IndexMap;
-use rustc_hash::FxHasher;
+use rustc_hash::FxBuildHasher;
 use serde::Deserialize;
 
 use oxc_allocator::{Address, GetAddress};
@@ -158,7 +156,7 @@ mod private;
 mod static_prop;
 mod utils;
 
-type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -88,11 +88,11 @@
 use std::{
     cell::Cell,
     fmt::{Debug, Display},
-    hash::{BuildHasherDefault, Hash},
+    hash::Hash,
 };
 
 use indexmap::IndexMap;
-use rustc_hash::FxHasher;
+use rustc_hash::FxBuildHasher;
 
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast::{ast::*, visit::walk, Visit};
@@ -105,7 +105,7 @@ use oxc_syntax::{
     symbol::SymbolId,
 };
 
-type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 /// Check `ScopeTree` and `SymbolTable` are correct after transform
 pub fn check_semantic_after_transform(


### PR DESCRIPTION
Pure refactor. Simplify `FxIndexMap` type aliases by using `rustc_hash`'s `FxBuildHasher`, instead of longhand `BuildHasherDefault<FxHasher>`.