### PR TITLE
perf(syntax): use `FxDashMap` for exported bindings

### DIFF
--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -78,7 +78,7 @@ pub struct ModuleRecord {
 
     /// Reexported bindings from `export * from 'specifier'`
     /// Keyed by resolved path
-    pub exported_bindings_from_star_export: DashMap<PathBuf, Vec<CompactStr>>,
+    pub exported_bindings_from_star_export: FxDashMap<PathBuf, Vec<CompactStr>>,
 
     /// `export default name`
     ///         ^^^^^^^ span


### PR DESCRIPTION
Same as #7521. Use `FxDashMap` instead of plain `DashMap` for hash map storing exported bindings.