### PR TITLE
refactor(linter): call `str::ends_with` with array not slice

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -90,7 +90,7 @@ impl Rule for PreferObjectHasOwn {
                     let needs_space = replace_target_span.start > 1
                         && !ctx
                             .source_range(Span::new(0, replace_target_span.start))
-                            .ends_with(&[' ', '=', '/', '(']);
+                            .ends_with([' ', '=', '/', '(']);
 
                     let replacement = if needs_space { " Object.hasOwn" } else { "Object.hasOwn" };
                     fixer.replace(replace_target_span, replacement)


### PR DESCRIPTION
Arrays are more performant than slices where it's possible to use them. Caught by newly enabled lint rule in Rust 1.82.0 in #6649.