### PR TITLE
ci(tools): `just submodules` clean git repos

### DIFF
--- a/justfile
+++ b/justfile
@@ -201,13 +201,13 @@ new-security-rule name:
 clone-submodule dir url sha:
   cd {{dir}} || git init {{dir}}
   cd {{dir}} && git remote add origin {{url}} || true
-  cd {{dir}} && git fetch --depth=1 origin {{sha}} && git reset --hard {{sha}}
+  cd {{dir}} && git fetch --depth=1 origin {{sha}} && git reset --hard {{sha}} && git clean -f -q
 
 [windows]
 clone-submodule dir url sha:
   if (-not (Test-Path {{dir}}/.git)) { git init {{dir}} }
   cd {{dir}} ; if ((git remote) -notcontains 'origin') { git remote add origin {{url}} } else { git remote set-url origin {{url}} }
-  cd {{dir}} ; git fetch --depth=1 origin {{sha}} ; git reset --hard {{sha}}
+  cd {{dir}} ; git fetch --depth=1 origin {{sha}} ; git reset --hard {{sha}} ; git clean -f -q
 
 website path:
   cargo run -p website -- linter-rules --table {{path}}/src/docs/guide/usage/linter/generated-rules.md --rule-docs {{path}}/src/docs/guide/usage/linter/rules --git-ref $(git rev-parse HEAD)


### PR DESCRIPTION
[update_fixtures.js](https://github.com/oxc-project/oxc/blob/defaf4bf2b85a011f977dfa23b14312500875555/tasks/transform_conformance/update_fixtures.js) script updates Babel test fixtures in place for class properties transform.

When we update submodules, we want to re-run amending the fixtures, starting afresh from the updated Babel submodule.

`git reset --hard` already gets rid of any changes that `update_fixtures.js` had made to existing files, but it doesn't remove new files the script had created. This PR adds `git clean` to the `just` script to completely reset the submodule to fresh cloned state before `update_fixtures.js` runs again.