### PR TITLE
refactor(transformer/class-properties): rename `class_binding`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -342,13 +342,13 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         if private_props.is_empty() {
             self.private_props_stack.push(None);
         } else {
-            let class_name_binding = match &self.class_name {
+            let class_binding = match &self.class_name {
                 ClassName::Binding(binding) => Some(binding.clone()),
                 ClassName::Name(_) => None,
             };
             self.private_props_stack.push(Some(PrivateProps {
                 props: private_props,
-                class_name_binding,
+                class_binding,
                 is_declaration: self.is_declaration,
             }));
         }
@@ -460,11 +460,11 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             self.insert_private_static_init_assignment(ident, value, ctx);
         } else {
             // Convert to assignment or `_defineProperty` call, depending on `loose` option
-            let ClassName::Binding(class_name_binding) = &self.class_name else {
+            let ClassName::Binding(class_binding) = &self.class_name else {
                 // Binding is initialized in 1st pass in `transform_class` when a static prop is found
                 unreachable!();
             };
-            let assignee = class_name_binding.create_read_expression(ctx);
+            let assignee = class_binding.create_read_expression(ctx);
             let init_expr = self.create_init_assignment(prop, value, assignee, true, ctx);
             self.insert_expr_after_class(init_expr, ctx);
         }

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -227,8 +227,8 @@ struct PrivateProps<'a> {
     /// Private properties for class. Indexed by property name.
     // TODO(improve-on-babel): Order that temp vars are created in is not important. Use `FxHashMap` instead.
     props: FxIndexMap<Atom<'a>, PrivateProp<'a>>,
-    /// Binding for class name
-    class_name_binding: Option<BoundIdentifier<'a>>,
+    /// Binding for class, if class has name
+    class_binding: Option<BoundIdentifier<'a>>,
     /// `true` for class declaration, `false` for class expression
     is_declaration: bool,
 }


### PR DESCRIPTION
Pure refactor. Just rename a variable. `class_binding` is preferable, since this binding isn't always for the class *name*.