### PR TITLE
chore: Rust v1.83.0 changes

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -33,7 +33,7 @@ pub trait GetAddress {
     fn address(&self) -> Address;
 }
 
-impl<'a, T> GetAddress for Box<'a, T> {
+impl<T> GetAddress for Box<'_, T> {
     /// Get the memory address of a value allocated in the arena.
     ///
     /// AST nodes in a `Box` in an arena are guaranteed to never move in memory,

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -28,7 +28,7 @@ use crate::Allocator;
 /// being called to guarantee soundness.
 pub struct Box<'alloc, T: ?Sized>(NonNull<T>, PhantomData<(&'alloc (), T)>);
 
-impl<'alloc, T> Box<'alloc, T> {
+impl<T> Box<'_, T> {
     /// Take ownership of the value stored in this [`Box`], consuming the box in
     /// the process.
     ///
@@ -56,7 +56,7 @@ impl<'alloc, T> Box<'alloc, T> {
     }
 }
 
-impl<'alloc, T> Box<'alloc, T> {
+impl<T> Box<'_, T> {
     /// Put a `value` into a memory arena and get back a [`Box`] with ownership
     /// to the allocation.
     ///
@@ -82,7 +82,7 @@ impl<'alloc, T> Box<'alloc, T> {
     }
 }
 
-impl<'alloc, T: ?Sized> Box<'alloc, T> {
+impl<T: ?Sized> Box<'_, T> {
     /// Create a [`Box`] from a raw pointer to a value.
     ///
     /// The [`Box`] takes ownership of the data pointed to by `ptr`.
@@ -108,7 +108,7 @@ impl<'alloc, T: ?Sized> Box<'alloc, T> {
     }
 }
 
-impl<'alloc, T: ?Sized> ops::Deref for Box<'alloc, T> {
+impl<T: ?Sized> ops::Deref for Box<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -117,26 +117,26 @@ impl<'alloc, T: ?Sized> ops::Deref for Box<'alloc, T> {
     }
 }
 
-impl<'alloc, T: ?Sized> ops::DerefMut for Box<'alloc, T> {
+impl<T: ?Sized> ops::DerefMut for Box<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         // SAFETY: self.0 is always a unique reference allocated from a Bump in Box::new_in
         unsafe { self.0.as_mut() }
     }
 }
 
-impl<'alloc, T: ?Sized> AsRef<T> for Box<'alloc, T> {
+impl<T: ?Sized> AsRef<T> for Box<'_, T> {
     fn as_ref(&self) -> &T {
         self
     }
 }
 
-impl<'alloc, T: ?Sized> AsMut<T> for Box<'alloc, T> {
+impl<T: ?Sized> AsMut<T> for Box<'_, T> {
     fn as_mut(&mut self) -> &mut T {
         self
     }
 }
 
-impl<'alloc, T: ?Sized + Debug> Debug for Box<'alloc, T> {
+impl<T: ?Sized + Debug> Debug for Box<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.deref().fmt(f)
     }
@@ -153,7 +153,7 @@ impl<'alloc, T: ?Sized + Debug> Debug for Box<'alloc, T> {
 // }
 
 #[cfg(any(feature = "serialize", test))]
-impl<'alloc, T> Serialize for Box<'alloc, T>
+impl<T> Serialize for Box<'_, T>
 where
     T: Serialize,
 {
@@ -165,7 +165,7 @@ where
     }
 }
 
-impl<'alloc, T: Hash> Hash for Box<'alloc, T> {
+impl<T: Hash> Hash for Box<'_, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.deref().hash(state);
     }

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -41,7 +41,7 @@ where
     }
 }
 
-impl<'old_alloc, 'new_alloc, T, C> CloneIn<'new_alloc> for Box<'old_alloc, T>
+impl<'new_alloc, T, C> CloneIn<'new_alloc> for Box<'_, T>
 where
     T: CloneIn<'new_alloc, Cloned = C>,
 {
@@ -52,7 +52,7 @@ where
     }
 }
 
-impl<'old_alloc, 'new_alloc, T, C> CloneIn<'new_alloc> for Vec<'old_alloc, T>
+impl<'new_alloc, T, C> CloneIn<'new_alloc> for Vec<'_, T>
 where
     T: CloneIn<'new_alloc, Cloned = C>,
 {
@@ -71,7 +71,7 @@ impl<'alloc, T: Copy> CloneIn<'alloc> for Cell<T> {
     }
 }
 
-impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for &'old_alloc str {
+impl<'new_alloc> CloneIn<'new_alloc> for &str {
     type Cloned = &'new_alloc str;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -215,7 +215,7 @@ impl<'alloc, T> IntoIterator for &'alloc Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T> ops::Index<usize> for Vec<'alloc, T> {
+impl<T> ops::Index<usize> for Vec<'_, T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -223,14 +223,14 @@ impl<'alloc, T> ops::Index<usize> for Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T> ops::IndexMut<usize> for Vec<'alloc, T> {
+impl<T> ops::IndexMut<usize> for Vec<'_, T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.0.index_mut(index)
     }
 }
 
 #[cfg(any(feature = "serialize", test))]
-impl<'alloc, T> Serialize for Vec<'alloc, T>
+impl<T> Serialize for Vec<'_, T>
 where
     T: Serialize,
 {
@@ -246,7 +246,7 @@ where
     }
 }
 
-impl<'alloc, T: Hash> Hash for Vec<'alloc, T> {
+impl<T: Hash> Hash for Vec<'_, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for e in self.0.iter() {
             e.hash(state);
@@ -254,7 +254,7 @@ impl<'alloc, T: Hash> Hash for Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T: Debug> Debug for Vec<'alloc, T> {
+impl<T: Debug> Debug for Vec<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let inner = &*self.0;
         f.debug_tuple("Vec").field(inner).finish()

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -8,7 +8,7 @@ use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags, symbol::SymbolId};
 
 use crate::ast::*;
 
-impl<'a> Program<'a> {
+impl Program<'_> {
     /// Returns `true` if this program has no statements or directives.
     pub fn is_empty(&self) -> bool {
         self.body.is_empty() && self.directives.is_empty()
@@ -284,34 +284,34 @@ impl<'a> Expression<'a> {
     }
 }
 
-impl<'a> fmt::Display for IdentifierName<'a> {
+impl fmt::Display for IdentifierName<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl<'a> fmt::Display for IdentifierReference<'a> {
+impl fmt::Display for IdentifierReference<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl<'a> fmt::Display for BindingIdentifier<'a> {
+impl fmt::Display for BindingIdentifier<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl<'a> ArrayExpressionElement<'a> {
+impl ArrayExpressionElement<'_> {
     #[allow(missing_docs)]
     pub fn is_elision(&self) -> bool {
         matches!(self, Self::Elision(_))
     }
 }
 
-impl<'a> ObjectPropertyKind<'a> {
+impl ObjectPropertyKind<'_> {
     /// Returns `true` if this object property is a [spread](SpreadElement).
     #[inline]
     pub fn is_spread(&self) -> bool {
@@ -544,7 +544,7 @@ impl<'a> ChainElement<'a> {
     }
 }
 
-impl<'a> CallExpression<'a> {
+impl CallExpression<'_> {
     #[allow(missing_docs)]
     pub fn callee_name(&self) -> Option<&str> {
         match &self.callee {
@@ -684,7 +684,7 @@ impl<'a> ObjectAssignmentTarget<'a> {
     }
 }
 
-impl<'a> AssignmentTargetMaybeDefault<'a> {
+impl AssignmentTargetMaybeDefault<'_> {
     #[allow(missing_docs)]
     pub fn name(&self) -> Option<Atom> {
         match self {
@@ -701,7 +701,7 @@ impl<'a> AssignmentTargetMaybeDefault<'a> {
     }
 }
 
-impl<'a> Statement<'a> {
+impl Statement<'_> {
     #[allow(missing_docs)]
     pub fn is_typescript_syntax(&self) -> bool {
         match self {
@@ -737,7 +737,7 @@ impl<'a> FromIn<'a, Expression<'a>> for Statement<'a> {
     }
 }
 
-impl<'a> Directive<'a> {
+impl Directive<'_> {
     /// A Use Strict Directive is an ExpressionStatement in a Directive Prologue whose StringLiteral is either of the exact code point sequences "use strict" or 'use strict'.
     /// A Use Strict Directive may not contain an EscapeSequence or LineContinuation.
     /// <https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive>
@@ -791,7 +791,7 @@ impl<'a> Declaration<'a> {
     }
 }
 
-impl<'a> VariableDeclaration<'a> {
+impl VariableDeclaration<'_> {
     #[allow(missing_docs)]
     pub fn is_typescript_syntax(&self) -> bool {
         self.declare
@@ -843,7 +843,7 @@ impl fmt::Display for VariableDeclarationKind {
     }
 }
 
-impl<'a> ForStatementInit<'a> {
+impl ForStatementInit<'_> {
     /// LexicalDeclaration[In, Yield, Await] :
     ///   LetOrConst BindingList[?In, ?Yield, ?Await] ;
     pub fn is_lexical_declaration(&self) -> bool {
@@ -851,7 +851,7 @@ impl<'a> ForStatementInit<'a> {
     }
 }
 
-impl<'a> ForStatementLeft<'a> {
+impl ForStatementLeft<'_> {
     /// LexicalDeclaration[In, Yield, Await] :
     ///   LetOrConst BindingList[?In, ?Yield, ?Await] ;
     pub fn is_lexical_declaration(&self) -> bool {
@@ -859,7 +859,7 @@ impl<'a> ForStatementLeft<'a> {
     }
 }
 
-impl<'a> SwitchCase<'a> {
+impl SwitchCase<'_> {
     /// `true` for `default:` cases.
     pub fn is_default_case(&self) -> bool {
         self.test.is_none()
@@ -927,7 +927,7 @@ impl<'a> BindingPatternKind<'a> {
     }
 }
 
-impl<'a> ObjectPattern<'a> {
+impl ObjectPattern<'_> {
     /// `true` for empty object patterns (`{}`).
     pub fn is_empty(&self) -> bool {
         self.properties.is_empty() && self.rest.is_none()
@@ -939,7 +939,7 @@ impl<'a> ObjectPattern<'a> {
     }
 }
 
-impl<'a> ArrayPattern<'a> {
+impl ArrayPattern<'_> {
     /// `true` for empty array patterns (`[]`).
     pub fn is_empty(&self) -> bool {
         self.elements.is_empty() && self.rest.is_none()
@@ -1016,7 +1016,7 @@ impl<'a> FormalParameters<'a> {
     }
 }
 
-impl<'a> FormalParameter<'a> {
+impl FormalParameter<'_> {
     /// `true` if a `public` accessibility modifier is present. Use
     /// [`has_modifier`](FormalParameter::has_modifier) if you want to check for
     /// _any_ modifier, including `readonly` and `override`.
@@ -1060,7 +1060,7 @@ impl FormalParameterKind {
     }
 }
 
-impl<'a> FormalParameters<'a> {
+impl FormalParameters<'_> {
     /// `true` if no parameters are bound.
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
@@ -1072,7 +1072,7 @@ impl<'a> FormalParameters<'a> {
     }
 }
 
-impl<'a> FunctionBody<'a> {
+impl FunctionBody<'_> {
     /// `true` if this function body contains no statements or directives.
     pub fn is_empty(&self) -> bool {
         self.directives.is_empty() && self.statements.is_empty()
@@ -1097,7 +1097,7 @@ impl<'a> ArrowFunctionExpression<'a> {
     }
 }
 
-impl<'a> Class<'a> {
+impl Class<'_> {
     /// `true` if this [`Class`] is an expression.
     ///
     /// For example,
@@ -1412,7 +1412,7 @@ impl<'a> ImportAttributeKey<'a> {
     }
 }
 
-impl<'a> ExportNamedDeclaration<'a> {
+impl ExportNamedDeclaration<'_> {
     #[allow(missing_docs)]
     pub fn is_typescript_syntax(&self) -> bool {
         self.export_kind == ImportOrExportKind::Type
@@ -1420,21 +1420,21 @@ impl<'a> ExportNamedDeclaration<'a> {
     }
 }
 
-impl<'a> ExportDefaultDeclaration<'a> {
+impl ExportDefaultDeclaration<'_> {
     #[allow(missing_docs)]
     pub fn is_typescript_syntax(&self) -> bool {
         self.declaration.is_typescript_syntax()
     }
 }
 
-impl<'a> ExportAllDeclaration<'a> {
+impl ExportAllDeclaration<'_> {
     #[allow(missing_docs)]
     pub fn is_typescript_syntax(&self) -> bool {
         self.export_kind.is_type()
     }
 }
 
-impl<'a> ExportDefaultDeclarationKind<'a> {
+impl ExportDefaultDeclarationKind<'_> {
     #[allow(missing_docs)]
     #[inline]
     pub fn is_typescript_syntax(&self) -> bool {
@@ -1447,7 +1447,7 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     }
 }
 
-impl<'a> fmt::Display for ModuleExportName<'a> {
+impl fmt::Display for ModuleExportName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             Self::IdentifierName(identifier) => identifier.name.to_string(),

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -7,14 +7,14 @@ use crate::ast::*;
 
 // 1.2 JSX Elements
 
-impl<'a> fmt::Display for JSXIdentifier<'a> {
+impl fmt::Display for JSXIdentifier<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl<'a> fmt::Display for JSXNamespacedName<'a> {
+impl fmt::Display for JSXNamespacedName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.namespace.name, self.property.name)
     }
@@ -70,13 +70,13 @@ impl<'a> JSXMemberExpressionObject<'a> {
     }
 }
 
-impl<'a> fmt::Display for JSXMemberExpression<'a> {
+impl fmt::Display for JSXMemberExpression<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.object, self.property)
     }
 }
 
-impl<'a> fmt::Display for JSXMemberExpressionObject<'a> {
+impl fmt::Display for JSXMemberExpressionObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::IdentifierReference(id) => id.fmt(f),
@@ -86,7 +86,7 @@ impl<'a> fmt::Display for JSXMemberExpressionObject<'a> {
     }
 }
 
-impl<'a> fmt::Display for JSXElementName<'a> {
+impl fmt::Display for JSXElementName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Identifier(ident) => ident.fmt(f),
@@ -98,14 +98,14 @@ impl<'a> fmt::Display for JSXElementName<'a> {
     }
 }
 
-impl<'a> JSXExpression<'a> {
+impl JSXExpression<'_> {
     /// Determines whether the given expr is a `undefined` literal
     pub fn is_undefined(&self) -> bool {
         matches!(self, Self::Identifier(ident) if ident.name == "undefined")
     }
 }
 
-impl<'a> JSXAttribute<'a> {
+impl JSXAttribute<'_> {
     /// Returns `true` if this attribute's name is the expected `name`.
     ///
     /// Use [`JSXAttribute::is_identifier_ignore_case`] if you want to ignore
@@ -192,7 +192,7 @@ impl<'a> JSXAttributeItem<'a> {
     }
 }
 
-impl<'a> JSXChild<'a> {
+impl JSXChild<'_> {
     /// Returns `true` if this an [expression container](JSXChild::ExpressionContainer).
     pub const fn is_expression_container(&self) -> bool {
         matches!(self, Self::ExpressionContainer(_))

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -44,7 +44,7 @@ impl fmt::Display for NullLiteral {
     }
 }
 
-impl<'a> NumericLiteral<'a> {
+impl NumericLiteral<'_> {
     /// port from [closure compiler](https://github.com/google/closure-compiler/blob/a4c880032fba961f7a6c06ef99daa3641810bfdd/src/com/google/javascript/jscomp/base/JSCompDoubles.java#L113)
     ///
     /// <https://262.ecma-international.org/5.1/#sec-9.5>
@@ -73,33 +73,33 @@ impl<'a> NumericLiteral<'a> {
     }
 }
 
-impl<'a> ContentHash for NumericLiteral<'a> {
+impl ContentHash for NumericLiteral<'_> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(&self.base, state);
         ContentHash::content_hash(&self.raw, state);
     }
 }
 
-impl<'a> fmt::Display for NumericLiteral<'a> {
+impl fmt::Display for NumericLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.raw.fmt(f)
     }
 }
 
-impl<'a> BigIntLiteral<'a> {
+impl BigIntLiteral<'_> {
     /// Is this BigInt literal zero? (`0n`).
     pub fn is_zero(&self) -> bool {
         self.raw == "0n"
     }
 }
 
-impl<'a> fmt::Display for BigIntLiteral<'a> {
+impl fmt::Display for BigIntLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.raw.fmt(f)
     }
 }
 
-impl<'a> fmt::Display for RegExp<'a> {
+impl fmt::Display for RegExp<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "/{}/{}", self.pattern, self.flags)
     }
@@ -154,7 +154,7 @@ impl<'a> RegExpPattern<'a> {
     }
 }
 
-impl<'a> fmt::Display for RegExpPattern<'a> {
+impl fmt::Display for RegExpPattern<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Raw(it) | Self::Invalid(it) => write!(f, "{it}"),
@@ -249,7 +249,7 @@ impl fmt::Display for RegExpFlags {
     }
 }
 
-impl<'a> StringLiteral<'a> {
+impl StringLiteral<'_> {
     /// Static Semantics: `IsStringWellFormedUnicode`
     /// test for \uD800-\uDFFF
     ///
@@ -270,14 +270,14 @@ impl<'a> StringLiteral<'a> {
     }
 }
 
-impl<'a> AsRef<str> for StringLiteral<'a> {
+impl AsRef<str> for StringLiteral<'_> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.value.as_ref()
     }
 }
 
-impl<'a> fmt::Display for StringLiteral<'a> {
+impl fmt::Display for StringLiteral<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -116,7 +116,7 @@ impl<'a> TSTypeName<'a> {
     }
 }
 
-impl<'a> fmt::Display for TSTypeName<'a> {
+impl fmt::Display for TSTypeName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TSTypeName::IdentifierReference(ident) => ident.fmt(f),
@@ -125,13 +125,13 @@ impl<'a> fmt::Display for TSTypeName<'a> {
     }
 }
 
-impl<'a> fmt::Display for TSQualifiedName<'a> {
+impl fmt::Display for TSQualifiedName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.left, self.right)
     }
 }
 
-impl<'a> TSType<'a> {
+impl TSType<'_> {
     /// Remove nested parentheses from this type.
     pub fn without_parenthesized(&self) -> &Self {
         match self {
@@ -170,7 +170,7 @@ impl fmt::Display for TSAccessibility {
     }
 }
 
-impl<'a> TSModuleDeclaration<'a> {
+impl TSModuleDeclaration<'_> {
     /// Returns `true` if this module's body exists and uses strict mode
     /// semantics (as determined by [`TSModuleDeclarationBody::is_strict`]).
     pub fn is_strict(&self) -> bool {
@@ -223,7 +223,7 @@ impl<'a> TSModuleDeclarationName<'a> {
     }
 }
 
-impl<'a> fmt::Display for TSModuleDeclarationName<'a> {
+impl fmt::Display for TSModuleDeclarationName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Identifier(id) => id.fmt(f),
@@ -258,14 +258,14 @@ impl<'a> TSModuleDeclarationBody<'a> {
     }
 }
 
-impl<'a> TSModuleBlock<'a> {
+impl TSModuleBlock<'_> {
     /// Returns `true` if this module contains a `"use strict"` directive.
     pub fn is_strict(&self) -> bool {
         self.directives.iter().any(Directive::is_use_strict)
     }
 }
 
-impl<'a> TSModuleReference<'a> {
+impl TSModuleReference<'_> {
     /// Returns `true` if this is an [`TSModuleReference::ExternalModuleReference`].
     pub fn is_external(&self) -> bool {
         matches!(self, Self::ExternalModuleReference(_))

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -171,7 +171,7 @@ impl<'a> AstKind<'a> {
     }
 }
 
-impl<'a> AstKind<'a> {
+impl AstKind<'_> {
     #[allow(clippy::match_same_arms)]
     /// Get the AST kind name with minimal details. Particularly useful for
     /// when debugging an iteration over an AST.

--- a/crates/oxc_ast/src/precedence.rs
+++ b/crates/oxc_ast/src/precedence.rs
@@ -9,7 +9,7 @@ use crate::ast::{
     YieldExpression,
 };
 
-impl<'a> GetPrecedence for Expression<'a> {
+impl GetPrecedence for Expression<'_> {
     fn precedence(&self) -> Precedence {
         match self {
             Self::SequenceExpression(expr) => expr.precedence(),
@@ -29,55 +29,55 @@ impl<'a> GetPrecedence for Expression<'a> {
     }
 }
 
-impl<'a> GetPrecedence for SequenceExpression<'a> {
+impl GetPrecedence for SequenceExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Comma
     }
 }
 
-impl<'a> GetPrecedence for YieldExpression<'a> {
+impl GetPrecedence for YieldExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Yield
     }
 }
 
-impl<'a> GetPrecedence for ConditionalExpression<'a> {
+impl GetPrecedence for ConditionalExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Conditional
     }
 }
 
-impl<'a> GetPrecedence for AssignmentExpression<'a> {
+impl GetPrecedence for AssignmentExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Assign
     }
 }
 
-impl<'a> GetPrecedence for LogicalExpression<'a> {
+impl GetPrecedence for LogicalExpression<'_> {
     fn precedence(&self) -> Precedence {
         self.operator.precedence()
     }
 }
 
-impl<'a> GetPrecedence for BinaryExpression<'a> {
+impl GetPrecedence for BinaryExpression<'_> {
     fn precedence(&self) -> Precedence {
         self.operator.precedence()
     }
 }
 
-impl<'a> GetPrecedence for UnaryExpression<'a> {
+impl GetPrecedence for UnaryExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Prefix
     }
 }
 
-impl<'a> GetPrecedence for AwaitExpression<'a> {
+impl GetPrecedence for AwaitExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Prefix
     }
 }
 
-impl<'a> GetPrecedence for UpdateExpression<'a> {
+impl GetPrecedence for UpdateExpression<'_> {
     fn precedence(&self) -> Precedence {
         if self.prefix {
             Precedence::Prefix
@@ -87,55 +87,55 @@ impl<'a> GetPrecedence for UpdateExpression<'a> {
     }
 }
 
-impl<'a> GetPrecedence for CallExpression<'a> {
+impl GetPrecedence for CallExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Call
     }
 }
 
-impl<'a> GetPrecedence for ImportExpression<'a> {
+impl GetPrecedence for ImportExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Call
     }
 }
 
-impl<'a> GetPrecedence for NewExpression<'a> {
+impl GetPrecedence for NewExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Call
     }
 }
 
-impl<'a> GetPrecedence for ChainExpression<'a> {
+impl GetPrecedence for ChainExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Member
     }
 }
 
-impl<'a> GetPrecedence for MemberExpression<'a> {
+impl GetPrecedence for MemberExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Member
     }
 }
 
-impl<'a> GetPrecedence for ComputedMemberExpression<'a> {
+impl GetPrecedence for ComputedMemberExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Member
     }
 }
 
-impl<'a> GetPrecedence for StaticMemberExpression<'a> {
+impl GetPrecedence for StaticMemberExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Member
     }
 }
 
-impl<'a> GetPrecedence for PrivateFieldExpression<'a> {
+impl GetPrecedence for PrivateFieldExpression<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Member
     }
 }
 
-impl<'a> GetPrecedence for TSTypeAssertion<'a> {
+impl GetPrecedence for TSTypeAssertion<'_> {
     fn precedence(&self) -> Precedence {
         Precedence::Lowest
     }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -79,7 +79,7 @@ impl<'c> Iterator for CommentsRange<'c> {
     }
 }
 
-impl<'c> DoubleEndedIterator for CommentsRange<'c> {
+impl DoubleEndedIterator for CommentsRange<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.current_start < self.current_end {
             for comment in self.comments[self.current_start..self.current_end].iter().rev() {

--- a/crates/oxc_cfg/src/builder/context.rs
+++ b/crates/oxc_cfg/src/builder/context.rs
@@ -52,7 +52,7 @@ pub trait CtxCursor {
 
 pub struct QueryCtx<'a, 'c>(&'c mut ControlFlowGraphBuilder<'a>, /* label */ Option<&'a str>);
 
-impl<'a, 'c> CtxCursor for QueryCtx<'a, 'c> {
+impl CtxCursor for QueryCtx<'_, '_> {
     fn mark_break(self, jmp_pos: BlockNodeId) -> Self {
         self.0.in_break_context(self.1, |ctx| {
             debug_assert!(ctx.break_jmp.is_none());
@@ -177,7 +177,7 @@ impl<'a, 'c> QueryCtx<'a, 'c> {
 
 pub struct RefCtxCursor<'a, 'c>(&'c mut Ctx<'a>);
 
-impl<'a, 'c> RefCtxCursor<'a, 'c> {
+impl RefCtxCursor<'_, '_> {
     /// Allow break entries in this context.
     pub fn allow_break(self) -> Self {
         self.0.flags.insert(CtxFlags::BREAK);
@@ -191,7 +191,7 @@ impl<'a, 'c> RefCtxCursor<'a, 'c> {
     }
 }
 
-impl<'a, 'c> CtxCursor for RefCtxCursor<'a, 'c> {
+impl CtxCursor for RefCtxCursor<'_, '_> {
     fn mark_break(self, jmp_pos: BlockNodeId) -> Self {
         debug_assert!(self.0.break_jmp.is_none());
         self.0.break_jmp = Some(jmp_pos);

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -7,7 +7,7 @@ use crate::{Codegen, LegalComment};
 
 pub(crate) type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
 
-impl<'a> Codegen<'a> {
+impl Codegen<'_> {
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
         for comment in comments {
             self.comments.entry(comment.attached_to).or_default().push(*comment);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -36,7 +36,7 @@ pub trait GenExpr: GetSpan {
     }
 }
 
-impl<'a> Gen for Program<'a> {
+impl Gen for Program<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if let Some(hashbang) = &self.hashbang {
             hashbang.print(p, ctx);
@@ -53,7 +53,7 @@ impl<'a> Gen for Program<'a> {
     }
 }
 
-impl<'a> Gen for Hashbang<'a> {
+impl Gen for Hashbang<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_str("#!");
         p.print_str(self.value.as_str());
@@ -61,7 +61,7 @@ impl<'a> Gen for Hashbang<'a> {
     }
 }
 
-impl<'a> Gen for Directive<'a> {
+impl Gen for Directive<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -76,7 +76,7 @@ impl<'a> Gen for Directive<'a> {
     }
 }
 
-impl<'a> Gen for Statement<'a> {
+impl Gen for Statement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_statement_comments(self.span().start);
         match self {
@@ -150,7 +150,7 @@ impl<'a> Gen for Statement<'a> {
     }
 }
 
-impl<'a> Gen for ExpressionStatement<'a> {
+impl Gen for ExpressionStatement<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -164,7 +164,7 @@ impl<'a> Gen for ExpressionStatement<'a> {
     }
 }
 
-impl<'a> Gen for IfStatement<'a> {
+impl Gen for IfStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -245,7 +245,7 @@ fn wrap_to_avoid_ambiguous_else(stmt: &Statement) -> bool {
     }
 }
 
-impl<'a> Gen for BlockStatement<'a> {
+impl Gen for BlockStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
         p.print_block_statement(self, ctx);
@@ -253,7 +253,7 @@ impl<'a> Gen for BlockStatement<'a> {
     }
 }
 
-impl<'a> Gen for ForStatement<'a> {
+impl Gen for ForStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -284,7 +284,7 @@ impl<'a> Gen for ForStatement<'a> {
     }
 }
 
-impl<'a> Gen for ForInStatement<'a> {
+impl Gen for ForInStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -302,7 +302,7 @@ impl<'a> Gen for ForInStatement<'a> {
     }
 }
 
-impl<'a> Gen for ForOfStatement<'a> {
+impl Gen for ForOfStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -322,7 +322,7 @@ impl<'a> Gen for ForOfStatement<'a> {
     }
 }
 
-impl<'a> Gen for ForStatementInit<'a> {
+impl Gen for ForStatementInit<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_expression!(ForStatementInit) => {
@@ -333,7 +333,7 @@ impl<'a> Gen for ForStatementInit<'a> {
     }
 }
 
-impl<'a> Gen for ForStatementLeft<'a> {
+impl Gen for ForStatementLeft<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             ForStatementLeft::VariableDeclaration(var) => var.print(p, ctx),
@@ -348,7 +348,7 @@ impl<'a> Gen for ForStatementLeft<'a> {
     }
 }
 
-impl<'a> Gen for WhileStatement<'a> {
+impl Gen for WhileStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -361,7 +361,7 @@ impl<'a> Gen for WhileStatement<'a> {
     }
 }
 
-impl<'a> Gen for DoWhileStatement<'a> {
+impl Gen for DoWhileStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -395,7 +395,7 @@ impl Gen for EmptyStatement {
     }
 }
 
-impl<'a> Gen for ContinueStatement<'a> {
+impl Gen for ContinueStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -408,7 +408,7 @@ impl<'a> Gen for ContinueStatement<'a> {
     }
 }
 
-impl<'a> Gen for BreakStatement<'a> {
+impl Gen for BreakStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -421,7 +421,7 @@ impl<'a> Gen for BreakStatement<'a> {
     }
 }
 
-impl<'a> Gen for SwitchStatement<'a> {
+impl Gen for SwitchStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -442,7 +442,7 @@ impl<'a> Gen for SwitchStatement<'a> {
     }
 }
 
-impl<'a> Gen for SwitchCase<'a> {
+impl Gen for SwitchCase<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_semicolon_if_needed();
         p.print_indent();
@@ -470,7 +470,7 @@ impl<'a> Gen for SwitchCase<'a> {
     }
 }
 
-impl<'a> Gen for ReturnStatement<'a> {
+impl Gen for ReturnStatement<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -484,7 +484,7 @@ impl<'a> Gen for ReturnStatement<'a> {
     }
 }
 
-impl<'a> Gen for LabeledStatement<'a> {
+impl Gen for LabeledStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if !p.options.minify && (p.indent > 0 || p.print_next_indent_as_space) {
             p.add_source_mapping(self.span);
@@ -497,7 +497,7 @@ impl<'a> Gen for LabeledStatement<'a> {
     }
 }
 
-impl<'a> Gen for TryStatement<'a> {
+impl Gen for TryStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -527,7 +527,7 @@ impl<'a> Gen for TryStatement<'a> {
     }
 }
 
-impl<'a> Gen for ThrowStatement<'a> {
+impl Gen for ThrowStatement<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -537,7 +537,7 @@ impl<'a> Gen for ThrowStatement<'a> {
     }
 }
 
-impl<'a> Gen for WithStatement<'a> {
+impl Gen for WithStatement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -558,7 +558,7 @@ impl Gen for DebuggerStatement {
     }
 }
 
-impl<'a> Gen for VariableDeclaration<'a> {
+impl Gen for VariableDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         if self.declare {
@@ -588,7 +588,7 @@ impl<'a> Gen for VariableDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for VariableDeclarator<'a> {
+impl Gen for VariableDeclarator<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.id.kind.print(p, ctx);
         if self.definite {
@@ -612,7 +612,7 @@ impl<'a> Gen for VariableDeclarator<'a> {
     }
 }
 
-impl<'a> Gen for Function<'a> {
+impl Gen for Function<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let n = p.code_len();
         let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
@@ -662,7 +662,7 @@ impl<'a> Gen for Function<'a> {
     }
 }
 
-impl<'a> Gen for FunctionBody<'a> {
+impl Gen for FunctionBody<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let span_end = self.span.end;
         let comments_at_end = if !p.options.minify && span_end > 0 {
@@ -692,7 +692,7 @@ impl<'a> Gen for FunctionBody<'a> {
     }
 }
 
-impl<'a> Gen for FormalParameter<'a> {
+impl Gen for FormalParameter<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         for decorator in &self.decorators {
             decorator.print(p, ctx);
@@ -709,7 +709,7 @@ impl<'a> Gen for FormalParameter<'a> {
     }
 }
 
-impl<'a> Gen for FormalParameters<'a> {
+impl Gen for FormalParameters<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_list(&self.items, ctx);
         if let Some(rest) = &self.rest {
@@ -722,7 +722,7 @@ impl<'a> Gen for FormalParameters<'a> {
     }
 }
 
-impl<'a> Gen for ImportDeclaration<'a> {
+impl Gen for ImportDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -817,7 +817,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for WithClause<'a> {
+impl Gen for WithClause<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         self.attributes_keyword.print(p, ctx);
@@ -828,7 +828,7 @@ impl<'a> Gen for WithClause<'a> {
     }
 }
 
-impl<'a> Gen for ImportAttribute<'a> {
+impl Gen for ImportAttribute<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match &self.key {
             ImportAttributeKey::Identifier(identifier) => {
@@ -842,7 +842,7 @@ impl<'a> Gen for ImportAttribute<'a> {
     }
 }
 
-impl<'a> Gen for ExportNamedDeclaration<'a> {
+impl Gen for ExportNamedDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -909,7 +909,7 @@ impl<'a> Gen for ExportNamedDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSExportAssignment<'a> {
+impl Gen for TSExportAssignment<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
         p.print_str("export = ");
@@ -918,7 +918,7 @@ impl<'a> Gen for TSExportAssignment<'a> {
     }
 }
 
-impl<'a> Gen for TSNamespaceExportDeclaration<'a> {
+impl Gen for TSNamespaceExportDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
         p.print_str("export as namespace ");
@@ -940,7 +940,7 @@ fn get_module_export_name<'a>(
     }
 }
 
-impl<'a> Gen for ExportSpecifier<'a> {
+impl Gen for ExportSpecifier<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.export_kind.is_type() {
             p.print_str("type ");
@@ -955,7 +955,7 @@ impl<'a> Gen for ExportSpecifier<'a> {
     }
 }
 
-impl<'a> Gen for ModuleExportName<'a> {
+impl Gen for ModuleExportName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::IdentifierName(ident) => ident.print(p, ctx),
@@ -965,7 +965,7 @@ impl<'a> Gen for ModuleExportName<'a> {
     }
 }
 
-impl<'a> Gen for ExportAllDeclaration<'a> {
+impl Gen for ExportAllDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -990,7 +990,7 @@ impl<'a> Gen for ExportAllDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for ExportDefaultDeclaration<'a> {
+impl Gen for ExportDefaultDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_indent();
@@ -998,7 +998,7 @@ impl<'a> Gen for ExportDefaultDeclaration<'a> {
         self.declaration.print(p, ctx);
     }
 }
-impl<'a> Gen for ExportDefaultDeclarationKind<'a> {
+impl Gen for ExportDefaultDeclarationKind<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_expression!(Self) => {
@@ -1019,7 +1019,7 @@ impl<'a> Gen for ExportDefaultDeclarationKind<'a> {
     }
 }
 
-impl<'a> GenExpr for Expression<'a> {
+impl GenExpr for Expression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         match self {
             Self::BooleanLiteral(lit) => lit.print(p, ctx),
@@ -1068,13 +1068,13 @@ impl<'a> GenExpr for Expression<'a> {
     }
 }
 
-impl<'a> GenExpr for ParenthesizedExpression<'a> {
+impl GenExpr for ParenthesizedExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         self.expression.print_expr(p, precedence, ctx);
     }
 }
 
-impl<'a> Gen for IdentifierReference<'a> {
+impl Gen for IdentifierReference<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         let name = p.get_identifier_reference_name(self);
         p.print_space_before_identifier();
@@ -1083,14 +1083,14 @@ impl<'a> Gen for IdentifierReference<'a> {
     }
 }
 
-impl<'a> Gen for IdentifierName<'a> {
+impl Gen for IdentifierName<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_str(self.name.as_str());
     }
 }
 
-impl<'a> Gen for BindingIdentifier<'a> {
+impl Gen for BindingIdentifier<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         let name = p.get_binding_identifier_name(self);
         p.add_source_mapping_for_name(self.span, name);
@@ -1098,7 +1098,7 @@ impl<'a> Gen for BindingIdentifier<'a> {
     }
 }
 
-impl<'a> Gen for LabelIdentifier<'a> {
+impl Gen for LabelIdentifier<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping_for_name(self.span, &self.name);
         p.print_str(self.name.as_str());
@@ -1121,7 +1121,7 @@ impl Gen for NullLiteral {
     }
 }
 
-impl<'a> GenExpr for NumericLiteral<'a> {
+impl GenExpr for NumericLiteral<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.add_source_mapping(self.span);
         let value = self.value;
@@ -1161,7 +1161,7 @@ impl<'a> GenExpr for NumericLiteral<'a> {
     }
 }
 
-impl<'a> Gen for BigIntLiteral<'a> {
+impl Gen for BigIntLiteral<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         let raw = self.raw.as_str().cow_replace('_', "");
         if raw.starts_with('-') {
@@ -1174,7 +1174,7 @@ impl<'a> Gen for BigIntLiteral<'a> {
     }
 }
 
-impl<'a> Gen for RegExpLiteral<'a> {
+impl Gen for RegExpLiteral<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         let last = p.last_byte();
@@ -1275,7 +1275,7 @@ fn print_unquoted_str(s: &str, quote: u8, p: &mut Codegen) {
     }
 }
 
-impl<'a> Gen for StringLiteral<'a> {
+impl Gen for StringLiteral<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         let s = self.value.as_str();
@@ -1293,7 +1293,7 @@ impl Gen for ThisExpression {
     }
 }
 
-impl<'a> GenExpr for MemberExpression<'a> {
+impl GenExpr for MemberExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         match self {
             Self::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
@@ -1303,7 +1303,7 @@ impl<'a> GenExpr for MemberExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for ComputedMemberExpression<'a> {
+impl GenExpr for ComputedMemberExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
         // `(let[0] = 100);` -> `(let)[0] = 100`;
         let wrap = self.object.get_identifier_reference().is_some_and(|r| r.name == "let");
@@ -1319,7 +1319,7 @@ impl<'a> GenExpr for ComputedMemberExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for StaticMemberExpression<'a> {
+impl GenExpr for StaticMemberExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
         self.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
         if self.optional {
@@ -1333,7 +1333,7 @@ impl<'a> GenExpr for StaticMemberExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for PrivateFieldExpression<'a> {
+impl GenExpr for PrivateFieldExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
         self.object.print_expr(p, Precedence::Prefix, ctx.intersection(Context::FORBID_CALL));
         if self.optional {
@@ -1344,7 +1344,7 @@ impl<'a> GenExpr for PrivateFieldExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for CallExpression<'a> {
+impl GenExpr for CallExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let is_export_default = p.start_of_default_export == p.code_len();
         let mut wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
@@ -1387,7 +1387,7 @@ impl<'a> GenExpr for CallExpression<'a> {
     }
 }
 
-impl<'a> Gen for Argument<'a> {
+impl Gen for Argument<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::SpreadElement(elem) => elem.print(p, ctx),
@@ -1398,7 +1398,7 @@ impl<'a> Gen for Argument<'a> {
     }
 }
 
-impl<'a> Gen for ArrayExpressionElement<'a> {
+impl Gen for ArrayExpressionElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_expression!(Self) => {
@@ -1410,7 +1410,7 @@ impl<'a> Gen for ArrayExpressionElement<'a> {
     }
 }
 
-impl<'a> Gen for SpreadElement<'a> {
+impl Gen for SpreadElement<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ellipsis();
@@ -1418,7 +1418,7 @@ impl<'a> Gen for SpreadElement<'a> {
     }
 }
 
-impl<'a> Gen for ArrayExpression<'a> {
+impl Gen for ArrayExpression<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.elements.len() > 2;
         p.add_source_mapping(self.span);
@@ -1451,7 +1451,7 @@ impl<'a> Gen for ArrayExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for ObjectExpression<'a> {
+impl GenExpr for ObjectExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
         let n = p.code_len();
         let len = self.properties.len();
@@ -1488,7 +1488,7 @@ impl<'a> GenExpr for ObjectExpression<'a> {
     }
 }
 
-impl<'a> Gen for ObjectPropertyKind<'a> {
+impl Gen for ObjectPropertyKind<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::ObjectProperty(prop) => prop.print(p, ctx),
@@ -1497,7 +1497,7 @@ impl<'a> Gen for ObjectPropertyKind<'a> {
     }
 }
 
-impl<'a> Gen for ObjectProperty<'a> {
+impl Gen for ObjectProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if let Expression::FunctionExpression(func) = &self.value {
             p.add_source_mapping(self.span);
@@ -1582,7 +1582,7 @@ impl<'a> Gen for ObjectProperty<'a> {
     }
 }
 
-impl<'a> Gen for PropertyKey<'a> {
+impl Gen for PropertyKey<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::StaticIdentifier(ident) => ident.print(p, ctx),
@@ -1594,7 +1594,7 @@ impl<'a> Gen for PropertyKey<'a> {
     }
 }
 
-impl<'a> GenExpr for ArrowFunctionExpression<'a> {
+impl GenExpr for ArrowFunctionExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= Precedence::Assign, |p| {
             p.print_annotation_comments(self.span.start);
@@ -1634,7 +1634,7 @@ impl<'a> GenExpr for ArrowFunctionExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for YieldExpression<'a> {
+impl GenExpr for YieldExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, _ctx: Context) {
         p.wrap(precedence >= Precedence::Assign, |p| {
             p.add_source_mapping(self.span);
@@ -1654,7 +1654,7 @@ impl<'a> GenExpr for YieldExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for UpdateExpression<'a> {
+impl GenExpr for UpdateExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let operator = self.operator.as_str();
         p.wrap(precedence >= self.precedence(), |p| {
@@ -1676,7 +1676,7 @@ impl<'a> GenExpr for UpdateExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for UnaryExpression<'a> {
+impl GenExpr for UnaryExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
             let operator = self.operator.as_str();
@@ -1695,7 +1695,7 @@ impl<'a> GenExpr for UnaryExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for BinaryExpression<'a> {
+impl GenExpr for BinaryExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let v = BinaryExpressionVisitor {
             // SAFETY:
@@ -1715,7 +1715,7 @@ impl<'a> GenExpr for BinaryExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for PrivateInExpression<'a> {
+impl GenExpr for PrivateInExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= Precedence::Compare, |p| {
             self.left.print(p, ctx);
@@ -1725,7 +1725,7 @@ impl<'a> GenExpr for PrivateInExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for LogicalExpression<'a> {
+impl GenExpr for LogicalExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let v = BinaryExpressionVisitor {
             // SAFETY:
@@ -1745,7 +1745,7 @@ impl<'a> GenExpr for LogicalExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for ConditionalExpression<'a> {
+impl GenExpr for ConditionalExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let mut ctx = ctx;
         let wrap = precedence >= self.precedence();
@@ -1766,7 +1766,7 @@ impl<'a> GenExpr for ConditionalExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for AssignmentExpression<'a> {
+impl GenExpr for AssignmentExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let n = p.code_len();
         // Destructuring assignments must be parenthesized
@@ -1782,7 +1782,7 @@ impl<'a> GenExpr for AssignmentExpression<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTarget<'a> {
+impl Gen for AssignmentTarget<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_simple_assignment_target!(Self) => {
@@ -1799,7 +1799,7 @@ impl<'a> Gen for AssignmentTarget<'a> {
     }
 }
 
-impl<'a> GenExpr for SimpleAssignmentTarget<'a> {
+impl GenExpr for SimpleAssignmentTarget<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         match self {
             Self::AssignmentTargetIdentifier(ident) => ident.print(p, ctx),
@@ -1815,7 +1815,7 @@ impl<'a> GenExpr for SimpleAssignmentTarget<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetPattern<'a> {
+impl Gen for AssignmentTargetPattern<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::ArrayAssignmentTarget(target) => target.print(p, ctx),
@@ -1824,7 +1824,7 @@ impl<'a> Gen for AssignmentTargetPattern<'a> {
     }
 }
 
-impl<'a> Gen for ArrayAssignmentTarget<'a> {
+impl Gen for ArrayAssignmentTarget<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
@@ -1852,7 +1852,7 @@ impl<'a> Gen for ArrayAssignmentTarget<'a> {
     }
 }
 
-impl<'a> Gen for ObjectAssignmentTarget<'a> {
+impl Gen for ObjectAssignmentTarget<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'{');
@@ -1869,7 +1869,7 @@ impl<'a> Gen for ObjectAssignmentTarget<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetMaybeDefault<'a> {
+impl Gen for AssignmentTargetMaybeDefault<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_assignment_target!(Self) => self.to_assignment_target().print(p, ctx),
@@ -1878,7 +1878,7 @@ impl<'a> Gen for AssignmentTargetMaybeDefault<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetWithDefault<'a> {
+impl Gen for AssignmentTargetWithDefault<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.binding.print(p, ctx);
         p.print_soft_space();
@@ -1888,7 +1888,7 @@ impl<'a> Gen for AssignmentTargetWithDefault<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetProperty<'a> {
+impl Gen for AssignmentTargetProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::AssignmentTargetPropertyIdentifier(ident) => ident.print(p, ctx),
@@ -1897,7 +1897,7 @@ impl<'a> Gen for AssignmentTargetProperty<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetPropertyIdentifier<'a> {
+impl Gen for AssignmentTargetPropertyIdentifier<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let ident_name = p.get_identifier_reference_name(&self.binding).to_owned();
         if ident_name == self.binding.name.as_str() {
@@ -1918,7 +1918,7 @@ impl<'a> Gen for AssignmentTargetPropertyIdentifier<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetPropertyProperty<'a> {
+impl Gen for AssignmentTargetPropertyProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match &self.name {
             PropertyKey::StaticIdentifier(ident) => {
@@ -1939,14 +1939,14 @@ impl<'a> Gen for AssignmentTargetPropertyProperty<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentTargetRest<'a> {
+impl Gen for AssignmentTargetRest<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_ellipsis();
         self.target.print(p, ctx);
     }
 }
 
-impl<'a> GenExpr for SequenceExpression<'a> {
+impl GenExpr for SequenceExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
             p.print_expressions(&self.expressions, Precedence::Lowest, ctx);
@@ -1954,7 +1954,7 @@ impl<'a> GenExpr for SequenceExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for ImportExpression<'a> {
+impl GenExpr for ImportExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
         let has_comment_before_right_paren = self.span.end > 0 && p.has_comment(self.span.end - 1);
@@ -1997,7 +1997,7 @@ impl<'a> GenExpr for ImportExpression<'a> {
     }
 }
 
-impl<'a> Gen for TemplateLiteral<'a> {
+impl Gen for TemplateLiteral<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_ascii_byte(b'`');
         let mut expressions = self.expressions.iter();
@@ -2017,7 +2017,7 @@ impl<'a> Gen for TemplateLiteral<'a> {
     }
 }
 
-impl<'a> Gen for TaggedTemplateExpression<'a> {
+impl Gen for TaggedTemplateExpression<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         self.tag.print_expr(p, Precedence::Postfix, Context::empty());
@@ -2035,7 +2035,7 @@ impl Gen for Super {
     }
 }
 
-impl<'a> GenExpr for AwaitExpression<'a> {
+impl GenExpr for AwaitExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
             p.add_source_mapping(self.span);
@@ -2045,7 +2045,7 @@ impl<'a> GenExpr for AwaitExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for ChainExpression<'a> {
+impl GenExpr for ChainExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= Precedence::Postfix, |p| match &self.expression {
             ChainElement::CallExpression(expr) => expr.print_expr(p, precedence, ctx),
@@ -2057,7 +2057,7 @@ impl<'a> GenExpr for ChainExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for NewExpression<'a> {
+impl GenExpr for NewExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let mut wrap = precedence >= self.precedence();
         if precedence >= Precedence::Postfix && p.has_annotation_comment(self.span.start) {
@@ -2088,7 +2088,7 @@ impl<'a> GenExpr for NewExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for TSAsExpression<'a> {
+impl GenExpr for TSAsExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let wrap = precedence >= Precedence::Shift;
 
@@ -2100,7 +2100,7 @@ impl<'a> GenExpr for TSAsExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for TSSatisfiesExpression<'a> {
+impl GenExpr for TSSatisfiesExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.print_ascii_byte(b'(');
         p.print_ascii_byte(b'(');
@@ -2112,7 +2112,7 @@ impl<'a> GenExpr for TSSatisfiesExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for TSNonNullExpression<'a> {
+impl GenExpr for TSNonNullExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(matches!(self.expression, Expression::ParenthesizedExpression(_)), |p| {
             self.expression.print_expr(p, precedence, ctx);
@@ -2124,7 +2124,7 @@ impl<'a> GenExpr for TSNonNullExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for TSInstantiationExpression<'a> {
+impl GenExpr for TSInstantiationExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         self.expression.print_expr(p, precedence, ctx);
         self.type_parameters.print(p, ctx);
@@ -2134,7 +2134,7 @@ impl<'a> GenExpr for TSInstantiationExpression<'a> {
     }
 }
 
-impl<'a> GenExpr for TSTypeAssertion<'a> {
+impl GenExpr for TSTypeAssertion<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
             p.print_str("<");
@@ -2150,7 +2150,7 @@ impl<'a> GenExpr for TSTypeAssertion<'a> {
     }
 }
 
-impl<'a> Gen for MetaProperty<'a> {
+impl Gen for MetaProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         self.meta.print(p, ctx);
@@ -2159,7 +2159,7 @@ impl<'a> Gen for MetaProperty<'a> {
     }
 }
 
-impl<'a> Gen for Class<'a> {
+impl Gen for Class<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         let n = p.code_len();
@@ -2201,7 +2201,7 @@ impl<'a> Gen for Class<'a> {
     }
 }
 
-impl<'a> Gen for ClassBody<'a> {
+impl Gen for ClassBody<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_curly_braces(self.span, self.body.is_empty(), |p| {
             for item in &self.body {
@@ -2214,7 +2214,7 @@ impl<'a> Gen for ClassBody<'a> {
     }
 }
 
-impl<'a> Gen for ClassElement<'a> {
+impl Gen for ClassElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::StaticBlock(elem) => {
@@ -2241,14 +2241,14 @@ impl<'a> Gen for ClassElement<'a> {
     }
 }
 
-impl<'a> Gen for JSXIdentifier<'a> {
+impl Gen for JSXIdentifier<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping_for_name(self.span, &self.name);
         p.print_str(self.name.as_str());
     }
 }
 
-impl<'a> Gen for JSXMemberExpressionObject<'a> {
+impl Gen for JSXMemberExpressionObject<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::IdentifierReference(ident) => ident.print(p, ctx),
@@ -2258,7 +2258,7 @@ impl<'a> Gen for JSXMemberExpressionObject<'a> {
     }
 }
 
-impl<'a> Gen for JSXMemberExpression<'a> {
+impl Gen for JSXMemberExpression<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.object.print(p, ctx);
         p.print_ascii_byte(b'.');
@@ -2266,7 +2266,7 @@ impl<'a> Gen for JSXMemberExpression<'a> {
     }
 }
 
-impl<'a> Gen for JSXElementName<'a> {
+impl Gen for JSXElementName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Identifier(identifier) => identifier.print(p, ctx),
@@ -2278,7 +2278,7 @@ impl<'a> Gen for JSXElementName<'a> {
     }
 }
 
-impl<'a> Gen for JSXNamespacedName<'a> {
+impl Gen for JSXNamespacedName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.namespace.print(p, ctx);
         p.print_colon();
@@ -2286,7 +2286,7 @@ impl<'a> Gen for JSXNamespacedName<'a> {
     }
 }
 
-impl<'a> Gen for JSXAttributeName<'a> {
+impl Gen for JSXAttributeName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Identifier(ident) => ident.print(p, ctx),
@@ -2295,7 +2295,7 @@ impl<'a> Gen for JSXAttributeName<'a> {
     }
 }
 
-impl<'a> Gen for JSXAttribute<'a> {
+impl Gen for JSXAttribute<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.name.print(p, ctx);
         if let Some(value) = &self.value {
@@ -2309,7 +2309,7 @@ impl Gen for JSXEmptyExpression {
     fn gen(&self, _: &mut Codegen, _ctx: Context) {}
 }
 
-impl<'a> Gen for JSXExpression<'a> {
+impl Gen for JSXExpression<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_expression!(Self) => p.print_expression(self.to_expression()),
@@ -2318,7 +2318,7 @@ impl<'a> Gen for JSXExpression<'a> {
     }
 }
 
-impl<'a> Gen for JSXExpressionContainer<'a> {
+impl Gen for JSXExpressionContainer<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_ascii_byte(b'{');
         self.expression.print(p, ctx);
@@ -2326,7 +2326,7 @@ impl<'a> Gen for JSXExpressionContainer<'a> {
     }
 }
 
-impl<'a> Gen for JSXAttributeValue<'a> {
+impl Gen for JSXAttributeValue<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Fragment(fragment) => fragment.print(p, ctx),
@@ -2342,7 +2342,7 @@ impl<'a> Gen for JSXAttributeValue<'a> {
     }
 }
 
-impl<'a> Gen for JSXSpreadAttribute<'a> {
+impl Gen for JSXSpreadAttribute<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_str("{...");
         self.argument.print_expr(p, Precedence::Comma, Context::empty());
@@ -2350,7 +2350,7 @@ impl<'a> Gen for JSXSpreadAttribute<'a> {
     }
 }
 
-impl<'a> Gen for JSXAttributeItem<'a> {
+impl Gen for JSXAttributeItem<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Attribute(attr) => attr.print(p, ctx),
@@ -2359,7 +2359,7 @@ impl<'a> Gen for JSXAttributeItem<'a> {
     }
 }
 
-impl<'a> Gen for JSXOpeningElement<'a> {
+impl Gen for JSXOpeningElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'<');
@@ -2383,7 +2383,7 @@ impl<'a> Gen for JSXOpeningElement<'a> {
     }
 }
 
-impl<'a> Gen for JSXClosingElement<'a> {
+impl Gen for JSXClosingElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_str("</");
@@ -2392,7 +2392,7 @@ impl<'a> Gen for JSXClosingElement<'a> {
     }
 }
 
-impl<'a> Gen for JSXElement<'a> {
+impl Gen for JSXElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.opening_element.print(p, ctx);
         for child in &self.children {
@@ -2418,21 +2418,21 @@ impl Gen for JSXClosingFragment {
     }
 }
 
-impl<'a> Gen for JSXText<'a> {
+impl Gen for JSXText<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_str(self.value.as_str());
     }
 }
 
-impl<'a> Gen for JSXSpreadChild<'a> {
+impl Gen for JSXSpreadChild<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_str("...");
         p.print_expression(&self.expression);
     }
 }
 
-impl<'a> Gen for JSXChild<'a> {
+impl Gen for JSXChild<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Fragment(fragment) => fragment.print(p, ctx),
@@ -2444,7 +2444,7 @@ impl<'a> Gen for JSXChild<'a> {
     }
 }
 
-impl<'a> Gen for JSXFragment<'a> {
+impl Gen for JSXFragment<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.opening_fragment.print(p, ctx);
         for child in &self.children {
@@ -2454,7 +2454,7 @@ impl<'a> Gen for JSXFragment<'a> {
     }
 }
 
-impl<'a> Gen for StaticBlock<'a> {
+impl Gen for StaticBlock<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_str("static");
@@ -2469,7 +2469,7 @@ impl<'a> Gen for StaticBlock<'a> {
     }
 }
 
-impl<'a> Gen for MethodDefinition<'a> {
+impl Gen for MethodDefinition<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         for decorator in &self.decorators {
@@ -2536,7 +2536,7 @@ impl<'a> Gen for MethodDefinition<'a> {
     }
 }
 
-impl<'a> Gen for PropertyDefinition<'a> {
+impl Gen for PropertyDefinition<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         for decorator in &self.decorators {
@@ -2583,7 +2583,7 @@ impl<'a> Gen for PropertyDefinition<'a> {
     }
 }
 
-impl<'a> Gen for AccessorProperty<'a> {
+impl Gen for AccessorProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         for decorator in &self.decorators {
@@ -2625,7 +2625,7 @@ impl<'a> Gen for AccessorProperty<'a> {
     }
 }
 
-impl<'a> Gen for PrivateIdentifier<'a> {
+impl Gen for PrivateIdentifier<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping_for_name(self.span, &self.name);
         p.print_ascii_byte(b'#');
@@ -2633,7 +2633,7 @@ impl<'a> Gen for PrivateIdentifier<'a> {
     }
 }
 
-impl<'a> Gen for BindingPattern<'a> {
+impl Gen for BindingPattern<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.kind.print(p, ctx);
         if self.optional {
@@ -2647,7 +2647,7 @@ impl<'a> Gen for BindingPattern<'a> {
     }
 }
 
-impl<'a> Gen for BindingPatternKind<'a> {
+impl Gen for BindingPatternKind<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             BindingPatternKind::BindingIdentifier(ident) => ident.print(p, ctx),
@@ -2658,7 +2658,7 @@ impl<'a> Gen for BindingPatternKind<'a> {
     }
 }
 
-impl<'a> Gen for ObjectPattern<'a> {
+impl Gen for ObjectPattern<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'{');
@@ -2680,7 +2680,7 @@ impl<'a> Gen for ObjectPattern<'a> {
     }
 }
 
-impl<'a> Gen for BindingProperty<'a> {
+impl Gen for BindingProperty<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         if self.computed {
@@ -2722,7 +2722,7 @@ impl<'a> Gen for BindingProperty<'a> {
     }
 }
 
-impl<'a> Gen for BindingRestElement<'a> {
+impl Gen for BindingRestElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ellipsis();
@@ -2730,7 +2730,7 @@ impl<'a> Gen for BindingRestElement<'a> {
     }
 }
 
-impl<'a> Gen for ArrayPattern<'a> {
+impl Gen for ArrayPattern<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
@@ -2755,7 +2755,7 @@ impl<'a> Gen for ArrayPattern<'a> {
     }
 }
 
-impl<'a> Gen for AssignmentPattern<'a> {
+impl Gen for AssignmentPattern<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.left.print(p, ctx);
         p.print_soft_space();
@@ -2765,7 +2765,7 @@ impl<'a> Gen for AssignmentPattern<'a> {
     }
 }
 
-impl<'a> Gen for Decorator<'a> {
+impl Gen for Decorator<'_> {
     fn gen(&self, p: &mut Codegen, _ctx: Context) {
         fn need_wrap(expr: &Expression) -> bool {
             match expr {
@@ -2792,7 +2792,7 @@ impl<'a> Gen for Decorator<'a> {
     }
 }
 
-impl<'a> Gen for TSClassImplements<'a> {
+impl Gen for TSClassImplements<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.expression.print(p, ctx);
         if let Some(type_parameters) = self.type_parameters.as_ref() {
@@ -2801,7 +2801,7 @@ impl<'a> Gen for TSClassImplements<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeParameterDeclaration<'a> {
+impl Gen for TSTypeParameterDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.params.len() >= 2;
         p.print_ascii_byte(b'<');
@@ -2829,13 +2829,13 @@ impl<'a> Gen for TSTypeParameterDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeAnnotation<'a> {
+impl Gen for TSTypeAnnotation<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.type_annotation.print(p, ctx);
     }
 }
 
-impl<'a> Gen for TSType<'a> {
+impl Gen for TSType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let ctx = ctx.with_typescript();
         match self {
@@ -2881,14 +2881,14 @@ impl<'a> Gen for TSType<'a> {
     }
 }
 
-impl<'a> Gen for TSArrayType<'a> {
+impl Gen for TSArrayType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.element_type.print(p, ctx);
         p.print_str("[]");
     }
 }
 
-impl<'a> Gen for TSTupleType<'a> {
+impl Gen for TSTupleType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("[");
         p.print_list(&self.element_types, ctx);
@@ -2896,7 +2896,7 @@ impl<'a> Gen for TSTupleType<'a> {
     }
 }
 
-impl<'a> Gen for TSUnionType<'a> {
+impl Gen for TSUnionType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.types.len() == 1 {
             self.types[0].print(p, ctx);
@@ -2913,7 +2913,7 @@ impl<'a> Gen for TSUnionType<'a> {
     }
 }
 
-impl<'a> Gen for TSParenthesizedType<'a> {
+impl Gen for TSParenthesizedType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_ascii_byte(b'(');
         self.type_annotation.print(p, ctx);
@@ -2921,7 +2921,7 @@ impl<'a> Gen for TSParenthesizedType<'a> {
     }
 }
 
-impl<'a> Gen for TSIntersectionType<'a> {
+impl Gen for TSIntersectionType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.types.len() == 1 {
             self.types[0].print(p, ctx);
@@ -2938,7 +2938,7 @@ impl<'a> Gen for TSIntersectionType<'a> {
     }
 }
 
-impl<'a> Gen for TSConditionalType<'a> {
+impl Gen for TSConditionalType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.check_type.print(p, ctx);
         p.print_str(" extends ");
@@ -2950,14 +2950,14 @@ impl<'a> Gen for TSConditionalType<'a> {
     }
 }
 
-impl<'a> Gen for TSInferType<'a> {
+impl Gen for TSInferType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("infer ");
         self.type_parameter.print(p, ctx);
     }
 }
 
-impl<'a> Gen for TSIndexedAccessType<'a> {
+impl Gen for TSIndexedAccessType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.object_type.print(p, ctx);
         p.print_str("[");
@@ -2966,7 +2966,7 @@ impl<'a> Gen for TSIndexedAccessType<'a> {
     }
 }
 
-impl<'a> Gen for TSMappedType<'a> {
+impl Gen for TSMappedType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("{");
         p.print_soft_space();
@@ -3020,7 +3020,7 @@ impl<'a> Gen for TSMappedType<'a> {
     }
 }
 
-impl<'a> Gen for TSQualifiedName<'a> {
+impl Gen for TSQualifiedName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.left.print(p, ctx);
         p.print_str(".");
@@ -3028,7 +3028,7 @@ impl<'a> Gen for TSQualifiedName<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeOperator<'a> {
+impl Gen for TSTypeOperator<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self.operator {
             TSTypeOperatorOperator::Keyof => {
@@ -3045,7 +3045,7 @@ impl<'a> Gen for TSTypeOperator<'a> {
     }
 }
 
-impl<'a> Gen for TSTypePredicate<'a> {
+impl Gen for TSTypePredicate<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.asserts {
             p.print_str("asserts ");
@@ -3065,7 +3065,7 @@ impl<'a> Gen for TSTypePredicate<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeReference<'a> {
+impl Gen for TSTypeReference<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.type_name.print(p, ctx);
         if let Some(type_parameters) = &self.type_parameters {
@@ -3074,7 +3074,7 @@ impl<'a> Gen for TSTypeReference<'a> {
     }
 }
 
-impl<'a> Gen for JSDocNullableType<'a> {
+impl Gen for JSDocNullableType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.postfix {
             self.type_annotation.print(p, ctx);
@@ -3086,7 +3086,7 @@ impl<'a> Gen for JSDocNullableType<'a> {
     }
 }
 
-impl<'a> Gen for JSDocNonNullableType<'a> {
+impl Gen for JSDocNonNullableType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.postfix {
             self.type_annotation.print(p, ctx);
@@ -3098,7 +3098,7 @@ impl<'a> Gen for JSDocNonNullableType<'a> {
     }
 }
 
-impl<'a> Gen for TSTemplateLiteralType<'a> {
+impl Gen for TSTemplateLiteralType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("`");
         for (index, item) in self.quasis.iter().enumerate() {
@@ -3115,7 +3115,7 @@ impl<'a> Gen for TSTemplateLiteralType<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeLiteral<'a> {
+impl Gen for TSTypeLiteral<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let single_line = self.members.len() <= 1;
         p.print_curly_braces(self.span, single_line, |p| {
@@ -3137,7 +3137,7 @@ impl<'a> Gen for TSTypeLiteral<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeName<'a> {
+impl Gen for TSTypeName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::IdentifierReference(ident) => {
@@ -3152,7 +3152,7 @@ impl<'a> Gen for TSTypeName<'a> {
     }
 }
 
-impl<'a> Gen for TSLiteral<'a> {
+impl Gen for TSLiteral<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::BooleanLiteral(decl) => decl.print(p, ctx),
@@ -3167,7 +3167,7 @@ impl<'a> Gen for TSLiteral<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeParameter<'a> {
+impl Gen for TSTypeParameter<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.r#const {
             p.print_str("const ");
@@ -3184,7 +3184,7 @@ impl<'a> Gen for TSTypeParameter<'a> {
     }
 }
 
-impl<'a> Gen for TSFunctionType<'a> {
+impl Gen for TSFunctionType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if let Some(type_parameters) = &self.type_parameters {
             type_parameters.print(p, ctx);
@@ -3206,7 +3206,7 @@ impl<'a> Gen for TSFunctionType<'a> {
     }
 }
 
-impl<'a> Gen for TSThisParameter<'a> {
+impl Gen for TSThisParameter<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("this");
         if let Some(type_annotation) = &self.type_annotation {
@@ -3216,7 +3216,7 @@ impl<'a> Gen for TSThisParameter<'a> {
     }
 }
 
-impl<'a> Gen for TSSignature<'a> {
+impl Gen for TSSignature<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::TSIndexSignature(signature) => signature.print(p, ctx),
@@ -3333,7 +3333,7 @@ impl<'a> Gen for TSSignature<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeQuery<'a> {
+impl Gen for TSTypeQuery<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("typeof ");
         self.expr_name.print(p, ctx);
@@ -3343,7 +3343,7 @@ impl<'a> Gen for TSTypeQuery<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeQueryExprName<'a> {
+impl Gen for TSTypeQueryExprName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_ts_type_name!(Self) => self.to_ts_type_name().print(p, ctx),
@@ -3352,7 +3352,7 @@ impl<'a> Gen for TSTypeQueryExprName<'a> {
     }
 }
 
-impl<'a> Gen for TSImportType<'a> {
+impl Gen for TSImportType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.is_type_of {
             p.print_str("typeof ");
@@ -3374,7 +3374,7 @@ impl<'a> Gen for TSImportType<'a> {
     }
 }
 
-impl<'a> Gen for TSImportAttributes<'a> {
+impl Gen for TSImportAttributes<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_ascii_byte(b'{');
         p.print_soft_space();
@@ -3391,7 +3391,7 @@ impl<'a> Gen for TSImportAttributes<'a> {
     }
 }
 
-impl<'a> Gen for TSImportAttribute<'a> {
+impl Gen for TSImportAttribute<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.name.print(p, ctx);
         p.print_str(": ");
@@ -3399,7 +3399,7 @@ impl<'a> Gen for TSImportAttribute<'a> {
     }
 }
 
-impl<'a> Gen for TSImportAttributeName<'a> {
+impl Gen for TSImportAttributeName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             TSImportAttributeName::Identifier(ident) => ident.print(p, ctx),
@@ -3408,7 +3408,7 @@ impl<'a> Gen for TSImportAttributeName<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeParameterInstantiation<'a> {
+impl Gen for TSTypeParameterInstantiation<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("<");
         p.print_list(&self.params, ctx);
@@ -3416,7 +3416,7 @@ impl<'a> Gen for TSTypeParameterInstantiation<'a> {
     }
 }
 
-impl<'a> Gen for TSIndexSignature<'a> {
+impl Gen for TSIndexSignature<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.readonly {
             p.print_str("readonly ");
@@ -3438,7 +3438,7 @@ impl<'a> Gen for TSIndexSignature<'a> {
     }
 }
 
-impl<'a> Gen for TSTupleElement<'a> {
+impl Gen for TSTupleElement<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_ts_type!(TSTupleElement) => self.to_ts_type().print(p, ctx),
@@ -3454,7 +3454,7 @@ impl<'a> Gen for TSTupleElement<'a> {
     }
 }
 
-impl<'a> Gen for TSNamedTupleMember<'a> {
+impl Gen for TSNamedTupleMember<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.label.print(p, ctx);
         if self.optional {
@@ -3466,7 +3466,7 @@ impl<'a> Gen for TSNamedTupleMember<'a> {
     }
 }
 
-impl<'a> Gen for TSModuleDeclaration<'a> {
+impl Gen for TSModuleDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.declare {
             p.print_str("declare ");
@@ -3503,7 +3503,7 @@ impl<'a> Gen for TSModuleDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSModuleDeclarationName<'a> {
+impl Gen for TSModuleDeclarationName<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::Identifier(ident) => ident.print(p, ctx),
@@ -3512,7 +3512,7 @@ impl<'a> Gen for TSModuleDeclarationName<'a> {
     }
 }
 
-impl<'a> Gen for TSModuleBlock<'a> {
+impl Gen for TSModuleBlock<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         let is_empty = self.directives.is_empty() && self.body.is_empty();
         p.print_curly_braces(self.span, is_empty, |p| {
@@ -3528,7 +3528,7 @@ impl<'a> Gen for TSModuleBlock<'a> {
     }
 }
 
-impl<'a> Gen for TSTypeAliasDeclaration<'a> {
+impl Gen for TSTypeAliasDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.declare {
             p.print_str("declare ");
@@ -3546,7 +3546,7 @@ impl<'a> Gen for TSTypeAliasDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSInterfaceDeclaration<'a> {
+impl Gen for TSInterfaceDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("interface");
         p.print_hard_space();
@@ -3573,7 +3573,7 @@ impl<'a> Gen for TSInterfaceDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSInterfaceHeritage<'a> {
+impl Gen for TSInterfaceHeritage<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.expression.print_expr(p, Precedence::Call, ctx);
         if let Some(type_parameters) = &self.type_parameters {
@@ -3582,7 +3582,7 @@ impl<'a> Gen for TSInterfaceHeritage<'a> {
     }
 }
 
-impl<'a> Gen for TSEnumDeclaration<'a> {
+impl Gen for TSEnumDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_indent();
         if self.declare {
@@ -3607,7 +3607,7 @@ impl<'a> Gen for TSEnumDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSEnumMember<'a> {
+impl Gen for TSEnumMember<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match &self.id {
             TSEnumMemberName::Identifier(decl) => decl.print(p, ctx),
@@ -3622,7 +3622,7 @@ impl<'a> Gen for TSEnumMember<'a> {
     }
 }
 
-impl<'a> Gen for TSConstructorType<'a> {
+impl Gen for TSConstructorType<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         if self.r#abstract {
             p.print_str("abstract ");
@@ -3641,7 +3641,7 @@ impl<'a> Gen for TSConstructorType<'a> {
     }
 }
 
-impl<'a> Gen for TSImportEqualsDeclaration<'a> {
+impl Gen for TSImportEqualsDeclaration<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("import ");
         self.id.print(p, ctx);
@@ -3650,7 +3650,7 @@ impl<'a> Gen for TSImportEqualsDeclaration<'a> {
     }
 }
 
-impl<'a> Gen for TSModuleReference<'a> {
+impl Gen for TSModuleReference<'_> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             Self::ExternalModuleReference(decl) => {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -126,7 +126,7 @@ pub struct Codegen<'a> {
     sourcemap_builder: Option<SourcemapBuilder>,
 }
 
-impl<'a> Default for Codegen<'a> {
+impl Default for Codegen<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/oxc_ecmascript/src/constant_evaluation/is_literal_value.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/is_literal_value.rs
@@ -32,7 +32,7 @@ pub fn is_immutable_value(expr: &Expression<'_>) -> bool {
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for Expression<'a> {
+impl<'a> IsLiteralValue<'a, '_> for Expression<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         match self {
             Self::FunctionExpression(_) | Self::ArrowFunctionExpression(_) => include_functions,
@@ -47,7 +47,7 @@ impl<'a, 'b> IsLiteralValue<'a, 'b> for Expression<'a> {
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for ArrayExpressionElement<'a> {
+impl<'a> IsLiteralValue<'a, '_> for ArrayExpressionElement<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         match self {
             Self::SpreadElement(element) => element.is_literal_value(include_functions),
@@ -57,13 +57,13 @@ impl<'a, 'b> IsLiteralValue<'a, 'b> for ArrayExpressionElement<'a> {
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for SpreadElement<'a> {
+impl<'a> IsLiteralValue<'a, '_> for SpreadElement<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         self.argument.is_literal_value(include_functions)
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for ObjectPropertyKind<'a> {
+impl<'a> IsLiteralValue<'a, '_> for ObjectPropertyKind<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         match self {
             Self::ObjectProperty(method) => method.is_literal_value(include_functions),
@@ -72,14 +72,14 @@ impl<'a, 'b> IsLiteralValue<'a, 'b> for ObjectPropertyKind<'a> {
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for ObjectProperty<'a> {
+impl<'a> IsLiteralValue<'a, '_> for ObjectProperty<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         self.key.is_literal_value(include_functions)
             && self.value.is_literal_value(include_functions)
     }
 }
 
-impl<'a, 'b> IsLiteralValue<'a, 'b> for PropertyKey<'a> {
+impl<'a> IsLiteralValue<'a, '_> for PropertyKey<'a> {
     fn is_literal_value(&self, include_functions: bool) -> bool {
         match self {
             Self::StaticIdentifier(_) => true,

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -280,19 +280,19 @@ pub trait ConstantEvaluation<'a> {
                 None
             }
             BinaryOperator::LessThan => {
-                return self.is_less_than(left, right, true).map(|value| match value {
+                self.is_less_than(left, right, true).map(|value| match value {
                     ConstantValue::Undefined => ConstantValue::Boolean(false),
                     _ => value,
                 })
             }
             BinaryOperator::GreaterThan => {
-                return self.is_less_than(right, left, false).map(|value| match value {
+                self.is_less_than(right, left, false).map(|value| match value {
                     ConstantValue::Undefined => ConstantValue::Boolean(false),
                     _ => value,
                 })
             }
             BinaryOperator::LessEqualThan => {
-                return self.is_less_than(right, left, false).map(|value| match value {
+                self.is_less_than(right, left, false).map(|value| match value {
                     ConstantValue::Boolean(true) | ConstantValue::Undefined => {
                         ConstantValue::Boolean(false)
                     }
@@ -301,7 +301,7 @@ pub trait ConstantEvaluation<'a> {
                 })
             }
             BinaryOperator::GreaterEqualThan => {
-                return self.is_less_than(left, right, true).map(|value| match value {
+                self.is_less_than(left, right, true).map(|value| match value {
                     ConstantValue::Boolean(true) | ConstantValue::Undefined => {
                         ConstantValue::Boolean(false)
                     }
@@ -436,6 +436,6 @@ pub trait ConstantEvaluation<'a> {
             return Some(ConstantValue::Undefined);
         }
 
-        return Some(ConstantValue::Boolean(left_num < right_num));
+        Some(ConstantValue::Boolean(left_num < right_num))
     }
 }

--- a/crates/oxc_ecmascript/src/is_simple_parameter_list.rs
+++ b/crates/oxc_ecmascript/src/is_simple_parameter_list.rs
@@ -5,7 +5,7 @@ pub trait IsSimpleParameterList {
     fn is_simple_parameter_list(&self) -> bool;
 }
 
-impl<'a> IsSimpleParameterList for FormalParameters<'a> {
+impl IsSimpleParameterList for FormalParameters<'_> {
     fn is_simple_parameter_list(&self) -> bool {
         self.items.iter().all(|pat| pat.pattern.kind.is_binding_identifier()) && self.rest.is_none()
     }

--- a/crates/oxc_ecmascript/src/private_bound_identifiers.rs
+++ b/crates/oxc_ecmascript/src/private_bound_identifiers.rs
@@ -8,7 +8,7 @@ pub trait PrivateBoundIdentifiers {
     fn private_bound_identifiers(&self) -> Option<PrivateIdentifier>;
 }
 
-impl<'a> PrivateBoundIdentifiers for ClassElement<'a> {
+impl PrivateBoundIdentifiers for ClassElement<'_> {
     fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
         match self {
             ClassElement::StaticBlock(_) | ClassElement::TSIndexSignature(_) => None,
@@ -19,7 +19,7 @@ impl<'a> PrivateBoundIdentifiers for ClassElement<'a> {
     }
 }
 
-impl<'a> PrivateBoundIdentifiers for MethodDefinition<'a> {
+impl PrivateBoundIdentifiers for MethodDefinition<'_> {
     fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
         self.value.body.as_ref()?;
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
@@ -29,7 +29,7 @@ impl<'a> PrivateBoundIdentifiers for MethodDefinition<'a> {
     }
 }
 
-impl<'a> PrivateBoundIdentifiers for PropertyDefinition<'a> {
+impl PrivateBoundIdentifiers for PropertyDefinition<'_> {
     fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
             return Some((*ident).clone());
@@ -38,7 +38,7 @@ impl<'a> PrivateBoundIdentifiers for PropertyDefinition<'a> {
     }
 }
 
-impl<'a> PrivateBoundIdentifiers for AccessorProperty<'a> {
+impl PrivateBoundIdentifiers for AccessorProperty<'_> {
     fn private_bound_identifiers(&self) -> Option<PrivateIdentifier> {
         if let PropertyKey::PrivateIdentifier(ident) = &self.key {
             return Some((*ident).clone());

--- a/crates/oxc_ecmascript/src/prop_name.rs
+++ b/crates/oxc_ecmascript/src/prop_name.rs
@@ -9,7 +9,7 @@ pub trait PropName {
     fn prop_name(&self) -> Option<(&str, Span)>;
 }
 
-impl<'a> PropName for ObjectPropertyKind<'a> {
+impl PropName for ObjectPropertyKind<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         match self {
             ObjectPropertyKind::ObjectProperty(prop) => prop.prop_name(),
@@ -18,7 +18,7 @@ impl<'a> PropName for ObjectPropertyKind<'a> {
     }
 }
 
-impl<'a> PropName for ObjectProperty<'a> {
+impl PropName for ObjectProperty<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         if self.shorthand || self.computed {
             return None;
@@ -27,7 +27,7 @@ impl<'a> PropName for ObjectProperty<'a> {
     }
 }
 
-impl<'a> PropName for PropertyKey<'a> {
+impl PropName for PropertyKey<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         match self {
             PropertyKey::StaticIdentifier(ident) => Some((&ident.name, ident.span)),
@@ -38,7 +38,7 @@ impl<'a> PropName for PropertyKey<'a> {
     }
 }
 
-impl<'a> PropName for ClassElement<'a> {
+impl PropName for ClassElement<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         match self {
             ClassElement::MethodDefinition(def) => def.prop_name(),
@@ -48,7 +48,7 @@ impl<'a> PropName for ClassElement<'a> {
     }
 }
 
-impl<'a> PropName for MethodDefinition<'a> {
+impl PropName for MethodDefinition<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         if self.computed {
             return None;
@@ -57,7 +57,7 @@ impl<'a> PropName for MethodDefinition<'a> {
     }
 }
 
-impl<'a> PropName for PropertyDefinition<'a> {
+impl PropName for PropertyDefinition<'_> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         if self.computed {
             return None;

--- a/crates/oxc_ecmascript/src/side_effects/check_for_state_change.rs
+++ b/crates/oxc_ecmascript/src/side_effects/check_for_state_change.rs
@@ -15,7 +15,7 @@ pub trait CheckForStateChange<'a, 'b> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool;
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for Expression<'a> {
+impl<'a> CheckForStateChange<'a, '_> for Expression<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         match self {
             Self::NumericLiteral(_)
@@ -78,7 +78,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for Expression<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for UnaryExpression<'a> {
+impl<'a> CheckForStateChange<'a, '_> for UnaryExpression<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         if is_simple_unary_operator(self.operator) {
             return self.argument.check_for_state_change(check_for_new_objects);
@@ -87,7 +87,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for UnaryExpression<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for BinaryExpression<'a> {
+impl<'a> CheckForStateChange<'a, '_> for BinaryExpression<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         let left = self.left.check_for_state_change(check_for_new_objects);
         let right = self.right.check_for_state_change(check_for_new_objects);
@@ -96,7 +96,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for BinaryExpression<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for ArrayExpressionElement<'a> {
+impl<'a> CheckForStateChange<'a, '_> for ArrayExpressionElement<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         match self {
             Self::SpreadElement(element) => element.check_for_state_change(check_for_new_objects),
@@ -108,7 +108,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for ArrayExpressionElement<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for ObjectPropertyKind<'a> {
+impl<'a> CheckForStateChange<'a, '_> for ObjectPropertyKind<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         match self {
             Self::ObjectProperty(method) => method.check_for_state_change(check_for_new_objects),
@@ -119,7 +119,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for ObjectPropertyKind<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for SpreadElement<'a> {
+impl<'a> CheckForStateChange<'a, '_> for SpreadElement<'a> {
     fn check_for_state_change(&self, _check_for_new_objects: bool) -> bool {
         // Object-rest and object-spread may trigger a getter.
         // TODO: Closure Compiler assumes that getters may side-free when set `assumeGettersArePure`.
@@ -128,14 +128,14 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for SpreadElement<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for ObjectProperty<'a> {
+impl<'a> CheckForStateChange<'a, '_> for ObjectProperty<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         self.key.check_for_state_change(check_for_new_objects)
             || self.value.check_for_state_change(check_for_new_objects)
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for PropertyKey<'a> {
+impl<'a> CheckForStateChange<'a, '_> for PropertyKey<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         match self {
             Self::StaticIdentifier(_) | Self::PrivateIdentifier(_) => false,
@@ -146,7 +146,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for PropertyKey<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for ForStatementLeft<'a> {
+impl<'a> CheckForStateChange<'a, '_> for ForStatementLeft<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         match self {
             match_assignment_target!(Self) => {
@@ -159,13 +159,13 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for ForStatementLeft<'a> {
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for VariableDeclaration<'a> {
+impl<'a> CheckForStateChange<'a, '_> for VariableDeclaration<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         self.declarations.iter().any(|decl| decl.check_for_state_change(check_for_new_objects))
     }
 }
 
-impl<'a, 'b> CheckForStateChange<'a, 'b> for VariableDeclarator<'a> {
+impl<'a> CheckForStateChange<'a, '_> for VariableDeclarator<'a> {
     fn check_for_state_change(&self, check_for_new_objects: bool) -> bool {
         self.id.check_for_state_change(check_for_new_objects)
             || self

--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -16,7 +16,7 @@ where
     }
 }
 
-impl<'a, 'b> MayHaveSideEffects<'a, 'b> for Expression<'a> {}
-impl<'a, 'b> MayHaveSideEffects<'a, 'b> for UnaryExpression<'a> {}
-impl<'a, 'b> MayHaveSideEffects<'a, 'b> for ForStatementLeft<'a> {}
-impl<'a, 'b> MayHaveSideEffects<'a, 'b> for PropertyKey<'a> {}
+impl<'a> MayHaveSideEffects<'a, '_> for Expression<'a> {}
+impl<'a> MayHaveSideEffects<'a, '_> for UnaryExpression<'a> {}
+impl<'a> MayHaveSideEffects<'a, '_> for ForStatementLeft<'a> {}
+impl<'a> MayHaveSideEffects<'a, '_> for PropertyKey<'a> {}

--- a/crates/oxc_ecmascript/src/string_to_big_int.rs
+++ b/crates/oxc_ecmascript/src/string_to_big_int.rs
@@ -9,7 +9,7 @@ pub trait StringToBigInt<'a> {
     fn string_to_big_int(&self) -> Option<BigInt>;
 }
 
-impl<'a> StringToBigInt<'a> for &str {
+impl StringToBigInt<'_> for &str {
     fn string_to_big_int(&self) -> Option<BigInt> {
         if self.contains('\u{000b}') {
             // vertical tab is not always whitespace
@@ -37,6 +37,6 @@ impl<'a> StringToBigInt<'a> for &str {
             return BigInt::parse_bytes(s[2..].as_bytes(), radix);
         }
 
-        return BigInt::parse_bytes(s.as_bytes(), 10);
+        BigInt::parse_bytes(s.as_bytes(), 10)
     }
 }

--- a/crates/oxc_estree/src/ser.rs
+++ b/crates/oxc_estree/src/ser.rs
@@ -7,7 +7,7 @@ pub struct AppendTo<'a, TVec, TAfter> {
     pub after: &'a Option<TAfter>,
 }
 
-impl<'b, TVec: Serialize, TAfter: Serialize> Serialize for AppendTo<'b, TVec, TAfter> {
+impl<TVec: Serialize, TAfter: Serialize> Serialize for AppendTo<'_, TVec, TAfter> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if let Some(after) = self.after {
             let mut seq = serializer.serialize_seq(Some(self.array.len() + 1))?;

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -498,7 +498,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
     fn get_assignable_properties_for_namespaces(
         stmts: &'a oxc_allocator::Vec<'a, Statement<'a>>,
-    ) -> FxHashMap<&'a str, FxHashSet<Atom>> {
+    ) -> FxHashMap<&'a str, FxHashSet<Atom<'a>>> {
         let mut assignable_properties_for_namespace = FxHashMap::<&str, FxHashSet<Atom>>::default();
         for stmt in stmts {
             let decl = match stmt {

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -25,7 +25,7 @@ struct Scope<'a> {
     flags: ScopeFlags,
 }
 
-impl<'a> Scope<'a> {
+impl Scope<'_> {
     fn new(flags: ScopeFlags) -> Self {
         Self { bindings: FxHashMap::default(), references: FxHashMap::default(), flags }
     }

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -64,7 +64,7 @@ pub trait IsConstant<'a, 'b> {
     fn is_constant(&self, in_boolean_position: bool, semantic: &Semantic<'a>) -> bool;
 }
 
-impl<'a, 'b> IsConstant<'a, 'b> for Expression<'a> {
+impl<'a> IsConstant<'a, '_> for Expression<'a> {
     fn is_constant(&self, in_boolean_position: bool, semantic: &Semantic<'a>) -> bool {
         match self {
             Self::ArrowFunctionExpression(_)
@@ -138,7 +138,7 @@ impl<'a, 'b> IsConstant<'a, 'b> for Expression<'a> {
     }
 }
 
-impl<'a, 'b> IsConstant<'a, 'b> for CallExpression<'a> {
+impl<'a> IsConstant<'a, '_> for CallExpression<'a> {
     fn is_constant(&self, _in_boolean_position: bool, semantic: &Semantic<'a>) -> bool {
         if let Expression::Identifier(ident) = &self.callee {
             if ident.name == "Boolean"
@@ -155,7 +155,7 @@ impl<'a, 'b> IsConstant<'a, 'b> for CallExpression<'a> {
     }
 }
 
-impl<'a, 'b> IsConstant<'a, 'b> for Argument<'a> {
+impl<'a> IsConstant<'a, '_> for Argument<'a> {
     fn is_constant(&self, in_boolean_position: bool, semantic: &Semantic<'a>) -> bool {
         match self {
             Self::SpreadElement(element) => element.is_constant(in_boolean_position, semantic),
@@ -166,7 +166,7 @@ impl<'a, 'b> IsConstant<'a, 'b> for Argument<'a> {
     }
 }
 
-impl<'a, 'b> IsConstant<'a, 'b> for ArrayExpressionElement<'a> {
+impl<'a> IsConstant<'a, '_> for ArrayExpressionElement<'a> {
     fn is_constant(&self, in_boolean_position: bool, semantic: &Semantic<'a>) -> bool {
         match self {
             Self::SpreadElement(element) => element.is_constant(in_boolean_position, semantic),
@@ -178,7 +178,7 @@ impl<'a, 'b> IsConstant<'a, 'b> for ArrayExpressionElement<'a> {
     }
 }
 
-impl<'a, 'b> IsConstant<'a, 'b> for SpreadElement<'a> {
+impl<'a> IsConstant<'a, '_> for SpreadElement<'a> {
     fn is_constant(&self, in_boolean_position: bool, semantic: &Semantic<'a>) -> bool {
         self.argument.is_constant(in_boolean_position, semantic)
     }

--- a/crates/oxc_linter/src/builder.rs
+++ b/crates/oxc_linter/src/builder.rs
@@ -286,15 +286,13 @@ impl LinterBuilder {
         let new_rules = self
             .rules
             .iter()
-            .map(|r: &RuleWithSeverity| {
-                return ESLintRule {
-                    plugin_name: r.plugin_name().to_string(),
-                    rule_name: r.rule.name().to_string(),
-                    severity: r.severity,
-                    config: rule_name_to_rule
-                        .get(&get_name(r.plugin_name(), r.rule.name()))
-                        .and_then(|r| r.config.clone()),
-                };
+            .map(|r: &RuleWithSeverity| ESLintRule {
+                plugin_name: r.plugin_name().to_string(),
+                rule_name: r.rule.name().to_string(),
+                severity: r.severity,
+                config: rule_name_to_rule
+                    .get(&get_name(r.plugin_name(), r.rule.name()))
+                    .and_then(|r| r.config.clone()),
             })
             .collect();
 

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -100,7 +100,7 @@ impl fmt::Display for GlobalValue {
 }
 
 struct GlobalValueVisitor;
-impl<'de> Visitor<'de> for GlobalValueVisitor {
+impl Visitor<'_> for GlobalValueVisitor {
     type Value = GlobalValue;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -532,13 +532,13 @@ impl<'a> CompositeFix<'a> {
 mod test {
     use super::*;
 
-    impl<'a> PartialEq for Fix<'a> {
+    impl PartialEq for Fix<'_> {
         fn eq(&self, other: &Self) -> bool {
             self.span == other.span && self.content == other.content
         }
     }
 
-    impl<'a> Clone for CompositeFix<'a> {
+    impl Clone for CompositeFix<'_> {
         fn clone(&self) -> Self {
             match self {
                 Self::None => Self::None,
@@ -548,7 +548,7 @@ mod test {
         }
     }
 
-    impl<'a> PartialEq for CompositeFix<'a> {
+    impl PartialEq for CompositeFix<'_> {
         fn eq(&self, other: &Self) -> bool {
             match self {
                 Self::None => matches!(other, CompositeFix::None),

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -256,7 +256,7 @@ impl From<Message<'_>> for OxcDiagnostic {
     }
 }
 
-impl<'a> GetSpan for Message<'a> {
+impl GetSpan for Message<'_> {
     #[inline]
     fn span(&self) -> Span {
         self.span

--- a/crates/oxc_linter/src/options/allow_warn_deny.rs
+++ b/crates/oxc_linter/src/options/allow_warn_deny.rs
@@ -116,7 +116,7 @@ impl<'de> Deserialize<'de> for AllowWarnDeny {
     {
         struct AllowWarnDenyVisitor;
 
-        impl<'de> de::Visitor<'de> for AllowWarnDenyVisitor {
+        impl de::Visitor<'_> for AllowWarnDenyVisitor {
             type Value = AllowWarnDeny;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -54,7 +54,7 @@ impl Rule for NoDebugger {
                     | AstKind::WhileStatement(_)
                     | AstKind::ForStatement(_)
                     | AstKind::ForInStatement(_)
-                    | AstKind::ForOfStatement(_) => return fixer.replace(stmt.span, "{}"),
+                    | AstKind::ForOfStatement(_) => fixer.replace(stmt.span, "{}"),
                     // NOTE: no need to check for
                     // AstKind::ArrowFunctionExpression because
                     // `const x = () => debugger` is a parse error

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -63,7 +63,7 @@ struct EmptyClassFinder {
     empty_classes: Vec<Span>,
 }
 
-impl<'a> Visit<'a> for EmptyClassFinder {
+impl Visit<'_> for EmptyClassFinder {
     fn visit_character_class(&mut self, class: &CharacterClass) {
         if !class.negative && class.body.is_empty() {
             self.empty_classes.push(class.span);

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -112,11 +112,11 @@ fn resolve_global_binding<'a, 'b: 'a>(
                 // handles "let a = JSON; let b = a; a();"
                 Some(Expression::Identifier(parent_ident)) if parent_ident.name != ident.name => {
                     let decl_scope = decl.scope_id();
-                    return resolve_global_binding(parent_ident, decl_scope, ctx);
+                    resolve_global_binding(parent_ident, decl_scope, ctx)
                 }
                 // handles "let a = globalThis.JSON; let b = a; a();"
                 Some(parent_expr) if parent_expr.is_member_expression() => {
-                    return global_this_member(parent_expr.to_member_expression());
+                    global_this_member(parent_expr.to_member_expression())
                 }
                 _ => None,
             }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -6,7 +6,7 @@ use oxc_semantic::{NodeId, Semantic};
 use super::{options::ArgsOption, NoUnusedVars, Symbol};
 use crate::rules::eslint::no_unused_vars::binding_pattern::{BindingContext, HasAnyUsedBinding};
 
-impl<'s, 'a> Symbol<'s, 'a> {
+impl Symbol<'_, '_> {
     /// Check if the declaration of this [`Symbol`] is use.
     ///
     /// If it's an expression, then it's always passed in as an argument

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
@@ -50,7 +50,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
             return fixer.replace(delete_range, ", ");
         }
 
-        return fixer.delete(&delete_range);
+        fixer.delete(&delete_range)
     }
 
     pub(super) fn rename(&self, new_name: &CompactStr) -> RuleFix<'a> {
@@ -72,8 +72,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
             }
         }
 
-        return RuleFix::from(fixes)
-            .with_message(format!("Rename '{}' to '{new_name}'", self.name()));
+        RuleFix::from(fixes).with_message(format!("Rename '{}' to '{new_name}'", self.name()))
     }
 
     /// - `true` if `pattern` is a destructuring pattern and only contains one symbol

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -165,7 +165,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 }
 
-impl<'s, 'a> Symbol<'s, 'a> {
+impl<'a> Symbol<'_, 'a> {
     /// Is this [`Symbol`] exported?
     ///
     /// NOTE: does not support CJS right now.
@@ -270,7 +270,7 @@ impl<'a> PartialEq<AssignmentTarget<'a>> for Symbol<'_, 'a> {
     }
 }
 
-impl<'s, 'a> PartialEq<ImportDeclarationSpecifier<'a>> for Symbol<'s, 'a> {
+impl<'a> PartialEq<ImportDeclarationSpecifier<'a>> for Symbol<'_, 'a> {
     fn eq(&self, import: &ImportDeclarationSpecifier<'a>) -> bool {
         self == import.local()
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -7,7 +7,7 @@ use oxc_span::{GetSpan, Span};
 
 use super::{ignored::FoundStatus, NoUnusedVars, Symbol};
 
-impl<'s, 'a> Symbol<'s, 'a> {
+impl<'a> Symbol<'_, 'a> {
     // =========================================================================
     // ==================== ENABLE/DISABLE USAGE SUB-CHECKS ====================
     // =========================================================================

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -61,13 +61,13 @@ impl Rule for UnicodeBom {
 
         if has_bomb && matches!(self.bom_option, BomOptionType::Never) {
             ctx.diagnostic_with_fix(unexpected_unicode_bom_diagnostic(SPAN), |fixer| {
-                return fixer.delete_range(Span::new(0, 3));
+                fixer.delete_range(Span::new(0, 3))
             });
         }
 
         if !has_bomb && matches!(self.bom_option, BomOptionType::Always) {
             ctx.diagnostic_with_fix(expected_unicode_bom_diagnostic(SPAN), |fixer| {
-                return fixer.replace(SPAN, "﻿");
+                fixer.replace(SPAN, "﻿")
             });
         }
     }

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -31,8 +31,8 @@ fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool
         return false;
     };
 
-    return mem_expr.static_property_name() == Some("exports")
-        && obj_id.is_global_reference_name("module", ctx.symbols());
+    mem_expr.static_property_name() == Some("exports")
+        && obj_id.is_global_reference_name("module", ctx.symbols())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -629,7 +629,7 @@ impl<'a> CallbackNode<'a> {
     }
 }
 
-impl<'a> GetSpan for CallbackNode<'a> {
+impl GetSpan for CallbackNode<'_> {
     fn span(&self) -> Span {
         match self {
             CallbackNode::Function(func) => func.span,
@@ -991,7 +991,7 @@ impl<'a, 'b> ExhaustiveDepsVisitor<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Visit<'a> for ExhaustiveDepsVisitor<'a, 'b> {
+impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
     fn enter_node(&mut self, kind: AstKind<'a>) {
         self.stack.push(kind);
     }

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -138,7 +138,7 @@ pub fn is_children<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> b
 
     let Some(local_name) = inner_member.static_property_name() else { return false };
 
-    return is_import(ctx, ident.name.as_str(), REACT, REACT) && local_name == CHILDREN;
+    is_import(ctx, ident.name.as_str(), REACT, REACT) && local_name == CHILDREN
 }
 fn is_within_children_to_array<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
     let parents_iter = ctx.nodes().ancestors(node.id()).skip(2);

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
     correctness
 );
 
-fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a IdentifierReference> {
+fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a IdentifierReference<'a>> {
     match node {
         JSXElementName::Identifier(_)
         | JSXElementName::NamespacedName(_)
@@ -45,7 +45,9 @@ fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a Identifi
     }
 }
 
-fn get_member_ident<'a>(mut expr: &'a JSXMemberExpression<'a>) -> Option<&'a IdentifierReference> {
+fn get_member_ident<'a>(
+    mut expr: &'a JSXMemberExpression<'a>,
+) -> Option<&'a IdentifierReference<'a>> {
     loop {
         match &expr.object {
             JSXMemberExpressionObject::IdentifierReference(ident) => return Some(ident),

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -110,7 +110,7 @@ fn is_invalid_expression<'a>(expression: Option<&Expression<'a>>, ctx: &LintCont
                 return is_invalid_type(&asd.type_annotation);
             };
 
-            return is_invalid_expression(var_decl.init.as_ref(), ctx);
+            is_invalid_expression(var_decl.init.as_ref(), ctx)
         }
         _ => false,
     }

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -83,9 +83,9 @@ impl Rule for ConsistentGenericConstructors {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_declarator) => {
-                let type_ann = &variable_declarator.id.type_annotation;
-                let init = &variable_declarator.init;
-                self.check(type_ann, init.as_ref(), ctx);
+                let type_ann = variable_declarator.id.type_annotation.as_ref();
+                let init = variable_declarator.init.as_ref();
+                self.check(type_ann, init, ctx);
             }
             AstKind::AssignmentPattern(assignment_pattern) => {
                 let Some(parent) = ctx.nodes().parent_kind(node.id()) else {
@@ -96,15 +96,14 @@ impl Rule for ConsistentGenericConstructors {
                     return;
                 }
 
-                let type_ann = &assignment_pattern.left.type_annotation;
+                let type_ann = assignment_pattern.left.type_annotation.as_ref();
                 let init = &assignment_pattern.right;
                 self.check(type_ann, Some(init), ctx);
             }
             AstKind::PropertyDefinition(property_definition) => {
-                let type_ann = &property_definition.type_annotation;
-                let init = &property_definition.value;
-
-                self.check(type_ann, init.as_ref(), ctx);
+                let type_ann = property_definition.type_annotation.as_ref();
+                let init = property_definition.value.as_ref();
+                self.check(type_ann, init, ctx);
             }
             _ => {}
         }
@@ -124,7 +123,7 @@ impl Rule for ConsistentGenericConstructors {
 impl ConsistentGenericConstructors {
     fn check(
         &self,
-        type_annotation: &Option<oxc_allocator::Box<TSTypeAnnotation>>,
+        type_annotation: Option<&oxc_allocator::Box<TSTypeAnnotation>>,
         init: Option<&Expression>,
         ctx: &LintContext,
     ) {
@@ -309,8 +308,8 @@ fn test() {
         ("const a: /* comment */ Foo/* another */ <string> = new Foo();", None),
         ("const a: Foo/* comment */ <string> = new Foo /* another */();", None),
         (
-            "const a: Foo<string> = new 
-			 Foo 
+            "const a: Foo<string> = new
+			 Foo
 			 ();",
             None,
         ),
@@ -367,8 +366,8 @@ fn test() {
         ("const a = new Map <string, number> ();", Some(serde_json::json!(["type-annotation"]))),
         ("const a = new Map< string, number >();", Some(serde_json::json!(["type-annotation"]))),
         (
-            "const a = new 
-			 Foo<string> 
+            "const a = new
+			 Foo<string>
 			 ();",
             Some(serde_json::json!(["type-annotation"])),
         ),
@@ -468,11 +467,11 @@ fn test() {
             None,
         ),
         (
-            "const a: Foo<string> = new 
-			 Foo 
+            "const a: Foo<string> = new
+			 Foo
 			 ();",
-            "const a = new 
-			 Foo<string> 
+            "const a = new
+			 Foo<string>
 			 ();",
             None,
         ),
@@ -572,11 +571,11 @@ fn test() {
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
-            "const a = new 
-			 Foo<string> 
+            "const a = new
+			 Foo<string>
 			 ();",
-            "const a: Foo<string> = new 
-			 Foo 
+            "const a: Foo<string> = new
+			 Foo
 			 ();",
             Some(serde_json::json!(["type-annotation"])),
         ),

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -119,10 +119,10 @@ declare_oxc_lint!(
 );
 
 fn match_argument_value_with_regex(allow: &[CompactStr], argument_value: &str) -> bool {
-    return allow
+    allow
         .iter()
         .map(|pattern| Regex::new(pattern).unwrap())
-        .any(|regex| regex.is_match(argument_value));
+        .any(|regex| regex.is_match(argument_value))
 }
 
 impl Rule for NoRequireImports {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -81,7 +81,7 @@ fn check_and_diagnostic(
 }
 
 fn get_symbol_kind<'a>(symbol_id: SymbolId, ctx: &LintContext<'a>) -> AstKind<'a> {
-    return ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id)).kind();
+    ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id)).kind()
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -66,7 +66,7 @@ trait ExpressionExt {
     fn is_increment_of(&self, var_name: &str) -> bool;
 }
 
-impl<'a> ExpressionExt for Expression<'a> {
+impl ExpressionExt for Expression<'_> {
     fn is_increment_of(&self, var_name: &str) -> bool {
         match self {
             Expression::UpdateExpression(expr) => match (&expr.argument, &expr.operator) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -87,7 +87,7 @@ fn get_last_comment_line(comment: Comment, raw: &str) -> String {
         return String::from(raw);
     }
 
-    return String::from(raw.lines().last().unwrap_or(raw));
+    String::from(raw.lines().last().unwrap_or(raw))
 }
 
 fn is_valid_ts_ignore_present(comment: Comment, raw: &str) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -119,7 +119,7 @@ struct HexEscapeFinder {
     hex_escapes: Vec<Span>,
 }
 
-impl<'a> Visit<'a> for HexEscapeFinder {
+impl Visit<'_> for HexEscapeFinder {
     fn visit_character(&mut self, ch: &Character) {
         if ch.kind == CharacterKind::HexadecimalEscape {
             self.hex_escapes.push(ch.span);

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/const_eval.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/const_eval.rs
@@ -53,7 +53,7 @@ pub(super) trait ConstEval {
     fn const_eval(&self) -> ValueHint;
 }
 
-impl<'a> ConstEval for Expression<'a> {
+impl ConstEval for Expression<'_> {
     fn const_eval(&self) -> ValueHint {
         match self.get_inner_expression() {
             Self::ArrayExpression(_) => ValueHint::NewArray,
@@ -70,13 +70,13 @@ impl<'a> ConstEval for Expression<'a> {
     }
 }
 
-impl<'a> ConstEval for ConditionalExpression<'a> {
+impl ConstEval for ConditionalExpression<'_> {
     fn const_eval(&self) -> ValueHint {
         self.consequent.const_eval() & self.alternate.const_eval()
     }
 }
 
-impl<'a> ConstEval for Argument<'a> {
+impl ConstEval for Argument<'_> {
     fn const_eval(&self) -> ValueHint {
         match self {
             // using a spread as an initial accumulator value creates a new
@@ -87,7 +87,7 @@ impl<'a> ConstEval for Argument<'a> {
     }
 }
 
-impl<'a> ConstEval for NewExpression<'a> {
+impl ConstEval for NewExpression<'_> {
     fn const_eval(&self) -> ValueHint {
         if is_new_array(self) || is_new_typed_array(self) {
             ValueHint::NewArray
@@ -137,7 +137,7 @@ pub fn is_new_typed_array(new_expr: &NewExpression) -> bool {
     )
 }
 
-impl<'a> ConstEval for CallExpression<'a> {
+impl ConstEval for CallExpression<'_> {
     fn const_eval(&self) -> ValueHint {
         if is_array_from(self)
             || is_split_method(self)

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -254,7 +254,7 @@ impl Rule for NoUselessUndefined {
                         if is_has_function_return_type(parent_node, ctx) {
                             return;
                         }
-                        return ctx.diagnostic_with_fix(
+                        ctx.diagnostic_with_fix(
                             no_useless_undefined_diagnostic(undefined_literal.span),
                             |fixer| {
                                 fixer.delete_range(Span::new(
@@ -271,7 +271,7 @@ impl Rule for NoUselessUndefined {
                         if is_has_function_return_type(parent_node, ctx) {
                             return;
                         }
-                        return ctx.diagnostic_with_fix(
+                        ctx.diagnostic_with_fix(
                             no_useless_undefined_diagnostic(undefined_literal.span),
                             |fixer| fixer.delete_range(delete_span),
                         );
@@ -325,7 +325,7 @@ impl Rule for NoUselessUndefined {
                 }
 
                 let delete_span = Span::new(start, end);
-                return ctx.diagnostic_with_fix(
+                ctx.diagnostic_with_fix(
                     no_useless_undefined_diagnostic_spans(undefined_args_spans),
                     |fixer| fixer.delete_range(delete_span),
                 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
@@ -202,7 +202,7 @@ fn is_same_node(left: &Expression, right: &Expression, ctx: &LintContext) -> boo
                 return false;
             };
 
-            return template_str.as_str() == right_string_lit.to_string();
+            template_str.as_str() == right_string_lit.to_string()
         }
         (
             Expression::StringLiteral(left_string_lit),
@@ -212,7 +212,7 @@ fn is_same_node(left: &Expression, right: &Expression, ctx: &LintContext) -> boo
                 return false;
             };
 
-            return left_string_lit.to_string() == template_str.as_str();
+            left_string_lit.to_string() == template_str.as_str()
         }
         _ => false,
     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -124,7 +124,7 @@ impl Rule for PreferQuerySelector {
                     let quotes_symbol = source_text.chars().next().unwrap();
                     let sharp = if cur_property_name.eq(&"getElementById") { "#" } else { "" };
                     let span = property_span.merge(&argument_expr.span());
-                    return fixer.replace(span, format!("{preferred_selector}({quotes_symbol}{sharp}{literal_value}{quotes_symbol}"));
+                    fixer.replace(span, format!("{preferred_selector}({quotes_symbol}{sharp}{literal_value}{quotes_symbol}"))
                 });
             }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -282,7 +282,7 @@ impl Rule for PreferSetHas {
                 };
                 references_fix.push(fixer.replace(property_info.0, "has"));
             }
-            return declaration_fix.extend(references_fix);
+            declaration_fix.extend(references_fix)
         });
     }
 }

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+snapshot_kind: text
 ---
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
    ╭─[consistent_generic_constructors.tsx:1:8]
@@ -59,9 +60,9 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
    ╭─[consistent_generic_constructors.tsx:1:8]
- 1 │ const a: Foo<string> = new 
+ 1 │ const a: Foo<string> = new
    ·        ─────────────
- 2 │              Foo 
+ 2 │              Foo
    ╰────
   help: Move the type annotation to the constructor
 
@@ -158,8 +159,8 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
    ╭─[consistent_generic_constructors.tsx:2:8]
- 1 │ const a = new 
- 2 │              Foo<string> 
+ 1 │ const a = new
+ 2 │              Foo<string>
    ·                 ────────
  3 │              ();
    ╰────

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -161,11 +161,11 @@ fn parse_jest_expect_fn_call<'a>(
         expect_error,
     };
 
-    return Some(if is_type_of {
+    Some(if is_type_of {
         ParsedJestFnCall::ExpectTypeOf(parsed_expect_fn)
     } else {
         ParsedJestFnCall::Expect(parsed_expect_fn)
-    });
+    })
 }
 
 type ModifiersAndMatcherIndex = (Vec<usize>, Option<usize>);
@@ -265,12 +265,12 @@ fn parse_jest_jest_fn_call<'a>(
     let kind =
         if lowercase_name == "jest" { JestGeneralFnKind::Jest } else { JestGeneralFnKind::Vitest };
 
-    return Some(ParsedJestFnCall::GeneralJest(ParsedGeneralJestFnCall {
+    Some(ParsedJestFnCall::GeneralJest(ParsedGeneralJestFnCall {
         kind: JestFnKind::General(kind),
         members,
         name: Cow::Borrowed(name),
         local: Cow::Borrowed(local),
-    }));
+    }))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -340,7 +340,7 @@ pub enum ParsedJestFnCall<'a> {
     ExpectTypeOf(ParsedExpectFnCall<'a>),
 }
 
-impl<'a> ParsedJestFnCall<'a> {
+impl ParsedJestFnCall<'_> {
     pub fn kind(&self) -> JestFnKind {
         match self {
             Self::GeneralJest(call) => call.kind,

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -246,9 +246,9 @@ pub fn is_same_member_expression(
         }
     }
 
-    return is_same_reference(
+    is_same_reference(
         left.object().get_inner_expression(),
         right.object().get_inner_expression(),
         ctx,
-    );
+    )
 }

--- a/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
+++ b/crates/oxc_minifier/src/ast_passes/exploit_assigns.rs
@@ -17,7 +17,7 @@ impl<'a> CompressorPass<'a> for ExploitAssigns {
     }
 }
 
-impl<'a> Traverse<'a> for ExploitAssigns {}
+impl Traverse<'_> for ExploitAssigns {}
 
 impl ExploitAssigns {
     pub fn new() -> Self {

--- a/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_remove_dead_code.rs
@@ -304,10 +304,10 @@ impl<'a, 'b> PeepholeRemoveDeadCode {
                         );
                     }
 
-                    return Some(ctx.ast.statement_expression(
+                    Some(ctx.ast.statement_expression(
                         template_lit.span,
                         ctx.ast.expression_sequence(template_lit.span, expressions),
-                    ));
+                    ))
                 }
                 Expression::FunctionExpression(function_expr) if function_expr.id.is_none() => {
                     Some(ctx.ast.statement_empty(SPAN))

--- a/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_replace_known_methods.rs
@@ -164,11 +164,11 @@ impl PeepholeReplaceKnownMethods {
             }
         };
 
-        return Some(ctx.ast.expression_string_literal(
+        Some(ctx.ast.expression_string_literal(
             span,
             string_lit.value.as_str().substring(start_idx, end_idx),
             None,
-        ));
+        ))
     }
 
     fn try_fold_string_char_at<'a>(
@@ -201,7 +201,7 @@ impl PeepholeReplaceKnownMethods {
             .char_at(char_at_index)
             .map_or(String::new(), |v| v.to_string());
 
-        return Some(ctx.ast.expression_string_literal(span, result, None));
+        Some(ctx.ast.expression_string_literal(span, result, None))
     }
 
     fn try_fold_string_char_code_at<'a>(

--- a/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
+++ b/crates/oxc_minifier/src/ast_passes/statement_fusion.rs
@@ -165,7 +165,7 @@ impl<'a> StatementFusion {
 }
 
 fn can_merge_block_stmt(node: &BlockStatement) -> bool {
-    return node.body.iter().all(can_merge_block_stmt_member);
+    node.body.iter().all(can_merge_block_stmt_member)
 }
 
 fn can_merge_block_stmt_member(node: &Statement) -> bool {

--- a/crates/oxc_minifier/src/node_util/mod.rs
+++ b/crates/oxc_minifier/src/node_util/mod.rs
@@ -15,7 +15,7 @@ impl<'a, 'b> Deref for Ctx<'a, 'b> {
     }
 }
 
-impl<'a, 'b> ConstantEvaluation<'a> for Ctx<'a, 'b> {
+impl<'a> ConstantEvaluation<'a> for Ctx<'a, '_> {
     fn is_global_reference(&self, ident: &oxc_ast::ast::IdentifierReference<'a>) -> bool {
         ident.is_global_reference(self.0.symbols())
     }
@@ -25,7 +25,7 @@ pub fn is_exact_int64(num: f64) -> bool {
     num.fract() == 0.0
 }
 
-impl<'a, 'b> Ctx<'a, 'b> {
+impl<'a> Ctx<'a, '_> {
     fn symbols(&self) -> &SymbolTable {
         self.0.symbols()
     }

--- a/crates/oxc_module_lexer/src/lib.rs
+++ b/crates/oxc_module_lexer/src/lib.rs
@@ -97,7 +97,7 @@ pub struct ModuleLexer<'a> {
     pub facade: bool,
 }
 
-impl<'a> Default for ModuleLexer<'a> {
+impl Default for ModuleLexer<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -20,7 +20,7 @@ static LINE_BREAK_TABLE: SafeByteMatchTable =
 static MULTILINE_COMMENT_START_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| matches!(b, b'*' | b'\r' | b'\n' | LS_OR_PS_FIRST));
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// Section 12.4 Single Line Comment
     pub(super) fn skip_single_line_comment(&mut self) -> Kind {
         byte_search! {

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -11,7 +11,7 @@ use crate::diagnostics;
 static NOT_ASCII_JSX_ID_CONTINUE_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !(b.is_ascii_alphanumeric() || matches!(b, b'_' | b'$' | b'-')));
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// `JSXDoubleStringCharacters` ::
     ///   `JSXDoubleStringCharacter` `JSXDoubleStringCharactersopt`
     /// `JSXDoubleStringCharacter` ::

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -3,7 +3,7 @@ use oxc_syntax::identifier::{is_identifier_part_ascii, is_identifier_start};
 use super::{Kind, Lexer, Span};
 use crate::diagnostics;
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// 12.9.3 Numeric Literals with `0` prefix
     pub(super) fn read_zero(&mut self) -> Kind {
         match self.peek_byte() {

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -1,6 +1,6 @@
 use super::{Kind, Lexer, Token};
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// Section 12.8 Punctuators
     pub(super) fn read_dot(&mut self) -> Kind {
         if self.peek_2_bytes() == Some([b'.', b'.']) {

--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -4,7 +4,7 @@ use oxc_syntax::identifier::is_line_terminator;
 use super::{Kind, Lexer, RegExpFlags, Token};
 use crate::diagnostics;
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// Re-tokenize the current `/` or `/=` and return `RegExp`
     /// See Section 12:
     ///   The `InputElementRegExp` goal symbol is used in all syntactic grammar contexts

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -555,7 +555,7 @@ pub struct SourcePosition<'a> {
     _marker: PhantomData<&'a u8>,
 }
 
-impl<'a> SourcePosition<'a> {
+impl SourcePosition<'_> {
     /// Create a new `SourcePosition` from a pointer.
     ///
     /// # SAFETY

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -1,6 +1,6 @@
 use super::{Kind, Lexer, Token};
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     /// Re-tokenize '<<' or '<=' or '<<=' to '<'
     pub(crate) fn re_lex_as_typescript_l_angle(&mut self, kind: Kind) -> Token {
         let offset = match kind {

--- a/crates/oxc_parser/src/lexer/whitespace.rs
+++ b/crates/oxc_parser/src/lexer/whitespace.rs
@@ -6,7 +6,7 @@ use super::{
 static NOT_REGULAR_WHITESPACE_OR_LINE_BREAK_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'));
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     pub(super) fn line_break_handler(&mut self) -> Kind {
         self.token.is_on_new_line = true;
         self.trivia_builder.handle_newline();

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -140,7 +140,7 @@ pub struct Modifiers<'a> {
     flags: ModifierFlags,
 }
 
-impl<'a> Default for Modifiers<'a> {
+impl Default for Modifiers<'_> {
     fn default() -> Self {
         Self::empty()
     }

--- a/crates/oxc_prettier/src/format/array.rs
+++ b/crates/oxc_prettier/src/format/array.rs
@@ -19,7 +19,7 @@ pub enum Array<'a, 'b> {
     ArrayAssignmentTarget(&'b ArrayAssignmentTarget<'a>),
 }
 
-impl<'a, 'b> Array<'a, 'b> {
+impl Array<'_, '_> {
     fn len(&self) -> usize {
         match self {
             Self::ArrayExpression(array) => array.elements.len(),
@@ -45,7 +45,7 @@ impl<'a, 'b> Array<'a, 'b> {
                     return false;
                 }
 
-                return array.elements.iter().all(|element| match element {
+                array.elements.iter().all(|element| match element {
                     ArrayExpressionElement::NumericLiteral(_) => true,
                     ArrayExpressionElement::UnaryExpression(unary_expr) => {
                         matches!(
@@ -54,7 +54,7 @@ impl<'a, 'b> Array<'a, 'b> {
                         ) && matches!(unary_expr.argument, Expression::NumericLiteral(_))
                     }
                     _ => false,
-                });
+                })
             }
             Self::ArrayPattern(_) | Self::ArrayAssignmentTarget(_) | Self::TSTupleType(_) => false,
         }

--- a/crates/oxc_prettier/src/format/call_expression.rs
+++ b/crates/oxc_prettier/src/format/call_expression.rs
@@ -13,7 +13,7 @@ pub(super) enum CallExpressionLike<'a, 'b> {
     NewExpression(&'b NewExpression<'a>),
 }
 
-impl<'a, 'b> CallExpressionLike<'a, 'b> {
+impl<'a> CallExpressionLike<'a, '_> {
     pub fn is_new(&self) -> bool {
         matches!(self, CallExpressionLike::NewExpression(_))
     }

--- a/crates/oxc_prettier/src/format/class.rs
+++ b/crates/oxc_prettier/src/format/class.rs
@@ -140,7 +140,7 @@ pub enum ClassMemberish<'a, 'b> {
     AccessorProperty(&'b AccessorProperty<'a>),
 }
 
-impl<'a, 'b> ClassMemberish<'a, 'b> {
+impl<'a> ClassMemberish<'a, '_> {
     fn format_key(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         match self {
             ClassMemberish::PropertyDefinition(property_definition) => {

--- a/crates/oxc_prettier/src/format/template_literal.rs
+++ b/crates/oxc_prettier/src/format/template_literal.rs
@@ -12,7 +12,7 @@ pub enum TemplateLiteralPrinter<'a, 'b> {
     TSTemplateLiteralType(&'b TSTemplateLiteralType<'a>),
 }
 
-impl<'a, 'b> TemplateLiteralPrinter<'a, 'b> {
+impl<'a> TemplateLiteralPrinter<'a, '_> {
     fn quasis(&self) -> &[TemplateElement<'a>] {
         match self {
             Self::TemplateLiteral(template_literal) => &template_literal.quasis,

--- a/crates/oxc_prettier/src/ir/display.rs
+++ b/crates/oxc_prettier/src/ir/display.rs
@@ -1,6 +1,6 @@
 use crate::ir::{Doc, Line};
 
-impl<'a> std::fmt::Display for Doc<'a> {
+impl std::fmt::Display for Doc<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", print_doc_to_debug(self))
     }

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -52,7 +52,7 @@ pub enum Term<'a> {
     NamedReference(Box<'a, NamedReference<'a>>) = 11,
 }
 
-impl<'a> GetSpan for Term<'a> {
+impl GetSpan for Term<'_> {
     #[inline]
     fn span(&self) -> Span {
         match self {
@@ -241,7 +241,7 @@ pub enum CharacterClassContents<'a> {
     ClassStringDisjunction(Box<'a, ClassStringDisjunction<'a>>) = 5,
 }
 
-impl<'a> GetSpan for CharacterClassContents<'a> {
+impl GetSpan for CharacterClassContents<'_> {
     #[inline]
     fn span(&self) -> Span {
         match self {

--- a/crates/oxc_regular_expression/src/ast_impl/display.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/display.rs
@@ -7,19 +7,19 @@ use std::{
 use crate::ast::*;
 use crate::surrogate_pair::{combine_surrogate_pair, is_lead_surrogate, is_trail_surrogate};
 
-impl<'a> Display for Pattern<'a> {
+impl Display for Pattern<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.body)
     }
 }
 
-impl<'a> Display for Disjunction<'a> {
+impl Display for Disjunction<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_join(f, "|", &self.body)
     }
 }
 
-impl<'a> Display for Alternative<'a> {
+impl Display for Alternative<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn as_character<'a>(term: &'a Term) -> Option<&'a Character> {
             if let Term::Character(ch) = term {
@@ -44,7 +44,7 @@ impl<'a> Display for Alternative<'a> {
     }
 }
 
-impl<'a> Display for Term<'a> {
+impl Display for Term<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::BoundaryAssertion(it) => write!(f, "{}", it.as_ref()),
@@ -80,7 +80,7 @@ impl Display for BoundaryAssertionKind {
     }
 }
 
-impl<'a> Display for LookAroundAssertion<'a> {
+impl Display for LookAroundAssertion<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({}{})", self.kind, self.body)
     }
@@ -97,7 +97,7 @@ impl Display for LookAroundAssertionKind {
     }
 }
 
-impl<'a> Display for Quantifier<'a> {
+impl Display for Quantifier<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.body)?;
 
@@ -154,7 +154,7 @@ impl Display for CharacterClassEscapeKind {
     }
 }
 
-impl<'a> Display for UnicodePropertyEscape<'a> {
+impl Display for UnicodePropertyEscape<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.negative {
             write!(f, r"\P")?;
@@ -172,7 +172,7 @@ impl<'a> Display for UnicodePropertyEscape<'a> {
     }
 }
 
-impl<'a> Display for CharacterClass<'a> {
+impl Display for CharacterClass<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn as_character<'a>(content: &'a CharacterClassContents) -> Option<&'a Character> {
             if let CharacterClassContents::Character(ch) = content {
@@ -214,7 +214,7 @@ impl<'a> Display for CharacterClass<'a> {
     }
 }
 
-impl<'a> Display for CharacterClassContents<'a> {
+impl Display for CharacterClassContents<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CharacterClassRange(it) => write!(f, "{}", it.as_ref()),
@@ -233,7 +233,7 @@ impl Display for CharacterClassRange {
     }
 }
 
-impl<'a> Display for ClassStringDisjunction<'a> {
+impl Display for ClassStringDisjunction<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r"\q{{")?;
         write_join(f, "|", &self.body)?;
@@ -241,13 +241,13 @@ impl<'a> Display for ClassStringDisjunction<'a> {
     }
 }
 
-impl<'a> Display for ClassString<'a> {
+impl Display for ClassString<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_join(f, "", &self.body)
     }
 }
 
-impl<'a> Display for CapturingGroup<'a> {
+impl Display for CapturingGroup<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
 
@@ -260,7 +260,7 @@ impl<'a> Display for CapturingGroup<'a> {
     }
 }
 
-impl<'a> Display for IgnoreGroup<'a> {
+impl Display for IgnoreGroup<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn write_flags(f: &mut fmt::Formatter<'_>, flags: &Modifier) -> fmt::Result {
             if flags.ignore_case {
@@ -297,7 +297,7 @@ impl Display for IndexedReference {
     }
 }
 
-impl<'a> Display for NamedReference<'a> {
+impl Display for NamedReference<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r"\k<{}>", self.name)
     }

--- a/crates/oxc_regular_expression/src/ast_impl/visit.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/visit.rs
@@ -36,7 +36,7 @@ pub enum RegExpAstKind<'a> {
     NamedReference(&'a NamedReference<'a>),
 }
 
-impl<'a> GetSpan for RegExpAstKind<'a> {
+impl GetSpan for RegExpAstKind<'_> {
     #[inline]
     fn span(&self) -> Span {
         match self {

--- a/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
@@ -47,7 +47,7 @@ pub struct Parser {
     options: Options,
 }
 
-impl<'a> Parser {
+impl Parser {
     // This is public because it is used in `parse_regexp_literal()`.
     pub fn handle_code_point(
         body: &mut Vec<ast::CodePoint>,
@@ -71,7 +71,7 @@ impl<'a> Parser {
 
     // ---
 
-    pub fn new(source_text: &'a str, options: Options) -> Self {
+    pub fn new(source_text: &str, options: Options) -> Self {
         Self { chars: source_text.chars().collect::<Vec<_>>(), index: 0, offset: 0, options }
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -116,7 +116,7 @@ pub struct SemanticBuilderReturn<'a> {
     pub errors: Vec<OxcDiagnostic>,
 }
 
-impl<'a> Default for SemanticBuilder<'a> {
+impl Default for SemanticBuilder<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/oxc_semantic/src/dot.rs
+++ b/crates/oxc_semantic/src/dot.rs
@@ -35,7 +35,7 @@ impl<'a, 'b> DebugDotContext<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DebugDotContext<'a, 'b> {
+impl DebugDotContext<'_, '_> {
     fn debug_ast_kind(self, id: NodeId) -> String {
         self.nodes.kind(id).debug_name().into_owned()
     }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -277,7 +277,7 @@ impl IsGlobalReference for ReferenceId {
     }
 }
 
-impl<'a> IsGlobalReference for IdentifierReference<'a> {
+impl IsGlobalReference for IdentifierReference<'_> {
     fn is_global_reference(&self, symbols: &SymbolTable) -> bool {
         self.reference_id
             .get()
@@ -289,7 +289,7 @@ impl<'a> IsGlobalReference for IdentifierReference<'a> {
     }
 }
 
-impl<'a> IsGlobalReference for Expression<'a> {
+impl IsGlobalReference for Expression<'_> {
     fn is_global_reference(&self, symbols: &SymbolTable) -> bool {
         if let Expression::Identifier(ident) = self {
             return ident.is_global_reference(symbols);

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -57,7 +57,7 @@ impl<'a> Atom<'a> {
     }
 }
 
-impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Atom<'old_alloc> {
+impl<'new_alloc> CloneIn<'new_alloc> for Atom<'_> {
     type Cloned = Atom<'new_alloc>;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
@@ -128,7 +128,7 @@ impl<'a> From<Atom<'a>> for Cow<'a, str> {
     }
 }
 
-impl<'a> Deref for Atom<'a> {
+impl Deref for Atom<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -136,19 +136,19 @@ impl<'a> Deref for Atom<'a> {
     }
 }
 
-impl<'a> AsRef<str> for Atom<'a> {
+impl AsRef<str> for Atom<'_> {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<'a> Borrow<str> for Atom<'a> {
+impl Borrow<str> for Atom<'_> {
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<'a, T: AsRef<str>> PartialEq<T> for Atom<'a> {
+impl<T: AsRef<str>> PartialEq<T> for Atom<'_> {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
@@ -160,7 +160,7 @@ impl<'a> PartialEq<Atom<'a>> for &str {
     }
 }
 
-impl<'a> PartialEq<str> for Atom<'a> {
+impl PartialEq<str> for Atom<'_> {
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
     }
@@ -178,31 +178,31 @@ impl<'a> PartialEq<&Atom<'a>> for Cow<'_, str> {
     }
 }
 
-impl<'a> ContentEq for Atom<'a> {
+impl ContentEq for Atom<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         self == other
     }
 }
 
-impl<'a> ContentHash for Atom<'a> {
+impl ContentHash for Atom<'_> {
     fn content_hash<H: hash::Hasher>(&self, state: &mut H) {
         hash::Hash::hash(self, state);
     }
 }
 
-impl<'a> hash::Hash for Atom<'a> {
+impl hash::Hash for Atom<'_> {
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
         self.as_str().hash(hasher);
     }
 }
 
-impl<'a> fmt::Debug for Atom<'a> {
+impl fmt::Debug for Atom<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
-impl<'a> fmt::Display for Atom<'a> {
+impl fmt::Display for Atom<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }

--- a/crates/oxc_span/src/cmp.rs
+++ b/crates/oxc_span/src/cmp.rs
@@ -52,7 +52,7 @@ impl<T: ContentEq> ContentEq for Option<T> {
 }
 
 /// Blanket implementation for [oxc_allocator::Box] types
-impl<'a, T: ContentEq> ContentEq for oxc_allocator::Box<'a, T> {
+impl<T: ContentEq> ContentEq for oxc_allocator::Box<'_, T> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         self.as_ref().content_eq(other.as_ref())
@@ -65,7 +65,7 @@ impl<'a, T: ContentEq> ContentEq for oxc_allocator::Box<'a, T> {
 /// This implementation is slow compared to [PartialEq] for native types which are [Copy] (e.g. `u32`).
 /// Prefer comparing the 2 vectors using `==` if they contain such native types (e.g. `Vec<u32>`).
 /// <https://godbolt.org/z/54on5sMWc>
-impl<'a, T: ContentEq> ContentEq for oxc_allocator::Vec<'a, T> {
+impl<T: ContentEq> ContentEq for oxc_allocator::Vec<'_, T> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         if self.len() == other.len() {

--- a/crates/oxc_span/src/hash.rs
+++ b/crates/oxc_span/src/hash.rs
@@ -32,13 +32,13 @@ impl<T: ContentHash> ContentHash for Option<T> {
     }
 }
 
-impl<'a, T: ContentHash> ContentHash for oxc_allocator::Box<'a, T> {
+impl<T: ContentHash> ContentHash for oxc_allocator::Box<'_, T> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         ContentHash::content_hash(self.as_ref(), state);
     }
 }
 
-impl<'a, T: ContentHash> ContentHash for oxc_allocator::Vec<'a, T> {
+impl<T: ContentHash> ContentHash for oxc_allocator::Vec<'_, T> {
     fn content_hash<H: Hasher>(&self, state: &mut H) {
         for piece in self {
             piece.content_hash(state);

--- a/crates/oxc_syntax/src/module_graph_visitor.rs
+++ b/crates/oxc_syntax/src/module_graph_visitor.rs
@@ -110,7 +110,7 @@ impl<'a, T> ModuleGraphVisitorBuilder<'a, T> {
     }
 }
 
-impl<'a, T> Default for ModuleGraphVisitorBuilder<'a, T> {
+impl<T> Default for ModuleGraphVisitorBuilder<'_, T> {
     fn default() -> Self {
         Self {
             max_depth: u32::MAX,

--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -271,13 +271,13 @@ impl<'a> GatherNodeParts<'a> for ObjectExpression<'a> {
     }
 }
 
-impl<'a> GatherNodeParts<'a> for ThisExpression {
+impl GatherNodeParts<'_> for ThisExpression {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         f("this");
     }
 }
 
-impl<'a> GatherNodeParts<'a> for Super {
+impl GatherNodeParts<'_> for Super {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         f("super");
     }
@@ -470,7 +470,7 @@ impl<'a> GatherNodeParts<'a> for NumericLiteral<'a> {
     }
 }
 
-impl<'a> GatherNodeParts<'a> for BooleanLiteral {
+impl GatherNodeParts<'_> for BooleanLiteral {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         if self.value {
             f("true");
@@ -506,7 +506,7 @@ impl<'a> GatherNodeParts<'a> for JSXOpeningElement<'a> {
     }
 }
 
-impl<'a> GatherNodeParts<'a> for JSXOpeningFragment {
+impl GatherNodeParts<'_> for JSXOpeningFragment {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         f("Fragment");
     }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -375,7 +375,7 @@ impl Oxc {
             }
         }
 
-        impl<'a, 's> Visit<'a> for ScopesTextWriter<'s> {
+        impl Visit<'_> for ScopesTextWriter<'_> {
             fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
                 let scope_id = scope_id.get().unwrap();
                 self.write_line(format!("Scope {} ({flags:?}) {{", scope_id.index()));

--- a/napi/parser/src/module_lexer.rs
+++ b/napi/parser/src/module_lexer.rs
@@ -60,7 +60,7 @@ pub struct ModuleLexerExportSpecifier {
     pub le: Option<u32>,
 }
 
-impl<'a> From<oxc_module_lexer::ImportSpecifier<'a>> for ModuleLexerImportSpecifier {
+impl From<oxc_module_lexer::ImportSpecifier<'_>> for ModuleLexerImportSpecifier {
     #[allow(clippy::cast_lossless)]
     fn from(i: oxc_module_lexer::ImportSpecifier) -> Self {
         Self {
@@ -80,7 +80,7 @@ impl<'a> From<oxc_module_lexer::ImportSpecifier<'a>> for ModuleLexerImportSpecif
     }
 }
 
-impl<'a> From<oxc_module_lexer::ExportSpecifier<'a>> for ModuleLexerExportSpecifier {
+impl From<oxc_module_lexer::ExportSpecifier<'_>> for ModuleLexerExportSpecifier {
     fn from(e: oxc_module_lexer::ExportSpecifier) -> Self {
         Self {
             n: e.n.to_string(),

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -331,7 +331,7 @@ rebuilt        : {value_rebuilt}
     }
 }
 
-impl<'a, 's> PostTransformChecker<'a, 's> {
+impl PostTransformChecker<'_, '_> {
     fn check_scopes(&mut self) {
         for scope_ids in self.scope_ids_map.pairs() {
             // Check bindings are the same
@@ -642,7 +642,7 @@ impl<'a, 'e> SemanticIdsCollector<'a, 'e> {
     }
 }
 
-impl<'a, 'e> Visit<'a> for SemanticIdsCollector<'a, 'e> {
+impl<'a> Visit<'a> for SemanticIdsCollector<'a, '_> {
     fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
         let scope_id = scope_id.get();
         self.scope_ids.push(scope_id);


### PR DESCRIPTION
This PR does not upgrade rustc. Only changes are applied.

We cannot upgrade to the lastet Rust version yet due to wasm-bindgen breaking some generated types.

THere's also some elided lifetimes in `**/generated/**`, which requires modification to ast tools.