### PR TITLE
chore: bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://oxc.rs"
 keywords = ["JavaScript", "TypeScript", "linter", "minifier", "parser"]
 license = "MIT"
 repository = "https://github.com/oxc-project/oxc"
-rust-version = "1.76" # Support last 6 minor versions.
+rust-version = "1.78" # Support last 6 minor versions.
 description = "A collection of JavaScript tools written in Rust."
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>


### PR DESCRIPTION
#7537 bumped Rust version to 1.83.0. Our policy is to support last 6 minor versions, so bump MSRV accordingly to 1.78.