### PR TITLE
refactor(semantic)!: remove `ModuleRecord` from `Semantic`

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -290,9 +290,10 @@ impl IsolatedLintHandler {
                 return Some(Self::wrap_diagnostics(path, &source_text, reports, start));
             };
 
+            let module_record = Arc::new(ret.module_record);
             let mut semantic = semantic_ret.semantic;
             semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
-            let result = self.linter.run(path, Rc::new(semantic));
+            let result = self.linter.run(path, Rc::new(semantic), module_record);
 
             let reports = result
                 .into_iter()

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -7,6 +7,7 @@ use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::Semantic;
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::module_record::ModuleRecord;
 
 #[cfg(debug_assertions)]
 use crate::rule::RuleFixMeta;
@@ -103,6 +104,11 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn semantic(&self) -> &Rc<Semantic<'a>> {
         &self.parent.semantic
+    }
+
+    #[inline]
+    pub fn module_record(&self) -> &ModuleRecord {
+        self.parent.module_record()
     }
 
     /// Get the control flow graph for the current program.

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -2,6 +2,7 @@
 //! consider variables ignored by name pattern, but by where they are declared.
 use oxc_ast::{ast::*, AstKind};
 use oxc_semantic::{NodeId, Semantic};
+use oxc_syntax::module_record::ModuleRecord;
 
 use super::{options::ArgsOption, NoUnusedVars, Symbol};
 use crate::rules::eslint::no_unused_vars::binding_pattern::{BindingContext, HasAnyUsedBinding};
@@ -120,6 +121,7 @@ impl NoUnusedVars {
     pub(super) fn is_allowed_argument<'a>(
         &self,
         semantic: &Semantic<'a>,
+        module_record: &ModuleRecord,
         symbol: &Symbol<'_, 'a>,
         param: &FormalParameter<'a>,
     ) -> bool {
@@ -178,7 +180,7 @@ impl NoUnusedVars {
             return false;
         }
 
-        let ctx = BindingContext { options: self, semantic };
+        let ctx = BindingContext { options: self, semantic, module_record };
         params
             .items
             .iter()

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_semantic::{Semantic, SymbolId};
+use oxc_syntax::module_record::ModuleRecord;
 
 use super::{symbol::Symbol, NoUnusedVars};
 
@@ -7,16 +8,18 @@ use super::{symbol::Symbol, NoUnusedVars};
 pub(super) struct BindingContext<'s, 'a> {
     pub options: &'s NoUnusedVars,
     pub semantic: &'s Semantic<'a>,
+    pub module_record: &'s ModuleRecord,
 }
+
 impl<'s, 'a> BindingContext<'s, 'a> {
     #[inline]
-    pub fn symbol(&self, symbol_id: SymbolId) -> Symbol<'s, 'a> {
-        Symbol::new(self.semantic, symbol_id)
+    pub fn symbol(&self, module_record: &'s ModuleRecord, symbol_id: SymbolId) -> Symbol<'s, 'a> {
+        Symbol::new(self.semantic, module_record, symbol_id)
     }
 
     #[inline]
-    pub fn has_usages(&self, symbol_id: SymbolId) -> bool {
-        self.symbol(symbol_id).has_usages(self.options)
+    pub fn has_usages(&self, symbol_id: SymbolId, module_record: &'s ModuleRecord) -> bool {
+        self.symbol(module_record, symbol_id).has_usages(self.options)
     }
 }
 
@@ -44,7 +47,7 @@ impl<'a> HasAnyUsedBinding<'a> for BindingPatternKind<'a> {
 
 impl<'a> HasAnyUsedBinding<'a> for BindingIdentifier<'a> {
     fn has_any_used_binding(&self, ctx: BindingContext<'_, 'a>) -> bool {
-        ctx.has_usages(self.symbol_id())
+        ctx.has_usages(self.symbol_id(), ctx.module_record)
     }
 }
 impl<'a> HasAnyUsedBinding<'a> for ObjectPattern<'a> {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -205,7 +205,7 @@ impl Rule for NoUnusedVars {
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol = Symbol::new(ctx.semantic().as_ref(), symbol_id);
+        let symbol = Symbol::new(ctx.semantic().as_ref(), ctx.module_record(), symbol_id);
         if Self::should_skip_symbol(&symbol) {
             return;
         }
@@ -294,7 +294,12 @@ impl NoUnusedVars {
                 });
             }
             AstKind::FormalParameter(param) => {
-                if self.is_allowed_argument(ctx.semantic().as_ref(), symbol, param) {
+                if self.is_allowed_argument(
+                    ctx.semantic().as_ref(),
+                    ctx.module_record(),
+                    symbol,
+                    param,
+                ) {
                     return;
                 }
                 ctx.diagnostic(diagnostic::param(symbol, &self.args_ignore_pattern));

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -12,10 +12,12 @@ use oxc_semantic::{
     SymbolTable,
 };
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::module_record::ModuleRecord;
 
 #[derive(Clone)]
 pub(super) struct Symbol<'s, 'a> {
     semantic: &'s Semantic<'a>,
+    module_record: &'s ModuleRecord,
     id: SymbolId,
     flags: SymbolFlags,
     span: OnceCell<Span>,
@@ -29,9 +31,13 @@ impl PartialEq for Symbol<'_, '_> {
 
 // constructor and simple getters
 impl<'s, 'a> Symbol<'s, 'a> {
-    pub fn new(semantic: &'s Semantic<'a>, symbol_id: SymbolId) -> Self {
+    pub fn new(
+        semantic: &'s Semantic<'a>,
+        module_record: &'s ModuleRecord,
+        symbol_id: SymbolId,
+    ) -> Self {
         let flags = semantic.symbols().get_flags(symbol_id);
-        Self { semantic, id: symbol_id, flags, span: OnceCell::new() }
+        Self { semantic, module_record, id: symbol_id, flags, span: OnceCell::new() }
     }
 
     #[inline]
@@ -172,7 +178,7 @@ impl<'a> Symbol<'_, 'a> {
     pub fn is_exported(&self) -> bool {
         let is_in_exportable_scope = self.is_root() || self.is_in_ts_namespace();
         is_in_exportable_scope
-            && (self.semantic.module_record().exported_bindings.contains_key(self.name())
+            && (self.module_record.exported_bindings.contains_key(self.name())
                 || self.in_export_node())
     }
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -86,7 +86,7 @@ impl Rule for Named {
             return;
         }
 
-        let module_record = semantic.module_record();
+        let module_record = ctx.module_record();
 
         for import_entry in &module_record.import_entries {
             // Get named import

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
     fn run_once(&self, ctx: &LintContext<'_>) {
-        if ctx.semantic().module_record().not_esm {
+        if ctx.module_record().not_esm {
             ctx.diagnostic(unambiguous_diagnostic(Span::default()));
         }
     }

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -69,8 +69,7 @@ impl Rule for NoBarrelFile {
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {
-        let semantic = ctx.semantic();
-        let module_record = semantic.module_record();
+        let module_record = ctx.module_record();
 
         if module_record.not_esm {
             return;

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -97,7 +97,7 @@ pub fn import_matcher<'a>(
     expected_module_name: &'a str,
 ) -> bool {
     let expected_module_name = expected_module_name.cow_to_lowercase();
-    ctx.semantic().module_record().import_entries.iter().any(|import| {
+    ctx.module_record().import_entries.iter().any(|import| {
         import.module_request.name().as_str() == expected_module_name
             && import.local_name.name().as_str() == actual_local_name
     })
@@ -109,7 +109,7 @@ pub fn is_import<'a>(
     expected_local_name: &'a str,
     expected_module_name: &'a str,
 ) -> bool {
-    if ctx.semantic().module_record().requested_modules.is_empty()
+    if ctx.module_record().requested_modules.is_empty()
         && ctx.scopes().get_bindings(ctx.scopes().root_scope_id()).is_empty()
     {
         return actual_local_name == expected_local_name;

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -297,9 +297,8 @@ impl Runtime {
         };
 
         let mut semantic = semantic_ret.semantic;
-        semantic.set_module_record(&module_record);
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
-        self.linter.run(path, Rc::new(semantic))
+        self.linter.run(path, Rc::new(semantic), Arc::clone(&module_record))
     }
 
     pub(super) fn init_cache_state(&self, path: &Path) -> bool {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -321,10 +321,12 @@ mod test {
             SemanticBuilder::new().with_cfg(true).build(&parser_ret.program).semantic;
         let semantic_ret = Rc::new(semantic_ret);
 
+        let module_record = Arc::new(parser_ret.module_record);
         let build_ctx = |path: &'static str| {
             Rc::new(ContextHost::new(
                 path,
                 Rc::clone(&semantic_ret),
+                Arc::clone(&module_record),
                 LintOptions::default(),
                 Arc::default(),
             ))

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1,9 +1,6 @@
 //! Semantic Builder
 
-use std::{
-    cell::{Cell, RefCell},
-    sync::Arc,
-};
+use std::cell::{Cell, RefCell};
 
 use rustc_hash::FxHashMap;
 
@@ -289,7 +286,6 @@ impl<'a> SemanticBuilder<'a> {
             source_type: self.source_type,
             comments,
             irregular_whitespaces: [].into(),
-            module_record: Arc::new(oxc_syntax::module_record::ModuleRecord::default()),
             nodes: self.nodes,
             scopes: self.scope,
             symbols: self.symbols,

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -6,14 +6,12 @@
 //! ```
 
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
 use oxc_ast::{
     ast::IdentifierReference, comments_range, has_comments_between, AstKind, Comment, CommentsRange,
 };
 use oxc_cfg::ControlFlowGraph;
 use oxc_span::{GetSpan, SourceType, Span};
-use oxc_syntax::module_record::ModuleRecord;
 pub use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
@@ -81,8 +79,6 @@ pub struct Semantic<'a> {
     comments: &'a oxc_allocator::Vec<'a, Comment>,
     irregular_whitespaces: Box<[Span]>,
 
-    module_record: Arc<ModuleRecord>,
-
     /// Parsed JSDoc comments.
     jsdoc: JSDocFinder<'a>,
 
@@ -134,10 +130,6 @@ impl<'a> Semantic<'a> {
         self.irregular_whitespaces = irregular_whitespaces;
     }
 
-    pub fn set_module_record(&mut self, module_record: &Arc<ModuleRecord>) {
-        self.module_record = Arc::clone(module_record);
-    }
-
     /// Trivias (comments) found while parsing
     pub fn comments(&self) -> &[Comment] {
         self.comments
@@ -163,11 +155,6 @@ impl<'a> Semantic<'a> {
     /// Will be empty if JSDoc parsing is disabled.
     pub fn jsdoc(&self) -> &JSDocFinder<'a> {
         &self.jsdoc
-    }
-
-    /// ESM module record containing imports and exports.
-    pub fn module_record(&self) -> &ModuleRecord {
-        self.module_record.as_ref()
     }
 
     /// [`SymbolTable`] containing all symbols in the program and their

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path, rc::Rc};
+use std::{env, path::Path, rc::Rc, sync::Arc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -39,7 +39,8 @@ fn bench_linter(criterion: &mut Criterion) {
                     .build(&ret.program);
                 let linter = LinterBuilder::all().with_fix(FixKind::All).build();
                 let semantic = Rc::new(semantic_ret.semantic);
-                b.iter(|| linter.run(path, Rc::clone(&semantic)));
+                let module_record = Arc::new(ret.module_record);
+                b.iter(|| linter.run(path, Rc::clone(&semantic), Arc::clone(&module_record)));
             },
         );
     }


### PR DESCRIPTION
`ModuleRecord` will eventually be moved to be linter specific thing for cross module data sharing, which means we can add more data to it.