### PR TITLE
feat(parser,linter)!: use a different `ModuleRecord` for linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,7 +1986,6 @@ version = "0.38.0"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.6.0",
- "dashmap 6.1.0",
  "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",

--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -13,7 +13,7 @@ use oxc_allocator::Allocator;
 use oxc_diagnostics::{Error, NamedSource, Severity};
 use oxc_linter::{
     loader::{JavaScriptSource, Loader},
-    FixKind, Linter,
+    FixKind, Linter, ModuleRecord,
 };
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::SemanticBuilder;
@@ -290,7 +290,7 @@ impl IsolatedLintHandler {
                 return Some(Self::wrap_diagnostics(path, &source_text, reports, start));
             };
 
-            let module_record = Arc::new(ret.module_record);
+            let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record));
             let mut semantic = semantic_ret.semantic;
             semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
             let result = self.linter.run(path, Rc::new(semantic), module_record);

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -2,13 +2,13 @@ use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
 use oxc_semantic::Semantic;
 use oxc_span::SourceType;
-use oxc_syntax::module_record::ModuleRecord;
 
 use crate::{
     config::{LintConfig, LintPlugins},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
     fixer::{FixKind, Message},
     frameworks,
+    module_record::ModuleRecord,
     options::LintOptions,
     utils, FrameworkFlags, RuleWithSeverity,
 };

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -7,7 +7,6 @@ use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::Semantic;
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::module_record::ModuleRecord;
 
 #[cfg(debug_assertions)]
 use crate::rule::RuleFixMeta;
@@ -15,7 +14,7 @@ use crate::{
     disable_directives::DisableDirectives,
     fixer::{FixKind, Message, RuleFix, RuleFixer},
     javascript_globals::GLOBALS,
-    AllowWarnDeny, FrameworkFlags, OxlintEnv, OxlintGlobals, OxlintSettings,
+    AllowWarnDeny, FrameworkFlags, ModuleRecord, OxlintEnv, OxlintGlobals, OxlintSettings,
 };
 
 pub(crate) use host::ContextHost;

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -1,7 +1,8 @@
 use std::{hash, path::Path};
 
 use bitflags::bitflags;
-use oxc_syntax::module_record::ModuleRecord;
+
+use crate::ModuleRecord;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -12,6 +12,8 @@ mod fixer;
 mod frameworks;
 mod globals;
 mod javascript_globals;
+mod module_graph_visitor;
+mod module_record;
 mod options;
 mod rule;
 mod rules;
@@ -24,7 +26,6 @@ pub mod table;
 use std::{io::Write, path::Path, rc::Rc, sync::Arc};
 
 use oxc_semantic::{AstNode, Semantic};
-use oxc_syntax::module_record::ModuleRecord;
 
 pub use crate::{
     builder::{LinterBuilder, LinterBuilderError},
@@ -32,6 +33,7 @@ pub use crate::{
     context::LintContext,
     fixer::FixKind,
     frameworks::FrameworkFlags,
+    module_record::ModuleRecord,
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -4,7 +4,7 @@ use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 use oxc_span::CompactStr;
 use rustc_hash::FxHashSet;
 
-use crate::module_record::ModuleRecord;
+use crate::ModuleRecord;
 
 type ModulePair<'a> = (&'a CompactStr, &'a Arc<ModuleRecord>);
 
@@ -73,19 +73,19 @@ impl<'a, T> ModuleGraphVisitorBuilder<'a, T> {
         self
     }
 
-    /// Sets the enter module event closure.
-    #[must_use]
-    pub fn enter<F: FnMut(ModulePair, &ModuleRecord) + 'a>(mut self, enter: F) -> Self {
-        self.enter = Some(Box::new(enter));
-        self
-    }
+    // /// Sets the enter module event closure.
+    // #[must_use]
+    // pub fn enter<F: FnMut(ModulePair, &ModuleRecord) + 'a>(mut self, enter: F) -> Self {
+    // self.enter = Some(Box::new(enter));
+    // self
+    // }
 
-    /// Sets the leave module event closure.
-    #[must_use]
-    pub fn leave<F: FnMut(ModulePair, &ModuleRecord) + 'a>(mut self, leave: F) -> Self {
-        self.leave = Some(Box::new(leave));
-        self
-    }
+    // /// Sets the leave module event closure.
+    // #[must_use]
+    // pub fn leave<F: FnMut(ModulePair, &ModuleRecord) + 'a>(mut self, leave: F) -> Self {
+    // self.leave = Some(Box::new(leave));
+    // self
+    // }
 
     /// Behaves similar to a flat fold_while iteration.
     pub fn visit_fold<V: Fn(T, ModulePair, &ModuleRecord) -> VisitFoldWhile<T>>(
@@ -125,13 +125,13 @@ impl<T> Default for ModuleGraphVisitorBuilder<'_, T> {
 
 pub struct ModuleGraphVisitResult<T> {
     pub result: T,
-    pub traversed: FxHashSet<PathBuf>,
-    pub max_depth: u32,
+    pub _traversed: FxHashSet<PathBuf>,
+    pub _max_depth: u32,
 }
 
 impl<T> ModuleGraphVisitResult<T> {
     fn with_result(result: T, visitor: ModuleGraphVisitor) -> Self {
-        Self { result, traversed: visitor.traversed, max_depth: visitor.max_depth }
+        Self { result, _traversed: visitor.traversed, _max_depth: visitor.max_depth }
     }
 }
 

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -1,0 +1,494 @@
+//! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
+#![allow(missing_docs)] // fixme
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use dashmap::DashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
+use oxc_span::{CompactStr, Span};
+pub use oxc_syntax::module_record::RequestedModule;
+
+type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
+
+/// ESM Module Record
+///
+/// All data inside this data structure are for ESM, no commonjs data is allowed.
+///
+/// See
+/// * <https://tc39.es/ecma262/#table-additional-fields-of-source-text-module-records>
+/// * <https://tc39.es/ecma262/#cyclic-module-record>
+#[derive(Default)]
+pub struct ModuleRecord {
+    /// This module has no import / export statements
+    pub not_esm: bool,
+
+    /// Resolved absolute path to this module record
+    pub resolved_absolute_path: PathBuf,
+
+    /// `[[RequestedModules]]`
+    ///
+    /// A List of all the ModuleSpecifier strings used by the module represented by this record to request the importation of a module. The List is in source text occurrence order.
+    ///
+    /// Module requests from:
+    ///   import ImportClause FromClause
+    ///   import ModuleSpecifier
+    ///   export ExportFromClause FromClause
+    /// Keyed by ModuleSpecifier, valued by all node occurrences
+    pub requested_modules: FxHashMap<CompactStr, Vec<RequestedModule>>,
+
+    /// `[[LoadedModules]]`
+    ///
+    /// A map from the specifier strings used by the module represented by this record to request
+    /// the importation of a module to the resolved Module Record. The list does not contain two
+    /// different Records with the same `[[Specifier]]`.
+    ///
+    /// Note that Oxc does not support cross-file analysis, so this map will be empty after
+    /// [`ModuleRecord`] is created. You must link the module records yourself.
+    pub loaded_modules: FxDashMap<CompactStr, Arc<ModuleRecord>>,
+
+    /// `[[ImportEntries]]`
+    ///
+    /// A List of `ImportEntry` records derived from the code of this module
+    pub import_entries: Vec<ImportEntry>,
+
+    /// `[[LocalExportEntries]]`
+    ///
+    /// A List of `ExportEntry` records derived from the code of this module
+    /// that correspond to declarations that occur within the module
+    pub local_export_entries: Vec<ExportEntry>,
+
+    /// `[[IndirectExportEntries]]`
+    ///
+    /// A List of `ExportEntry` records derived from the code of this module
+    /// that correspond to reexported imports that occur within the module
+    /// or exports from `export * as namespace` declarations.
+    pub indirect_export_entries: Vec<ExportEntry>,
+
+    /// `[[StarExportEntries]]`
+    ///
+    /// A List of `ExportEntry` records derived from the code of this module
+    /// that correspond to `export *` declarations that occur within the module,
+    /// not including `export * as namespace` declarations.
+    pub star_export_entries: Vec<ExportEntry>,
+
+    /// Local exported bindings
+    pub exported_bindings: FxHashMap<CompactStr, Span>,
+
+    /// Local duplicated exported bindings, for diagnostics
+    pub exported_bindings_duplicated: Vec<NameSpan>,
+
+    /// Reexported bindings from `export * from 'specifier'`
+    /// Keyed by resolved path
+    pub exported_bindings_from_star_export: FxDashMap<PathBuf, Vec<CompactStr>>,
+
+    /// `export default name`
+    ///         ^^^^^^^ span
+    pub export_default: Option<Span>,
+
+    /// Duplicated span of `export default` for diagnostics
+    pub export_default_duplicated: Vec<Span>,
+}
+
+impl fmt::Debug for ModuleRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        // recursively formatting loaded modules can crash when the module graph is cyclic
+        let loaded_modules = self
+            .loaded_modules
+            .iter()
+            .map(|entry| (entry.key().to_string()))
+            .reduce(|acc, key| format!("{acc}, {key}"))
+            .unwrap_or_default();
+        let loaded_modules = format!("{{ {loaded_modules} }}");
+        f.debug_struct("ModuleRecord")
+            .field("not_esm", &self.not_esm)
+            .field("resolved_absolute_path", &self.resolved_absolute_path)
+            .field("requested_modules", &self.requested_modules)
+            .field("loaded_modules", &loaded_modules)
+            .field("import_entries", &self.import_entries)
+            .field("local_export_entries", &self.local_export_entries)
+            .field("indirect_export_entries", &self.indirect_export_entries)
+            .field("star_export_entries", &self.star_export_entries)
+            .field("exported_bindings", &self.exported_bindings)
+            .field("exported_bindings_duplicated", &self.exported_bindings_duplicated)
+            .field("exported_bindings_from_star_export", &self.exported_bindings_from_star_export)
+            .field("export_default", &self.export_default)
+            .field("export_default_duplicated", &self.export_default_duplicated)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NameSpan {
+    name: CompactStr,
+    span: Span,
+}
+
+impl NameSpan {
+    pub fn new(name: CompactStr, span: Span) -> Self {
+        Self { name, span }
+    }
+
+    pub const fn name(&self) -> &CompactStr {
+        &self.name
+    }
+
+    pub const fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<'a> From<&oxc_syntax::module_record::NameSpan<'a>> for NameSpan {
+    fn from(other: &oxc_syntax::module_record::NameSpan<'a>) -> Self {
+        Self { name: CompactStr::from(other.name.as_str()), span: other.span }
+    }
+}
+
+/// [`ImportEntry`](https://tc39.es/ecma262/#importentry-record)
+///
+/// ## Examples
+///
+/// ```ts
+/// //     _ local_name
+/// import v from "mod";
+/// //             ^^^ module_request
+///
+/// //     ____ is_type will be `true`
+/// import type { foo as bar } from "mod";
+/// // import_name^^^    ^^^ local_name
+///
+/// import * as ns from "mod";
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportEntry {
+    /// String value of the ModuleSpecifier of the ImportDeclaration.
+    ///
+    /// ## Examples
+    ///
+    /// ```ts
+    /// import { foo } from "mod";
+    /// //                   ^^^
+    /// ```
+    pub module_request: NameSpan,
+
+    /// The name under which the desired binding is exported by the module identified by `[[ModuleRequest]]`.
+    ///
+    /// ## Examples
+    ///
+    /// ```ts
+    /// import { foo } from "mod";
+    /// //       ^^^
+    /// import { foo as bar } from "mod";
+    /// //       ^^^
+    /// ```
+    pub import_name: ImportImportName,
+
+    /// The name that is used to locally access the imported value from within the importing module.
+    ///
+    /// ## Examples
+    ///
+    /// ```ts
+    /// import { foo } from "mod";
+    /// //       ^^^
+    /// import { foo as bar } from "mod";
+    /// //              ^^^
+    /// ```
+    pub local_name: NameSpan,
+
+    /// Whether this binding is for a TypeScript type-only import. This is a non-standard field.
+    /// When creating a [`ModuleRecord`] for a JavaScript file, this will always be false.
+    ///
+    /// ## Examples
+    ///
+    /// `is_type` will be `true` for the following imports:
+    /// ```ts
+    /// import type { foo } from "mod";
+    /// import { type foo } from "mod";
+    /// ```
+    ///
+    /// and will be `false` for these imports:
+    /// ```ts
+    /// import { foo } from "mod";
+    /// import { foo as type } from "mod";
+    /// ```
+    pub is_type: bool,
+}
+
+impl<'a> From<&oxc_syntax::module_record::ImportEntry<'a>> for ImportEntry {
+    fn from(other: &oxc_syntax::module_record::ImportEntry<'a>) -> Self {
+        Self {
+            module_request: NameSpan::from(&other.module_request),
+            import_name: ImportImportName::from(&other.import_name),
+            local_name: NameSpan::from(&other.local_name),
+            is_type: other.is_type,
+        }
+    }
+}
+
+/// `ImportName` For `ImportEntry`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportImportName {
+    Name(NameSpan),
+    NamespaceObject,
+    Default(Span),
+}
+
+impl ImportImportName {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default(_))
+    }
+
+    pub fn is_namespace_object(&self) -> bool {
+        matches!(self, Self::NamespaceObject)
+    }
+}
+
+impl<'a> From<&oxc_syntax::module_record::ImportImportName<'a>> for ImportImportName {
+    fn from(other: &oxc_syntax::module_record::ImportImportName<'a>) -> Self {
+        match other {
+            oxc_syntax::module_record::ImportImportName::Name(name_span) => {
+                Self::Name(NameSpan::from(name_span))
+            }
+            oxc_syntax::module_record::ImportImportName::NamespaceObject => Self::NamespaceObject,
+            oxc_syntax::module_record::ImportImportName::Default(span) => Self::Default(*span),
+        }
+    }
+}
+
+/// [`ExportEntry`](https://tc39.es/ecma262/#exportentry-record)
+///
+/// Describes a single exported binding from a module. Named export statements that contain more
+/// than one binding produce multiple ExportEntry records.
+///
+/// ## Examples
+///
+/// ```ts
+/// // foo's ExportEntry nas no `module_request` or `import_name.
+/// //       ___ local_name
+/// export { foo };
+/// //       ^^^ export_name. Since there's no alias, it's the same as local_name.
+///
+/// // re-exports do not produce local bindings, so `local_name` is null.
+/// //       ___ import_name    __ module_request
+/// export { foo as bar } from "mod";
+/// //              ^^^ export_name
+///
+/// ```
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ExportEntry {
+    /// Span for the entire export entry
+    pub span: Span,
+
+    /// The String value of the ModuleSpecifier of the ExportDeclaration.
+    /// null if the ExportDeclaration does not have a ModuleSpecifier.
+    pub module_request: Option<NameSpan>,
+
+    /// The name under which the desired binding is exported by the module identified by `[[ModuleRequest]]`.
+    /// null if the ExportDeclaration does not have a ModuleSpecifier.
+    /// "all" is used for `export * as ns from "mod"`` declarations.
+    /// "all-but-default" is used for `export * from "mod" declarations`.
+    pub import_name: ExportImportName,
+
+    /// The name used to export this binding by this module.
+    pub export_name: ExportExportName,
+
+    /// The name that is used to locally access the exported value from within the importing module.
+    /// null if the exported value is not locally accessible from within the module.
+    pub local_name: ExportLocalName,
+}
+
+impl<'a> From<&oxc_syntax::module_record::ExportEntry<'a>> for ExportEntry {
+    fn from(other: &oxc_syntax::module_record::ExportEntry<'a>) -> Self {
+        Self {
+            span: other.span,
+            module_request: other.module_request.as_ref().map(NameSpan::from),
+            import_name: ExportImportName::from(&other.import_name),
+            export_name: ExportExportName::from(&other.export_name),
+            local_name: ExportLocalName::from(&other.local_name),
+        }
+    }
+}
+
+/// `ImportName` for `ExportEntry`
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum ExportImportName {
+    Name(NameSpan),
+    /// all is used for export * as ns from "mod" declarations.
+    All,
+    /// all-but-default is used for export * from "mod" declarations.
+    AllButDefault,
+    /// the ExportDeclaration does not have a ModuleSpecifier
+    #[default]
+    Null,
+}
+
+impl<'a> From<&oxc_syntax::module_record::ExportImportName<'a>> for ExportImportName {
+    fn from(other: &oxc_syntax::module_record::ExportImportName<'a>) -> Self {
+        match other {
+            oxc_syntax::module_record::ExportImportName::Name(name_span) => {
+                Self::Name(NameSpan::from(name_span))
+            }
+            oxc_syntax::module_record::ExportImportName::All => Self::All,
+            oxc_syntax::module_record::ExportImportName::AllButDefault => Self::AllButDefault,
+            oxc_syntax::module_record::ExportImportName::Null => Self::Null,
+        }
+    }
+}
+
+impl ExportImportName {
+    pub fn is_all(&self) -> bool {
+        matches!(self, Self::All)
+    }
+
+    pub fn is_all_but_default(&self) -> bool {
+        matches!(self, Self::AllButDefault)
+    }
+}
+
+/// `ExportName` for `ExportEntry`
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum ExportExportName {
+    Name(NameSpan),
+    Default(Span),
+    #[default]
+    Null,
+}
+
+impl ExportExportName {
+    /// Returns `true` if this is [`ExportExportName::Default`].
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default(_))
+    }
+
+    /// Returns `true` if this is [`ExportExportName::Null`].
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Attempt to get the [`Span`] of this export name.
+    pub fn span(&self) -> Option<Span> {
+        match self {
+            Self::Name(name) => Some(name.span()),
+            Self::Default(span) => Some(*span),
+            Self::Null => None,
+        }
+    }
+}
+
+impl<'a> From<&oxc_syntax::module_record::ExportExportName<'a>> for ExportExportName {
+    fn from(other: &oxc_syntax::module_record::ExportExportName<'a>) -> Self {
+        match other {
+            oxc_syntax::module_record::ExportExportName::Name(name_span) => {
+                Self::Name(NameSpan::from(name_span))
+            }
+            oxc_syntax::module_record::ExportExportName::Default(span) => Self::Default(*span),
+            oxc_syntax::module_record::ExportExportName::Null => Self::Null,
+        }
+    }
+}
+
+/// `LocalName` for `ExportEntry`
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum ExportLocalName {
+    Name(NameSpan),
+    /// `export default name_span`
+    Default(NameSpan),
+    #[default]
+    Null,
+}
+
+impl ExportLocalName {
+    /// `true` if this is a [`ExportLocalName::Default`].
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default(_))
+    }
+
+    /// `true` if this is a [`ExportLocalName::Null`].
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Get the bound name of this export. [`None`] for [`ExportLocalName::Null`].
+    pub const fn name(&self) -> Option<&CompactStr> {
+        match self {
+            Self::Name(name) | Self::Default(name) => Some(name.name()),
+            Self::Null => None,
+        }
+    }
+}
+
+impl<'a> From<&oxc_syntax::module_record::ExportLocalName<'a>> for ExportLocalName {
+    fn from(other: &oxc_syntax::module_record::ExportLocalName<'a>) -> Self {
+        match other {
+            oxc_syntax::module_record::ExportLocalName::Name(name_span) => {
+                Self::Name(NameSpan::from(name_span))
+            }
+            oxc_syntax::module_record::ExportLocalName::Default(name_span) => {
+                Self::Default(NameSpan::from(name_span))
+            }
+            oxc_syntax::module_record::ExportLocalName::Null => Self::Null,
+        }
+    }
+}
+
+impl ModuleRecord {
+    pub fn new(path: &Path, other: &oxc_syntax::module_record::ModuleRecord) -> Self {
+        Self {
+            not_esm: other.not_esm,
+            resolved_absolute_path: path.to_path_buf(),
+            requested_modules: other
+                .requested_modules
+                .iter()
+                .map(|(name, requested_modules)| {
+                    (
+                        CompactStr::from(name.as_str()),
+                        requested_modules.iter().copied().collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+            import_entries: other.import_entries.iter().map(ImportEntry::from).collect(),
+
+            local_export_entries: other
+                .local_export_entries
+                .iter()
+                .map(ExportEntry::from)
+                .collect(),
+            indirect_export_entries: other
+                .indirect_export_entries
+                .iter()
+                .map(ExportEntry::from)
+                .collect(),
+            star_export_entries: other.star_export_entries.iter().map(ExportEntry::from).collect(),
+            exported_bindings: other
+                .exported_bindings
+                .iter()
+                .map(|(name, span)| (CompactStr::from(name.as_str()), *span))
+                .collect(),
+            exported_bindings_duplicated: other
+                .exported_bindings_duplicated
+                .iter()
+                .map(NameSpan::from)
+                .collect(),
+            exported_bindings_from_star_export: other
+                .exported_bindings_from_star_export
+                .iter()
+                .map(|(name, values)| {
+                    (
+                        PathBuf::from(name.as_str()),
+                        values
+                            .into_iter()
+                            .map(|v| CompactStr::from(v.as_str()))
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+            export_default: other.export_default,
+            export_default_duplicated: other.export_default_duplicated.iter().copied().collect(),
+            ..ModuleRecord::default()
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -3,9 +3,12 @@ use rustc_hash::FxHashMap;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
-use oxc_syntax::module_record::{ExportImportName, ImportImportName};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_record::{ExportImportName, ImportImportName},
+    rule::Rule,
+};
 
 fn no_duplicate_imports_diagnostic(module_name: &str, span: Span, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{module_name}' import is duplicated"))

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -2,10 +2,12 @@
 //! consider variables ignored by name pattern, but by where they are declared.
 use oxc_ast::{ast::*, AstKind};
 use oxc_semantic::{NodeId, Semantic};
-use oxc_syntax::module_record::ModuleRecord;
 
 use super::{options::ArgsOption, NoUnusedVars, Symbol};
-use crate::rules::eslint::no_unused_vars::binding_pattern::{BindingContext, HasAnyUsedBinding};
+use crate::{
+    rules::eslint::no_unused_vars::binding_pattern::{BindingContext, HasAnyUsedBinding},
+    ModuleRecord,
+};
 
 impl Symbol<'_, '_> {
     /// Check if the declaration of this [`Symbol`] is use.

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
@@ -1,8 +1,9 @@
 use oxc_ast::ast::*;
 use oxc_semantic::{Semantic, SymbolId};
-use oxc_syntax::module_record::ModuleRecord;
 
 use super::{symbol::Symbol, NoUnusedVars};
+
+use crate::ModuleRecord;
 
 #[derive(Clone, Copy)]
 pub(super) struct BindingContext<'s, 'a> {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -12,7 +12,8 @@ use oxc_semantic::{
     SymbolTable,
 };
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::module_record::ModuleRecord;
+
+use crate::ModuleRecord;
 
 #[derive(Clone)]
 pub(super) struct Symbol<'s, 'a> {

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -1,9 +1,8 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{Span, VALID_EXTENSIONS};
-use oxc_syntax::module_record::ImportImportName;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
 fn default_diagnostic(imported_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No default export found in imported module {imported_name:?}"))

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -5,9 +5,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
-use oxc_syntax::module_record::ModuleRecord;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, rule::Rule, ModuleRecord};
 
 fn no_named_export(module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No named exports found in module '{module_name}'"))

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -1,9 +1,12 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use oxc_syntax::module_record::{ExportImportName, ImportImportName};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_record::{ExportImportName, ImportImportName},
+    rule::Rule,
+};
 
 fn named_diagnostic(imported_name: &str, module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("named import {imported_name:?} not found"))

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -8,11 +8,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::module_record::{
-    ExportExportName, ExportImportName, ImportImportName, ModuleRecord,
-};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_record::{ExportExportName, ExportImportName, ImportImportName, ModuleRecord},
+    rule::Rule,
+};
 
 fn no_export(span: Span, specifier_name: &str, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -5,12 +5,13 @@ use cow_utils::CowUtils;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
-use oxc_syntax::{
-    module_graph_visitor::{ModuleGraphVisitorBuilder, ModuleGraphVisitorEvent, VisitFoldWhile},
-    module_record::ModuleRecord,
-};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_graph_visitor::{ModuleGraphVisitorBuilder, ModuleGraphVisitorEvent, VisitFoldWhile},
+    rule::Rule,
+    ModuleRecord,
+};
 
 fn no_cycle_diagnostic(span: Span, paths: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Dependency cycle detected")

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -4,10 +4,13 @@ use itertools::Itertools;
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use oxc_syntax::module_record::{ImportImportName, RequestedModule};
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_record::{ImportImportName, RequestedModule},
+    rule::Rule,
+};
 
 fn no_duplicates_diagnostic<I>(
     module_name: &str,

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -1,9 +1,8 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use oxc_syntax::module_record::ImportImportName;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
 fn no_named_as_default_diagnostic(
     span: Span,

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -6,10 +6,9 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
-use oxc_syntax::module_record::ImportImportName;
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
 fn no_named_as_default_member_dignostic(
     span: Span,

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -3,9 +3,8 @@ use oxc_diagnostics::OxcDiagnostic;
 
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, Span};
-use oxc_syntax::module_record::ImportImportName;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
 
 fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Usage of namespaced aka wildcard \"*\" imports prohibited")

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -1,11 +1,12 @@
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
-use oxc_syntax::{
-    module_graph_visitor::{ModuleGraphVisitorBuilder, VisitFoldWhile},
-    module_record::ModuleRecord,
-};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::LintContext,
+    module_graph_visitor::{ModuleGraphVisitorBuilder, VisitFoldWhile},
+    rule::Rule,
+    ModuleRecord,
+};
 
 fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(

--- a/crates/oxc_linter/src/service/module_cache.rs
+++ b/crates/oxc_linter/src/service/module_cache.rs
@@ -7,7 +7,7 @@ use std::{
 use dashmap::{mapref::one::Ref, DashMap};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use oxc_syntax::module_record::ModuleRecord;
+use crate::ModuleRecord;
 
 type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -7,18 +7,19 @@ use std::{
     sync::Arc,
 };
 
+use rayon::{iter::ParallelBridge, prelude::ParallelIterator};
+use rustc_hash::FxHashSet;
+
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_resolver::Resolver;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::{SourceType, VALID_EXTENSIONS};
-use oxc_syntax::module_record::ModuleRecord;
-use rayon::{iter::ParallelBridge, prelude::ParallelIterator};
-use rustc_hash::FxHashSet;
 
 use crate::{
     loader::{JavaScriptSource, PartialLoader, LINT_PARTIAL_LOADER_EXT},
+    module_record::ModuleRecord,
     utils::read_to_string,
     Fixer, Linter, Message,
 };
@@ -218,7 +219,7 @@ impl Runtime {
             .with_build_jsdoc(true)
             .with_check_syntax_error(check_syntax_errors);
 
-        let mut module_record = ret.module_record;
+        let mut module_record = ModuleRecord::new(path, &ret.module_record);
         module_record.resolved_absolute_path = path.to_path_buf();
         let module_record = Arc::new(module_record);
 

--- a/crates/oxc_linter/src/snapshots/import_no_duplicates.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_duplicates.snap
@@ -18,11 +18,11 @@ snapshot_kind: text
    ╰────
   help: Merge these imports into a single import statement
 
-  ⚠ eslint-plugin-import(no-duplicates): Module './bar?optionX' is imported more than once in this file
-   ╭─[index.ts:1:49]
+  ⚠ eslint-plugin-import(no-duplicates): Module './bar.js?optionX' is imported more than once in this file
+   ╭─[index.ts:1:15]
  1 │ import x from './bar.js?optionX'; import y from './bar?optionX';
-   ·               ──────────────────                ───────┬───────
-   ·                        │                               ╰── It is first imported here
+   ·               ─────────┬────────                ───────────────
+   ·                        ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
 
@@ -34,11 +34,11 @@ snapshot_kind: text
    ╰────
   help: Merge these imports into a single import statement
 
-  ⚠ eslint-plugin-import(no-duplicates): Module './bar.js?optionX' is imported more than once in this file
-   ╭─[index.ts:1:46]
+  ⚠ eslint-plugin-import(no-duplicates): Module './bar?optionX' is imported more than once in this file
+   ╭─[index.ts:1:15]
  1 │ import x from './bar?optionX'; import y from './bar.js?optionX';
-   ·               ───────────────                ─────────┬────────
-   ·                      │                                ╰── It is first imported here
+   ·               ───────┬───────                ──────────────────
+   ·                      ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
 

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -310,7 +310,7 @@ mod test {
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
 
-    use crate::{options::LintOptions, ContextHost};
+    use crate::{options::LintOptions, ContextHost, ModuleRecord};
 
     #[test]
     fn test_is_jest_file() {
@@ -321,12 +321,11 @@ mod test {
             SemanticBuilder::new().with_cfg(true).build(&parser_ret.program).semantic;
         let semantic_ret = Rc::new(semantic_ret);
 
-        let module_record = Arc::new(parser_ret.module_record);
         let build_ctx = |path: &'static str| {
             Rc::new(ContextHost::new(
                 path,
                 Rc::clone(&semantic_ret),
-                Arc::clone(&module_record),
+                Arc::new(ModuleRecord::default()),
                 LintOptions::default(),
                 Arc::default(),
             ))

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -154,7 +154,7 @@ pub struct ParserReturn<'a> {
     pub program: Program<'a>,
 
     /// See <https://tc39.es/ecma262/#sec-abstract-module-records>
-    pub module_record: ModuleRecord,
+    pub module_record: ModuleRecord<'a>,
 
     /// Syntax errors encountered while parsing.
     ///
@@ -370,7 +370,7 @@ struct ParserImpl<'a> {
     ast: AstBuilder<'a>,
 
     /// Module Record Builder
-    module_record_builder: ModuleRecordBuilder,
+    module_record_builder: ModuleRecordBuilder<'a>,
 
     /// Precomputed typescript detection
     is_ts: bool,
@@ -389,8 +389,6 @@ impl<'a> ParserImpl<'a> {
         options: ParseOptions,
         unique: UniquePromise,
     ) -> Self {
-        let mut module_record_builder = ModuleRecordBuilder::default();
-        module_record_builder.module_record.not_esm = true;
         Self {
             options,
             lexer: Lexer::new(allocator, source_text, source_type, unique),
@@ -402,7 +400,7 @@ impl<'a> ParserImpl<'a> {
             state: ParserState::default(),
             ctx: Self::default_context(source_type, options),
             ast: AstBuilder::new(allocator),
-            module_record_builder,
+            module_record_builder: ModuleRecordBuilder::new(allocator),
             is_ts: source_type.is_typescript(),
         }
     }

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -28,7 +28,6 @@ oxc_span = { workspace = true }
 
 assert-unchecked = { workspace = true }
 bitflags = { workspace = true }
-dashmap = { workspace = true }
 nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod class;
 pub mod identifier;
 pub mod keyword;
-pub mod module_graph_visitor;
 pub mod module_record;
 pub mod node;
 pub mod number;

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -1,13 +1,12 @@
 //! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
 #![allow(missing_docs)] // fixme
 
-use std::{fmt, path::PathBuf, sync::Arc};
+use std::fmt;
 
-use dashmap::DashMap;
-use oxc_span::{CompactStr, Span};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use oxc_allocator::{Allocator, Vec};
+use oxc_span::{Atom, Span};
 
-type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
+use rustc_hash::FxHashMap;
 
 /// ESM Module Record
 ///
@@ -16,13 +15,9 @@ type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
 /// See
 /// * <https://tc39.es/ecma262/#table-additional-fields-of-source-text-module-records>
 /// * <https://tc39.es/ecma262/#cyclic-module-record>
-#[derive(Default)]
-pub struct ModuleRecord {
+pub struct ModuleRecord<'a> {
     /// This module has no import / export statements
     pub not_esm: bool,
-
-    /// Resolved absolute path to this module record
-    pub resolved_absolute_path: PathBuf,
 
     /// `[[RequestedModules]]`
     ///
@@ -33,82 +28,73 @@ pub struct ModuleRecord {
     ///   import ModuleSpecifier
     ///   export ExportFromClause FromClause
     /// Keyed by ModuleSpecifier, valued by all node occurrences
-    pub requested_modules: FxHashMap<CompactStr, Vec<RequestedModule>>,
-
-    /// `[[LoadedModules]]`
-    ///
-    /// A map from the specifier strings used by the module represented by this record to request
-    /// the importation of a module to the resolved Module Record. The list does not contain two
-    /// different Records with the same `[[Specifier]]`.
-    ///
-    /// Note that Oxc does not support cross-file analysis, so this map will be empty after
-    /// [`ModuleRecord`] is created. You must link the module records yourself.
-    pub loaded_modules: FxDashMap<CompactStr, Arc<ModuleRecord>>,
+    pub requested_modules: FxHashMap<Atom<'a>, Vec<'a, RequestedModule>>,
 
     /// `[[ImportEntries]]`
     ///
     /// A List of ImportEntry records derived from the code of this module
-    pub import_entries: Vec<ImportEntry>,
+    pub import_entries: Vec<'a, ImportEntry<'a>>,
 
     /// `[[LocalExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to declarations that occur within the module
-    pub local_export_entries: Vec<ExportEntry>,
+    pub local_export_entries: Vec<'a, ExportEntry<'a>>,
 
     /// `[[IndirectExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to reexported imports that occur within the module
     /// or exports from `export * as namespace` declarations.
-    pub indirect_export_entries: Vec<ExportEntry>,
+    pub indirect_export_entries: Vec<'a, ExportEntry<'a>>,
 
     /// `[[StarExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to `export *` declarations that occur within the module,
     /// not including `export * as namespace` declarations.
-    pub star_export_entries: Vec<ExportEntry>,
+    pub star_export_entries: Vec<'a, ExportEntry<'a>>,
 
     /// Local exported bindings
-    pub exported_bindings: FxHashMap<CompactStr, Span>,
+    pub exported_bindings: FxHashMap<Atom<'a>, Span>,
 
     /// Local duplicated exported bindings, for diagnostics
-    pub exported_bindings_duplicated: Vec<NameSpan>,
+    pub exported_bindings_duplicated: Vec<'a, NameSpan<'a>>,
 
     /// Reexported bindings from `export * from 'specifier'`
     /// Keyed by resolved path
-    pub exported_bindings_from_star_export: FxDashMap<PathBuf, Vec<CompactStr>>,
+    pub exported_bindings_from_star_export: FxHashMap<Atom<'a>, Vec<'a, Atom<'a>>>,
 
     /// `export default name`
     ///         ^^^^^^^ span
     pub export_default: Option<Span>,
 
     /// Duplicated span of `export default` for diagnostics
-    pub export_default_duplicated: Vec<Span>,
+    pub export_default_duplicated: Vec<'a, Span>,
 }
 
-impl ModuleRecord {
-    pub fn new(resolved_absolute_path: PathBuf) -> Self {
-        Self { resolved_absolute_path, ..Self::default() }
+impl<'a> ModuleRecord<'a> {
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self {
+            not_esm: true,
+            requested_modules: FxHashMap::default(),
+            import_entries: Vec::new_in(allocator),
+            local_export_entries: Vec::new_in(allocator),
+            indirect_export_entries: Vec::new_in(allocator),
+            star_export_entries: Vec::new_in(allocator),
+            exported_bindings: FxHashMap::default(),
+            exported_bindings_duplicated: Vec::new_in(allocator),
+            exported_bindings_from_star_export: FxHashMap::default(),
+            export_default: None,
+            export_default_duplicated: Vec::new_in(allocator),
+        }
     }
 }
 
-impl fmt::Debug for ModuleRecord {
+impl fmt::Debug for ModuleRecord<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        // recursively formatting loaded modules can crash when the module graph is cyclic
-        let loaded_modules = self
-            .loaded_modules
-            .iter()
-            .map(|entry| (entry.key().to_string()))
-            .reduce(|acc, key| format!("{acc}, {key}"))
-            .unwrap_or_default();
-        let loaded_modules = format!("{{ {loaded_modules} }}");
         f.debug_struct("ModuleRecord")
             .field("not_esm", &self.not_esm)
-            .field("resolved_absolute_path", &self.resolved_absolute_path)
-            .field("requested_modules", &self.requested_modules)
-            .field("loaded_modules", &loaded_modules)
             .field("import_entries", &self.import_entries)
             .field("local_export_entries", &self.local_export_entries)
             .field("indirect_export_entries", &self.indirect_export_entries)
@@ -123,22 +109,14 @@ impl fmt::Debug for ModuleRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NameSpan {
-    name: CompactStr,
-    span: Span,
+pub struct NameSpan<'a> {
+    pub name: Atom<'a>,
+    pub span: Span,
 }
 
-impl NameSpan {
-    pub fn new(name: CompactStr, span: Span) -> Self {
+impl<'a> NameSpan<'a> {
+    pub fn new(name: Atom<'a>, span: Span) -> Self {
         Self { name, span }
-    }
-
-    pub const fn name(&self) -> &CompactStr {
-        &self.name
-    }
-
-    pub const fn span(&self) -> Span {
-        self.span
     }
 }
 
@@ -158,7 +136,7 @@ impl NameSpan {
 /// import * as ns from "mod";
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImportEntry {
+pub struct ImportEntry<'a> {
     /// String value of the ModuleSpecifier of the ImportDeclaration.
     ///
     /// ## Examples
@@ -167,7 +145,7 @@ pub struct ImportEntry {
     /// import { foo } from "mod";
     /// //                   ^^^
     /// ```
-    pub module_request: NameSpan,
+    pub module_request: NameSpan<'a>,
 
     /// The name under which the desired binding is exported by the module identified by `[[ModuleRequest]]`.
     ///
@@ -179,7 +157,7 @@ pub struct ImportEntry {
     /// import { foo as bar } from "mod";
     /// //       ^^^
     /// ```
-    pub import_name: ImportImportName,
+    pub import_name: ImportImportName<'a>,
 
     /// The name that is used to locally access the imported value from within the importing module.
     ///
@@ -191,7 +169,7 @@ pub struct ImportEntry {
     /// import { foo as bar } from "mod";
     /// //              ^^^
     /// ```
-    pub local_name: NameSpan,
+    pub local_name: NameSpan<'a>,
 
     /// Whether this binding is for a TypeScript type-only import. This is a non-standard field.
     /// When creating a [`ModuleRecord`] for a JavaScript file, this will always be false.
@@ -214,13 +192,13 @@ pub struct ImportEntry {
 
 /// `ImportName` For `ImportEntry`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImportImportName {
-    Name(NameSpan),
+pub enum ImportImportName<'a> {
+    Name(NameSpan<'a>),
     NamespaceObject,
     Default(Span),
 }
 
-impl ImportImportName {
+impl ImportImportName<'_> {
     pub fn is_default(&self) -> bool {
         matches!(self, Self::Default(_))
     }
@@ -250,32 +228,32 @@ impl ImportImportName {
 ///
 /// ```
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct ExportEntry {
+pub struct ExportEntry<'a> {
     /// Span for the entire export entry
     pub span: Span,
 
     /// The String value of the ModuleSpecifier of the ExportDeclaration.
     /// null if the ExportDeclaration does not have a ModuleSpecifier.
-    pub module_request: Option<NameSpan>,
+    pub module_request: Option<NameSpan<'a>>,
 
     /// The name under which the desired binding is exported by the module identified by `[[ModuleRequest]]`.
     /// null if the ExportDeclaration does not have a ModuleSpecifier.
     /// "all" is used for `export * as ns from "mod"`` declarations.
     /// "all-but-default" is used for `export * from "mod" declarations`.
-    pub import_name: ExportImportName,
+    pub import_name: ExportImportName<'a>,
 
     /// The name used to export this binding by this module.
-    pub export_name: ExportExportName,
+    pub export_name: ExportExportName<'a>,
 
     /// The name that is used to locally access the exported value from within the importing module.
     /// null if the exported value is not locally accessible from within the module.
-    pub local_name: ExportLocalName,
+    pub local_name: ExportLocalName<'a>,
 }
 
 /// `ImportName` for `ExportEntry`
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub enum ExportImportName {
-    Name(NameSpan),
+pub enum ExportImportName<'a> {
+    Name(NameSpan<'a>),
     /// all is used for export * as ns from "mod" declarations.
     All,
     /// all-but-default is used for export * from "mod" declarations.
@@ -285,7 +263,7 @@ pub enum ExportImportName {
     Null,
 }
 
-impl ExportImportName {
+impl ExportImportName<'_> {
     pub fn is_all(&self) -> bool {
         matches!(self, Self::All)
     }
@@ -297,14 +275,14 @@ impl ExportImportName {
 
 /// `ExportName` for `ExportEntry`
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub enum ExportExportName {
-    Name(NameSpan),
+pub enum ExportExportName<'a> {
+    Name(NameSpan<'a>),
     Default(Span),
     #[default]
     Null,
 }
 
-impl ExportExportName {
+impl ExportExportName<'_> {
     /// Returns `true` if this is [`ExportExportName::Default`].
     pub fn is_default(&self) -> bool {
         matches!(self, Self::Default(_))
@@ -318,7 +296,7 @@ impl ExportExportName {
     /// Attempt to get the [`Span`] of this export name.
     pub fn span(&self) -> Option<Span> {
         match self {
-            Self::Name(name) => Some(name.span()),
+            Self::Name(name) => Some(name.span),
             Self::Default(span) => Some(*span),
             Self::Null => None,
         }
@@ -327,15 +305,15 @@ impl ExportExportName {
 
 /// `LocalName` for `ExportEntry`
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub enum ExportLocalName {
-    Name(NameSpan),
+pub enum ExportLocalName<'a> {
+    Name(NameSpan<'a>),
     /// `export default name_span`
-    Default(NameSpan),
+    Default(NameSpan<'a>),
     #[default]
     Null,
 }
 
-impl ExportLocalName {
+impl<'a> ExportLocalName<'a> {
     /// `true` if this is a [`ExportLocalName::Default`].
     pub fn is_default(&self) -> bool {
         matches!(self, Self::Default(_))
@@ -347,19 +325,15 @@ impl ExportLocalName {
     }
 
     /// Get the bound name of this export. [`None`] for [`ExportLocalName::Null`].
-    pub const fn name(&self) -> Option<&CompactStr> {
+    pub fn name(&self) -> Option<&Atom<'a>> {
         match self {
-            Self::Name(name) | Self::Default(name) => Some(name.name()),
+            Self::Name(name) | Self::Default(name) => Some(&name.name),
             Self::Null => None,
         }
     }
 }
 
-pub struct FunctionMeta {
-    pub deprecated: bool,
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RequestedModule {
     span: Span,
     is_type: bool,

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -21,11 +21,10 @@ use oxc::{
         ScopeFlags, ScopeId, ScopeTree, SemanticBuilder, SymbolTable,
     },
     span::SourceType,
-    syntax::module_record::ModuleRecord,
     transformer::{TransformOptions, Transformer},
 };
 use oxc_index::Idx;
-use oxc_linter::Linter;
+use oxc_linter::{Linter, ModuleRecord};
 use oxc_prettier::{Prettier, PrettierOptions};
 use serde::Serialize;
 use tsify::Tsify;
@@ -229,7 +228,7 @@ impl Oxc {
             );
         }
 
-        let module_record = Arc::new(module_record);
+        let module_record = Arc::new(ModuleRecord::new(&path, &module_record));
         self.run_linter(&run_options, &path, &program, &module_record);
 
         self.run_prettier(&run_options, source_text, source_type);

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -2,7 +2,7 @@ use std::{env, path::Path, rc::Rc, sync::Arc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{FixKind, LinterBuilder};
+use oxc_linter::{FixKind, LinterBuilder, ModuleRecord};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -39,7 +39,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     .build(&ret.program);
                 let linter = LinterBuilder::all().with_fix(FixKind::All).build();
                 let semantic = Rc::new(semantic_ret.semantic);
-                let module_record = Arc::new(ret.module_record);
+                let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record));
                 b.iter(|| linter.run(path, Rc::clone(&semantic), Arc::clone(&module_record)));
             },
         );


### PR DESCRIPTION
The parser returns a simple `ModuleRecord` that is allocated in the arena for performance reasons.

The linter uses a more complicated, `Send` + `Sync` `ModuleRecord` that will hold more cross-module information.

The next step is to return more esm information from the parser to eliminated the need of the `oxc_module_lexer` crate.