### PR TITLE
fix(linter): false positive in `typescript/consistent-type-definitions`

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_definitions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_definitions.snap
@@ -147,3 +147,31 @@ snapshot_kind: text
  3 │               foo: string;
    ╰────
   help: Use an `type` instead of a `interface`
+
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
+   ╭─[consistent_type_definitions.tsx:1:10]
+ 1 │ declaretype S={}
+   ·        ────
+   ╰────
+  help: Use an `interface` instead of a `type`
+
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
+   ╭─[consistent_type_definitions.tsx:1:10]
+ 1 │ declareinterface S {}
+   ·        ─────────
+   ╰────
+  help: Use an `type` instead of a `interface`
+
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
+   ╭─[consistent_type_definitions.tsx:1:17]
+ 1 │ export declaretype S={}
+   ·               ────
+   ╰────
+  help: Use an `interface` instead of a `type`
+
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
+   ╭─[consistent_type_definitions.tsx:1:17]
+ 1 │ export declareinterface S {}
+   ·               ─────────
+   ╰────
+  help: Use an `type` instead of a `interface`


### PR DESCRIPTION
closes #7552 