### PR TITLE
chore(deps): remove `memoffset` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,15 +1160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mimalloc"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,7 +2078,6 @@ version = "0.38.0"
 dependencies = [
  "compact_str",
  "itoa",
- "memoffset",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,6 @@ lazy_static = "1.5.0"
 log = "0.4.22"
 markdown = "1.0.0-alpha.21"
 memchr = "2.7.4"
-memoffset = "0.9.1"
 miette = { package = "oxc-miette", version = "1.0.2", features = ["fancy-no-syscall"] }
 mimalloc = "0.1.43"
 mime_guess = "2.0.5"

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -33,5 +33,4 @@ oxc_syntax = { workspace = true }
 
 compact_str = { workspace = true }
 itoa = { workspace = true }
-memoffset = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -121,9 +121,7 @@ export default function generateAncestorsCode(types) {
       clippy::needless_lifetimes
     )]
 
-    use std::{cell::Cell, marker::PhantomData};
-
-    use memoffset::offset_of;
+    use std::{cell::Cell, marker::PhantomData, mem::offset_of};
 
     use oxc_allocator::{Address, Box, GetAddress, Vec};
     use oxc_ast::ast::*;

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -11,9 +11,7 @@
     clippy::needless_lifetimes
 )]
 
-use std::{cell::Cell, marker::PhantomData};
-
-use memoffset::offset_of;
+use std::{cell::Cell, marker::PhantomData, mem::offset_of};
 
 use oxc_allocator::{Address, Box, GetAddress, Vec};
 use oxc_ast::ast::*;


### PR DESCRIPTION
`offset_of!` macro [became stable in Rust 1.77.0](https://doc.rust-lang.org/nightly/core/mem/macro.offset_of.html) which is now within our MSRV. Remove the `memoffset` crate, and use `std::mem::offset_of` instead.