### PR TITLE
feat(transformer/class-properties): transform `ChainExpression`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -276,8 +276,14 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
             }
             // `object?.#prop`
             Expression::ChainExpression(_) => {
-                // TODO: `transform_chain_expression` is no-op at present
                 self.transform_chain_expression(expr, ctx);
+            }
+            // `delete object?.#prop.xyz`
+            Expression::UnaryExpression(unary)
+                if unary.operator == UnaryOperator::Delete
+                    && matches!(unary.argument, Expression::ChainExpression(_)) =>
+            {
+                self.transform_unary_expression(expr, ctx);
             }
             // "object.#prop`xyz`"
             Expression::TaggedTemplateExpression(_) => {

--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -10,13 +10,19 @@ use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     symbol::{SymbolFlags, SymbolId},
 };
-use oxc_traverse::{ast_operations::get_var_name_from_node, BoundIdentifier, TraverseCtx};
+use oxc_traverse::{
+    ast_operations::get_var_name_from_node, Ancestor, BoundIdentifier, MaybeBoundIdentifier,
+    TraverseCtx,
+};
 
 use crate::common::helper_loader::Helper;
 
 use super::{
     private_props::ResolvedPrivateProp,
-    utils::{create_assignment, create_underscore_ident_name},
+    utils::{
+        assert_expr_neither_parenthesis_nor_typescript_syntax, create_assignment,
+        create_underscore_ident_name,
+    },
     ClassProperties,
 };
 
@@ -157,16 +163,32 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         let Some((callee, object)) = self.transform_private_field_callee(field_expr, ctx) else {
             return;
         };
+        Self::substitute_callee_and_insert_context(call_expr, callee, object, ctx);
+    }
 
+    /// Substitute callee and add object as first argument to call expression.
+    ///
+    /// Non-Optional:
+    ///  * `callee(...arguments)` -> `callee.call(object, ...arguments)`
+    ///
+    /// Optional:
+    ///  * `callee?.(...arguments)` -> `callee?.call(object, ...arguments)`
+    fn substitute_callee_and_insert_context(
+        call_expr: &mut CallExpression<'a>,
+        callee: Expression<'a>,
+        context: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         // Substitute `<callee>.call` as callee of call expression
         call_expr.callee = Expression::from(ctx.ast.member_expression_static(
             SPAN,
             callee,
             ctx.ast.identifier_name(SPAN, Atom::from("call")),
-            false,
+            // Make sure the `callee` can access `call` safely. i.e `callee?.()` -> `callee?.call()`
+            mem::replace(&mut call_expr.optional, false),
         ));
-        // Add `object` to call arguments
-        call_expr.arguments.insert(0, Argument::from(object));
+        // Insert `context` to call arguments
+        call_expr.arguments.insert(0, Argument::from(context));
     }
 
     /// Transform [`CallExpression::callee`] or [`TaggedTemplateExpression::tag`] that is a private field.
@@ -198,7 +220,9 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             self.private_props_stack.find(&field_expr.field)?;
         let prop_ident = prop_binding.create_read_expression(ctx);
 
-        let object = ctx.ast.move_expression(&mut field_expr.object);
+        // `(object.#method)()`
+        //  ^^^^^^^^^^^^^^^^ is a parenthesized expression
+        let object = ctx.ast.move_expression(field_expr.object.get_inner_expression_mut());
 
         // Get replacement for callee
         let replacement = if is_static {
@@ -850,16 +874,496 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     //
     // `#[inline]` so that compiler sees that `expr` is an `Expression::ChainExpression`
     #[inline]
-    #[expect(clippy::unused_self)]
     pub(super) fn transform_chain_expression(
         &mut self,
         expr: &mut Expression<'a>,
-        _ctx: &mut TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
-        let Expression::ChainExpression(_chain_expr) = expr else { unreachable!() };
+        if let Some((result, chain_expr)) = self.transform_chain_expression_impl(expr, ctx) {
+            *expr = Self::wrap_conditional_check(result, chain_expr, ctx);
+        }
+    }
 
-        // TODO: `object?.#prop`
-        // TODO: `object?.#prop()`
+    fn transform_chain_expression_impl(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<(Expression<'a>, Expression<'a>)> {
+        let Expression::ChainExpression(chain_expr) = expr else { unreachable!() };
+
+        let element = &mut chain_expr.expression;
+        if matches!(element, ChainElement::PrivateFieldExpression(_)) {
+            // The PrivateFieldExpression must be transformed, so we can convert it to a normal expression here.
+            let mut chain_expr = Self::convert_chain_expression_to_expression(expr, ctx);
+            let result =
+                self.transform_private_field_expression_of_chain_expression(&mut chain_expr, ctx);
+            Some((result, chain_expr))
+        } else if let Some(result) = self.transform_chain_expression_element(element, ctx) {
+            let chain_expr = Self::convert_chain_expression_to_expression(expr, ctx);
+            Some((result, chain_expr))
+        } else {
+            // "Entering this branch indicates that the chain element has been changed and updated directly in
+            // `element` or do nothing because haven't found any private field."
+            None
+        }
+    }
+
+    /// Transform non-private field expression of chain element.
+    ///
+    /// [`ChainElement::PrivateFieldExpression`] is handled in [`Self::transform_chain_expression`].
+    fn transform_chain_expression_element(
+        &mut self,
+        element: &mut ChainElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        match element {
+            expression @ match_member_expression!(ChainElement) => self
+                .transform_member_expression_of_chain_expression(
+                    expression.to_member_expression_mut(),
+                    ctx,
+                ),
+            ChainElement::CallExpression(call) => {
+                self.transform_call_expression_of_chain_expression(call, ctx)
+            }
+            ChainElement::TSNonNullExpression(non_null) => {
+                self.transform_chain_element_recursively(&mut non_null.expression, ctx)
+            }
+        }
+    }
+
+    /// Recursively find the first private field expression in the chain element and transform it.
+    fn transform_chain_element_recursively(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        assert_expr_neither_parenthesis_nor_typescript_syntax(expr);
+        match expr {
+            Expression::PrivateFieldExpression(_) => {
+                Some(self.transform_private_field_expression_of_chain_expression(expr, ctx))
+            }
+            match_member_expression!(Expression) => self
+                .transform_member_expression_of_chain_expression(
+                    expr.to_member_expression_mut(),
+                    ctx,
+                ),
+            Expression::CallExpression(call) => {
+                self.transform_call_expression_of_chain_expression(call, ctx)
+            }
+            _ => {
+                assert_expr_neither_parenthesis_nor_typescript_syntax(expr);
+                None
+            }
+        }
+    }
+
+    /// Go through the part of chain element and transform the object/callee of first encountered optional member/call.
+    ///
+    /// Ident:
+    ///  * `Foo?.bar`:
+    ///      - Passed-in `expr` will be mutated to `Foo.bar`
+    ///      - Returns `Foo === null || Foo === void 0 ? void 0`
+    ///
+    /// MemberExpression:
+    ///  * `Foo?.bar?.baz`:
+    ///     - Passed-in `expr` will be mutated to `_Foo$bar.baz`
+    ///     - Returns `Foo === null || Foo === void 0 ? void 0`
+    ///
+    /// CallExpression:
+    ///  See [`Self::transform_call_expression_to_bind_proper_context`]
+    ///
+    fn transform_first_optional_expression(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        let object = match expr {
+            Expression::CallExpression(call) => {
+                if call.optional {
+                    call.optional = false;
+                    if call.callee.is_member_expression() {
+                        // Special case for call expression because we need to make sure it has a proper context
+                        return Some(
+                            self.transform_call_expression_to_bind_proper_context(expr, ctx),
+                        );
+                    }
+                    &mut call.callee
+                } else {
+                    return self.transform_first_optional_expression(&mut call.callee, ctx);
+                }
+            }
+            Expression::StaticMemberExpression(member) => {
+                if member.optional {
+                    member.optional = false;
+                    &mut member.object
+                } else {
+                    return self.transform_first_optional_expression(&mut member.object, ctx);
+                }
+            }
+            Expression::ComputedMemberExpression(member) => {
+                if member.optional {
+                    member.optional = false;
+                    &mut member.object
+                } else {
+                    return self.transform_first_optional_expression(&mut member.object, ctx);
+                }
+            }
+            Expression::PrivateFieldExpression(member) => {
+                if member.optional {
+                    member.optional = false;
+                    &mut member.object
+                } else {
+                    return self.transform_first_optional_expression(&mut member.object, ctx);
+                }
+            }
+            _ => return None,
+        };
+
+        let result = self.transform_expression_to_wrap_nullish_check(object, ctx);
+        Some(result)
+    }
+
+    fn transform_private_field_expression_of_chain_expression(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let Expression::PrivateFieldExpression(field_expr) = expr else { unreachable!() };
+
+        let object = &mut field_expr.object;
+        let left = self.transform_first_optional_expression(object, ctx).unwrap_or_else(|| {
+            // Even though no optional expression, we still need to transform the object
+            self.transform_expression_to_wrap_nullish_check(object, ctx)
+        });
+
+        if matches!(ctx.ancestor(1), Ancestor::CallExpressionCallee(_)) {
+            // `(Foo?.#m)();` -> `(Foo === null || Foo === void 0 ? void 0 : _m._.bind(Foo))();`
+            // ^^^^^^^^^^^^ is a call expression, we need to bind the proper context
+            *expr = self
+                .transform_bindable_private_field(field_expr, ctx)
+                .unwrap_or_else(|| unreachable!());
+        } else {
+            self.transform_private_field_expression(expr, ctx);
+        }
+
+        left
+    }
+
+    fn transform_member_expression_of_chain_expression(
+        &mut self,
+        member: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        let is_optional = member.optional();
+        let object = member.object_mut();
+        let result = self.transform_chain_element_recursively(object, ctx)?;
+        if is_optional {
+            // `o?.Foo.#self.self?.self.unicorn;` -> `(result ? void 0 : object)?.self.unicorn`
+            //  ^^^^^^^^^^^^^^^^^ the object has transformed, if the current member is optional,
+            //                    then we need to wrap it to a conditional expression
+            let object_owner = ctx.ast.move_expression(object);
+            *object = Self::wrap_conditional_check(result, object_owner, ctx);
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    fn transform_call_expression_of_chain_expression(
+        &mut self,
+        call_expr: &mut CallExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        let is_optional = call_expr.optional;
+        let callee = call_expr.callee.get_inner_expression_mut();
+        if matches!(callee, Expression::PrivateFieldExpression(_)) {
+            let result = self.transform_first_optional_expression(callee, ctx);
+            // If the `callee` has no optional expression, we need to transform it using `transform_call_expression_impl` directly.
+            // `Foo.bar.#m?.();` -> `_assertClassBrand(Foo, _Foo$bar = Foo.bar, _m)._?.call(_Foo$bar);`
+            //          ^^^^ only the private field is optional
+            // Move out parenthesis and typescript syntax
+            call_expr.callee = ctx.ast.move_expression(callee);
+            self.transform_call_expression_impl(call_expr, ctx);
+            return result;
+        }
+
+        let result = self.transform_chain_element_recursively(callee, ctx)?;
+        if !is_optional {
+            return Some(result);
+        }
+
+        // `o?.Foo.#self.getSelf?.()?.self.#m();`
+        //               ^^^^^^^^^^^  this is a optional function call, to make sure it has a proper context,
+        //                            we also need to assign `o?.Foo.#self` to a temp variable, and
+        //                            then use it as a first argument of `getSelf` call.
+        //
+        // TODO(improve-on-babel): Consider remove this logic, because it seems no runtime behavior change.
+        let object = callee.to_member_expression_mut().object_mut();
+        let (assignment, context) = self.duplicate_object(ctx.ast.move_expression(object), ctx);
+        *object = assignment;
+        let callee = ctx.ast.move_expression(&mut call_expr.callee);
+        let callee = Self::wrap_conditional_check(result, callee, ctx);
+        Self::substitute_callee_and_insert_context(call_expr, callee, context, ctx);
+
+        None
+    }
+
+    /// Transform expression to wrap nullish check.
+    ///
+    /// Returns:
+    ///   * Bound Identifier: `A` -> `A === null || A === void 0`
+    ///   * Unbound Identifier or anything else: `A.B` -> `(_A$B = A.B) === null || _A$B === void 0`
+    ///
+    /// NOTE: This method will mutate the passed-in `object` to a temp variable identifier.
+    fn transform_expression_to_wrap_nullish_check(
+        &mut self,
+        object: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        // `A` -> `A === null || A === void 0`
+        if let Expression::Identifier(ident) = object {
+            if let Some(binding) = self.get_existing_binding_for_identifier(ident, ctx) {
+                let left1 = binding.create_read_expression(ctx);
+                let left2 = binding.create_read_expression(ctx);
+                return self.wrap_nullish_check(left1, left2, ctx);
+            }
+        }
+
+        // `A.B` -> `(_A$B = A.B) === null || _A$B === void 0`
+        // TODO: should add an API `generate_uid_in_current_hoist_scope_based_on_node` to instead this
+        let temp_var_binding = ctx.generate_uid_in_current_scope_based_on_node(
+            object,
+            SymbolFlags::FunctionScopedVariable,
+        );
+        self.ctx.var_declarations.insert_var(&temp_var_binding, None, ctx);
+
+        let object = mem::replace(object, temp_var_binding.create_read_expression(ctx));
+        let assignment = create_assignment(
+            &temp_var_binding,
+            Self::ensure_optional_expression_wrapped_by_chain_expression(object, ctx),
+            ctx,
+        );
+        let reference = temp_var_binding.create_read_expression(ctx);
+        self.wrap_nullish_check(assignment, reference, ctx)
+    }
+
+    /// Converts chain expression to expression
+    ///
+    /// - [ChainElement::CallExpression] -> [Expression::CallExpression]
+    /// - [ChainElement::StaticMemberExpression] -> [Expression::StaticMemberExpression]
+    /// - [ChainElement::ComputedMemberExpression] -> [Expression::ComputedMemberExpression]
+    /// - [ChainElement::PrivateFieldExpression] -> [Expression::PrivateFieldExpression]
+    /// - [ChainElement::TSNonNullExpression] -> [TSNonNullExpression::expression]
+    //
+    // `#[inline]` so that compiler sees that `expr` is an [`Expression::ChainExpression`].
+    #[inline]
+    fn convert_chain_expression_to_expression(
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let Expression::ChainExpression(chain_expr) = ctx.ast.move_expression(expr) else {
+            unreachable!()
+        };
+        match chain_expr.unbox().expression {
+            element @ match_member_expression!(ChainElement) => {
+                Expression::from(element.into_member_expression())
+            }
+            ChainElement::CallExpression(call) => Expression::CallExpression(call),
+            ChainElement::TSNonNullExpression(non_null) => non_null.unbox().expression,
+        }
+    }
+
+    /// Get an MaybeBoundIdentifier from an bound identifier reference.
+    ///
+    /// If no temp variable required, returns `MaybeBoundIdentifier` for existing variable/global.
+    /// If temp variable is required, returns `None`.
+    fn get_existing_binding_for_identifier(
+        &self,
+        ident: &IdentifierReference<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> Option<MaybeBoundIdentifier<'a>> {
+        let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);
+        if self.ctx.assumptions.pure_getters || binding.to_bound_identifier().is_some() {
+            Some(binding)
+        } else {
+            None
+        }
+    }
+
+    /// Ensure that the expression is wrapped by a chain expression.
+    ///
+    /// If the given expression contains optional expression, it will be wrapped by
+    /// a chain expression, this way we can ensure the remain optional expression can
+    /// be handled by optional-chaining plugin correctly.
+    fn ensure_optional_expression_wrapped_by_chain_expression(
+        expr: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        if Self::has_optional_expression(&expr) {
+            let chain_element = match expr {
+                Expression::CallExpression(call) => ChainElement::CallExpression(call),
+                expr @ match_member_expression!(Expression) => {
+                    ChainElement::from(expr.into_member_expression())
+                }
+                _ => unreachable!(),
+            };
+            ctx.ast.expression_chain(SPAN, chain_element)
+        } else {
+            expr
+        }
+    }
+
+    /// Recursively check if the expression has optional expression.
+    #[inline]
+    fn has_optional_expression(expr: &Expression<'a>) -> bool {
+        match expr {
+            Expression::CallExpression(call) => {
+                call.optional || Self::has_optional_expression(call.callee.get_inner_expression())
+            }
+            Expression::StaticMemberExpression(member) => {
+                member.optional || Self::has_optional_expression(&member.object)
+            }
+            Expression::ComputedMemberExpression(member) => {
+                member.optional || Self::has_optional_expression(&member.object)
+            }
+            Expression::PrivateFieldExpression(member) => {
+                member.optional || Self::has_optional_expression(&member.object)
+            }
+            _ => false,
+        }
+    }
+
+    /// Transform call expression to bind a proper context.
+    ///
+    /// * Callee without a private field:
+    ///  `Foo?.bar()?.zoo?.().#x;`
+    ///    -> `(_Foo$bar$zoo = (_Foo$bar = Foo?.bar())?.zoo) === null || _Foo$bar$zoo === void 0 ? void 0
+    ///   : babelHelpers.assertClassBrand(Foo, _Foo$bar$zoo.call(_Foo$bar), _x)._;`
+    ///
+    /// * Callee has a private field:
+    ///  `o?.Foo.#self.getSelf?.().#m?.();`
+    ///    -> `(_ref = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC =
+    ///       babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null ||
+    ///       _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref$call
+    ///       = _ref.call(_babelHelpers$assertC), _m)._?.call(_ref$call);`
+    ///
+    fn transform_call_expression_to_bind_proper_context(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let Expression::CallExpression(call) = expr else { unreachable!() };
+
+        let callee = &mut call.callee;
+        // `Foo?.bar()?.zoo?.()`
+        // ^^^^^^^^^^^^^^^^^ callee is a member expression
+        // ^^^^^^^^^^^ object
+        let object = callee.to_member_expression_mut().object_mut();
+
+        let context = if let Some(result) = self.transform_chain_element_recursively(object, ctx) {
+            // `o?.Foo.#self.getSelf?.().#m?.();` -> `(_ref = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC =
+            //                                        babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf)`
+            // ^^^^^^^^^^^^^^^^^^^^^^ to make sure get `getSelf` call has a proper context, we need to assign
+            //                        the parent of callee (i.e `o?.Foo.#self`) to a temp variable,
+            //                        and then use it as a first argument of `_ref.call`.
+            let (assignment, context) = self.duplicate_object(ctx.ast.move_expression(object), ctx);
+            *object = assignment;
+            *callee = Self::wrap_conditional_check(result, ctx.ast.move_expression(callee), ctx);
+            context
+        } else {
+            // `Foo?.bar()?.zoo?.().#x;` -> `(_Foo$bar$zoo = (_Foo$bar = Foo?.bar())?.zoo)`
+            // ^^^^^^^^^^^^^^^^ this is a optional function call, to make sure it has a proper context,
+            //                  we also need to assign `Foo?.bar()` to a temp variable, and then use
+            //                  it as a first argument of `_Foo$bar$zoo`.
+            let (assignment, context) = self.duplicate_object(ctx.ast.move_expression(object), ctx);
+            *object = assignment;
+            context
+        };
+
+        // After the below transformation, the `callee` will be a temp variable.
+        let result = self.transform_expression_to_wrap_nullish_check(callee, ctx);
+        let callee_owner = ctx.ast.move_expression(callee);
+        Self::substitute_callee_and_insert_context(call, callee_owner, context, ctx);
+        result
+    }
+
+    /// Returns `left === null`
+    fn wrap_null_check(&self, left: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
+        let operator = if self.ctx.assumptions.no_document_all {
+            BinaryOperator::Equality
+        } else {
+            BinaryOperator::StrictEquality
+        };
+        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.expression_null_literal(SPAN))
+    }
+
+    /// Returns `left === void 0`
+    fn wrap_void0_check(left: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
+        let operator = BinaryOperator::StrictEquality;
+        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.void_0(SPAN))
+    }
+
+    /// Returns `left1 === null || left2 === void 0`
+    fn wrap_nullish_check(
+        &self,
+        left1: Expression<'a>,
+        left2: Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let null_check = self.wrap_null_check(left1, ctx);
+        if self.ctx.assumptions.no_document_all {
+            null_check
+        } else {
+            let void0_check = Self::wrap_void0_check(left2, ctx);
+            ctx.ast.expression_logical(SPAN, null_check, LogicalOperator::Or, void0_check)
+        }
+    }
+
+    /// Returns `test ? void 0 : alternative`
+    fn wrap_conditional_check(
+        test: Expression<'a>,
+        alternative: Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        ctx.ast.expression_conditional(SPAN, test, ctx.ast.void_0(SPAN), alternative)
+    }
+
+    /// Transform chain expression inside unary expression.
+    ///
+    /// Instance prop:
+    /// * "delete object?.#prop.xyz`"
+    ///   -> "object === null || object === void 0 ? true : delete _classPrivateFieldGet(_prop, object).xyz;"
+    /// * "delete object?.#prop?.xyz;"
+    ///   -> "delete (object === null || object === void 0 ? void 0 : _classPrivateFieldGet(_prop, object))?.xyz;"
+    ///
+    /// Static prop:
+    /// * "delete object?.#prop.xyz`"
+    ///   -> "object === null || object === void 0 ? true : delete _assertClassBrand(Foo, object, _prop)._.xyz;"
+    /// * "delete object?.#prop?.xyz;"
+    ///   -> "delete (object === null || object === void 0 ? void 0 : _assertClassBrand(Foo, object, _prop)._)?.xyz;"
+    //
+    // `#[inline]` so that compiler sees that `expr` is an `Expression::UnaryExpression`.
+    #[inline]
+    pub(super) fn transform_unary_expression(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let Expression::UnaryExpression(unary_expr) = expr else { unreachable!() };
+        if let Some((result, chain_expr)) =
+            self.transform_chain_expression_impl(&mut unary_expr.argument, ctx)
+        {
+            *expr = ctx.ast.expression_conditional(
+                unary_expr.span,
+                result,
+                ctx.ast.expression_boolean_literal(SPAN, true),
+                {
+                    // We still need this unary expr, but it needs to be used as the alternative of the conditional
+                    unary_expr.argument = chain_expr;
+                    ctx.ast.move_expression(expr)
+                },
+            );
+        }
     }
 
     /// Transform tagged template expression where tag is a private field.
@@ -887,17 +1391,17 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         let Expression::PrivateFieldExpression(field_expr) = &mut tagged_temp_expr.tag else {
             return;
         };
-        if let Some(tag) = self.transform_tagged_template_expression_impl(field_expr, ctx) {
+        if let Some(tag) = self.transform_bindable_private_field(field_expr, ctx) {
             tagged_temp_expr.tag = tag;
         };
     }
 
-    pub(super) fn transform_tagged_template_expression_impl(
+    fn transform_bindable_private_field(
         &mut self,
         field_expr: &mut PrivateFieldExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
-        let (callee, object) = self.transform_private_field_callee(field_expr, ctx)?;
+        let (callee, context) = self.transform_private_field_callee(field_expr, ctx)?;
 
         // Return `<callee>.bind(object)`, to be substituted as tag of tagged template expression
         let callee = Expression::from(ctx.ast.member_expression_static(
@@ -906,7 +1410,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             ctx.ast.identifier_name(SPAN, Atom::from("bind")),
             false,
         ));
-        let arguments = ctx.ast.vec1(Argument::from(object));
+        let arguments = ctx.ast.vec1(Argument::from(context));
         Some(ctx.ast.expression_call(field_expr.span, callee, NONE, arguments, false))
     }
 
@@ -967,6 +1471,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         object: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, Expression<'a>) {
+        assert_expr_neither_parenthesis_nor_typescript_syntax(&object);
         // TODO: Handle if in a function's params
         let temp_var_binding = match &object {
             Expression::Identifier(ident) => {

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -53,3 +53,11 @@ where
 pub(super) fn create_underscore_ident_name<'a>(ctx: &mut TraverseCtx<'a>) -> IdentifierName<'a> {
     ctx.ast.identifier_name(SPAN, Atom::from("_"))
 }
+
+#[inline]
+pub(super) fn assert_expr_neither_parenthesis_nor_typescript_syntax(expr: &Expression) {
+    debug_assert!(
+        !(matches!(expr, Expression::ParenthesizedExpression(_)) || expr.is_typescript_syntax()),
+        "Should not be: {expr:?}",
+    );
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 415/846
+Passed: 416/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (88/264)
+# babel-plugin-transform-class-properties (89/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -503,9 +503,6 @@ x Output mismatch
 * private/optional-chain-cast-to-boolean/input.js
 x Output mismatch
 
-* private/optional-chain-delete-property/input.js
-x Output mismatch
-
 * private/optional-chain-delete-property-with-transform/input.js
 x Output mismatch
 
@@ -537,7 +534,18 @@ x Output mismatch
 x Output mismatch
 
 * private/parenthesized-optional-member-call/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(5): Some(ScopeId(0))
 
 * private/parenthesized-optional-member-call-with-transform/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -1,7 +1,7 @@
 commit: 54a8389f
 
 node: v22.11.0
-⎯⎯⎯⎯⎯⎯ Failed Suites 38 ⎯⎯⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯ Failed Suites 32 ⎯⎯⎯⎯⎯⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-arrow-functions-test-fixtures-arrow-functions-implicit-var-arguments-exec.test.js [ fixtures/babel/babel-plugin-transform-arrow-functions-test-fixtures-arrow-functions-implicit-var-arguments-exec.test.js ]
 Error: 'eval' and 'arguments' cannot be used as a binding identifier in strict mode
@@ -11,11 +11,11 @@ Error: 'eval' and 'arguments' cannot be used as a binding identifier in strict m
  ❯ ssrTransformScript ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52381:11
  ❯ loadAndTransform ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:51979:72
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noUninitializedPrivateFieldAccess-static-private-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noUninitializedPrivateFieldAccess-static-private-exec.test.js ]
 SyntaxError: Private field '#x' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-setPublicClassFields-static-super-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-setPublicClassFields-static-super-exec.test.js ]
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-delete-super-property-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-delete-super-property-exec.test.js ]
@@ -28,7 +28,7 @@ Error: Invalid access to super
  ❯ ssrTransformScript ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52381:11
  ❯ loadAndTransform ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:51979:72
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-accessor-key-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-accessor-key-exec.test.js ]
 Error: Unexpected token `[`. Expected * for generator, private key, identifier or async
@@ -38,163 +38,109 @@ Error: Unexpected token `[`. Expected * for generator, private key, identifier o
  ❯ ssrTransformScript ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52381:11
  ❯ loadAndTransform ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.9.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:51979:72
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-access-before-declaration-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-access-before-declaration-exec.test.js ]
 SyntaxError: Private field '#p' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-1-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-1-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-2-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-2-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-3-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-3-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-static-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-array-pattern-static-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-1-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-1-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[11/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[11/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-2-exec-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-2-exec-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[12/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[12/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-3-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-3-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[13/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[13/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[14/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[14/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-static-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-destructuring-object-pattern-static-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[15/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[15/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-access-before-declaration-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-access-before-declaration-exec.test.js ]
 SyntaxError: Private field '#p' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[16/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[16/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-1-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-1-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[17/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[17/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-2-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-2-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[18/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[18/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-3-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-3-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[19/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[19/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[20/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[20/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-static-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-array-pattern-static-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[21/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[21/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-1-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-1-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[22/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[22/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-2-exec-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-2-exec-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[23/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[23/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-3-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-3-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[24/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[24/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[25/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[25/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-static-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-destructuring-object-pattern-static-exec.test.js ]
 SyntaxError: Private field '#client' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[26/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[26/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-computed-redeclared-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-computed-redeclared-exec.test.js ]
 SyntaxError: Private field '#foo' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[27/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-property-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-property-exec.test.js ]
-SyntaxError: Private field '#x' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[28/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-property-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-property-exec.test.js ]
-SyntaxError: Private field '#x' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[29/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-exec.test.js ]
-SyntaxError: Private field '#m' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[30/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[27/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-computed-redeclared-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-computed-redeclared-exec.test.js ]
 SyntaxError: Private field '#foo' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[31/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-property-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-property-exec.test.js ]
-SyntaxError: Private field '#x' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[32/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-property-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-property-exec.test.js ]
-SyntaxError: Private field '#x' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[33/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-parenthesized-optional-member-call-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-parenthesized-optional-member-call-exec.test.js ]
-SyntaxError: Private field '#m' must be declared in an enclosing class
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[34/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[28/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-regression-7371-exec.test.js [ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-regression-7371-exec.test.js ]
 SyntaxError: 'super' keyword unexpected here
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[35/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[29/50]⎯
 
-⎯⎯⎯⎯⎯⎯ Failed Tests 46 ⎯⎯⎯⎯⎯⎯⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-before-member-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-before-member-call-exec.test.js:112:10
-    110|  var _x = { _: 1 };
-    111|  var _m = { _: function() {
-    112|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    113|  } };
-    114|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-before-member-call-exec.test.js:21:46
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-before-member-call-exec.test.js:116:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[36/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-cast-to-boolean-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.testIf fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-cast-to-boolean-exec.test.js:7:8
-      5|  class C {
-      6|   static testIf(o) {
-      7|    if (_assertClassBrand(C, o, _a)._.b.c.d) {
-       |        ^
-      8|     return true;
-      9|    }
- ❯ Function.testNullish fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-cast-to-boolean-exec.test.js:89:14
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-noDocumentAll-optional-chain-cast-to-boolean-exec.test.js:105:4
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[37/84]⎯
+⎯⎯⎯⎯⎯⎯ Failed Tests 18 ⎯⎯⎯⎯⎯⎯⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-assumption-setPublicClassFields-static-infer-name-exec.test.js > exec
 AssertionError: expected '_Class' to be 'Foo' // Object.is equality
@@ -209,7 +155,7 @@ Received: "_Class"
        |                   ^
       9| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[38/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[30/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-call-in-decorator-exec.test.js > exec
 AssertionError: expected undefined to be 'hello' // Object.is equality
@@ -227,7 +173,7 @@ undefined
        |                            ^
      22| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[39/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[31/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-decorator-exec.test.js > exec
 AssertionError: expected undefined to be 'hello' // Object.is equality
@@ -245,7 +191,7 @@ undefined
        |                            ^
      23| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[40/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[32/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-constructor-collision-exec.test.js > exec
 AssertionError: expected undefined to be 'bar' // Object.is equality
@@ -264,7 +210,7 @@ undefined
      19|  expect("bar" in f).toBe(false);
      20| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[41/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[33/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js > exec
 AssertionError: expected undefined to be 'bar' // Object.is equality
@@ -283,7 +229,7 @@ undefined
      19|  expect("bar" in f).toBe(false);
      20| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[42/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[34/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js > exec
 AssertionError: expected [Function] to not throw an error but 'TypeError: Private element is not pre…' was thrown
@@ -301,173 +247,7 @@ undefined
        |         ^
      31| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[43/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-exec.test.js:111:10
-    109|  var _x = { _: 1 };
-    110|  var _m = { _: function() {
-    111|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    112|  } };
-    113|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-exec.test.js:20:46
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-exec.test.js:115:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[44/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-with-transform-exec.test.js:32:168
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-member-call-with-transform-exec.test.js:115:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[45/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-property-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-property-with-transform-exec.test.js:32:166
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-before-property-with-transform-exec.test.js:112:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[46/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-cast-to-boolean-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.testIf fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-cast-to-boolean-exec.test.js:7:8
-      5|  class C {
-      6|   static testIf(o) {
-      7|    if (_assertClassBrand(C, o, _a)._.b.c.d) {
-       |        ^
-      8|     return true;
-      9|    }
- ❯ Function.testNullish fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-cast-to-boolean-exec.test.js:89:14
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-cast-to-boolean-exec.test.js:105:4
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[47/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.testNull fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-exec.test.js:57:18
-     55|     return deep;
-     56|    }
-     57|    expect(delete _assertClassBrand(Foo, deep?.very.o?.Foo, _self)._.un…
-       |                  ^
-     58|    expect(delete _assertClassBrand(Foo, o?.Foo, _self)._.unicorn).toBe…
-     59|    expect(delete _assertClassBrand(Foo, o?.Foo, _self)._.self.unicorn)…
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-exec.test.js:94:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[48/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-with-transform-exec.test.js > exec
-AssertionError: expected function to throw an error, but it didn't
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-with-transform-exec.test.js:42:7
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-delete-property-with-transform-exec.test.js:160:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[49/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-exec.test.js:44:10
-     42|  var _x = { _: 1 };
-     43|  var _m = { _: function() {
-     44|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-     45|  } };
-     46|  var _self = { _: _Foo };
- ❯ f fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-exec.test.js:19:57
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-exec.test.js:34:11
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-exec.test.js:48:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[50/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ _ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:59:10
-     57|  var _x = { _: 1 };
-     58|  var _m = { _: function() {
-     59|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-     60|  } };
-     61|  var _self = { _: _Foo };
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:45:181
- ❯ j fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:46:6
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:53:11
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:63:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[51/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-exec.test.js:114:10
-    112|  var _x = { _: 1 };
-    113|  var _m = { _: function() {
-    114|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    115|  } };
-    116|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-exec.test.js:20:17
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-exec.test.js:118:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[52/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:114:10
-    112|  var _x = { _: 1 };
-    113|  var _m = { _: function() {
-    114|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    115|  } };
-    116|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:23:142
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:118:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[53/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-exec.test.js:114:10
-    112|  var _x = { _: 1 };
-    113|  var _m = { _: function() {
-    114|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    115|  } };
-    116|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-exec.test.js:20:14
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-exec.test.js:118:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[54/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-with-transform-exec.test.js:35:269
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-member-call-with-transform-exec.test.js:118:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[55/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-property-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-property-with-transform-exec.test.js:35:269
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-optional-property-with-transform-exec.test.js:115:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[56/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[35/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js > exec
 TypeError: e.has is not a function
@@ -482,7 +262,7 @@ TypeError: e.has is not a function
  ❯ Function.method fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js:12:11
  ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js:16:14
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[57/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[36/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-extends-computed-exec.test.js > exec
 AssertionError: expected [Function] to not throw an error but 'TypeError: Private element is not pre…' was thrown
@@ -500,173 +280,7 @@ undefined
        |         ^
      32| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[58/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-exec.test.js:112:10
-    110|  var _x = { _: 1 };
-    111|  var _m = { _: function() {
-    112|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    113|  } };
-    114|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-exec.test.js:21:46
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-exec.test.js:116:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[59/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-with-transform-exec.test.js:33:168
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-member-call-with-transform-exec.test.js:116:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[60/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-property-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-property-with-transform-exec.test.js:33:166
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-before-property-with-transform-exec.test.js:113:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[61/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-cast-to-boolean-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.testIf fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-cast-to-boolean-exec.test.js:7:8
-      5|  class C {
-      6|   static testIf(o) {
-      7|    if (_assertClassBrand(C, o, _a)._.b.c.d) {
-       |        ^
-      8|     return true;
-      9|    }
- ❯ Function.testNullish fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-cast-to-boolean-exec.test.js:89:14
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-cast-to-boolean-exec.test.js:105:4
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[62/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.testNull fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-exec.test.js:58:18
-     56|     return deep;
-     57|    }
-     58|    expect(delete _assertClassBrand(Foo, deep?.very.o?.Foo, _self)._.un…
-       |                  ^
-     59|    expect(delete _assertClassBrand(Foo, o?.Foo, _self)._.unicorn).toBe…
-     60|    expect(delete _assertClassBrand(Foo, o?.Foo, _self)._.self.unicorn)…
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-exec.test.js:95:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[63/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-with-transform-exec.test.js > exec
-AssertionError: expected function to throw an error, but it didn't
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-with-transform-exec.test.js:42:7
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-delete-property-with-transform-exec.test.js:160:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[64/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-exec.test.js:45:10
-     43|  var _x = { _: 1 };
-     44|  var _m = { _: function() {
-     45|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-     46|  } };
-     47|  var _self = { _: _Foo };
- ❯ f fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-exec.test.js:20:57
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-exec.test.js:35:11
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-exec.test.js:49:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[65/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ _ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js:60:10
-     58|  var _x = { _: 1 };
-     59|  var _m = { _: function() {
-     60|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-     61|  } };
-     62|  var _self = { _: _Foo };
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js:46:181
- ❯ j fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js:47:6
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js:54:11
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-in-function-param-with-transform-exec.test.js:64:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[66/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-exec.test.js:115:10
-    113|  var _x = { _: 1 };
-    114|  var _m = { _: function() {
-    115|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    116|  } };
-    117|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-exec.test.js:21:17
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-exec.test.js:119:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[67/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-with-transform-exec.test.js:115:10
-    113|  var _x = { _: 1 };
-    114|  var _m = { _: function() {
-    115|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    116|  } };
-    117|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-with-transform-exec.test.js:24:142
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-member-optional-call-with-transform-exec.test.js:119:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[68/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Object._ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-exec.test.js:115:10
-    113|  var _x = { _: 1 };
-    114|  var _m = { _: function() {
-    115|   return _assertClassBrand(_Foo, this, _x)._;
-       |          ^
-    116|  } };
-    117|  var _self = { _: _Foo };
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-exec.test.js:21:14
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-exec.test.js:119:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[69/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-with-transform-exec.test.js:36:269
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-member-call-with-transform-exec.test.js:119:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[70/84]⎯
-
- FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-property-with-transform-exec.test.js > exec
-TypeError: Private element is not present on this object
- ❯ _assertClassBrand ../../node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:3:9
- ❯ Function.test fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-property-with-transform-exec.test.js:36:269
-
- ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-optional-chain-optional-property-with-transform-exec.test.js:116:6
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[71/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[37/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-static-shadow-exec.test.js > exec
 TypeError: e.has is not a function
@@ -681,7 +295,7 @@ TypeError: e.has is not a function
  ❯ Function.method fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-static-shadow-exec.test.js:12:11
  ❯ fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-static-shadow-exec.test.js:16:14
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[72/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[38/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-computed-toPrimitive-exec.test.js > exec
 AssertionError: expected [Function] to throw error including '@@toPrimitive must return a primitive…' but got 'Cannot convert object to primitive va…'
@@ -697,7 +311,7 @@ Received: "Cannot convert object to primitive value"
      38|  expect(() => class {
      39|   static get [arrayLike]() {
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[73/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[39/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-loose-static-infer-name-exec.test.js > exec
 AssertionError: expected '_Class' to be 'Foo' // Object.is equality
@@ -712,7 +326,7 @@ Received: "_Class"
        |                   ^
       9| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[74/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[40/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-static-infer-name-exec.test.js > exec
 AssertionError: expected '_Class' to be 'Foo' // Object.is equality
@@ -727,7 +341,7 @@ Received: "_Class"
        |                   ^
      10| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[75/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[41/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-assumption-noDocumentAll-parenthesized-expression-member-call-exec.test.js > exec
 TypeError: Cannot read properties of undefined (reading 'x')
@@ -741,7 +355,7 @@ TypeError: Cannot read properties of undefined (reading 'x')
  ❯ Foo.test fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-assumption-noDocumentAll-parenthesized-expression-member-call-exec.test.js:25:63
  ❯ fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-assumption-noDocumentAll-parenthesized-expression-member-call-exec.test.js:68:12
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[76/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[42/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-exec.test.js > exec
 TypeError: Cannot read properties of undefined (reading 'x')
@@ -755,7 +369,7 @@ TypeError: Cannot read properties of undefined (reading 'x')
  ❯ Foo.test fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-exec.test.js:25:63
  ❯ fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-exec.test.js:68:12
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[77/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[43/50]⎯
 
  FAIL  fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-loose-exec.test.js > exec
 TypeError: Cannot read properties of undefined (reading 'x')
@@ -769,7 +383,7 @@ TypeError: Cannot read properties of undefined (reading 'x')
  ❯ Foo.test fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-loose-exec.test.js:25:63
  ❯ fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-loose-exec.test.js:68:12
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[78/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[44/50]⎯
 
  FAIL  fixtures/babel/babel-preset-env-test-fixtures-plugins-integration-issue-15170-exec.test.js > exec
 AssertionError: expected [Function] to not throw an error but 'ReferenceError: x is not defined' was thrown
@@ -787,7 +401,7 @@ undefined
        |         ^
       7| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[79/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[45/50]⎯
 
  FAIL  fixtures/babel/babel-preset-env-test-fixtures-sanity-check-es2015-constants-exec.test.js > exec
 TypeError: Assignment to constant variable.
@@ -798,7 +412,7 @@ TypeError: Assignment to constant variable.
        |      ^
       6| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[80/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[46/50]⎯
 
  FAIL  fixtures/babel/babel-preset-env-test-fixtures-sanity-regex-dot-all-exec.test.js > exec
 AssertionError: expected false to be true // Object.is equality
@@ -817,5 +431,5 @@ AssertionError: expected false to be true // Object.is equality
      11|  expect(/hello.world/su.test(input)).toBe(true);
      12| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[81/84]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[47/50]⎯
 


### PR DESCRIPTION
Fully support transforming ChainExpression in class properties. Our implementation has some differences in execution order compared to Babel, but we have passed all execution-related tests.