### PR TITLE
fix(linter): no-unused-expressions false positive with arrow fn expressions

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_no_unused_expressions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unused_expressions.snap
@@ -200,3 +200,10 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Consider removing this expression
+
+  ⚠ typescript-eslint(no-unused-expressions): Disallow unused expressions
+   ╭─[no_unused_expressions.tsx:1:36]
+ 1 │ const _func = (value: number) => { value + 1; }
+   ·                                    ──────────
+   ╰────
+  help: Consider removing this expression


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/7584