### PR TITLE
docs(transformer/class-properties): add missing docs

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -125,11 +125,12 @@
 //!
 //! Implementation is split into several files:
 //!
-//! * `mod.rs`:         Setup, visitor and ancillary types.
-//! * `class.rs`:       Transform of class body.
-//! * `constructor.rs`: Insertion of property initializers into class constructor.
-//! * `private.rs`:     Transform of private property usages (`this.#prop`).
-//! * `utils.rs`:       Utility functions.
+//! * `mod.rs`:            Setup, visitor, and ancillary types.
+//! * `class.rs`:          Transform of class body.
+//! * `constructor.rs`:    Insertion of property initializers into class constructor.
+//! * `private.rs`:        Transform of private property usages (`this.#prop`).
+//! * `static_prop.rs`:    Transform of static property initializers.
+//! * `utils.rs`:          Utility functions.
 //!
 //! ## References
 //!


### PR DESCRIPTION
Docs only. Add mention of what `static_prop.rs` does to the main doc comment for the transform.