### PR TITLE
refactor(transformer/class-properties): `PrivatePropsStack` type

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -14,11 +14,12 @@ use crate::common::helper_loader::Helper;
 
 use super::super::ClassStaticBlock;
 use super::{
+    private_props::{PrivateProp, PrivateProps},
     utils::{
         create_assignment, create_underscore_ident_name, create_variable_declaration,
         exprs_into_stmts,
     },
-    ClassName, ClassProperties, FxIndexMap, PrivateProp, PrivateProps,
+    ClassName, ClassProperties, FxIndexMap,
 };
 
 impl<'a, 'ctx> ClassProperties<'a, 'ctx> {

--- a/crates/oxc_transformer/src/es2022/class_properties/private_props.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_props.rs
@@ -1,0 +1,95 @@
+use oxc_ast::ast::PrivateIdentifier;
+use oxc_data_structures::stack::SparseStack;
+use oxc_span::Atom;
+use oxc_traverse::BoundIdentifier;
+
+use super::FxIndexMap;
+
+/// Stack of private props defined by classes.
+///
+/// Pushed to when entering a class (`None` if class has no private props, `Some` if it does).
+/// Entries contain a mapping from private prop name to binding for temp var for that property,
+/// and details of the class that defines the private prop.
+///
+/// This is used as lookup when transforming e.g. `this.#x`.
+#[derive(Default)]
+pub(super) struct PrivatePropsStack<'a> {
+    stack: SparseStack<PrivateProps<'a>>,
+}
+
+impl<'a> PrivatePropsStack<'a> {
+    // Forward methods to underlying `SparseStack`
+
+    #[inline]
+    pub fn push(&mut self, props: Option<PrivateProps<'a>>) {
+        self.stack.push(props);
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<PrivateProps<'a>> {
+        self.stack.pop()
+    }
+
+    #[inline]
+    pub fn last(&self) -> Option<&PrivateProps<'a>> {
+        self.stack.last()
+    }
+
+    #[inline]
+    #[expect(dead_code)]
+    pub fn last_mut(&mut self) -> Option<&mut PrivateProps<'a>> {
+        self.stack.last_mut()
+    }
+
+    /// Lookup details of private property referred to by `ident`.
+    pub fn find<'b>(
+        &'b self,
+        ident: &PrivateIdentifier<'a>,
+    ) -> Option<ResolvedPrivateProp<'a, 'b>> {
+        // Check for binding in closest class first, then enclosing classes
+        // TODO: Check there are tests for bindings in enclosing classes.
+        for private_props in self.stack.as_slice().iter().rev() {
+            if let Some(prop) = private_props.props.get(&ident.name) {
+                return Some(ResolvedPrivateProp {
+                    prop_binding: &prop.binding,
+                    class_binding: private_props.class_binding.as_ref(),
+                    is_static: prop.is_static,
+                    is_declaration: private_props.is_declaration,
+                });
+            }
+        }
+        // TODO: This should be unreachable. Only returning `None` because implementation is incomplete.
+        None
+    }
+}
+
+/// Details of private properties for a class.
+pub(super) struct PrivateProps<'a> {
+    /// Private properties for class. Indexed by property name.
+    // TODO(improve-on-babel): Order that temp vars are created in is not important. Use `FxHashMap` instead.
+    pub props: FxIndexMap<Atom<'a>, PrivateProp<'a>>,
+    /// Binding for class, if class has name
+    pub class_binding: Option<BoundIdentifier<'a>>,
+    /// `true` for class declaration, `false` for class expression
+    pub is_declaration: bool,
+}
+
+/// Details of a private property.
+pub(super) struct PrivateProp<'a> {
+    pub binding: BoundIdentifier<'a>,
+    pub is_static: bool,
+}
+
+/// Details of a private property resolved for a private field.
+///
+/// This is the return value of [`PrivatePropsStack::find`].
+pub(super) struct ResolvedPrivateProp<'a, 'b> {
+    /// Binding for temp var representing the property
+    pub prop_binding: &'b BoundIdentifier<'a>,
+    /// Binding for class (if it has one)
+    pub class_binding: Option<&'b BoundIdentifier<'a>>,
+    /// `true` if is a static property
+    pub is_static: bool,
+    /// `true` if class which defines this property is a class declaration
+    pub is_declaration: bool,
+}


### PR DESCRIPTION
Pure refactor. Move all logic and types related to storing details of what private properties classes have into a separate file `private_props.rs`. Introduce a type `PrivatePropsStack` to represent the stack of classes.