### PR TITLE
fix(napi/transform): respect `options.sourcemap` for id

### DIFF
--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -39,11 +39,12 @@ pub fn isolated_declaration(
     )
     .build(&ret.program);
 
+    let source_map_path = match options.sourcemap {
+        Some(true) => Some(source_path.to_path_buf()),
+        _ => None,
+    };
     let codegen_ret = CodeGenerator::new()
-        .with_options(CodegenOptions {
-            source_map_path: Some(source_path.to_path_buf()),
-            ..CodegenOptions::default()
-        })
+        .with_options(CodegenOptions { source_map_path, ..CodegenOptions::default() })
         .build(&transformed_ret.program);
 
     let errors = ret.errors.into_iter().chain(transformed_ret.errors).collect();

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -25,9 +25,14 @@ describe('simple', () => {
     assert.equal(ret.code, 'export class A {}\n');
   });
 
-  it('uses the `declaration option`', () => {
+  it('uses the `declaration` option', () => {
     const ret = transform('test.ts', code, { typescript: { declaration: {} } });
     assert.equal(ret.declaration, 'export declare class A<T> {}\n');
+  });
+
+  it('uses the `sourcemap` option', () => {
+    const ret = transform('test.ts', code, { typescript: { declaration: {} }, sourcemap: true });
+    assert(ret.declarationMap);
   });
 });
 


### PR DESCRIPTION
Don't pass `source_map_path` if `options.sourcemap` is undefined or false; then, `IsolatedDeclarationsResult.map` should be undefined.

Downstream issue https://github.com/unplugin/unplugin-isolated-decl/issues/42