### PR TITLE
fix(span): fix clippy warning

### DIFF
--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -486,7 +486,7 @@ impl SourceType {
                 #[cfg(debug_assertions)]
                 unreachable!();
                 #[cfg(not(debug_assertions))]
-                return Err(UnknownExtension(format!("Unknown extension: {}", extension).into()));
+                return Err(UnknownExtension(format!("Unknown extension: {extension}").into()));
             }
         };
 


### PR DESCRIPTION
Fix clippy warning. Only triggers when running clippy in `--release` mode.