### PR TITLE
feat(semantic): add `SymbolTable::add_resolved_reference` method

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -238,6 +238,12 @@ impl SymbolTable {
             .map(|&reference_id| &self.references[reference_id])
     }
 
+    /// Add a reference to a symbol.
+    pub fn add_resolved_reference(&mut self, symbol_id: SymbolId, reference_id: ReferenceId) {
+        let reference_ids = &mut self.resolved_references[symbol_id];
+        reference_ids.push(reference_id);
+    }
+
     /// Delete a reference to a symbol.
     ///
     /// # Panics


### PR DESCRIPTION
Add `SymbolTable::add_resolved_reference` method to add a reference for a symbol.