### PR TITLE
fix(codegen): print parentheses correctly for ClassHeritage

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2185,7 +2185,7 @@ impl Gen for Class<'_> {
             }
             if let Some(super_class) = self.super_class.as_ref() {
                 p.print_str(" extends ");
-                super_class.print_expr(p, Precedence::Call, Context::empty());
+                super_class.print_expr(p, Precedence::Postfix, Context::empty());
                 if let Some(super_type_parameters) = &self.super_type_parameters {
                     super_type_parameters.print(p, ctx);
                 }

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -615,6 +615,8 @@ fn test_class() {
     test("class Foo { static foo() {} }", "class Foo {\n\tstatic foo() {}\n}\n");
     test("class Foo { static get foo() {} }", "class Foo {\n\tstatic get foo() {}\n}\n");
     test("class Foo { static set foo(x) {} }", "class Foo {\n\tstatic set foo(x) {}\n}\n");
+
+    test("class Foo extends foo() {}", "class Foo extends foo() {}\n");
 }
 
 #[test]


### PR DESCRIPTION
closes #7631