### PR TITLE
refactor(transformer/class-properties): move logic for handling `delete` of chain expression into `transform_unary_expression`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -279,10 +279,7 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
                 self.transform_chain_expression(expr, ctx);
             }
             // `delete object?.#prop.xyz`
-            Expression::UnaryExpression(unary)
-                if unary.operator == UnaryOperator::Delete
-                    && matches!(unary.argument, Expression::ChainExpression(_)) =>
-            {
+            Expression::UnaryExpression(_) => {
                 self.transform_unary_expression(expr, ctx);
             }
             // "object.#prop`xyz`"


### PR DESCRIPTION
Follow-on after #7575. Pure refactor. Move all logic for transforming `delete <chain expression>` into the handler `transform_unary_expression`. Aim is to keep logic in one place and keep the main visitor as simple as possible.