### PR TITLE
fix(transformer/class-properties): transform `delete` chain expression in static prop initializers

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -252,7 +252,8 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
     // `#[inline]` because this is a hot path
     #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Note: `delete this.#prop` is an early syntax error, so no need to handle transforming it
+        // IMPORTANT: If add any other visitors here to handle private fields,
+        // also need to add them to visitor in `static_prop.rs`.
         match expr {
             // `class {}`
             Expression::ClassExpression(_) => {

--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -1375,12 +1375,15 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         }
     }
 
-    fn transform_unary_expression_impl(
+    // Note: This is also called by visitor in `static_prop.rs`
+    pub(super) fn transform_unary_expression_impl(
         &mut self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         let Expression::UnaryExpression(unary_expr) = expr else { unreachable!() };
+        debug_assert!(unary_expr.operator == UnaryOperator::Delete);
+        debug_assert!(matches!(unary_expr.argument, Expression::ChainExpression(_)));
 
         if let Some((result, chain_expr)) =
             self.transform_chain_expression_impl(&mut unary_expr.argument, ctx)


### PR DESCRIPTION
Follow-on after #7575. Annoyingly, we have to transform private fields in static prop initializers separately, to make sure the stack of private properties is in sync while visiting them.