### PR TITLE
fix(estree): `raw: null` in ESTree AST for generated `BooleanLiteral`s

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,7 +20,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw: string")]
+#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw: string | null")]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -32,13 +32,13 @@ pub struct ESTreeLiteral<'a, T> {
 
 impl From<&BooleanLiteral> for ESTreeLiteral<'_, bool> {
     fn from(lit: &BooleanLiteral) -> Self {
-        Self {
-            span: lit.span,
-            value: lit.value,
-            raw: Some(if lit.value { "true" } else { "false" }),
-            bigint: None,
-            regex: None,
-        }
+        let raw = if lit.span.is_unspanned() {
+            None
+        } else {
+            Some(if lit.value { "true" } else { "false" })
+        };
+
+        Self { span: lit.span, value: lit.value, raw, bigint: None, regex: None }
     }
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -4,7 +4,7 @@
 export interface BooleanLiteral extends Span {
   type: 'Literal';
   value: boolean;
-  raw: string;
+  raw: string | null;
 }
 
 export interface NullLiteral extends Span {


### PR DESCRIPTION
In JS-side AST, leave `raw` field as `null` for `BooleanLiteral`s, if they are generated and have no raw representation in source text.