### PR TITLE
fix(estree): `raw: null` in ESTree AST for generated `NullLiteral`s

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -34,7 +34,7 @@ pub struct BooleanLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, raw: \"null\"")]
+#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, raw: \"null\" | null")]
 pub struct NullLiteral {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -44,7 +44,8 @@ impl From<&BooleanLiteral> for ESTreeLiteral<'_, bool> {
 
 impl From<&NullLiteral> for ESTreeLiteral<'_, ()> {
     fn from(lit: &NullLiteral) -> Self {
-        Self { span: lit.span, value: (), raw: Some("null"), bigint: None, regex: None }
+        let raw = if lit.span.is_unspanned() { None } else { Some("null") };
+        Self { span: lit.span, value: (), raw, bigint: None, regex: None }
     }
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -10,7 +10,7 @@ export interface BooleanLiteral extends Span {
 export interface NullLiteral extends Span {
   type: 'Literal';
   value: null;
-  raw: 'null';
+  raw: 'null' | null;
 }
 
 export interface NumericLiteral extends Span {


### PR DESCRIPTION
In JS-side AST, leave `raw` field as `null` for `NullLiteral`s, if they are generated and have no raw representation in source text.