### PR TITLE
fix(estree): make type of `BigIntLiteral::raw` prop in ESTree AST optional

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -91,6 +91,7 @@ pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
     /// The bigint as it appears in source code
+    #[estree(type = "string | null")]
     pub raw: Atom<'a>,
     /// The base representation used by the literal in source code
     #[estree(skip)]

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -27,7 +27,7 @@ export interface StringLiteral extends Span {
 
 export interface BigIntLiteral extends Span {
   type: 'Literal';
-  raw: string;
+  raw: string | null;
   value: null;
   bigint: string;
 }


### PR DESCRIPTION
`BigIntLiteral`'s `raw` field is not an `Option` on Rust side, but this is an internal implementation detail - we may parse bigints to a `BigInt` in future (as we did in the past before we hit a memory leak problem), and make `raw` an `Option`.

So at present, the `raw` field is always non-null in JS-side AST. But update the TS type def to reflect that it should be an optional property. This aligns with ESTree.