### PR TITLE
refactor(transformer): use `ctx.var_declarations.create_var*` methods

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -101,7 +101,6 @@ impl<'a> VarDeclarationsStore<'a> {
     /// Create a new [`BoundIdentifier`], add a var declaration to be inserted at the top of
     /// the current enclosing statement block, and then return the [`BoundIdentifier`].
     #[inline]
-    #[expect(unused)]
     pub fn create_var(&self, name: &str, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
         self.insert_var(&binding, None, ctx);
@@ -112,7 +111,6 @@ impl<'a> VarDeclarationsStore<'a> {
     /// to be inserted at the top of the current enclosing statement block, and then return
     /// the [`BoundIdentifier`].
     #[inline]
-    #[expect(unused)]
     pub fn create_var_with_init(
         &self,
         name: &str,
@@ -127,7 +125,6 @@ impl<'a> VarDeclarationsStore<'a> {
     /// Create a new [`BoundIdentifier`] based on node, add a var declaration to be inserted
     /// at the top of the current enclosing statement block, and then return the [`BoundIdentifier`].
     #[inline]
-    #[expect(unused)]
     pub fn create_var_based_on_node<N: GatherNodeParts<'a>>(
         &self,
         node: &N,

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -34,7 +34,7 @@
 
 use oxc_allocator::{CloneIn, Vec as ArenaVec};
 use oxc_ast::{ast::*, NONE};
-use oxc_semantic::{ReferenceFlags, SymbolFlags};
+use oxc_semantic::ReferenceFlags;
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
@@ -558,13 +558,8 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
         temp_var_inits: &mut ArenaVec<'a, Expression<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
-        let binding = ctx.generate_uid_in_current_scope_based_on_node(
-            &expr,
-            SymbolFlags::FunctionScopedVariable,
-        );
-
         // var _name;
-        self.ctx.var_declarations.insert_var(&binding, None, ctx);
+        let binding = self.ctx.var_declarations.create_var_based_on_node(&expr, ctx);
 
         // Add new reference `_name = name` to `temp_var_inits`
         temp_var_inits.push(ctx.ast.expression_assignment(

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -56,7 +56,7 @@
 
 use oxc_allocator::CloneIn;
 use oxc_ast::ast::*;
-use oxc_semantic::{ReferenceFlags, SymbolFlags};
+use oxc_semantic::ReferenceFlags;
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 use oxc_traverse::{BoundIdentifier, MaybeBoundIdentifier, Traverse, TraverseCtx};
@@ -310,12 +310,6 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         if ctx.is_static(expr) {
             return None;
         }
-
-        // var _name;
-        let binding = ctx
-            .generate_uid_in_current_scope_based_on_node(expr, SymbolFlags::FunctionScopedVariable);
-        self.ctx.var_declarations.insert_var(&binding, None, ctx);
-
-        Some(binding)
+        Some(self.ctx.var_declarations.create_var_based_on_node(expr, ctx))
     }
 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -582,7 +582,15 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
             arguments.push(function);
         }
 
-        let binding = ctx.generate_uid_in_current_hoist_scope("s");
+        // _s = refresh_sig();
+        let init = ctx.ast.expression_call(
+            SPAN,
+            self.refresh_sig.to_expression(ctx),
+            NONE,
+            ctx.ast.vec(),
+            false,
+        );
+        let binding = self.ctx.var_declarations.create_var_with_init("s", init, ctx);
 
         // _s();
         let call_expression = ctx.ast.statement_expression(
@@ -597,19 +605,6 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
         );
 
         body.statements.insert(0, call_expression);
-
-        // _s = refresh_sig();
-        self.ctx.var_declarations.insert_var(
-            &binding,
-            Some(ctx.ast.expression_call(
-                SPAN,
-                self.refresh_sig.to_expression(ctx),
-                NONE,
-                ctx.ast.vec(),
-                false,
-            )),
-            ctx,
-        );
 
         // Following is the signature call expression, will be generated in call site.
         // _s(App, signature_key, false, function() { return [] });

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -55,12 +55,6 @@ tasks/coverage/misc/pass/oxc-3948-1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BrowserWorkingCopyBackupTracker", "CancellationToken", "DisposableStore", "EditorPart", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "IInstantiationService", "ILifecycleService", "ILogService", "IUntitledTextResourceEditorInput", "IWorkingCopyBackup", "IWorkingCopyBackupService", "IWorkingCopyEditorHandler", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
 rebuilt        : ScopeId(0): ["BrowserWorkingCopyBackupTracker", "DisposableStore", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "ILifecycleService", "ILogService", "IWorkingCopyBackupService", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
-Bindings mismatch:
-after transform: ScopeId(13): ["_await$accessor$edito", "accessor", "untitled", "untitledTextEditor", "untitledTextModel", "workingCopyBackupService"]
-rebuilt        : ScopeId(20): ["_await$accessor$edito", "_untitledTextModel$te", "accessor", "untitled", "untitledTextEditor", "untitledTextModel", "workingCopyBackupService"]
-Bindings mismatch:
-after transform: ScopeId(14): ["_untitledTextModel$te"]
-rebuilt        : ScopeId(21): []
 Symbol reference IDs mismatch for "URI":
 after transform: SymbolId(1): [ReferenceId(109), ReferenceId(117), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
 rebuilt        : SymbolId(1): [ReferenceId(158), ReferenceId(160), ReferenceId(162), ReferenceId(164)]
@@ -103,9 +97,6 @@ rebuilt        : SymbolId(26): [ReferenceId(16)]
 Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): [ReferenceId(42), ReferenceId(74), ReferenceId(154), ReferenceId(215)]
 rebuilt        : SymbolId(34): [ReferenceId(65), ReferenceId(216)]
-Symbol scope ID mismatch for "_untitledTextModel$te":
-after transform: SymbolId(138): ScopeId(14)
-rebuilt        : SymbolId(63): ScopeId(20)
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(36), ReferenceId(39), ReferenceId(82), ReferenceId(114), ReferenceId(153), ReferenceId(282)]
 rebuilt        : [ReferenceId(289)]

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: fd979d85
 
 semantic_test262 Summary:
 AST Parsed     : 44026/44026 (100.00%)
-Positive Passed: 43495/44026 (98.79%)
+Positive Passed: 43497/44026 (98.80%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(3): ScopeId(4294967294)
@@ -3739,43 +3739,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["$DONE", "Object", "assert", "require"]
 rebuilt        : ["$DONE", "Object", "_superprop_getMethod", "assert", "require"]
-
-tasks/coverage/test262/test/language/expressions/optional-chaining/iteration-statement-for-of-type-error.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(1): []
-rebuilt        : ScopeId(1): ["_ref"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_ref", "key"]
-rebuilt        : ScopeId(2): ["key"]
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["_ref2"]
-Bindings mismatch:
-after transform: ScopeId(4): ["_ref2", "key"]
-rebuilt        : ScopeId(4): ["key"]
-Symbol scope ID mismatch for "_ref":
-after transform: SymbolId(5): ScopeId(2)
-rebuilt        : SymbolId(0): ScopeId(1)
-Symbol scope ID mismatch for "_ref2":
-after transform: SymbolId(6): ScopeId(4)
-rebuilt        : SymbolId(2): ScopeId(3)
-
-tasks/coverage/test262/test/language/expressions/optional-chaining/iteration-statement-for.js
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["count", "count2", "obj", "obj2", "obj3", "touched"]
-rebuilt        : ScopeId(0): ["_obj3$a", "_undefined", "count", "count2", "obj", "obj2", "obj3", "touched"]
-Bindings mismatch:
-after transform: ScopeId(5): ["_undefined"]
-rebuilt        : ScopeId(5): []
-Bindings mismatch:
-after transform: ScopeId(8): ["_obj3$a"]
-rebuilt        : ScopeId(8): []
-Symbol scope ID mismatch for "_undefined":
-after transform: SymbolId(6): ScopeId(5)
-rebuilt        : SymbolId(0): ScopeId(0)
-Symbol scope ID mismatch for "_obj3$a":
-after transform: SymbolId(7): ScopeId(8)
-rebuilt        : SymbolId(1): ScopeId(0)
 
 tasks/coverage/test262/test/language/module-code/top-level-await/syntax/for-await-await-expr-func-expression.js
 semantic error: Scope children mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: d85767ab
 
 semantic_typescript Summary:
 AST Parsed     : 6503/6503 (100.00%)
-Positive Passed: 2699/6503 (41.50%)
+Positive Passed: 2700/6503 (41.52%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -40005,21 +40005,12 @@ after transform: ["Object"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "_extends", "_objectDestructuringEmpty"]
-rebuilt        : ScopeId(0): ["C", "_extends", "_objectDestructuringEmpty", "_this", "_this2"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
-after transform: ScopeId(4): ["_this", "_this2", "_x"]
+after transform: ScopeId(4): ["_x"]
 rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(4)
-rebuilt        : SymbolId(2): ScopeId(0)
-Symbol scope ID mismatch for "_this2":
-after transform: SymbolId(2): ScopeId(4)
-rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "_x":
 after transform: SymbolId(3) "_x"
 rebuilt        : <None>
@@ -40040,21 +40031,12 @@ after transform: ["B", "require", "undefined"]
 rebuilt        : ["B", "_x", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "_extends", "_objectDestructuringEmpty"]
-rebuilt        : ScopeId(0): ["C", "_extends", "_objectDestructuringEmpty", "_this", "_this2"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
-after transform: ScopeId(4): ["_this", "_this2", "_x"]
+after transform: ScopeId(4): ["_x"]
 rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(4)
-rebuilt        : SymbolId(2): ScopeId(0)
-Symbol scope ID mismatch for "_this2":
-after transform: SymbolId(2): ScopeId(4)
-rebuilt        : SymbolId(3): ScopeId(0)
 Reference symbol mismatch for "_x":
 after transform: SymbolId(3) "_x"
 rebuilt        : <None>
@@ -40075,38 +40057,14 @@ after transform: ["B", "require", "undefined"]
 rebuilt        : ["B", "_x", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C"]
-rebuilt        : ScopeId(0): ["C", "_this", "_this2"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(4): ["_this", "_this2"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(4)
-rebuilt        : SymbolId(0): ScopeId(0)
-Symbol scope ID mismatch for "_this2":
-after transform: SymbolId(2): ScopeId(4)
-rebuilt        : SymbolId(1): ScopeId(0)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers4.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C"]
-rebuilt        : ScopeId(0): ["C", "_this", "_this2"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(4): ["_this", "_this2"]
-rebuilt        : ScopeId(1): []
-Symbol scope ID mismatch for "_this":
-after transform: SymbolId(1): ScopeId(4)
-rebuilt        : SymbolId(0): ScopeId(0)
-Symbol scope ID mismatch for "_this2":
-after transform: SymbolId(2): ScopeId(4)
-rebuilt        : SymbolId(1): ScopeId(0)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember2.ts
 semantic error: Bindings mismatch:
@@ -47565,17 +47523,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["o1", "o2", "o3", "o4", "o5", "o6"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInLoop.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["list"]
-rebuilt        : ScopeId(0): ["_item$t", "list"]
-Bindings mismatch:
-after transform: ScopeId(5): ["_item$t"]
-rebuilt        : ScopeId(5): []
-Symbol scope ID mismatch for "_item$t":
-after transform: SymbolId(4): ScopeId(5)
-rebuilt        : SymbolId(4): ScopeId(0)
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInParameterBindingPattern.ts
 semantic error: Scope children mismatch:


### PR DESCRIPTION
It turns out these APIs are very useful, we remove many boilerplate code.