### PR TITLE
refactor(var-declarations): remove unnecessary `init` parameter from `insert_var`

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -88,19 +88,14 @@ impl<'a> VarDeclarationsStore<'a> {
 
     /// Add a `var` declaration to be inserted at top of current enclosing statement block,
     /// given a `BoundIdentifier`.
-    pub fn insert_var(
-        &self,
-        binding: &BoundIdentifier<'a>,
-        init: Option<Expression<'a>>,
-        ctx: &TraverseCtx<'a>,
-    ) {
+    #[inline]
+    pub fn insert_var(&self, binding: &BoundIdentifier<'a>, ctx: &TraverseCtx<'a>) {
         let pattern = binding.create_binding_pattern(ctx);
-        self.insert_var_binding_pattern(pattern, init, ctx);
+        self.insert_var_binding_pattern(pattern, None, ctx);
     }
 
     /// Add a `var` declaration with the given init expression to be inserted at top of
     /// current enclosing statement block, given a `BoundIdentifier`.
-    #[expect(unused)]
     #[inline]
     pub fn insert_var_with_init(
         &self,
@@ -117,7 +112,7 @@ impl<'a> VarDeclarationsStore<'a> {
     #[inline]
     pub fn create_var(&self, name: &str, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
-        self.insert_var(&binding, None, ctx);
+        self.insert_var(&binding, ctx);
         binding
     }
 
@@ -132,7 +127,7 @@ impl<'a> VarDeclarationsStore<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
-        self.insert_var(&binding, Some(expression), ctx);
+        self.insert_var_with_init(&binding, expression, ctx);
         binding
     }
 
@@ -145,7 +140,7 @@ impl<'a> VarDeclarationsStore<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope_based_on_node(node);
-        self.insert_var(&binding, None, ctx);
+        self.insert_var(&binding, ctx);
         binding
     }
 

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -172,7 +172,7 @@ impl<'a, 'ctx> NullishCoalescingOperator<'a, 'ctx> {
             // `(x) => x;` -> `((x) => x)();`
             new_expr = ctx.ast.expression_call(SPAN, arrow_function, NONE, ctx.ast.vec(), false);
         } else {
-            self.ctx.var_declarations.insert_var(&binding, None, ctx);
+            self.ctx.var_declarations.insert_var(&binding, ctx);
         }
 
         new_expr

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -114,7 +114,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 // Insert `var _prop;` declaration.
                 // Do it here rather than when binding was created to maintain same order of `var`
                 // declarations as Babel. `c = class C { #x = 1; static y = 2; }` -> `var _C, _x;`
-                self.ctx.var_declarations.insert_var(&prop.binding, None, ctx);
+                self.ctx.var_declarations.insert_var(&prop.binding, ctx);
 
                 if prop.is_static {
                     return None;
@@ -137,7 +137,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         if let Some(binding) = &self.class_bindings.temp {
             // Insert `var _Class` statement, if it wasn't already in `transform_class`
             if !self.temp_var_is_created {
-                self.ctx.var_declarations.insert_var(binding, None, ctx);
+                self.ctx.var_declarations.insert_var(binding, ctx);
             }
 
             // `_Class = class {}`
@@ -188,7 +188,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             if let Some(ident) = &class.id {
                 // Insert `var _Class` statement, if it wasn't already in `transform_class`
                 if !self.temp_var_is_created {
-                    self.ctx.var_declarations.insert_var(temp_binding, None, ctx);
+                    self.ctx.var_declarations.insert_var(temp_binding, ctx);
                 }
 
                 // Insert `_Class = Class` after class.
@@ -342,7 +342,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 // TODO(improve-on-babel): Inserting the temp var `var _Class` statement here is only
                 // to match Babel's output. It'd be simpler just to insert it at the end and get rid of
                 // `temp_var_is_created` that tracks whether it's done already or not.
-                self.ctx.var_declarations.insert_var(&temp_binding, None, ctx);
+                self.ctx.var_declarations.insert_var(&temp_binding, ctx);
             }
             Some(temp_binding)
         } else {


### PR DESCRIPTION
If we want to pass `init`, we should use `insert_var_with_init`