### PR TITLE
fix(linter): ignore type references in `no-undef`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -50,6 +50,11 @@ impl Rule for NoUndef {
         for reference_id_list in ctx.scopes().root_unresolved_references_ids() {
             for reference_id in reference_id_list {
                 let reference = symbol_table.get_reference(reference_id);
+
+                if reference.is_type() {
+                    return;
+                }
+
                 let name = ctx.semantic().reference_name(reference);
 
                 if ctx.env_contains_var(name) {
@@ -153,7 +158,9 @@ fn test() {
         "class C { static { function a() {} a; } }",
         "class C { static { a; function a() {} } }",
         "String;Array;Boolean;",
-        "function resolve<T>(path: string): T { return { path } as T; }"
+        "function resolve<T>(path: string): T { return { path } as T; }",
+        "let xyz: NodeListOf<HTMLElement>",
+        "type Foo = Record<string, unknown>;"
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes #7007
fixes #7008