### PR TITLE
feat(editor): Create a command to apply all auto-fixes for the current active text editor

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -10,6 +10,8 @@ This crate provides an [LSP](https://microsoft.github.io/language-server-protoco
   - File Operations: `false`
 - [Code Actions Provider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind):
   - `quickfix`
+  - `source.fixAll.oxc`, behaves the same as `quickfix` only used when the `CodeActionContext#only` contains
+    `source.fixAll.oxc`.
 
 ## Supported LSP Specifications from Server
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -16,3 +16,6 @@ This is the linter for Oxc. The currently supported features are listed below.
 - Highlighting for warnings or errors identified by Oxlint
 - Quick fixes to fix a warning or error when possible
 - JSON schema validation for supported Oxlint configuration files (does not include ESLint configuration files)
+- Command to fix all auto-fixable content within the current text editor.
+- Support for `source.fixAll.oxc` as a code action provider. Configure this in your settings `editor.codeActionsOnSave`
+  to automatically apply fixes when saving the file.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -52,6 +52,11 @@
         "command": "oxc.showOutputChannel",
         "title": "Show Output Channel",
         "category": "Oxc"
+      },
+      {
+        "command": "oxc.applyAllFixesFile",
+        "title": "Fix all auto-fixable problems (file)",
+        "category": "Oxc"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Ref #7456

- Creates a custom action in the language server that applies all auto-fixes for a given file.
- Updates VS Code to use the custom action with a command to apply fixes for the currently active text editor.