### PR TITLE
fix(oxc_transformer): alias `es2015` to `es6`

### DIFF
--- a/crates/oxc_transformer/src/options/es_target.rs
+++ b/crates/oxc_transformer/src/options/es_target.rs
@@ -27,7 +27,7 @@ impl FromStr for ESTarget {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.cow_to_lowercase().as_ref() {
             "es5" => Ok(Self::ES5),
-            "es2015" => Ok(Self::ES2015),
+            "es6" | "es2015" => Ok(Self::ES2015),
             "es2016" => Ok(Self::ES2016),
             "es2017" => Ok(Self::ES2017),
             "es2018" => Ok(Self::ES2018),

--- a/crates/oxc_transformer/tests/integrations/es_target.rs
+++ b/crates/oxc_transformer/tests/integrations/es_target.rs
@@ -10,6 +10,7 @@ fn es_target() {
 
     let cases = [
         ("es5", "() => {}"),
+        ("es6", "a ** b"),
         ("es2015", "a ** b"),
         ("es2016", "async function foo() {}"),
         ("es2017", "({ ...x })"),

--- a/crates/oxc_transformer/tests/integrations/snapshots/es_target.snap
+++ b/crates/oxc_transformer/tests/integrations/snapshots/es_target.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_transformer/tests/integrations/es_target.rs
+assertion_line: 50
 snapshot_kind: text
 ---
 ########## 0 es5
@@ -7,12 +8,17 @@ snapshot_kind: text
 ----------
 (function() {});
 
-########## 1 es2015
+########## 1 es6
 a ** b
 ----------
 Math.pow(a, b);
 
-########## 2 es2016
+########## 2 es2015
+a ** b
+----------
+Math.pow(a, b);
+
+########## 3 es2016
 async function foo() {}
 ----------
 import _asyncToGenerator from '@babel/runtime/helpers/asyncToGenerator';
@@ -24,35 +30,35 @@ function _foo() {
 	return _foo.apply(this, arguments);
 }
 
-########## 3 es2017
+########## 4 es2017
 ({ ...x })
 ----------
 import _objectSpread from '@babel/runtime/helpers/objectSpread2';
 _objectSpread({}, x);
 
-########## 4 es2018
+########## 5 es2018
 try {} catch {}
 ----------
 try {} catch (_unused) {}
 
-########## 5 es2019
+########## 6 es2019
 a?.b
 ----------
 var _a;
 (_a = a) === null || _a === void 0 ? void 0 : _a.b;
 
-########## 6 es2019
+########## 7 es2019
 a ?? b
 ----------
 var _a;
 (_a = a) !== null && _a !== void 0 ? _a : b;
 
-########## 7 es2020
+########## 8 es2020
 a ||= b
 ----------
 a || (a = b);
 
-########## 8 es2019
+########## 9 es2019
 1n ** 2n
 ----------
 
@@ -71,14 +77,14 @@ a || (a = b);
    :       ^^
    `----
 
-########## 9 es2021
+########## 10 es2021
 class foo { static {} }
 ----------
 class foo {
 	static #_ = (() => {})();
 }
 
-########## 10 es2021
+########## 11 es2021
 class Foo { #a; }
 ----------
 class Foo {

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -57,6 +57,8 @@ describe('transform', () => {
 
 describe('target', () => {
   const data = [
+    ['es5', '() => {};\n'],
+    ['es6', 'a ** b;\n'],
     ['es2015', 'a ** b;\n'],
     ['es2016', 'async function foo() {}\n'],
     ['es2017', '({ ...x });\n'],


### PR DESCRIPTION
Supported in [esbuild](https://esbuild.github.io/try/#dAAwLjI0LjAALS10YXJnZXQ9ZXM2ADEqKjI)