### PR TITLE
refactor(transformer): rename `VarDeclarationsStore` methods

### DIFF
--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -107,20 +107,20 @@ impl<'a> VarDeclarationsStore<'a> {
         self.insert_var_binding_pattern(pattern, Some(init), ctx);
     }
 
-    /// Create a new [`BoundIdentifier`], add a var declaration to be inserted at the top of
-    /// the current enclosing statement block, and then return the [`BoundIdentifier`].
+    /// Create a new UID based on `name`, add a `var` declaration to be inserted at the top of
+    /// the current enclosing statement block, and return the [`BoundIdentifier`].
     #[inline]
-    pub fn create_var(&self, name: &str, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
+    pub fn create_uid_var(&self, name: &str, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
         self.insert_var(&binding, ctx);
         binding
     }
 
-    /// Create a new [`BoundIdentifier`], add a var declaration with the given init expression
-    /// to be inserted at the top of the current enclosing statement block, and then return
-    /// the [`BoundIdentifier`].
+    /// Create a new UID based on `name`, add a `var` declaration with the given init expression
+    /// to be inserted at the top of the current enclosing statement block, and return the
+    /// [`BoundIdentifier`].
     #[inline]
-    pub fn create_var_with_init(
+    pub fn create_uid_var_with_init(
         &self,
         name: &str,
         expression: Expression<'a>,
@@ -131,10 +131,10 @@ impl<'a> VarDeclarationsStore<'a> {
         binding
     }
 
-    /// Create a new [`BoundIdentifier`] based on node, add a var declaration to be inserted
-    /// at the top of the current enclosing statement block, and then return the [`BoundIdentifier`].
+    /// Create a new UID with name based on `node`, add a `var` declaration to be inserted
+    /// at the top of the current enclosing statement block, and return the [`BoundIdentifier`].
     #[inline]
-    pub fn create_var_based_on_node<N: GatherNodeParts<'a>>(
+    pub fn create_uid_var_based_on_node<N: GatherNodeParts<'a>>(
         &self,
         node: &N,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -559,7 +559,7 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         // var _name;
-        let binding = self.ctx.var_declarations.create_var_based_on_node(&expr, ctx);
+        let binding = self.ctx.var_declarations.create_uid_var_based_on_node(&expr, ctx);
 
         // Add new reference `_name = name` to `temp_var_inits`
         temp_var_inits.push(ctx.ast.expression_assignment(

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -396,7 +396,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
                     .create_read_expression(ctx)
             } else {
                 // `foo.bar` -> `_foo$bar = foo.bar`
-                let binding = self.ctx.var_declarations.create_var_based_on_node(object, ctx);
+                let binding = self.ctx.var_declarations.create_uid_var_based_on_node(object, ctx);
                 *object = Self::create_assignment_expression(
                     binding.create_write_target(ctx),
                     ctx.ast.move_expression(object),
@@ -571,7 +571,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
         }
 
         // We should generate a temp binding for the expression first to avoid the next step changing the expression.
-        let temp_binding = self.ctx.var_declarations.create_var_based_on_node(expr, ctx);
+        let temp_binding = self.ctx.var_declarations.create_uid_var_based_on_node(expr, ctx);
         if is_call && !self.ctx.assumptions.pure_getters {
             if let Some(member) = expr.as_member_expression_mut() {
                 let object = member.object_mut();
@@ -581,7 +581,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
                     let binding =
                         self.get_existing_binding_for_identifier(ident, ctx).unwrap_or_else(|| {
                             let binding =
-                                self.ctx.var_declarations.create_var_based_on_node(object, ctx);
+                                self.ctx.var_declarations.create_uid_var_based_on_node(object, ctx);
                             // `(_foo = foo)`
                             *object = Self::create_assignment_expression(
                                 binding.create_write_target(ctx),
@@ -638,7 +638,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
 
         let temp_binding = {
             if self.temp_binding.is_none() {
-                let binding = self.ctx.var_declarations.create_var_based_on_node(expr, ctx);
+                let binding = self.ctx.var_declarations.create_uid_var_based_on_node(expr, ctx);
                 self.set_temp_binding(binding);
             }
             self.temp_binding.as_ref().unwrap()

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -310,6 +310,6 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
         if ctx.is_static(expr) {
             return None;
         }
-        Some(self.ctx.var_declarations.create_var_based_on_node(expr, ctx))
+        Some(self.ctx.var_declarations.create_uid_var_based_on_node(expr, ctx))
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -735,7 +735,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             };
 
             // `_object$prop = _assertClassBrand(Class, object, _prop)._`
-            let temp_binding = self.ctx.var_declarations.create_var(&temp_var_name_base, ctx);
+            let temp_binding = self.ctx.var_declarations.create_uid_var(&temp_var_name_base, ctx);
             let assignment = create_assignment(&temp_binding, get_expr, ctx);
 
             // `++_object$prop` / `_object$prop++` (reusing existing `UpdateExpression`)
@@ -768,7 +768,8 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 // Source = `object.#prop++` (postfix `++`)
 
                 // `_object$prop2 = _object$prop++`
-                let temp_binding2 = self.ctx.var_declarations.create_var(&temp_var_name_base, ctx);
+                let temp_binding2 =
+                    self.ctx.var_declarations.create_uid_var(&temp_var_name_base, ctx);
                 let assignment2 = create_assignment(&temp_binding2, update_expr, ctx);
 
                 // `(_object$prop = _assertClassBrand(Class, object, _prop)._, _object$prop2 = _object$prop++, _object$prop)`
@@ -811,7 +812,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             let get_call = self.create_private_field_get(prop_ident, object2, SPAN, ctx);
 
             // `_object$prop = _classPrivateFieldGet(_prop, object)`
-            let temp_binding = self.ctx.var_declarations.create_var(&temp_var_name_base, ctx);
+            let temp_binding = self.ctx.var_declarations.create_uid_var(&temp_var_name_base, ctx);
             let assignment = create_assignment(&temp_binding, get_call, ctx);
 
             // `++_object$prop` / `_object$prop++` (reusing existing `UpdateExpression`)
@@ -831,7 +832,8 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             } else {
                 // Source = `object.#prop++` (postfix `++`)
                 // `_object$prop2 = _object$prop++`
-                let temp_binding2 = self.ctx.var_declarations.create_var(&temp_var_name_base, ctx);
+                let temp_binding2 =
+                    self.ctx.var_declarations.create_uid_var(&temp_var_name_base, ctx);
                 let assignment2 = create_assignment(&temp_binding2, update_expr, ctx);
 
                 // `(_object$prop = _classPrivateFieldGet(_prop, object), _object$prop2 = _object$prop++, _object$prop)`
@@ -1119,7 +1121,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 
         // `A.B` -> `(_A$B = A.B) === null || _A$B === void 0`
         // TODO: should add an API `generate_uid_in_current_hoist_scope_based_on_node` to instead this
-        let temp_var_binding = self.ctx.var_declarations.create_var_based_on_node(object, ctx);
+        let temp_var_binding = self.ctx.var_declarations.create_uid_var_based_on_node(object, ctx);
 
         let object = mem::replace(object, temp_var_binding.create_read_expression(ctx));
         let assignment = create_assignment(
@@ -1505,14 +1507,14 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 // Previously `x += 1` (`x` read + write), but moving to `_x = x` (`x` read only)
                 *reference.flags_mut() = ReferenceFlags::Read;
 
-                self.ctx.var_declarations.create_var(&ident.name, ctx)
+                self.ctx.var_declarations.create_uid_var(&ident.name, ctx)
             }
             Expression::ThisExpression(this) => {
                 // Reading `this` cannot have side effects, so no need for temp var
                 let object1 = ctx.ast.expression_this(this.span);
                 return (object1, object);
             }
-            _ => self.ctx.var_declarations.create_var_based_on_node(&object, ctx),
+            _ => self.ctx.var_declarations.create_uid_var_based_on_node(&object, ctx),
         };
 
         let object1 = create_assignment(&temp_var_binding, object, ctx);

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -590,7 +590,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
             ctx.ast.vec(),
             false,
         );
-        let binding = self.ctx.var_declarations.create_var_with_init("s", init, ctx);
+        let binding = self.ctx.var_declarations.create_uid_var_with_init("s", init, ctx);
 
         // _s();
         let call_expression = ctx.ast.statement_expression(


### PR DESCRIPTION
Follow-on after #7668. Rename `create_var*` methods to `create_uid_var*`.

Previous method name `create_var` might suggest that it creates a binding with the provided name. But actually it creates a UID with name *based on* the name provided.