### PR TITLE
refactor(transformer/class-properties): `duplicate_object_twice` method

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -1,6 +1,11 @@
 //! ES2022: Class Properties
 //! Utility functions.
 
+use std::{
+    mem::{ManuallyDrop, MaybeUninit},
+    ptr,
+};
+
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
@@ -60,4 +65,21 @@ pub(super) fn assert_expr_neither_parenthesis_nor_typescript_syntax(expr: &Expre
         !(matches!(expr, Expression::ParenthesizedExpression(_)) || expr.is_typescript_syntax()),
         "Should not be: {expr:?}",
     );
+}
+
+/// Create array of length `N`, with each item initialized with provided function `init`.
+#[inline]
+pub(super) fn create_array<const N: usize, T, I: FnMut() -> T>(mut init: I) -> [T; N] {
+    // https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
+    // https://github.com/rust-lang/rust/issues/61956
+    let mut array: [MaybeUninit<T>; N] = [const { MaybeUninit::uninit() }; N];
+    for elem in &mut array {
+        elem.write(init());
+    }
+    // Wrapping in `ManuallyDrop` should not be necessary because `MaybeUninit` does not impl `Drop`,
+    // but do it anyway just to make sure, as it's mentioned in issues above.
+    let mut array = ManuallyDrop::new(array);
+    // SAFETY: All elements of array are initialized.
+    // `[MaybeUninit<T>; N]` and `[T; N]` have equivalent layout.
+    unsafe { ptr::from_mut(&mut array).cast::<[T; N]>().read() }
 }


### PR DESCRIPTION
Follow-up after #7664.

Generalize `duplicate_object` to produce however many duplicates are required. Use it in `transform_expression_to_wrap_nullish_check`.

This should be slightly more efficient, and will make it fool-proof if we expand `duplicate_object` later to handle other `Expression` types.