### PR TITLE
fix(transformer/class-properties): create temp var for `this` in computed key

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,8 +1,9 @@
 commit: 54a8389f
 
-Passed: 93/104
+Passed: 94/105
 
 # All Passed:
+* babel-plugin-transform-class-properties
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/this-in-computed-key/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/this-in-computed-key/input.js
@@ -1,0 +1,22 @@
+function createClassDeclaration() {
+  class C {
+    [this] = 1;
+    [this + 'bar'] = 2;
+  }
+  return C;
+}
+
+function createClassExpression() {
+  return class {
+    [this] = 3;
+    [this + 'bar'] = 4;
+  };
+}
+
+const C = createClassDeclaration.call("foo");
+expect(new C().foo).toBe(1);
+expect(new C().foobar).toBe(2);
+
+const D = createClassExpression.call("foo");
+expect(new D().foo).toBe(3);
+expect(new D().foobar).toBe(4);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/this-in-computed-key/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/this-in-computed-key/output.js
@@ -1,0 +1,30 @@
+function createClassDeclaration() {
+  let _this, _ref;
+  _this = this;
+  _ref = this + "bar";
+  class C {
+    constructor() {
+      babelHelpers.defineProperty(this, _this, 1);
+      babelHelpers.defineProperty(this, _ref, 2);
+    }
+  }
+  return C;
+}
+
+function createClassExpression() {
+  let _this2, _ref2;
+  return _this2 = this, _ref2 = this + "bar", class {
+    constructor() {
+      babelHelpers.defineProperty(this, _this2, 3);
+      babelHelpers.defineProperty(this, _ref2, 4);
+    }
+  };
+}
+
+const C = createClassDeclaration.call("foo");
+expect(new C().foo).toBe(1);
+expect(new C().foobar).toBe(2);
+
+const D = createClassExpression.call("foo");
+expect(new D().foo).toBe(3);
+expect(new D().foobar).toBe(4);


### PR DESCRIPTION
`this` in computed key needs a temp var, otherwise once moved into constructor it refers to the wrong `this`.