### PR TITLE
test(transformer/class-properties): override fixtures

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -1,0 +1,16 @@
+var _bar = /*#__PURE__*/new WeakMap();
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      babelHelpers.classPrivateFieldInitSpec(this, _bar, "foo");
+      return this;
+    };
+
+    if (condition) {
+      _super();
+    } else {
+      _super();
+    }
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/regression-T7364/output.mjs
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/regression-T7364/output.mjs
@@ -1,0 +1,27 @@
+var _myAsyncMethod2;
+var _myAsyncMethod = new WeakMap();
+class MyClass {
+  constructor() {
+    var _this = this;
+    babelHelpers.classPrivateFieldInitSpec(this, _myAsyncMethod, babelHelpers.asyncToGenerator(function* () {
+      console.log(_this);
+    }));
+  }
+}
+_myAsyncMethod2 = new WeakMap(), class MyClass2 {
+  constructor() {
+    var _this2 = this;
+    babelHelpers.classPrivateFieldInitSpec(this, _myAsyncMethod2, babelHelpers.asyncToGenerator(function* () {
+      console.log(_this2);
+    }));
+  }
+};
+var _myAsyncMethod3 = new WeakMap();
+export default class MyClass3 {
+  constructor() {
+    var _this3 = this;
+    babelHelpers.classPrivateFieldInitSpec(this, _myAsyncMethod3, babelHelpers.asyncToGenerator(function* () {
+      console.log(_this3);
+    }));
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/options.json
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/reason.txt
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/reason.txt
@@ -1,0 +1,2 @@
+Disable arrow functions transform in `options.json` because it malfunctions.
+But these fixtures aren't to test arrow functions transform.

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-expression/output.js
@@ -1,0 +1,10 @@
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      this.bar = "foo";
+      return this;
+    };
+    foo(_super());
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/computed-toPrimitive/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/computed-toPrimitive/output.js
@@ -1,0 +1,48 @@
+var _Class;
+const foo = { [Symbol.toPrimitive]: () => "foo" };
+expect((_Class = class {}, babelHelpers.defineProperty(_Class, foo, 0), _Class).foo).toBe(0);
+expect(class {
+  static [foo]() {
+    return 0;
+  }
+}.foo()).toBe(0);
+expect(class {
+  static get [foo]() {
+    return 0;
+  }
+}.foo).toBe(0);
+expect(class {
+  static set [foo](v) {
+    return v;
+  }
+}.foo = 0).toBe(0);
+expect(new class {
+  constructor() {
+    babelHelpers.defineProperty(this, foo, 0);
+  }
+}().foo).toBe(0);
+const arrayLike = { [Symbol.toPrimitive]: () => [] };
+expect(() => {
+  var _Class2;
+  return _Class2 = class {}, babelHelpers.defineProperty(_Class2, arrayLike, 0), _Class2;
+}).toThrow("@@toPrimitive must return a primitive value.");
+expect(() => class {
+  static [arrayLike]() {
+    return 0;
+  }
+}).toThrow("@@toPrimitive must return a primitive value.");
+expect(() => class {
+  static get [arrayLike]() {
+    return 0;
+  }
+}).toThrow("@@toPrimitive must return a primitive value.");
+expect(() => class {
+  static set [arrayLike](v) {
+    return v;
+  }
+}).toThrow("@@toPrimitive must return a primitive value.");
+expect(() => new class {
+  constructor() {
+    babelHelpers.defineProperty(this, arrayLike, 0);
+  }
+}()).toThrow("@@toPrimitive must return a primitive value.");

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -1,0 +1,15 @@
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      babelHelpers.defineProperty(this, "bar", "foo");
+      return this;
+    };
+
+    if (condition) {
+      _super();
+    } else {
+      _super();
+    }
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
@@ -1,0 +1,7 @@
+let _super = function() {
+  babelHelpers.defineProperty(this, "bar", "foo");
+  return this;
+};
+class Foo extends Bar {
+  constructor(x = test ? _super.call(super()) : 0) {}
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
@@ -1,0 +1,9 @@
+let _super = function() {
+  babelHelpers.defineProperty(this, "bar", "foo");
+  return this;
+};
+class Foo extends Bar {
+  constructor(x = () => {
+    check(_super.call(super()));
+  }) {}
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
@@ -1,0 +1,7 @@
+let _super = function() {
+  babelHelpers.defineProperty(this, "bar", "foo");
+  return this;
+};
+class Foo extends Bar {
+  constructor(x = _super.call(super())) {}
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
@@ -1,0 +1,10 @@
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      babelHelpers.defineProperty(this, "bar", "foo");
+      return this;
+    };
+    foo(_super());
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/options.json
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
@@ -1,0 +1,89 @@
+"use strict";
+
+class C {}
+
+class A extends C {
+  constructor() {
+    super();
+    babelHelpers.defineProperty(this, "field", 1);
+    class B extends C {
+      constructor() {
+        super();
+        expect(this.field).toBeUndefined();
+      }
+    }
+    expect(this.field).toBe(1);
+    new B();
+  }
+}
+new A();
+
+class Obj {
+  constructor() {
+    return {};
+  }
+}
+
+// ensure superClass is still transformed
+class SuperClass extends Obj {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      babelHelpers.defineProperty(this, "field", 1);
+      return this;
+    };
+    class B extends (_super(), Obj) {
+      constructor() {
+        super();
+        expect(this.field).toBeUndefined();
+      }
+    }
+    expect(this.field).toBe(1);
+    new B();
+  }
+}
+new SuperClass();
+
+// ensure ComputedKey Method is still transformed
+class ComputedMethod extends Obj {
+  constructor() {
+    var _super2 = (..._args2) => {
+      super(..._args2);
+      babelHelpers.defineProperty(this, "field", 1);
+      return this;
+    };
+    class B extends Obj {
+      constructor() {
+        super();
+        expect(this.field).toBeUndefined();
+      }
+      [_super2()]() {}
+    }
+    expect(this.field).toBe(1);
+    new B();
+  }
+}
+new ComputedMethod();
+
+// ensure ComputedKey Field is still transformed
+class ComputedField extends Obj {
+  constructor() {
+    let _super4;
+    var _super3 = (..._args3) => {
+      super(..._args3);
+      babelHelpers.defineProperty(this, "field", 1);
+      return this;
+    };
+    _super4 = _super3();
+    class B extends Obj {
+      constructor() {
+        super();
+        babelHelpers.defineProperty(this, _super4, 1);
+        expect(this.field).toBeUndefined();
+      }
+    }
+    expect(this.field).toBe(1);
+    new B();
+  }
+}
+new ComputedField();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/reason.txt
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/reason.txt
@@ -1,0 +1,2 @@
+Disable arrow functions transform in `options.json` because it malfunctions.
+But these fixtures aren't to test arrow functions transform.

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
@@ -1,0 +1,10 @@
+class A extends B {
+  constructor() {
+    var _super = (..._args) => {
+      super(..._args);
+      babelHelpers.defineProperty(this, "x", 2);
+      return this;
+    };
+    x ? _super(a) : _super(b);
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 427/846
+Passed: 434/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (100/264)
+# babel-plugin-transform-class-properties (107/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -429,9 +429,6 @@ x Output mismatch
 * private/constructor-collision/input.js
 x Output mismatch
 
-* private/derived-multiple-supers/input.js
-x Output mismatch
-
 * private/extracted-this/input.js
 x Output mismatch
 
@@ -518,7 +515,33 @@ rebuilt        : ScopeId(5): Some(ScopeId(0))
 x Output mismatch
 
 * private/regression-T7364/input.mjs
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(7)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope children mismatch:
+after transform: ScopeId(7): []
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
+Scope children mismatch:
+after transform: ScopeId(3): [ScopeId(4), ScopeId(8)]
+rebuilt        : ScopeId(4): [ScopeId(5)]
+Scope children mismatch:
+after transform: ScopeId(8): []
+rebuilt        : ScopeId(5): [ScopeId(6)]
+Scope parent mismatch:
+after transform: ScopeId(4): Some(ScopeId(3))
+rebuilt        : ScopeId(6): Some(ScopeId(5))
+Scope children mismatch:
+after transform: ScopeId(5): [ScopeId(6), ScopeId(9)]
+rebuilt        : ScopeId(7): [ScopeId(8)]
+Scope children mismatch:
+after transform: ScopeId(9): []
+rebuilt        : ScopeId(8): [ScopeId(9)]
+Scope parent mismatch:
+after transform: ScopeId(6): Some(ScopeId(5))
+rebuilt        : ScopeId(9): Some(ScopeId(8))
 
 * private/static-call/input.js
 Scope children mismatch:
@@ -792,26 +815,35 @@ x Output mismatch
 * public/computed/input.js
 x Output mismatch
 
-* public/computed-toPrimitive/input.js
-x Output mismatch
-
 * public/constructor-collision/input.js
 x Output mismatch
 
 * public/delete-super-property/input.js
 x Output mismatch
 
-* public/derived-multiple-supers/input.js
-x Output mismatch
-
 * public/derived-super-in-default-params/input.js
-x Output mismatch
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "_super":
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/derived-super-in-default-params-complex/input.js
-x Output mismatch
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "_super":
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/derived-super-in-default-params-in-arrow/input.js
-x Output mismatch
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "_super":
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/extracted-this/input.js
 x Output mismatch
@@ -890,9 +922,6 @@ Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
 
-* public/super-expression/input.js
-x Output mismatch
-
 * public/super-with-collision/input.js
 x Output mismatch
 
@@ -909,7 +938,15 @@ x Output mismatch
 x Output mismatch
 
 * public-loose/foobar/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope children mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Scope parent mismatch:
+after transform: ScopeId(3): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 * public-loose/regression-T7364/input.mjs
 Scope children mismatch:
@@ -974,9 +1011,6 @@ Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
 
-* public-loose/super-expression/input.js
-x Output mismatch
-
 * public-loose/super-with-collision/input.js
 x Output mismatch
 
@@ -984,9 +1018,6 @@ x Output mismatch
 x Output mismatch
 
 * regression/6154/input.js
-x Output mismatch
-
-* regression/7371/input.js
 x Output mismatch
 
 * regression/7951/input.mjs
@@ -1034,9 +1065,6 @@ rebuilt        : ScopeId(8): [ScopeId(9)]
 Scope parent mismatch:
 after transform: ScopeId(6): Some(ScopeId(5))
 rebuilt        : ScopeId(9): Some(ScopeId(8))
-
-* regression/multiple-super-in-termary/input.js
-x Output mismatch
 
 
 # babel-plugin-transform-nullish-coalescing-operator (5/12)

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 187 of 215 (86.98%)
+Passed: 188 of 215 (87.44%)
 
 Failures:
 
@@ -99,9 +99,6 @@ AssertionError: expected '_Class' to be 'Foo' // Object.is equality
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-static-super-exec.test.js
 Invalid access to super
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-regression-7371-exec.test.js
-'super' keyword unexpected here
 
 ./fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-assumption-noDocumentAll-parenthesized-expression-member-call-exec.test.js
 TypeError: Cannot read properties of undefined (reading 'x')


### PR DESCRIPTION
Override some transform conformance test fixtures for class properties transform, where:

* Our output differs from Babel in cosmetic manner only.
* Our transform intentionally works differently from Babel.
* Babel's fixtures enable arrow functions transform, which malfunctions in our implementation. But we're not trying to test arrow functions transform here, so disable it.