### PR TITLE
feat(linter): change `react/rules-of-hooks` category to `pedantic`

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -104,7 +104,7 @@ declare_oxc_lint!(
     /// <https://reactjs.org/docs/hooks-rules.html>
     ///
     RulesOfHooks,
-    correctness
+    pedantic
 );
 
 impl Rule for RulesOfHooks {


### PR DESCRIPTION
Although this rule is recommended by the React team,
it does not report incorrect or wrong code for the `correctness` category.

When turned on by default, I find false positive warnings confusing,
I cannot tell whether my code is wrong or the rule implementation is
wrong - see examples in the affine repo.

```
  x eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ,-[packages/backend/server/src/config/affine.self.ts:80:1]
 79 |     /* Captcha Plugin Default Config */
 80 | ,-> AFFiNE.use('captcha', {
 81 | |     turnstile: {},
 82 | |     challenge: {
 83 | |       bits: 20,
 84 | |     },
 85 | `-> });
 86 |
    `----
```