### PR TITLE
refactor(transformer/class-properties): shorten code

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -1447,7 +1447,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             unreachable!()
         };
         let expr = self.transform_private_field_expression_impl(private_field, true, ctx);
-        AssignmentTarget::from(SimpleAssignmentTarget::from(expr.into_member_expression()))
+        AssignmentTarget::from(expr.into_member_expression())
     }
 
     /// Duplicate object to be used in get/set pair.


### PR DESCRIPTION
Follow-on after #7697. No need to cast twice. You can go from `MemberExpression` direct to `AssignmentTarget`.