### PR TITLE
refactor(transformer/class-properties): move code out of `transform_assignment_target`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -1432,7 +1432,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         // `object.#prop` in assignment pattern.
         // Must be in assignment pattern, as `enter_expression` already transformed `AssignmentExpression`s.
         if matches!(target, AssignmentTarget::PrivateFieldExpression(_)) {
-            *target = self.transform_assignment_target_impl(target, ctx);
+            self.transform_assignment_target_impl(target, ctx);
         }
     }
 
@@ -1440,14 +1440,14 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         &mut self,
         target: &mut AssignmentTarget<'a>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> AssignmentTarget<'a> {
+    ) {
         let AssignmentTarget::PrivateFieldExpression(private_field) =
             ctx.ast.move_assignment_target(target)
         else {
             unreachable!()
         };
         let expr = self.transform_private_field_expression_impl(private_field, true, ctx);
-        AssignmentTarget::from(expr.into_member_expression())
+        *target = AssignmentTarget::from(expr.into_member_expression());
     }
 
     /// Duplicate object to be used in get/set pair.


### PR DESCRIPTION
Follow-on after #7697.

`transform_assignment_target` is inlined into `enter_assignment_target` visitor, so we want it to be as small as possible. Move assigning to `target` into `transform_assignment_target_impl`, which is the cold path.

The principle is that in the transformer the most important thing for performance is to optimize for the path which is "nothing to do here, exit".

Here we are only transforming `object.#prop`, but very few `AssignmentTarget`s are `object.#prop`, so 99% of the time there is nothing to do. So we want to keep that "do nothing and exit" path as fast and small as possible.

In practice, the `*target =` assignment is only a single assembly operation, so this PR is a micro-optimization. But why not? Every little helps.