### PR TITLE
fix(codegen): missing parens for `in` in `for in` loop init

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -291,7 +291,7 @@ impl Gen for ForInStatement<'_> {
         p.print_str("for");
         p.print_soft_space();
         p.print_ascii_byte(b'(');
-        self.left.print(p, Context::empty().and_forbid_in(false));
+        self.left.print(p, Context::FORBID_IN);
         p.print_soft_space();
         p.print_space_before_identifier();
         p.print_str("in");

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -64,10 +64,10 @@ fn for_stmt() {
         "for (x = (y in z) || y || (y in z) || y || (y in z);;);",
         "for (x = (y in z) || y || (y in z) || y || (y in z);;);\n",
     );
-    // test(
-    //     "for (var a = 1 || (2 in {}) in { x: 1 }) count++;",
-    //     "for (var a = 1 || (2 in {}) in {x: 1}) count++;\n",
-    // );
+    test(
+        "for (var a = 1 || (2 in {}) in { x: 1 }) count++;",
+        "for (var a = 1 || (2 in {}) in { x: 1 }) count++;\n",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Well, this looks like an accidental change before, `Context::empty().and_forbid_in(false)` does nothing at all.