### PR TITLE
test(transformer): transform conformance print code with double-space indent

### DIFF
--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -296,8 +296,10 @@ impl TestCase {
                 }
             } else {
                 println!("Expected:\n");
+                let output = output.cow_replace("\t", "  ");
                 println!("{output}\n");
                 println!("Transformed:\n");
+                let transformed_code = transformed_code.cow_replace("\t", "  ");
                 println!("{transformed_code}");
                 println!("Errors:\n");
                 if let Some(actual_errors) = &actual_errors {


### PR DESCRIPTION
Transform conformance tester (`just test-transform`) print code with double-space indent, instead of tabs. This matches our formatting convention for JS files.