### PR TITLE
fix(transformer/class-properties): make `_super` function outside class strict mode

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
@@ -1,4 +1,5 @@
 let _super = function() {
+  "use strict";
   babelHelpers.defineProperty(this, "bar", "foo");
   return this;
 };

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
@@ -1,4 +1,5 @@
 let _super = function() {
+  "use strict";
   babelHelpers.defineProperty(this, "bar", "foo");
   return this;
 };

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
@@ -1,4 +1,5 @@
 let _super = function() {
+  "use strict";
   babelHelpers.defineProperty(this, "bar", "foo");
   return this;
 };

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -822,25 +822,16 @@ x Output mismatch
 x Output mismatch
 
 * public/derived-super-in-default-params/input.js
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "_super":
 after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/derived-super-in-default-params-complex/input.js
-Scope flags mismatch:
-after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "_super":
 after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/derived-super-in-default-params-in-arrow/input.js
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "_super":
 after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,9 +1,8 @@
 commit: 54a8389f
 
-Passed: 94/105
+Passed: 94/106
 
 # All Passed:
-* babel-plugin-transform-class-properties
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
@@ -14,6 +13,16 @@ Passed: 94/105
 * babel-preset-typescript
 * babel-plugin-transform-react-jsx-source
 * regexp
+
+
+# babel-plugin-transform-class-properties (1/2)
+* super-in-constructor-strict/input.js
+Symbol flags mismatch for "_super":
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "_super2":
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 
 # babel-plugin-transform-async-to-generator (14/15)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-strict/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-strict/input.js
@@ -1,0 +1,14 @@
+function sloppy() {
+  class C extends S {
+    prop = 1;
+    constructor(x = super()) {}
+  }
+}
+
+function strict() {
+  "use strict";
+  class C extends S {
+    prop = 1;
+    constructor(x = super()) {}
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-strict/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-strict/output.js
@@ -1,0 +1,21 @@
+function sloppy() {
+  let _super = function() {
+    "use strict";
+    babelHelpers.defineProperty(this, "prop", 1);
+    return this;
+  };
+  class C extends S {
+    constructor(x = _super.call(super())) {}
+  }
+}
+
+function strict() {
+  "use strict";
+  let _super2 = function() {
+    babelHelpers.defineProperty(this, "prop", 1);
+    return this;
+  };
+  class C extends S {
+    constructor(x = _super2.call(super())) {}
+  }
+}


### PR DESCRIPTION
When create a `_super` function outside class, ensure it's always strict mode. The code it contains was previously inside the class, so was strict mode.