### PR TITLE
fix(transformer/class-properties): fix `SymbolFlags` for `_super` function

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -377,7 +377,7 @@ impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
             self.ctx.generate_uid(
                 "super",
                 self.ctx.current_scope_id(),
-                SymbolFlags::FunctionScopedVariable,
+                SymbolFlags::BlockScopedVariable,
             )
         });
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 434/846
+Passed: 437/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (107/264)
+# babel-plugin-transform-class-properties (110/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -820,21 +820,6 @@ x Output mismatch
 
 * public/delete-super-property/input.js
 x Output mismatch
-
-* public/derived-super-in-default-params/input.js
-Symbol flags mismatch for "_super":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-* public/derived-super-in-default-params-complex/input.js
-Symbol flags mismatch for "_super":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-* public/derived-super-in-default-params-in-arrow/input.js
-Symbol flags mismatch for "_super":
-after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * public/extracted-this/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,8 +1,9 @@
 commit: 54a8389f
 
-Passed: 94/106
+Passed: 95/106
 
 # All Passed:
+* babel-plugin-transform-class-properties
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
@@ -13,16 +14,6 @@ Passed: 94/106
 * babel-preset-typescript
 * babel-plugin-transform-react-jsx-source
 * regexp
-
-
-# babel-plugin-transform-class-properties (1/2)
-* super-in-constructor-strict/input.js
-Symbol flags mismatch for "_super":
-after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
-Symbol flags mismatch for "_super2":
-after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable)
-rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 
 
 # babel-plugin-transform-async-to-generator (14/15)


### PR DESCRIPTION
Fix `SymbolFlags` for generated `_super` function outside class.