### PR TITLE
refactor(transformer/class-properties): shorten output when `_super` function

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/derived-multiple-supers/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/derived-multiple-supers/output.js
@@ -1,11 +1,11 @@
 var _bar = /*#__PURE__*/new WeakMap();
 class Foo extends Bar {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      babelHelpers.classPrivateFieldInitSpec(this, _bar, "foo");
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.classPrivateFieldInitSpec(this, _bar, "foo"),
+      this
+    );
 
     if (condition) {
       _super();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-expression/output.js
@@ -1,10 +1,10 @@
 class Foo extends Bar {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      this.bar = "foo";
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      this.bar = "foo",
+      this
+    );
     foo(_super());
   }
 }

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-multiple-supers/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/derived-multiple-supers/output.js
@@ -1,10 +1,10 @@
 class Foo extends Bar {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      babelHelpers.defineProperty(this, "bar", "foo");
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.defineProperty(this, "bar", "foo"),
+      this
+    );
 
     if (condition) {
       _super();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
@@ -1,10 +1,10 @@
 class Foo extends Bar {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      babelHelpers.defineProperty(this, "bar", "foo");
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.defineProperty(this, "bar", "foo"),
+      this
+    );
     foo(_super());
   }
 }

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
@@ -27,11 +27,11 @@ class Obj {
 // ensure superClass is still transformed
 class SuperClass extends Obj {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      babelHelpers.defineProperty(this, "field", 1);
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.defineProperty(this, "field", 1),
+      this
+    );
     class B extends (_super(), Obj) {
       constructor() {
         super();
@@ -47,11 +47,11 @@ new SuperClass();
 // ensure ComputedKey Method is still transformed
 class ComputedMethod extends Obj {
   constructor() {
-    var _super2 = (..._args2) => {
-      super(..._args2);
-      babelHelpers.defineProperty(this, "field", 1);
-      return this;
-    };
+    var _super2 = (..._args2) => (
+      super(..._args2),
+      babelHelpers.defineProperty(this, "field", 1),
+      this
+    );
     class B extends Obj {
       constructor() {
         super();
@@ -69,11 +69,11 @@ new ComputedMethod();
 class ComputedField extends Obj {
   constructor() {
     let _super4;
-    var _super3 = (..._args3) => {
-      super(..._args3);
-      babelHelpers.defineProperty(this, "field", 1);
-      return this;
-    };
+    var _super3 = (..._args3) => (
+      super(..._args3),
+      babelHelpers.defineProperty(this, "field", 1),
+      this
+    );
     _super4 = _super3();
     class B extends Obj {
       constructor() {

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
@@ -1,10 +1,10 @@
 class A extends B {
   constructor() {
-    var _super = (..._args) => {
-      super(..._args);
-      babelHelpers.defineProperty(this, "x", 2);
-      return this;
-    };
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.defineProperty(this, "x", 2),
+      this
+    );
     x ? _super(a) : _super(b);
   }
 }


### PR DESCRIPTION
Produce more compact output when insert a `_super` function into class constructor.