### PR TITLE
test(transformer): add `just` script to update transformer test fixtures

### DIFF
--- a/justfile
+++ b/justfile
@@ -135,6 +135,12 @@ autoinherit:
 test-transform *args='':
   cargo run -p oxc_transform_conformance -- --exec {{args}}
 
+# Update transformer conformance test fixtures, including overrides.
+# `just submodules` also does this, but this runs faster. Useful when working on transformer.
+update-transformer-fixtures:
+  cd tasks/coverage/babel && git reset --hard HEAD && git clean -f -q
+  node tasks/transform_conformance/update_fixtures.js
+
 # Install wasm-pack
 install-wasm:
   cargo binstall wasm-pack


### PR DESCRIPTION
Add `just update-transformer-fixtures` to update transformer conformance tests with overrides (see #7688).