### PR TITLE
feat(transformer/class-properties): support `private_fields_as_properties` assumption

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -156,6 +156,8 @@ pub enum Helper {
     ClassPrivateFieldSet2,
     AssertClassBrand,
     ToSetter,
+    ClassPrivateFieldLooseKey,
+    ClassPrivateFieldLooseBase,
 }
 
 impl Helper {
@@ -177,6 +179,8 @@ impl Helper {
             Self::ClassPrivateFieldSet2 => "classPrivateFieldSet2",
             Self::AssertClassBrand => "assertClassBrand",
             Self::ToSetter => "toSetter",
+            Self::ClassPrivateFieldLooseKey => "classPrivateFieldLooseKey",
+            Self::ClassPrivateFieldLooseBase => "classPrivateFieldLooseBase",
         }
     }
 }

--- a/crates/oxc_transformer/src/compiler_assumptions.rs
+++ b/crates/oxc_transformer/src/compiler_assumptions.rs
@@ -66,7 +66,6 @@ pub struct CompilerAssumptions {
     pub private_fields_as_symbols: bool,
 
     #[serde(default)]
-    #[deprecated = "Not Implemented"]
     pub private_fields_as_properties: bool,
 
     #[serde(default)]

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -181,6 +181,8 @@ pub struct ClassProperties<'a, 'ctx> {
     //
     /// If `true`, set properties with `=`, instead of `_defineProperty` helper.
     set_public_class_fields: bool,
+    /// If `true`, record private properties as string keys
+    private_fields_as_properties: bool,
     /// If `true`, transform static blocks.
     transform_static_blocks: bool,
 
@@ -227,9 +229,13 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     ) -> Self {
         // TODO: Raise error if these 2 options are inconsistent
         let set_public_class_fields = options.loose || ctx.assumptions.set_public_class_fields;
+        // TODO: Raise error if these 2 options are inconsistent
+        let private_fields_as_properties =
+            options.loose || ctx.assumptions.private_fields_as_properties;
 
         Self {
             set_public_class_fields,
+            private_fields_as_properties,
             transform_static_blocks,
             ctx,
             private_props_stack: PrivatePropsStack::default(),

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived-multiple-supers/output.js
@@ -1,0 +1,14 @@
+var _bar = babelHelpers.classPrivateFieldLooseKey("bar");
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => (super(..._args), Object.defineProperty(this, _bar, {
+      writable: true,
+      value: "foo"
+    }), this);
+    if (condition) {
+      _super();
+    } else {
+      _super();
+    }
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/options.json
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/reason.txt
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/reason.txt
@@ -1,0 +1,2 @@
+Disable arrow functions transform in `options.json` because it malfunctions.
+But these fixtures aren't to test arrow functions transform.

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -1,0 +1,31 @@
+var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _foo, {
+      writable: true,
+      value: 1
+    });
+  }
+  test() {
+    var _foo3;
+    let _this$foo;
+    var _foo2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
+    class Nested extends (_foo3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _this$foo = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], class {
+      constructor() {
+        Object.defineProperty(this, _foo3, {
+          writable: true,
+          value: 2
+        });
+        this[_this$foo] = 2;
+      }
+    }) {
+      constructor(...args) {
+        super(...args);
+        Object.defineProperty(this, _foo2, {
+          writable: true,
+          value: 3
+        });
+      }
+    }
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/super-expression/output.js
@@ -1,0 +1,14 @@
+var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => (
+      super(..._args),
+      Object.defineProperty(this, _bar, {
+        writable: true,
+        value: "foo"
+      }),
+      this
+    );
+    foo(_super());
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 441/846
+Passed: 480/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (114/264)
+# babel-plugin-transform-class-properties (153/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -588,14 +588,16 @@ Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
 
-* private-loose/assignment/input.js
-x Output mismatch
-
 * private-loose/call/input.js
-x Output mismatch
-
-* private-loose/canonical/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
+Scope children mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 * private-loose/class-shadow-builtins/input.mjs
 x Output mismatch
@@ -603,71 +605,19 @@ x Output mismatch
 * private-loose/constructor-collision/input.js
 x Output mismatch
 
-* private-loose/declaration-order/input.js
-x Output mismatch
-
-* private-loose/derived/input.js
-x Output mismatch
-
-* private-loose/derived-multiple-supers/input.js
-x Output mismatch
-
-* private-loose/destructuring-array-pattern/input.js
-x Output mismatch
-
-* private-loose/destructuring-array-pattern-1/input.js
-x Output mismatch
-
-* private-loose/destructuring-array-pattern-2/input.js
-x Output mismatch
-
-* private-loose/destructuring-array-pattern-3/input.js
-x Output mismatch
-
-* private-loose/destructuring-array-pattern-static/input.js
-x Output mismatch
-
-* private-loose/destructuring-object-pattern/input.js
-x Output mismatch
-
-* private-loose/destructuring-object-pattern-1/input.js
-x Output mismatch
-
-* private-loose/destructuring-object-pattern-2/input.js
-x Output mismatch
-
-* private-loose/destructuring-object-pattern-3/input.js
-x Output mismatch
-
-* private-loose/destructuring-object-pattern-static/input.js
-x Output mismatch
-
 * private-loose/extracted-this/input.js
 x Output mismatch
 
 * private-loose/foobar/input.js
-x Output mismatch
-
-* private-loose/instance/input.js
-x Output mismatch
-
-* private-loose/instance-undefined/input.js
-x Output mismatch
-
-* private-loose/logical-assignment/input.js
-x Output mismatch
-
-* private-loose/multiple/input.js
-x Output mismatch
-
-* private-loose/native-classes/input.js
-x Output mismatch
-
-* private-loose/nested-class/input.js
-x Output mismatch
-
-* private-loose/nested-class-computed/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope children mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Scope parent mismatch:
+after transform: ScopeId(3): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 * private-loose/nested-class-computed-redeclared/input.js
 x Output mismatch
@@ -676,16 +626,18 @@ x Output mismatch
 x Output mismatch
 
 * private-loose/nested-class-extends-computed-redeclared/input.js
-x Output mismatch
-
-* private-loose/nested-class-other-redeclared/input.js
-x Output mismatch
-
-* private-loose/nested-class-redeclared/input.js
-x Output mismatch
-
-* private-loose/non-block-arrow-func/input.mjs
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(2): ["Nested", "_foo2"]
+rebuilt        : ScopeId(3): ["Nested", "_foo2", "_foo3", "_this$foo"]
+Bindings mismatch:
+after transform: ScopeId(3): ["_foo3", "_this$foo"]
+rebuilt        : ScopeId(4): []
+Symbol scope ID mismatch for "_foo3":
+after transform: SymbolId(5): ScopeId(3)
+rebuilt        : SymbolId(2): ScopeId(3)
+Symbol scope ID mismatch for "_this$foo":
+after transform: SymbolId(6): ScopeId(3)
+rebuilt        : SymbolId(3): ScopeId(3)
 
 * private-loose/optional-chain-before-member-call/input.js
 x Output mismatch
@@ -702,9 +654,6 @@ x Output mismatch
 * private-loose/optional-chain-cast-to-boolean/input.js
 x Output mismatch
 
-* private-loose/optional-chain-delete-property/input.js
-x Output mismatch
-
 * private-loose/optional-chain-delete-property-with-transform/input.js
 x Output mismatch
 
@@ -715,9 +664,6 @@ x Output mismatch
 x Output mismatch
 
 * private-loose/optional-chain-member-optional-call/input.js
-x Output mismatch
-
-* private-loose/optional-chain-member-optional-call-spread-arguments/input.js
 x Output mismatch
 
 * private-loose/optional-chain-member-optional-call-with-transform/input.js
@@ -741,53 +687,50 @@ x Output mismatch
 * private-loose/parenthesized-optional-member-call-with-transform/input.js
 x Output mismatch
 
-* private-loose/preserve-comments/input.js
-x Output mismatch
-
-* private-loose/private-in-derived/input.js
-x Output mismatch
-
-* private-loose/reevaluated/input.js
-x Output mismatch
-
-* private-loose/reference-in-other-property/input.js
-x Output mismatch
-
-* private-loose/static/input.js
-x Output mismatch
-
 * private-loose/static-call/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(0))
 
 * private-loose/static-class-binding/input.js
-x Output mismatch
-
-* private-loose/static-export/input.mjs
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(2): Some(ScopeId(0))
 
 * private-loose/static-infer-name/input.js
 x Output mismatch
 
-* private-loose/static-inherited/input.js
-x Output mismatch
-
-* private-loose/static-shadow/input.js
-x Output mismatch
-
 * private-loose/static-this/input.js
-x Output mismatch
-
-* private-loose/static-undefined/input.js
-x Output mismatch
-
-* private-loose/super-expression/input.js
-x Output mismatch
-
-* private-loose/super-statement/input.js
-x Output mismatch
-
-* private-loose/update/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(2): Some(ScopeId(0))
 
 * public/call/input.js
 Scope children mismatch:

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 188 of 215 (87.44%)
+Passed: 186 of 215 (86.51%)
 
 Failures:
 
@@ -31,33 +31,47 @@ AssertionError: expected undefined to be 'hello' // Object.is equality
 AssertionError: expected undefined to be 'bar' // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-constructor-collision-exec.test.js:18:19
 
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-access-before-declaration-exec.test.js
-AssertionError: expected [Function] to throw error matching /attempted to use private field on non…/ but got 'Cannot read properties of undefined (…'
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1438:21)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-access-before-declaration-exec.test.js:14:5
-
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js
 AssertionError: expected undefined to be 'bar' // Object.is equality
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js:18:19
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js:21:19
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-computed-redeclared-exec.test.js
 Private field '#foo' must be declared in an enclosing class
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js
-AssertionError: expected [Function] to not throw an error but 'TypeError: Private element is not pre…' was thrown
+AssertionError: expected [Function] to not throw an error but 'TypeError: attempted to use private f…' was thrown
     at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1438:21)
     at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
     at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js:30:9
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js:36:9
 
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js
-TypeError: e.has is not a function
-    at _assertClassBrand (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/assertClassBrand.js:2:44)
-    at func (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js:10:12)
-    at Function.method (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js:12:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-static-shadow-exec.test.js:16:14
+./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js
+TypeError: Cannot convert undefined or null to object
+    at hasOwnProperty (<anonymous>)
+    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:26)
+    at value (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:63:11)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:44:198
+    at j (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:45:6)
+    at Function.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:52:11)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js:71:6
+
+./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js
+TypeError: Cannot convert undefined or null to object
+    at hasOwnProperty (<anonymous>)
+    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:26)
+    at value (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:123:11)
+    at Function.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:24:134)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-member-optional-call-with-transform-exec.test.js:131:6
+
+./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-exec.test.js
+TypeError: Cannot read properties of undefined (reading 'bind')
+    at Foo.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-exec.test.js:20:59)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-exec.test.js:78:12
+
+./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-with-transform-exec.test.js
+TypeError: Cannot read properties of undefined (reading 'bind')
+    at Foo.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-with-transform-exec.test.js:20:59)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-with-transform-exec.test.js:78:12
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-computed-redeclared-exec.test.js
 Private field '#foo' must be declared in an enclosing class

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 102/114
+Passed: 103/116
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,9 +16,31 @@ Passed: 102/114
 * regexp
 
 
-# babel-plugin-transform-class-properties (3/4)
-* private-loose-logical-assignment/input.js
-x Output mismatch
+# babel-plugin-transform-class-properties (4/6)
+* private-loose-tagged-template/input.js
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
+Scope children mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): [ScopeId(3)]
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
+
+* private-loose-tagged-template-static/input.js
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(0))
 
 
 # babel-plugin-transform-async-to-generator (14/15)

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,4 +2,4 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 1 of 1 (100.00%)
+Passed: 3 of 3 (100.00%)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/exec.js
@@ -1,0 +1,9 @@
+class Foo {
+  static #tag = function() { return this };
+
+  static getReceiver() {
+    return this.#tag`tagged template`;
+  }
+}
+
+expect(Foo.getReceiver()).toBe(Foo);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  static #tag = function() { return this };
+
+  static getReceiver() {
+    return this.#tag`tagged template`;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template-static/output.js
@@ -1,0 +1,14 @@
+var _tag = /*#__PURE__*/ babelHelpers.classPrivateFieldLooseKey("tag");
+
+class Foo {
+  static getReceiver() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _tag)[_tag]`tagged template`;
+  }
+}
+
+Object.defineProperty(Foo, _tag, {
+  writable: true,
+  value: function() {
+    return this;
+  }
+});

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/exec.js
@@ -1,0 +1,11 @@
+class Foo {
+  #tag = function() { return this };
+
+  getReceiver() {
+    return this.#tag`tagged template`;
+  }
+}
+
+const foo = new Foo();
+const receiver = foo.getReceiver();
+expect(receiver).toBe(foo);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/input.js
@@ -1,0 +1,7 @@
+class Foo {
+  #tag = function() { return this };
+
+  getReceiver() {
+    return this.#tag`tagged template`;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-tagged-template/output.js
@@ -1,0 +1,16 @@
+var _tag = /*#__PURE__*/ babelHelpers.classPrivateFieldLooseKey("tag");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _tag, {
+      writable: true,
+      value: function() {
+        return this;
+      }
+    });
+  }
+
+  getReceiver() {
+    return babelHelpers.classPrivateFieldLooseBase(this, _tag)[_tag]`tagged template`;
+  }
+}


### PR DESCRIPTION
Support `private_fields_as_properties` assumption in class properties transform. This assumption is also enabled by the transform's `loose` option.

Optional chain (e.g. `this?.#prop`) is not yet implemented, but all other usages of private fields are supported. We'll handle optional chain in a follow-on PR.