### PR TITLE
test(transformer/class-properties): override test output for `_super` in class constructor

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/super-expression/output.js
@@ -1,0 +1,11 @@
+var _bar = /*#__PURE__*/new WeakMap();
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => (
+      super(..._args),
+      babelHelpers.classPrivateFieldInitSpec(this, _bar, "foo"),
+      this
+    );
+    foo(_super());
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 439/846
+Passed: 440/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (112/264)
+# babel-plugin-transform-class-properties (113/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -590,9 +590,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
-
-* private/super-expression/input.js
-x Output mismatch
 
 * private-loose/assignment/input.js
 x Output mismatch


### PR DESCRIPTION
Our output for this test differs from Babel, because we handle `super()` in class constructors differently, but our output is valid.