### PR TITLE
test(transformer/class-properties): override test output for `_super` in class constructor

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/super-expression/output.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  constructor() {
+    var _super = (..._args) => (super(..._args), this.bar = "foo", this);
+    foo(_super());
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 440/846
+Passed: 441/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (113/264)
+# babel-plugin-transform-class-properties (114/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -374,9 +374,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
-
-* assumption-setPublicClassFields/super-expression/input.js
-x Output mismatch
 
 * assumption-setPublicClassFields/super-with-collision/input.js
 x Output mismatch


### PR DESCRIPTION
Our output for this test differs from Babel, because we handle `super()` in class constructors differently, but our output is valid.