### PR TITLE
test(transformer/class-properties): add more tests

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,9 +1,8 @@
 commit: 54a8389f
 
-Passed: 95/106
+Passed: 96/108
 
 # All Passed:
-* babel-plugin-transform-class-properties
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
@@ -14,6 +13,11 @@ Passed: 95/106
 * babel-preset-typescript
 * babel-plugin-transform-react-jsx-source
 * regexp
+
+
+# babel-plugin-transform-class-properties (3/4)
+* private-loose-logical-assignment/input.js
+x Output mismatch
 
 
 # babel-plugin-transform-async-to-generator (14/15)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-logical-assignment/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-logical-assignment/input.js
@@ -1,0 +1,17 @@
+class Foo {
+  #nullish = 0;
+  #and = 0;
+  #or = 0;
+
+  self() {
+    return this;
+  }
+
+  test() {
+    this.#nullish ??= 42;
+    this.#and &&= 0;
+    this.#or ||= 0;
+
+    this.self().#nullish ??= 42;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-logical-assignment/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-logical-assignment/output.js
@@ -1,0 +1,20 @@
+var _nullish = /*#__PURE__*/new WeakMap();
+var _and = /*#__PURE__*/new WeakMap();
+var _or = /*#__PURE__*/new WeakMap();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateFieldInitSpec(this, _nullish, 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _and, 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _or, 0);
+  }
+  self() {
+    return this;
+  }
+  test() {
+    var _this$self;
+    babelHelpers.classPrivateFieldGet2(_nullish, this) ?? babelHelpers.classPrivateFieldSet2(_nullish, this, 42);
+    babelHelpers.classPrivateFieldGet2(_and, this) && babelHelpers.classPrivateFieldSet2(_and, this, 0);
+    babelHelpers.classPrivateFieldGet2(_or, this) || babelHelpers.classPrivateFieldSet2(_or, this, 0);
+    babelHelpers.classPrivateFieldGet2(_nullish, _this$self = this.self()) ?? babelHelpers.classPrivateFieldSet2(_nullish, _this$self, 42);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/input.js
@@ -1,0 +1,17 @@
+class Foo {
+  #nullish = 0;
+  #and = 0;
+  #or = 0;
+
+  self() {
+    return this;
+  }
+
+  test() {
+    this.#nullish ??= 42;
+    this.#and &&= 0;
+    this.#or ||= 0;
+
+    this.self().#nullish ??= 42;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-loose-logical-assignment/output.js
@@ -1,0 +1,28 @@
+var _nullish = babelHelpers.classPrivateFieldLooseKey("nullish");
+var _and = babelHelpers.classPrivateFieldLooseKey("and");
+var _or = babelHelpers.classPrivateFieldLooseKey("or");
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _nullish, {
+      writable: true,
+      value: 0
+    });
+    Object.defineProperty(this, _and, {
+      writable: true,
+      value: 0
+    });
+    Object.defineProperty(this, _or, {
+      writable: true,
+      value: 0
+    });
+  }
+  self() {
+    return this;
+  }
+  test() {
+    babelHelpers.classPrivateFieldLooseBase(this, _nullish)[_nullish] ??= 42;
+    babelHelpers.classPrivateFieldLooseBase(this, _and)[_and] &&= 0;
+    babelHelpers.classPrivateFieldLooseBase(this, _or)[_or] ||= 0;
+    babelHelpers.classPrivateFieldLooseBase(this.self(), _nullish)[_nullish] ??= 42;
+  }
+}


### PR DESCRIPTION
Babel's tests only cover transforming `this.#prop &&= value` with logical assignment operators transform also enabled. Add tests for just class properties transform alone.