### PR TITLE
fix(transformer/logic-assignment-operator): always create `IdentifierReference`s with `ReferenceId`

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,9 +1,10 @@
 commit: 54a8389f
 
-Passed: 96/108
+Passed: 99/111
 
 # All Passed:
 * babel-plugin-transform-class-static-block
+* babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/computed-prop-identifier/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/computed-prop-identifier/input.js
@@ -1,0 +1,23 @@
+let boundObj, boundProp, mutatedObj, mutatedProp;
+mutatedObj = 'x';
+mutatedProp = 'x';
+
+boundObj[boundProp] &&= 1;
+boundObj[unboundProp] &&= 2;
+boundObj[mutatedProp] &&= 3;
+
+unboundObj[boundProp] &&= 4;
+unboundObj[unboundProp] &&= 5;
+unboundObj[mutatedProp] &&= 6;
+
+mutatedObj[boundProp] &&= 7;
+mutatedObj[unboundProp] &&= 8;
+mutatedObj[mutatedProp] &&= 9;
+
+boundObj.prop[boundProp] &&= 10;
+boundObj.prop[unboundProp] &&= 11;
+boundObj.prop[mutatedProp] &&= 12;
+
+this[boundProp] &&= 13;
+this[unboundProp] &&= 14;
+this[mutatedProp] &&= 15;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/computed-prop-identifier/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/computed-prop-identifier/output.js
@@ -1,0 +1,43 @@
+var _unboundProp,
+  _mutatedProp,
+  _unboundObj,
+  _unboundObj2,
+  _unboundProp2,
+  _unboundObj3,
+  _mutatedProp2,
+  _mutatedObj,
+  _mutatedObj2,
+  _unboundProp3,
+  _mutatedObj3,
+  _mutatedProp3,
+  _boundObj$prop,
+  _boundObj$prop2,
+  _unboundProp4,
+  _boundObj$prop3,
+  _mutatedProp4,
+  _unboundProp5,
+  _mutatedProp5;
+
+let boundObj, boundProp, mutatedObj, mutatedProp;
+mutatedObj = "x";
+mutatedProp = "x";
+
+boundObj[boundProp] && (boundObj[boundProp] = 1);
+boundObj[(_unboundProp = unboundProp)] && (boundObj[_unboundProp] = 2);
+boundObj[(_mutatedProp = mutatedProp)] && (boundObj[_mutatedProp] = 3);
+
+(_unboundObj = unboundObj)[boundProp] && (_unboundObj[boundProp] = 4);
+(_unboundObj2 = unboundObj)[(_unboundProp2 = unboundProp)] && (_unboundObj2[_unboundProp2] = 5);
+(_unboundObj3 = unboundObj)[(_mutatedProp2 = mutatedProp)] && (_unboundObj3[_mutatedProp2] = 6);
+
+(_mutatedObj = mutatedObj)[boundProp] && (_mutatedObj[boundProp] = 7);
+(_mutatedObj2 = mutatedObj)[(_unboundProp3 = unboundProp)] && (_mutatedObj2[_unboundProp3] = 8);
+(_mutatedObj3 = mutatedObj)[(_mutatedProp3 = mutatedProp)] && (_mutatedObj3[_mutatedProp3] = 9);
+
+(_boundObj$prop = boundObj.prop)[boundProp] && (_boundObj$prop[boundProp] = 10);
+(_boundObj$prop2 = boundObj.prop)[(_unboundProp4 = unboundProp)] && (_boundObj$prop2[_unboundProp4] = 11);
+(_boundObj$prop3 = boundObj.prop)[(_mutatedProp4 = mutatedProp)] && (_boundObj$prop3[_mutatedProp4] = 12);
+
+this[boundProp] && (this[boundProp] = 13);
+this[(_unboundProp5 = unboundProp)] && (this[_unboundProp5] = 14);
+this[(_mutatedProp5 = mutatedProp)] && (this[_mutatedProp5] = 15);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-logical-assignment-operators"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-computed/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-computed/input.js
@@ -1,0 +1,10 @@
+let boundProp, mutatedProp;
+mutatedProp = 'x';
+
+class C extends S {
+  method() {
+    super[boundProp] &&= 1;
+    super[unboundProp] &&= 2;
+    super[mutatedProp] &&= 3;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-computed/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-computed/output.js
@@ -1,0 +1,12 @@
+let boundProp, mutatedProp;
+mutatedProp = "x";
+
+class C extends S {
+  method() {
+    var _unboundProp, _mutatedProp;
+
+    super[boundProp] && (super[boundProp] = 1);
+    super[(_unboundProp = unboundProp)] && (super[_unboundProp] = 2);
+    super[(_mutatedProp = mutatedProp)] && (super[_mutatedProp] = 3);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-static/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-static/input.js
@@ -1,0 +1,7 @@
+class C extends S {
+  method() {
+    super.prop &&= 1;
+    super.prop ||= 2;
+    super.prop ??= 3;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-static/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-logical-assignment-operators/test/fixtures/super-prop-static/output.js
@@ -1,0 +1,7 @@
+class C extends S {
+  method() {
+    super.prop && (super.prop = 1);
+    super.prop || (super.prop = 2);
+    super.prop ?? (super.prop = 3);
+  }
+}


### PR DESCRIPTION
Use `TransformCtx::duplicate_expression` (introduced in #7754) to decide when to create temp vars for member expression object and computed property.

This fixes a bug where `IdentifierReference`s created when transforming `key` in `object[key] &&= value` were created without a `ReferenceId` (due to `clone_in`).

We didn't catch this before because Babel's test fixtures only cover `object[key++] &&= value` not the simpler `object[key] &&= value`. Add tests for this.