### PR TITLE
perf(traverse): faster `TraverseScoping::is_static`

### DIFF
--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -378,13 +378,14 @@ impl TraverseScoping {
     pub fn is_static(&self, expr: &Expression) -> bool {
         match expr {
             Expression::ThisExpression(_) | Expression::Super(_) => true,
-            Expression::Identifier(ident) => {
-                self.symbols.get_reference(ident.reference_id()).symbol_id().is_some_and(
-                    |symbol_id| {
-                        self.symbols.get_resolved_references(symbol_id).all(|r| !r.is_write())
-                    },
-                )
-            }
+            Expression::Identifier(ident) => self
+                .symbols
+                .get_reference(ident.reference_id())
+                .symbol_id()
+                .is_some_and(|symbol_id| {
+                    self.symbols.get_flags(symbol_id).contains(SymbolFlags::ConstVariable)
+                        || self.symbols.get_resolved_references(symbol_id).all(|r| !r.is_write())
+                }),
             _ => false,
         }
     }


### PR DESCRIPTION
Speed up `TraverseScoping::is_static` by checking if symbol is `const`. That check is faster than iterating through all references to see if they write to the binding.

This also subtly changes behavior. `is_static(x)` will now return `true` for `x` in `const x = 1; x = 2;`. But that's valid, because the purpose of `is_static` is to say whether the value of the var can be mutated, which it can't if it's `const`.