### PR TITLE
refactor(transformer/class-properties): prefer `contains` to `intersects` for bitflags

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -754,7 +754,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 // Test for it in first pass over class elements, and avoid temp vars where possible.
                 match ctx.symbols().get_reference(ident.reference_id()).symbol_id() {
                     Some(symbol_id) => {
-                        ctx.symbols().get_flags(symbol_id).intersects(SymbolFlags::ConstVariable)
+                        ctx.symbols().get_flags(symbol_id).contains(SymbolFlags::ConstVariable)
                             || ctx
                                 .symbols()
                                 .get_resolved_references(symbol_id)


### PR DESCRIPTION
Tiny refactor. `contains` is clearer than `intersects`, and they produce equivalent assembly when argument is a single flag value, and statically knowable.

https://godbolt.org/z/bTdfbv3f8
