### PR TITLE
test(transformer/class-properties): overrides optional-chain-related tests

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call-with-transform/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call-with-transform/output.js
@@ -1,0 +1,63 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o, _deep$very$o$Foo, _deep$very$o2, _deep$very$o2$Foo, _deep$very$o3, _deep$very$o3$Foo, _o$Foo$self, _o$Foo$self$self, _ref, _ref$self, _ref2, _ref2$self, _self2, _self2$self, _ref3, _o$Foo$self$getSelf, _babelHelpers$assertC, _ref4, _ref4$call, _ref5, _ref5$getSelf, _ref6, _ref6$getSelf, _ref6$getSelf$call, _ref7, _ref8, _ref8$self, _babelHelpers$assertC2, _call, _call$self, _ref9, _getSelf, _getSelf$self, _ref10, _getSelf2, _getSelf2$self, _ref11, _ref11$getSelf, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o, _fnDeep$very$o$Foo, _fnDeep$very$o2, _fnDeep$very$o2$Foo, _fnDeep$very$o3, _fnDeep$very$o3$Foo, _fn$Foo$self, _fn$Foo$self$self, _ref12, _ref12$self, _ref13, _ref13$self, _self3, _self3$self, _ref14, _fn$Foo$self$getSelf, _babelHelpers$assertC3, _ref15, _ref15$call, _ref16, _ref16$getSelf, _ref17, _ref17$getSelf, _ref17$getSelf$call, _ref18, _ref19, _ref19$self, _babelHelpers$assertC4, _call2, _call2$self, _ref20, _getSelf3, _getSelf3$self, _ref21, _getSelf4, _getSelf4$self, _ref22, _ref22$getSelf;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo = o.Foo, _m)._.call(_o$Foo);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2 = o.Foo, _m)._.call(_o$Foo2).toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3 = o.Foo, _m)._.call(_o$Foo3).toString();
+    (_deep$very$o = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo = _deep$very$o.Foo, _m)._.call(_deep$very$o$Foo);
+    (_deep$very$o2 = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2$Foo = _deep$very$o2.Foo, _m)._.call(_deep$very$o2$Foo).toString;
+    (_deep$very$o3 = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3$Foo = _deep$very$o3.Foo, _m)._.call(_deep$very$o3$Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _m)._.call(_o$Foo$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _m)._.call(_o$Foo$self$self);
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref$self = _ref.self, _m)._.call(_ref$self);
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2$self = _ref2.self, _m)._.call(_ref2$self);
+    (_self2 = (_ref3 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref3 === void 0 ? void 0 : _ref3.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2$self = _self2.self, _m)._.call(_self2$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _m)._.call(_o$Foo$self$getSelf);
+    (_ref4 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4$call = _ref4.call(_babelHelpers$assertC), _m)._.call(_ref4$call);
+    (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref5 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5$getSelf = _ref5.getSelf(), _m)._.call(_ref5$getSelf);
+    (_ref6$getSelf = (_ref7 = _ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref7 === void 0 ? void 0 : _ref7.getSelf) === null || _ref6$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6$getSelf$call = _ref6$getSelf.call(_ref6), _m)._.call(_ref6$getSelf$call);
+    (_ref8 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8$self = _ref8.self, _m)._.call(_ref8$self);
+    (_call = (_ref9 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : _ref9.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self = _call.self, _m)._.call(_call$self);
+    (_getSelf = (_ref10 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref10 === void 0 ? void 0 : _ref10.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self = _getSelf.self, _m)._.call(_getSelf$self);
+    (_getSelf2 = (_ref11 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref11 === void 0 || (_ref11$getSelf = _ref11.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : _ref11$getSelf.call(_ref11)) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2$self = _getSelf2.self, _m)._.call(_getSelf2$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo = fn().Foo, _m)._.call(_fn$Foo);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2 = fn().Foo, _m)._.call(_fn$Foo2).toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3 = fn().Foo, _m)._.call(_fn$Foo3).toString();
+    (_fnDeep$very$o = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo = _fnDeep$very$o.Foo, _m)._.call(_fnDeep$very$o$Foo);
+    (_fnDeep$very$o2 = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2$Foo = _fnDeep$very$o2.Foo, _m)._.call(_fnDeep$very$o2$Foo).toString;
+    (_fnDeep$very$o3 = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3$Foo = _fnDeep$very$o3.Foo, _m)._.call(_fnDeep$very$o3$Foo).toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _m)._.call(_fn$Foo$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _m)._.call(_fn$Foo$self$self);
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12$self = _ref12.self, _m)._.call(_ref12$self);
+    (_ref13 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref13 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref13$self = _ref13.self, _m)._.call(_ref13$self);
+    (_self3 = (_ref14 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref14 === void 0 ? void 0 : _ref14.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3$self = _self3.self, _m)._.call(_self3$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _m)._.call(_fn$Foo$self$getSelf);
+    (_ref15 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref15 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref15$call = _ref15.call(_babelHelpers$assertC3), _m)._.call(_ref15$call);
+    (_ref16 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref16 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref16$getSelf = _ref16.getSelf(), _m)._.call(_ref16$getSelf);
+    (_ref17$getSelf = (_ref18 = _ref17 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref18 === void 0 ? void 0 : _ref18.getSelf) === null || _ref17$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref17$getSelf$call = _ref17$getSelf.call(_ref17), _m)._.call(_ref17$getSelf$call);
+    (_ref19 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref19 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref19$self = _ref19.self, _m)._.call(_ref19$self);
+    (_call2 = (_ref20 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref20 === void 0 ? void 0 : _ref20.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2$self = _call2.self, _m)._.call(_call2$self);
+    (_getSelf3 = (_ref21 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref21 === void 0 ? void 0 : _ref21.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3$self = _getSelf3.self, _m)._.call(_getSelf3$self);
+    (_getSelf4 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4$self = _getSelf4.self, _m)._.call(_getSelf4$self);
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _m = { _: function() {
+  return babelHelpers.assertClassBrand(_Foo, this, _x)._;
+} };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call/output.js
@@ -1,0 +1,63 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o, _deep$very$o$Foo, _deep$very$o2, _deep$very$o2$Foo, _deep$very$o3, _deep$very$o3$Foo, _o$Foo$self, _o$Foo$self$self, _ref, _ref$self, _ref2, _ref2$self, _self2, _self2$self, _o$Foo$self$getSelf, _babelHelpers$assertC, _ref3, _ref3$call, _ref4, _ref4$getSelf, _ref5, _ref5$getSelf, _ref5$getSelf$call, _ref6, _ref6$self, _babelHelpers$assertC2, _call, _call$self, _getSelf, _getSelf$self, _getSelf2, _getSelf2$self, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o, _fnDeep$very$o$Foo, _fnDeep$very$o2, _fnDeep$very$o2$Foo, _fnDeep$very$o3, _fnDeep$very$o3$Foo, _fn$Foo$self, _fn$Foo$self$self, _ref7, _ref7$self, _ref8, _ref8$self, _self3, _self3$self, _fn$Foo$self$getSelf, _babelHelpers$assertC3, _ref9, _ref9$call, _ref10, _ref10$getSelf, _ref11, _ref11$getSelf, _ref11$getSelf$call, _ref12, _ref12$self, _babelHelpers$assertC4, _call2, _call2$self, _getSelf3, _getSelf3$self, _getSelf4, _getSelf4$self;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo = o.Foo, _m)._.call(_o$Foo);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2 = o.Foo, _m)._.call(_o$Foo2).toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3 = o.Foo, _m)._.call(_o$Foo3).toString();
+    (_deep$very$o = deep?.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo = _deep$very$o.Foo, _m)._.call(_deep$very$o$Foo);
+    (_deep$very$o2 = deep?.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2$Foo = _deep$very$o2.Foo, _m)._.call(_deep$very$o2$Foo).toString;
+    (_deep$very$o3 = deep?.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3$Foo = _deep$very$o3.Foo, _m)._.call(_deep$very$o3$Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _m)._.call(_o$Foo$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _m)._.call(_o$Foo$self$self);
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref$self = _ref.self, _m)._.call(_ref$self);
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2$self = _ref2.self, _m)._.call(_ref2$self);
+    (_self2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2$self = _self2.self, _m)._.call(_self2$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _m)._.call(_o$Foo$self$getSelf);
+    (_ref3 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref3$call = _ref3.call(_babelHelpers$assertC), _m)._.call(_ref3$call);
+    (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4$getSelf = _ref4.getSelf(), _m)._.call(_ref4$getSelf);
+    (_ref5$getSelf = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf) === null || _ref5$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5$getSelf$call = _ref5$getSelf.call(_ref5), _m)._.call(_ref5$getSelf$call);
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6$self = _ref6.self, _m)._.call(_ref6$self);
+    (_call = (o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf)?.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self = _call.self, _m)._.call(_call$self);
+    (_getSelf = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self = _getSelf.self, _m)._.call(_getSelf$self);
+    (_getSelf2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf?.()) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2$self = _getSelf2.self, _m)._.call(_getSelf2$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo = fn().Foo, _m)._.call(_fn$Foo);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2 = fn().Foo, _m)._.call(_fn$Foo2).toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3 = fn().Foo, _m)._.call(_fn$Foo3).toString();
+    (_fnDeep$very$o = fnDeep?.().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo = _fnDeep$very$o.Foo, _m)._.call(_fnDeep$very$o$Foo);
+    (_fnDeep$very$o2 = fnDeep?.().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2$Foo = _fnDeep$very$o2.Foo, _m)._.call(_fnDeep$very$o2$Foo).toString;
+    (_fnDeep$very$o3 = fnDeep?.().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3$Foo = _fnDeep$very$o3.Foo, _m)._.call(_fnDeep$very$o3$Foo).toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _m)._.call(_fn$Foo$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _m)._.call(_fn$Foo$self$self);
+    (_ref7 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref7$self = _ref7.self, _m)._.call(_ref7$self);
+    (_ref8 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8$self = _ref8.self, _m)._.call(_ref8$self);
+    (_self3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3$self = _self3.self, _m)._.call(_self3$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _m)._.call(_fn$Foo$self$getSelf);
+    (_ref9 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref9$call = _ref9.call(_babelHelpers$assertC3), _m)._.call(_ref9$call);
+    (_ref10 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref10 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref10$getSelf = _ref10.getSelf(), _m)._.call(_ref10$getSelf);
+    (_ref11$getSelf = (_ref11 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref11$getSelf$call = _ref11$getSelf.call(_ref11), _m)._.call(_ref11$getSelf$call);
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12$self = _ref12.self, _m)._.call(_ref12$self);
+    (_call2 = (fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf)?.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2$self = _call2.self, _m)._.call(_call2$self);
+    (_getSelf3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3$self = _getSelf3.self, _m)._.call(_getSelf3$self);
+    (_getSelf4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf?.()) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4$self = _getSelf4.self, _m)._.call(_getSelf4$self);
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _m = { _: function() {
+  return babelHelpers.assertClassBrand(_Foo, this, _x)._;
+} };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property-with-transform/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property-with-transform/output.js
@@ -1,0 +1,60 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _deep$very$o, _deep$very$o2, _deep$very$o3, _ref, _ref2, _self2, _ref3, _babelHelpers$assertC, _ref4, _ref5, _ref6, _ref6$getSelf, _ref7, _ref8, _babelHelpers$assertC2, _call, _ref9, _getSelf, _ref10, _getSelf2, _ref11, _ref11$getSelf, _fnDeep$very$o, _fnDeep$very$o2, _fnDeep$very$o3, _ref12, _ref13, _self3, _ref14, _babelHelpers$assertC3, _ref15, _ref16, _ref17, _ref17$getSelf, _ref18, _ref19, _babelHelpers$assertC4, _call2, _ref20, _getSelf3, _ref21, _getSelf4, _ref22, _ref22$getSelf;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._.toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._.toString();
+    (_deep$very$o = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o.Foo, _x)._;
+    (_deep$very$o2 = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2.Foo, _x)._.toString;
+    (_deep$very$o3 = deep === null || deep === void 0 ? void 0 : deep.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3.Foo, _x)._.toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _x)._;
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref.self, _x)._;
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2.self, _x)._;
+    (_self2 = (_ref3 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref3 === void 0 ? void 0 : _ref3.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2.self, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _x)._;
+    (_ref4 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4.call(_babelHelpers$assertC), _x)._;
+    (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref5 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5.getSelf(), _x)._;
+    (_ref6$getSelf = (_ref7 = _ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref7 === void 0 ? void 0 : _ref7.getSelf) === null || _ref6$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6$getSelf.call(_ref6), _x)._;
+    (_ref8 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8.self, _x)._;
+    (_call = (_ref9 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : _ref9.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call.self, _x)._;
+    (_getSelf = (_ref10 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref10 === void 0 ? void 0 : _ref10.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf.self, _x)._;
+    (_getSelf2 = (_ref11 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref11 === void 0 || (_ref11$getSelf = _ref11.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : _ref11$getSelf.call(_ref11)) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2.self, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._.toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._.toString();
+    (_fnDeep$very$o = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o.Foo, _x)._;
+    (_fnDeep$very$o2 = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2.Foo, _x)._.toString;
+    (_fnDeep$very$o3 = fnDeep === null || fnDeep === void 0 ? void 0 : fnDeep().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3.Foo, _x)._.toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _x)._;
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12.self, _x)._;
+    (_ref13 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref13 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref13.self, _x)._;
+    (_self3 = (_ref14 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref14 === void 0 ? void 0 : _ref14.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3.self, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _x)._;
+    (_ref15 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref15 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref15.call(_babelHelpers$assertC3), _x)._;
+    (_ref16 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref16 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref16.getSelf(), _x)._;
+    (_ref17$getSelf = (_ref18 = _ref17 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref18 === void 0 ? void 0 : _ref18.getSelf) === null || _ref17$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref17$getSelf.call(_ref17), _x)._;
+    (_ref19 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref19 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref19.self, _x)._;
+    (_call2 = (_ref20 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref20 === void 0 ? void 0 : _ref20.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2.self, _x)._;
+    (_getSelf3 = (_ref21 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref21 === void 0 ? void 0 : _ref21.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3.self, _x)._;
+    (_getSelf4 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4.self, _x)._;
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property/output.js
@@ -1,0 +1,60 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _deep$very$o, _deep$very$o2, _deep$very$o3, _ref, _ref2, _self2, _babelHelpers$assertC, _ref3, _ref4, _ref5, _ref5$getSelf, _ref6, _babelHelpers$assertC2, _call, _getSelf, _getSelf2, _fnDeep$very$o, _fnDeep$very$o2, _fnDeep$very$o3, _ref7, _ref8, _self3, _babelHelpers$assertC3, _ref9, _ref10, _ref11, _ref11$getSelf, _ref12, _babelHelpers$assertC4, _call2, _getSelf3, _getSelf4;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._.toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _x)._.toString();
+    (_deep$very$o = deep?.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o.Foo, _x)._;
+    (_deep$very$o2 = deep?.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2.Foo, _x)._.toString;
+    (_deep$very$o3 = deep?.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3.Foo, _x)._.toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _x)._;
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref.self, _x)._;
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2.self, _x)._;
+    (_self2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2.self, _x)._;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _x)._;
+    (_ref3 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref3.call(_babelHelpers$assertC), _x)._;
+    (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4.getSelf(), _x)._;
+    (_ref5$getSelf = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf) === null || _ref5$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5$getSelf.call(_ref5), _x)._;
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6.self, _x)._;
+    (_call = (o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf)?.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call.self, _x)._;
+    (_getSelf = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf.self, _x)._;
+    (_getSelf2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf?.()) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2.self, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._.toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _x)._.toString();
+    (_fnDeep$very$o = fnDeep?.().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o.Foo, _x)._;
+    (_fnDeep$very$o2 = fnDeep?.().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2.Foo, _x)._.toString;
+    (_fnDeep$very$o3 = fnDeep?.().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3.Foo, _x)._.toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _x)._;
+    (_ref7 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref7.self, _x)._;
+    (_ref8 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8.self, _x)._;
+    (_self3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3.self, _x)._;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _x)._;
+    (_ref9 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref9.call(_babelHelpers$assertC3), _x)._;
+    (_ref10 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref10 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref10.getSelf(), _x)._;
+    (_ref11$getSelf = (_ref11 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref11$getSelf.call(_ref11), _x)._;
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12.self, _x)._;
+    (_call2 = (fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf)?.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2.self, _x)._;
+    (_getSelf3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3.self, _x)._;
+    (_getSelf4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf?.()) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4.self, _x)._;
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call/output.js
@@ -1,0 +1,66 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o, _deep$very$o$Foo, _deep$very$o2, _deep$very$o2$Foo, _deep$very$o3, _deep$very$o3$Foo, _o$Foo$self, _o$Foo$self$self, _ref, _ref$self, _ref2, _ref2$self, _self2, _self2$self, _o$Foo$self$getSelf, _babelHelpers$assertC, _ref3, _ref3$call, _ref4, _ref4$getSelf, _ref5, _ref5$getSelf, _ref5$getSelf$call, _ref6, _ref6$self, _babelHelpers$assertC2, _call, _call$self, _getSelf, _getSelf$self, _getSelf2, _getSelf2$self, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o, _fnDeep$very$o$Foo, _fnDeep$very$o2, _fnDeep$very$o2$Foo, _fnDeep$very$o3, _fnDeep$very$o3$Foo, _fn$Foo$self, _fn$Foo$self$self, _ref7, _ref7$self, _ref8, _ref8$self, _self3, _self3$self, _fn$Foo$self$getSelf, _babelHelpers$assertC3, _ref9, _ref9$call, _ref10, _ref10$getSelf, _ref11, _ref11$getSelf, _ref11$getSelf$call, _ref12, _ref12$self, _babelHelpers$assertC4, _call2, _call2$self, _getSelf3, _getSelf3$self, _getSelf4, _getSelf4$self;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    _m._?.call(Foo);
+    _m._?.call(Foo).toString;
+    _m._?.call(Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo = o.Foo, _m)._?.call(_o$Foo);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2 = o.Foo, _m)._?.call(_o$Foo2).toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3 = o.Foo, _m)._?.call(_o$Foo3).toString();
+    (_deep$very$o = deep?.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo = _deep$very$o.Foo, _m)._?.call(_deep$very$o$Foo);
+    (_deep$very$o2 = deep?.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2$Foo = _deep$very$o2.Foo, _m)._?.call(_deep$very$o2$Foo).toString;
+    (_deep$very$o3 = deep?.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3$Foo = _deep$very$o3.Foo, _m)._?.call(_deep$very$o3$Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _m)._?.call(_o$Foo$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _m)._?.call(_o$Foo$self$self);
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref$self = _ref.self, _m)._?.call(_ref$self);
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2$self = _ref2.self, _m)._?.call(_ref2$self);
+    (_self2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2$self = _self2.self, _m)._?.call(_self2$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _m)._?.call(_o$Foo$self$getSelf);
+    (_ref3 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref3$call = _ref3.call(_babelHelpers$assertC), _m)._?.call(_ref3$call);
+    (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4$getSelf = _ref4.getSelf(), _m)._?.call(_ref4$getSelf);
+    (_ref5$getSelf = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf) === null || _ref5$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5$getSelf$call = _ref5$getSelf.call(_ref5), _m)._?.call(_ref5$getSelf$call);
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6$self = _ref6.self, _m)._?.call(_ref6$self);
+    (_call = (o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf)?.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self = _call.self, _m)._?.call(_call$self);
+    (_getSelf = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self = _getSelf.self, _m)._?.call(_getSelf$self);
+    (_getSelf2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf?.()) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2$self = _getSelf2.self, _m)._?.call(_getSelf2$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo = fn().Foo, _m)._?.call(_fn$Foo);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2 = fn().Foo, _m)._?.call(_fn$Foo2).toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3 = fn().Foo, _m)._?.call(_fn$Foo3).toString();
+    (_fnDeep$very$o = fnDeep?.().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo = _fnDeep$very$o.Foo, _m)._?.call(_fnDeep$very$o$Foo);
+    (_fnDeep$very$o2 = fnDeep?.().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2$Foo = _fnDeep$very$o2.Foo, _m)._?.call(_fnDeep$very$o2$Foo).toString;
+    (_fnDeep$very$o3 = fnDeep?.().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3$Foo = _fnDeep$very$o3.Foo, _m)._?.call(_fnDeep$very$o3$Foo).toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _m)._?.call(_fn$Foo$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _m)._?.call(_fn$Foo$self$self);
+    (_ref7 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref7$self = _ref7.self, _m)._?.call(_ref7$self);
+    (_ref8 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8$self = _ref8.self, _m)._?.call(_ref8$self);
+    (_self3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3$self = _self3.self, _m)._?.call(_self3$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _m)._?.call(_fn$Foo$self$getSelf);
+    (_ref9 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref9$call = _ref9.call(_babelHelpers$assertC3), _m)._?.call(_ref9$call);
+    (_ref10 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref10 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref10$getSelf = _ref10.getSelf(), _m)._?.call(_ref10$getSelf);
+    (_ref11$getSelf = (_ref11 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref11$getSelf$call = _ref11$getSelf.call(_ref11), _m)._?.call(_ref11$getSelf$call);
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12$self = _ref12.self, _m)._?.call(_ref12$self);
+    (_call2 = (fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf)?.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2$self = _call2.self, _m)._?.call(_call2$self);
+    (_getSelf3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3$self = _getSelf3.self, _m)._?.call(_getSelf3$self);
+    (_getSelf4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf?.()) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4$self = _getSelf4.self, _m)._?.call(_getSelf4$self);
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _m = { _: function() {
+  return babelHelpers.assertClassBrand(_Foo, this, _x)._;
+} };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call-with-transform/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call-with-transform/output.js
@@ -1,0 +1,78 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o$Foo, _deep$very$o, _deep$very$o$Foo2, _deep$very$o2, _deep$very$o$Foo3, _deep$very$o3, _ref, _ref2, _self2, _ref3, _self3, _ref4, _self$self, _ref5, _ref6, _babelHelpers$assertC, _call, _ref7, _getSelf, _ref8, _getSelf2, _ref9, _ref9$getSelf, _self4, _ref10, _babelHelpers$assertC2, _call$self, _ref11, _getSelf$self, _ref12, _getSelf$self2, _ref13, _ref13$getSelf, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o$Foo, _fnDeep$very$o, _fnDeep$very$o$Foo2, _fnDeep$very$o2, _fnDeep$very$o$Foo3, _fnDeep$very$o3, _ref14, _ref15, _self5, _ref16, _self6, _ref17, _self$self2, _ref18, _ref19, _babelHelpers$assertC3, _call2, _ref20, _getSelf3, _ref21, _getSelf4, _ref22, _ref22$getSelf, _self7, _ref23, _babelHelpers$assertC4, _call$self2, _ref24, _getSelf$self3, _ref25, _getSelf$self4, _ref26, _ref26$getSelf;
+    const o = {
+      Foo: Foo
+    };
+    const deep = {
+      very: {
+        o
+      }
+    };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo);
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo).toString;
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo).toString();
+    (_o$Foo = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo, _m)._.call(_o$Foo);
+    (_o$Foo2 = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2, _m)._.call(_o$Foo2).toString;
+    (_o$Foo3 = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3, _m)._.call(_o$Foo3).toString();
+    (_deep$very$o$Foo = deep === null || deep === void 0 || (_deep$very$o = deep.very.o) === null || _deep$very$o === void 0 ? void 0 : _deep$very$o.Foo) === null || _deep$very$o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo, _m)._.call(_deep$very$o$Foo);
+    (_deep$very$o$Foo2 = deep === null || deep === void 0 || (_deep$very$o2 = deep.very.o) === null || _deep$very$o2 === void 0 ? void 0 : _deep$very$o2.Foo) === null || _deep$very$o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo2, _m)._.call(_deep$very$o$Foo2).toString;
+    (_deep$very$o$Foo3 = deep === null || deep === void 0 || (_deep$very$o3 = deep.very.o) === null || _deep$very$o3 === void 0 ? void 0 : _deep$very$o3.Foo) === null || _deep$very$o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo3, _m)._.call(_deep$very$o$Foo3).toString();
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref, _m)._.call(_ref);
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2, _m)._.call(_ref2);
+    (_self2 = (_ref3 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref3 === void 0 ? void 0 : _ref3.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2, _m)._.call(_self2);
+    (_self3 = (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref4 === void 0 ? void 0 : _ref4.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3, _m)._.call(_self3);
+    (_self$self = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref5 === void 0 || (_ref5 = _ref5.self) === null || _ref5 === void 0 ? void 0 : _ref5.self) === null || _self$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self$self, _m)._.call(_self$self);
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6, _m)._.call(_ref6);
+    (_call = (_ref7 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref7 === void 0 ? void 0 : _ref7.call(_babelHelpers$assertC)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call, _m)._.call(_call);
+    (_getSelf = (_ref8 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref8 === void 0 ? void 0 : _ref8.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf, _m)._.call(_getSelf);
+    (_getSelf2 = (_ref9 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref9 === void 0 || (_ref9$getSelf = _ref9.getSelf) === null || _ref9$getSelf === void 0 ? void 0 : _ref9$getSelf.call(_ref9)) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2, _m)._.call(_getSelf2);
+    (_self4 = (_ref10 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref10 === void 0 ? void 0 : _ref10.self) === null || _self4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self4, _m)._.call(_self4);
+    (_call$self = (_ref11 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref11 === void 0 || (_ref11 = _ref11.call(_babelHelpers$assertC2)) === null || _ref11 === void 0 ? void 0 : _ref11.self) === null || _call$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self, _m)._.call(_call$self);
+    (_getSelf$self = (_ref12 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref12 === void 0 || (_ref12 = _ref12.getSelf()) === null || _ref12 === void 0 ? void 0 : _ref12.self) === null || _getSelf$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self, _m)._.call(_getSelf$self);
+    (_getSelf$self2 = (_ref13 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref13 === void 0 || (_ref13$getSelf = _ref13.getSelf) === null || _ref13$getSelf === void 0 || (_ref13$getSelf = _ref13$getSelf.call(_ref13)) === null || _ref13$getSelf === void 0 ? void 0 : _ref13$getSelf.self) === null || _getSelf$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self2, _m)._.call(_getSelf$self2);
+    (_fn$Foo = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo, _m)._.call(_fn$Foo);
+    (_fn$Foo2 = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2, _m)._.call(_fn$Foo2).toString;
+    (_fn$Foo3 = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3, _m)._.call(_fn$Foo3).toString();
+    (_fnDeep$very$o$Foo = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o = fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo, _m)._.call(_fnDeep$very$o$Foo);
+    (_fnDeep$very$o$Foo2 = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o2 = fnDeep().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : _fnDeep$very$o2.Foo) === null || _fnDeep$very$o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo2, _m)._.call(_fnDeep$very$o$Foo2).toString;
+    (_fnDeep$very$o$Foo3 = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o3 = fnDeep().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : _fnDeep$very$o3.Foo) === null || _fnDeep$very$o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo3, _m)._.call(_fnDeep$very$o$Foo3).toString();
+    (_ref14 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref14 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref14, _m)._.call(_ref14);
+    (_ref15 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref15 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref15, _m)._.call(_ref15);
+    (_self5 = (_ref16 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref16 === void 0 ? void 0 : _ref16.self) === null || _self5 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self5, _m)._.call(_self5);
+    (_self6 = (_ref17 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref17 === void 0 ? void 0 : _ref17.self) === null || _self6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self6, _m)._.call(_self6);
+    (_self$self2 = (_ref18 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref18 === void 0 || (_ref18 = _ref18.self) === null || _ref18 === void 0 ? void 0 : _ref18.self) === null || _self$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self$self2, _m)._.call(_self$self2);
+    (_ref19 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref19 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref19, _m)._.call(_ref19);
+    (_call2 = (_ref20 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref20 === void 0 ? void 0 : _ref20.call(_babelHelpers$assertC3)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2, _m)._.call(_call2);
+    (_getSelf3 = (_ref21 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref21 === void 0 ? void 0 : _ref21.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3, _m)._.call(_getSelf3);
+    (_getSelf4 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4, _m)._.call(_getSelf4);
+    (_self7 = (_ref23 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref23 === void 0 ? void 0 : _ref23.self) === null || _self7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self7, _m)._.call(_self7);
+    (_call$self2 = (_ref24 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref24 === void 0 || (_ref24 = _ref24.call(_babelHelpers$assertC4)) === null || _ref24 === void 0 ? void 0 : _ref24.self) === null || _call$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self2, _m)._.call(_call$self2);
+    (_getSelf$self3 = (_ref25 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref25 === void 0 || (_ref25 = _ref25.getSelf()) === null || _ref25 === void 0 ? void 0 : _ref25.self) === null || _getSelf$self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self3, _m)._.call(_getSelf$self3);
+    (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref26 === void 0 || (_ref26$getSelf = _ref26.getSelf) === null || _ref26$getSelf === void 0 || (_ref26$getSelf = _ref26$getSelf.call(_ref26)) === null || _ref26$getSelf === void 0 ? void 0 : _ref26$getSelf.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self4, _m)._.call(_getSelf$self4);
+  }
+}
+_Foo = Foo;
+var _x = {
+  _: 1
+};
+var _m = {
+  _: function () {
+    return babelHelpers.assertClassBrand(_Foo, this, _x)._;
+  }
+};
+var _self = {
+  _: _Foo
+};
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call/output.js
@@ -1,0 +1,66 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o, _deep$very$o$Foo, _deep$very$o2, _deep$very$o2$Foo, _deep$very$o3, _deep$very$o3$Foo, _o$Foo$self, _o$Foo$self$self, _ref, _ref$self, _ref2, _ref2$self, _self2, _self2$self, _o$Foo$self$getSelf, _babelHelpers$assertC, _ref3, _ref3$call, _ref4, _ref4$getSelf, _ref5, _ref5$getSelf, _ref5$getSelf$call, _ref6, _ref6$self, _babelHelpers$assertC2, _call, _call$self, _getSelf, _getSelf$self, _getSelf2, _getSelf2$self, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o, _fnDeep$very$o$Foo, _fnDeep$very$o2, _fnDeep$very$o2$Foo, _fnDeep$very$o3, _fnDeep$very$o3$Foo, _fn$Foo$self, _fn$Foo$self$self, _ref7, _ref7$self, _ref8, _ref8$self, _self3, _self3$self, _fn$Foo$self$getSelf, _babelHelpers$assertC3, _ref9, _ref9$call, _ref10, _ref10$getSelf, _ref11, _ref11$getSelf, _ref11$getSelf$call, _ref12, _ref12$self, _babelHelpers$assertC4, _call2, _call2$self, _getSelf3, _getSelf3$self, _getSelf4, _getSelf4$self;
+    const o = { Foo };
+    const deep = { very: { o } };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo);
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo).toString;
+    Foo === null || Foo === void 0 ? void 0 : _m._.call(Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo = o.Foo, _m)._.call(_o$Foo);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2 = o.Foo, _m)._.call(_o$Foo2).toString;
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3 = o.Foo, _m)._.call(_o$Foo3).toString();
+    (_deep$very$o = deep?.very.o) === null || _deep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo = _deep$very$o.Foo, _m)._.call(_deep$very$o$Foo);
+    (_deep$very$o2 = deep?.very.o) === null || _deep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o2$Foo = _deep$very$o2.Foo, _m)._.call(_deep$very$o2$Foo).toString;
+    (_deep$very$o3 = deep?.very.o) === null || _deep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o3$Foo = _deep$very$o3.Foo, _m)._.call(_deep$very$o3$Foo).toString();
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._, _m)._.call(_o$Foo$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$self = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self, _m)._.call(_o$Foo$self$self);
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref$self = _ref.self, _m)._.call(_ref$self);
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2$self = _ref2.self, _m)._.call(_ref2$self);
+    (_self2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2$self = _self2.self, _m)._.call(_self2$self);
+    o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf(), _m)._.call(_o$Foo$self$getSelf);
+    (_ref3 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref3$call = _ref3.call(_babelHelpers$assertC), _m)._.call(_ref3$call);
+    (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref4$getSelf = _ref4.getSelf(), _m)._.call(_ref4$getSelf);
+    (_ref5$getSelf = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf) === null || _ref5$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref5$getSelf$call = _ref5$getSelf.call(_ref5), _m)._.call(_ref5$getSelf$call);
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6$self = _ref6.self, _m)._.call(_ref6$self);
+    (_call = (o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf)?.call(_babelHelpers$assertC2)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self = _call.self, _m)._.call(_call$self);
+    (_getSelf = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self = _getSelf.self, _m)._.call(_getSelf$self);
+    (_getSelf2 = (o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._)?.getSelf?.()) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2$self = _getSelf2.self, _m)._.call(_getSelf2$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo = fn().Foo, _m)._.call(_fn$Foo);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2 = fn().Foo, _m)._.call(_fn$Foo2).toString;
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3 = fn().Foo, _m)._.call(_fn$Foo3).toString();
+    (_fnDeep$very$o = fnDeep?.().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo = _fnDeep$very$o.Foo, _m)._.call(_fnDeep$very$o$Foo);
+    (_fnDeep$very$o2 = fnDeep?.().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o2$Foo = _fnDeep$very$o2.Foo, _m)._.call(_fnDeep$very$o2$Foo).toString;
+    (_fnDeep$very$o3 = fnDeep?.().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o3$Foo = _fnDeep$very$o3.Foo, _m)._.call(_fnDeep$very$o3$Foo).toString();
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._, _m)._.call(_fn$Foo$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$self = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self, _m)._.call(_fn$Foo$self$self);
+    (_ref7 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref7$self = _ref7.self, _m)._.call(_ref7$self);
+    (_ref8 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref8 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref8$self = _ref8.self, _m)._.call(_ref8$self);
+    (_self3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3$self = _self3.self, _m)._.call(_self3$self);
+    fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo$self$getSelf = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf(), _m)._.call(_fn$Foo$self$getSelf);
+    (_ref9 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref9 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref9$call = _ref9.call(_babelHelpers$assertC3), _m)._.call(_ref9$call);
+    (_ref10 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref10 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref10$getSelf = _ref10.getSelf(), _m)._.call(_ref10$getSelf);
+    (_ref11$getSelf = (_ref11 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf) === null || _ref11$getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref11$getSelf$call = _ref11$getSelf.call(_ref11), _m)._.call(_ref11$getSelf$call);
+    (_ref12 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref12 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref12$self = _ref12.self, _m)._.call(_ref12$self);
+    (_call2 = (fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf)?.call(_babelHelpers$assertC4)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2$self = _call2.self, _m)._.call(_call2$self);
+    (_getSelf3 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3$self = _getSelf3.self, _m)._.call(_getSelf3$self);
+    (_getSelf4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._)?.getSelf?.()) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4$self = _getSelf4.self, _m)._.call(_getSelf4$self);
+  }
+}
+_Foo = Foo;
+var _x = { _: 1 };
+var _m = { _: function() {
+  return babelHelpers.assertClassBrand(_Foo, this, _x)._;
+} };
+var _self = { _: _Foo };
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property-with-transform/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property-with-transform/output.js
@@ -1,0 +1,72 @@
+var _Foo;
+class Foo {
+  static getSelf() {
+    return this;
+  }
+  static test() {
+    var _o$Foo, _o$Foo2, _o$Foo3, _deep$very$o$Foo, _deep$very$o, _deep$very$o$Foo2, _deep$very$o2, _deep$very$o$Foo3, _deep$very$o3, _ref, _ref2, _self2, _ref3, _self3, _ref4, _self$self, _ref5, _ref6, _babelHelpers$assertC, _call, _ref7, _getSelf, _ref8, _getSelf2, _ref9, _ref9$getSelf, _self4, _ref10, _babelHelpers$assertC2, _call$self, _ref11, _getSelf$self, _ref12, _getSelf$self2, _ref13, _ref13$getSelf, _fn$Foo, _fn$Foo2, _fn$Foo3, _fnDeep$very$o$Foo, _fnDeep$very$o, _fnDeep$very$o$Foo2, _fnDeep$very$o2, _fnDeep$very$o$Foo3, _fnDeep$very$o3, _ref14, _ref15, _self5, _ref16, _self6, _ref17, _self$self2, _ref18, _ref19, _babelHelpers$assertC3, _call2, _ref20, _getSelf3, _ref21, _getSelf4, _ref22, _ref22$getSelf, _self7, _ref23, _babelHelpers$assertC4, _call$self2, _ref24, _getSelf$self3, _ref25, _getSelf$self4, _ref26, _ref26$getSelf;    const o = {
+      Foo: Foo
+    };
+    const deep = {
+      very: {
+        o
+      }
+    };
+    function fn() {
+      return o;
+    }
+    function fnDeep() {
+      return deep;
+    }
+    Foo === null || Foo === void 0 ? void 0 : _x._;
+    Foo === null || Foo === void 0 ? void 0 : _x._.toString;
+    Foo === null || Foo === void 0 ? void 0 : _x._.toString();
+    (_o$Foo = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo, _x)._;
+    (_o$Foo2 = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo2, _x)._.toString;
+    (_o$Foo3 = o === null || o === void 0 ? void 0 : o.Foo) === null || _o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _o$Foo3, _x)._.toString();
+    (_deep$very$o$Foo = deep === null || deep === void 0 || (_deep$very$o = deep.very.o) === null || _deep$very$o === void 0 ? void 0 : _deep$very$o.Foo) === null || _deep$very$o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo, _x)._;
+    (_deep$very$o$Foo2 = deep === null || deep === void 0 || (_deep$very$o2 = deep.very.o) === null || _deep$very$o2 === void 0 ? void 0 : _deep$very$o2.Foo) === null || _deep$very$o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo2, _x)._.toString;
+    (_deep$very$o$Foo3 = deep === null || deep === void 0 || (_deep$very$o3 = deep.very.o) === null || _deep$very$o3 === void 0 ? void 0 : _deep$very$o3.Foo) === null || _deep$very$o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _deep$very$o$Foo3, _x)._.toString();
+    (_ref = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref, _x)._;
+    (_ref2 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref2, _x)._;
+    (_self2 = (_ref3 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref3 === void 0 ? void 0 : _ref3.self) === null || _self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self2, _x)._;
+    (_self3 = (_ref4 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.self) === null || _ref4 === void 0 ? void 0 : _ref4.self) === null || _self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self3, _x)._;
+    (_self$self = (_ref5 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref5 === void 0 || (_ref5 = _ref5.self) === null || _ref5 === void 0 ? void 0 : _ref5.self) === null || _self$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self$self, _x)._;
+    (_ref6 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref6, _x)._;
+    (_call = (_ref7 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref7 === void 0 ? void 0 : _ref7.call(_babelHelpers$assertC)) === null || _call === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call, _x)._;
+    (_getSelf = (_ref8 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref8 === void 0 ? void 0 : _ref8.getSelf()) === null || _getSelf === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf, _x)._;
+    (_getSelf2 = (_ref9 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref9 === void 0 || (_ref9$getSelf = _ref9.getSelf) === null || _ref9$getSelf === void 0 ? void 0 : _ref9$getSelf.call(_ref9)) === null || _getSelf2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf2, _x)._;
+    (_self4 = (_ref10 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._.getSelf()) === null || _ref10 === void 0 ? void 0 : _ref10.self) === null || _self4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self4, _x)._;
+    (_call$self = (_ref11 = o === null || o === void 0 ? void 0 : (_babelHelpers$assertC2 = babelHelpers.assertClassBrand(Foo, o.Foo, _self)._).getSelf) === null || _ref11 === void 0 || (_ref11 = _ref11.call(_babelHelpers$assertC2)) === null || _ref11 === void 0 ? void 0 : _ref11.self) === null || _call$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self, _x)._;
+    (_getSelf$self = (_ref12 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref12 === void 0 || (_ref12 = _ref12.getSelf()) === null || _ref12 === void 0 ? void 0 : _ref12.self) === null || _getSelf$self === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self, _x)._;
+    (_getSelf$self2 = (_ref13 = o === null || o === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, o.Foo, _self)._) === null || _ref13 === void 0 || (_ref13$getSelf = _ref13.getSelf) === null || _ref13$getSelf === void 0 || (_ref13$getSelf = _ref13$getSelf.call(_ref13)) === null || _ref13$getSelf === void 0 ? void 0 : _ref13$getSelf.self) === null || _getSelf$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self2, _x)._;
+    (_fn$Foo = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo, _x)._;
+    (_fn$Foo2 = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo2, _x)._.toString;
+    (_fn$Foo3 = fn === null || fn === void 0 ? void 0 : fn().Foo) === null || _fn$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fn$Foo3, _x)._.toString();
+    (_fnDeep$very$o$Foo = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o = fnDeep().very.o) === null || _fnDeep$very$o === void 0 ? void 0 : _fnDeep$very$o.Foo) === null || _fnDeep$very$o$Foo === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo, _x)._;
+    (_fnDeep$very$o$Foo2 = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o2 = fnDeep().very.o) === null || _fnDeep$very$o2 === void 0 ? void 0 : _fnDeep$very$o2.Foo) === null || _fnDeep$very$o$Foo2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo2, _x)._.toString;
+    (_fnDeep$very$o$Foo3 = fnDeep === null || fnDeep === void 0 || (_fnDeep$very$o3 = fnDeep().very.o) === null || _fnDeep$very$o3 === void 0 ? void 0 : _fnDeep$very$o3.Foo) === null || _fnDeep$very$o$Foo3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _fnDeep$very$o$Foo3, _x)._.toString();
+    (_ref14 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref14 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref14, _x)._;
+    (_ref15 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref15 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref15, _x)._;
+    (_self5 = (_ref16 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref16 === void 0 ? void 0 : _ref16.self) === null || _self5 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self5, _x)._;
+    (_self6 = (_ref17 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.self) === null || _ref17 === void 0 ? void 0 : _ref17.self) === null || _self6 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self6, _x)._;
+    (_self$self2 = (_ref18 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref18 === void 0 || (_ref18 = _ref18.self) === null || _ref18 === void 0 ? void 0 : _ref18.self) === null || _self$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self$self2, _x)._;
+    (_ref19 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref19 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _ref19, _x)._;
+    (_call2 = (_ref20 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC3 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref20 === void 0 ? void 0 : _ref20.call(_babelHelpers$assertC3)) === null || _call2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call2, _x)._;
+    (_getSelf3 = (_ref21 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref21 === void 0 ? void 0 : _ref21.getSelf()) === null || _getSelf3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf3, _x)._;
+    (_getSelf4 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf4, _x)._;
+    (_self7 = (_ref23 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._.getSelf()) === null || _ref23 === void 0 ? void 0 : _ref23.self) === null || _self7 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _self7, _x)._;
+    (_call$self2 = (_ref24 = fn === null || fn === void 0 ? void 0 : (_babelHelpers$assertC4 = babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._).getSelf) === null || _ref24 === void 0 || (_ref24 = _ref24.call(_babelHelpers$assertC4)) === null || _ref24 === void 0 ? void 0 : _ref24.self) === null || _call$self2 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _call$self2, _x)._;
+    (_getSelf$self3 = (_ref25 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref25 === void 0 || (_ref25 = _ref25.getSelf()) === null || _ref25 === void 0 ? void 0 : _ref25.self) === null || _getSelf$self3 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self3, _x)._;
+    (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, fn().Foo, _self)._) === null || _ref26 === void 0 || (_ref26$getSelf = _ref26.getSelf) === null || _ref26$getSelf === void 0 || (_ref26$getSelf = _ref26$getSelf.call(_ref26)) === null || _ref26$getSelf === void 0 ? void 0 : _ref26$getSelf.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.assertClassBrand(Foo, _getSelf$self4, _x)._;
+  }
+}
+_Foo = Foo;
+var _x = {
+  _: 1
+};
+var _self = {
+  _: _Foo
+};
+babelHelpers.defineProperty(Foo, "self", _Foo);
+Foo.test();

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 482/846
+Passed: 485/846
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (155/264)
+# babel-plugin-transform-class-properties (158/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -450,16 +450,32 @@ x Output mismatch
 x Output mismatch
 
 * private/optional-chain-before-member-call/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(6): Some(ScopeId(0))
 
 * private/optional-chain-before-member-call-with-transform/input.js
-x Output mismatch
-
-* private/optional-chain-before-property/input.js
-x Output mismatch
-
-* private/optional-chain-before-property-with-transform/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(6): Some(ScopeId(0))
 
 * private/optional-chain-cast-to-boolean/input.js
 x Output mismatch
@@ -474,7 +490,18 @@ x Output mismatch
 x Output mismatch
 
 * private/optional-chain-member-optional-call/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(6): Some(ScopeId(0))
 
 * private/optional-chain-member-optional-call-spread-arguments/input.js
 x Output mismatch
@@ -483,13 +510,32 @@ x Output mismatch
 x Output mismatch
 
 * private/optional-chain-optional-member-call/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(6): Some(ScopeId(0))
 
 * private/optional-chain-optional-member-call-with-transform/input.js
-x Output mismatch
-
-* private/optional-chain-optional-property-with-transform/input.js
-x Output mismatch
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(6): Some(ScopeId(0))
 
 * private/parenthesized-optional-member-call/input.js
 Scope children mismatch:


### PR DESCRIPTION
These tests only variable names difference from Babel's output, which is caused by transforming order.