### PR TITLE
refactor(transformer): use `NONE` in AST builder calls

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -565,7 +565,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             arrow_function_expr.r#async,
             false,
             arrow_function_expr.type_parameters,
-            None::<TSThisParameter<'a>>,
+            NONE,
             arrow_function_expr.params,
             arrow_function_expr.return_type,
             Some(body),

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -71,7 +71,10 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
 use oxc_allocator::{String as ArenaString, Vec as ArenaVec};
-use oxc_ast::ast::{Argument, CallExpression, Expression, TSTypeParameterInstantiation};
+use oxc_ast::{
+    ast::{Argument, CallExpression, Expression},
+    NONE,
+};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::{Atom, Span, SPAN};
 use oxc_traverse::{BoundIdentifier, TraverseCtx};
@@ -210,13 +213,7 @@ impl<'a> TransformCtx<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> CallExpression<'a> {
         let callee = self.helper_load(helper, ctx);
-        ctx.ast.call_expression(
-            span,
-            callee,
-            None::<TSTypeParameterInstantiation<'a>>,
-            arguments,
-            false,
-        )
+        ctx.ast.call_expression(span, callee, NONE, arguments, false)
     }
 
     /// Same as [`TransformCtx::helper_call`], but returns a `CallExpression` wrapped in an `Expression`.
@@ -228,13 +225,7 @@ impl<'a> TransformCtx<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let callee = self.helper_load(helper, ctx);
-        ctx.ast.expression_call(
-            span,
-            callee,
-            None::<TSTypeParameterInstantiation<'a>>,
-            arguments,
-            false,
-        )
+        ctx.ast.expression_call(span, callee, NONE, arguments, false)
     }
 
     /// Load a helper function and return a callee expression.

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -106,10 +106,10 @@ impl<'a> TypeScriptEnum<'a> {
             false,
             false,
             false,
-            None::<TSTypeParameterDeclaration>,
-            None::<TSThisParameter>,
+            NONE,
+            NONE,
             params,
-            None::<TSTypeAnnotation>,
+            NONE,
             Some(body),
             func_scope_id,
         ));


### PR DESCRIPTION
Pure refactor. `NONE` is shorter than `None::<TSThisParameter<'a>>`.