### PR TITLE
refactor(isolated_declarations): use `NONE` in AST builder calls

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -547,7 +547,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         kind: BindingPatternKind<'a>,
     ) -> Box<'a, FormalParameters<'a>> {
-        let pattern = self.ast.binding_pattern(kind, None::<TSTypeAnnotation<'a>>, false);
+        let pattern = self.ast.binding_pattern(kind, NONE, false);
         let parameter =
             self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, None, false, false);
         let items = self.ast.vec1(parameter);

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Box;
 use oxc_allocator::CloneIn;
 use oxc_allocator::Vec;
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::{Atom, GetSpan, SPAN};
 
 use crate::{diagnostics::default_export_inferred, IsolatedDeclarations};
@@ -19,7 +19,7 @@ impl<'a> IsolatedDeclarations<'a> {
             self.ast.vec(),
             None,
             ImportOrExportKind::Value,
-            None::<WithClause>,
+            NONE,
         ))
     }
 


### PR DESCRIPTION
Pure refactor. `NONE` is shorter than `None::<TSTypeAnnotation<'a>>`.