### PR TITLE
refactor(transformer): `duplicate_expression` take `mutated_symbol_needs_temp_var` param

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -1463,7 +1463,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, Expression<'a>) {
         assert_expr_neither_parenthesis_nor_typescript_syntax(&object);
-        self.ctx.duplicate_expression(object, ctx)
+        self.ctx.duplicate_expression(object, false, ctx)
     }
 
     /// Duplicate object to be used in triple.
@@ -1482,7 +1482,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, Expression<'a>, Expression<'a>) {
         assert_expr_neither_parenthesis_nor_typescript_syntax(&object);
-        self.ctx.duplicate_expression_twice(object, ctx)
+        self.ctx.duplicate_expression_twice(object, false, ctx)
     }
 
     /// `_classPrivateFieldGet2(_prop, object)`


### PR DESCRIPTION
`TransformCtx::duplicate_expression` method introduced in #7754 take a param `mutated_symbol_needs_temp_var`.

If `true`, `duplicate_expression` will create a temp var for an `IdentifierReference` whose's symbol is assigned to elsewhere in the AST. If `false`, it won't.

This is required because different transforms which use `duplicate_expression` have different requirements.