### PR TITLE
test(transformer): enable fixture overrides for `logical-assignment-operators` transform

### DIFF
--- a/tasks/transform_conformance/update_fixtures.js
+++ b/tasks/transform_conformance/update_fixtures.js
@@ -17,7 +17,10 @@ import assert from 'assert';
 import { copyFile, readdir, readFile, rename, writeFile } from 'fs/promises';
 import { extname, join as pathJoin } from 'path';
 
-const PACKAGES = ['babel-plugin-transform-class-properties'];
+const PACKAGES = [
+  'babel-plugin-transform-class-properties',
+  'babel-plugin-transform-logical-assignment-operators',
+];
 const FILTER_OUT_PRESETS = ['env'];
 const FILTER_OUT_PLUGINS = [
   'transform-classes',


### PR DESCRIPTION
Enable overriding Babel's fixtures for logical assignment operators transform.