### PR TITLE
chore(tasks/transform-conformance): support `--override` flag

### DIFF
--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -27,6 +27,9 @@ pub struct TestRunnerOptions {
     pub debug: bool,
     pub filter: Option<String>,
     pub exec: bool,
+    /// If it's true, will override the output of dismatch test cases,
+    /// and write it down to `overrides` folder
+    pub r#override: bool,
 }
 
 /// The test runner which walks the babel repository and searches for transformation tests.
@@ -155,6 +158,9 @@ impl TestRunner {
                 snapshot.push_str(&case);
                 snapshot.push_str(&format!(" ({}/{})\n", passed.len(), num_of_tests));
                 for test_case in failed {
+                    if self.options.r#override {
+                        test_case.write_override_output();
+                    }
                     snapshot.push_str("* ");
                     snapshot.push_str(&normalize_path(
                         test_case.path.strip_prefix(&case_root).unwrap(),

--- a/tasks/transform_conformance/src/main.rs
+++ b/tasks/transform_conformance/src/main.rs
@@ -7,8 +7,17 @@ fn main() {
     let options = TestRunnerOptions {
         debug: args.contains("--debug"),
         filter: args.opt_value_from_str("--filter").unwrap(),
+        r#override: args.contains("--override"),
         exec: args.contains("--exec"),
     };
+
+    if options.r#override {
+        debug_assert!(
+            options.filter.is_some(),
+            "Cannot use `--override` without a specific `--filter`, because there's no
+            doubt about it you do not want to override all Babel's tests"
+        );
+    }
 
     TestRunner::new(options.clone()).run();
 }


### PR DESCRIPTION
The `--override` flag used to write the output which is generated by the transformer to the `overrides` folder according to the test path. The acting is similar to the previous `takeover` mode