### PR TITLE
test(transformer/class-properties): add `output.js` files to override fixtures

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -1,0 +1,12 @@
+var _scopedFunctionWithThis = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("scopedFunctionWithThis");
+class Child extends Parent {
+  constructor() {
+    super();
+    Object.defineProperty(this, _scopedFunctionWithThis, {
+      writable: true,
+      value: () => {
+        this.name = {};
+      }
+    });
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/foobar/output.js
@@ -1,0 +1,8 @@
+class Child extends Parent {
+  constructor() {
+    super();
+    this.scopedFunctionWithThis = () => {
+      this.name = {};
+    };
+  }
+}


### PR DESCRIPTION
In two of the overridden text fixtures for class properties transform, there was no `output.js` file because what was overridden was just `options.json` and `update_fixtures.js` script then generated new output files using Babel with the new options.

That was fine, but doesn't work with #7771. So add `output.js` files to the these overrides too.