### PR TITLE
refactor(ast)!: rename `is_strict` methods to `has_use_strict_directive`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -25,7 +25,7 @@ use super::{macros::inherit_variants, *};
 #[ast(visit)]
 #[scope(
     flags(ScopeFlags::Top),
-    strict_if(self.source_type.is_strict() || self.directives.iter().any(Directive::is_use_strict)),
+    strict_if(self.source_type.is_strict() || self.has_use_strict_directive()),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
@@ -1565,7 +1565,7 @@ pub struct BindingRestElement<'a> {
 #[scope(
     // `flags` passed in to visitor via parameter defined by `#[visit(args(flags = ...))]` on parents
     flags(flags),
-    strict_if(self.is_strict()),
+    strict_if(self.has_use_strict_directive()),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1132,7 +1132,7 @@ pub enum TSTypePredicateName<'a> {
 #[ast(visit)]
 #[scope(
     flags(ScopeFlags::TsModuleBlock),
-    strict_if(self.body.as_ref().is_some_and(TSModuleDeclarationBody::is_strict)),
+    strict_if(self.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive)),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -14,10 +14,9 @@ impl Program<'_> {
         self.body.is_empty() && self.directives.is_empty()
     }
 
-    /// Returns `true` if this program uses strict mode semantics. Both source
-    /// type and `"use strict"` directives are considered.
-    pub fn is_strict(&self) -> bool {
-        self.source_type.is_strict() || self.directives.iter().any(Directive::is_use_strict)
+    /// Returns `true` if this program has a `"use strict"` directive.
+    pub fn has_use_strict_directive(&self) -> bool {
+        self.directives.iter().any(Directive::is_use_strict)
     }
 }
 
@@ -996,8 +995,8 @@ impl<'a> Function<'a> {
         matches!(self.r#type, FunctionType::FunctionDeclaration | FunctionType::TSDeclareFunction)
     }
 
-    /// `true` if this function's body has a `"use strict"` directive.
-    pub fn is_strict(&self) -> bool {
+    /// Returns `true` if this function's body has a `"use strict"` directive.
+    pub fn has_use_strict_directive(&self) -> bool {
         self.body.as_ref().is_some_and(|body| body.has_use_strict_directive())
     }
 }
@@ -1080,7 +1079,6 @@ impl FunctionBody<'_> {
     }
 
     /// `true` if this function body contains a `"use strict"` directive.
-    #[allow(missing_docs)]
     pub fn has_use_strict_directive(&self) -> bool {
         self.directives.iter().any(Directive::is_use_strict)
     }

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -171,10 +171,9 @@ impl fmt::Display for TSAccessibility {
 }
 
 impl TSModuleDeclaration<'_> {
-    /// Returns `true` if this module's body exists and uses strict mode
-    /// semantics (as determined by [`TSModuleDeclarationBody::is_strict`]).
-    pub fn is_strict(&self) -> bool {
-        self.body.as_ref().is_some_and(TSModuleDeclarationBody::is_strict)
+    /// Returns `true` if this module's body exists and has a `"use strict"` directive.
+    pub fn has_use_strict_directive(&self) -> bool {
+        self.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive)
     }
 }
 
@@ -233,9 +232,9 @@ impl fmt::Display for TSModuleDeclarationName<'_> {
 }
 
 impl<'a> TSModuleDeclarationBody<'a> {
-    /// Does the body of this module use strict mode semantics?
-    pub fn is_strict(&self) -> bool {
-        matches!(self, Self::TSModuleBlock(block) if block.is_strict())
+    /// Returns `true` if this module has a `"use strict"` directive.
+    pub fn has_use_strict_directive(&self) -> bool {
+        matches!(self, Self::TSModuleBlock(block) if block.has_use_strict_directive())
     }
 
     /// Returns `true` if this module contains no statements.
@@ -260,7 +259,7 @@ impl<'a> TSModuleDeclarationBody<'a> {
 
 impl TSModuleBlock<'_> {
     /// Returns `true` if this module contains a `"use strict"` directive.
-    pub fn is_strict(&self) -> bool {
+    pub fn has_use_strict_directive(&self) -> bool {
         self.directives.iter().any(Directive::is_use_strict)
     }
 }

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -1339,8 +1339,7 @@ pub mod walk {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Top;
-                if it.source_type.is_strict() || it.directives.iter().any(Directive::is_use_strict)
-                {
+                if it.source_type.is_strict() || it.has_use_strict_directive() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -3022,7 +3021,7 @@ pub mod walk {
         visitor.enter_scope(
             {
                 let mut flags = flags;
-                if it.is_strict() {
+                if it.has_use_strict_directive() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -3823,7 +3822,7 @@ pub mod walk {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::TsModuleBlock;
-                if it.body.as_ref().is_some_and(TSModuleDeclarationBody::is_strict) {
+                if it.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive) {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -1334,8 +1334,7 @@ pub mod walk_mut {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::Top;
-                if it.source_type.is_strict() || it.directives.iter().any(Directive::is_use_strict)
-                {
+                if it.source_type.is_strict() || it.has_use_strict_directive() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -3159,7 +3158,7 @@ pub mod walk_mut {
         visitor.enter_scope(
             {
                 let mut flags = flags;
-                if it.is_strict() {
+                if it.has_use_strict_directive() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -4041,7 +4040,7 @@ pub mod walk_mut {
         visitor.enter_scope(
             {
                 let mut flags = ScopeFlags::TsModuleBlock;
-                if it.body.as_ref().is_some_and(TSModuleDeclarationBody::is_strict) {
+                if it.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive) {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -606,7 +606,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         // Inline the specific logic for `Program` here instead.
         // This simplifies logic in `enter_scope`, as it doesn't have to handle the special case.
         let mut flags = ScopeFlags::Top;
-        if program.is_strict() {
+        if self.source_type.is_strict() || program.has_use_strict_directive() {
             flags |= ScopeFlags::StrictMode;
         }
         self.current_scope_id = self.scope.add_scope(None, self.current_node_id, flags);
@@ -1589,7 +1589,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_scope(
             {
                 let mut flags = flags;
-                if func.is_strict() {
+                if func.has_use_strict_directive() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags


### PR DESCRIPTION
The name `is_strict` was misleading for these methods, because it doesn't tell you if the e.g. function *is* strict mode, only whether it contains a `"use strict"` directive. `Function::is_strict` might return `false` for a function which does have strict mode semantics because it's e.g. in an ESM file.

Rename these methods to `has_use_strict_directive` to better reflect what they do.

For `Program`, change the method to only check for `"use strict"` directive and not to look at `source_type`. `Semantic` should be the source of truth on strict/sloppy mode of AST nodes. It's cheaper to look up the `ScopeFlags` than to iterate over `directives`, so don't encourage this anti-pattern by providing a "rival" method.