### PR TITLE
fix(transformer/class-properties): fix scope flags in static prop initializers

### DIFF
--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -345,9 +345,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -368,9 +365,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -456,9 +450,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(6): Some(ScopeId(0))
@@ -470,9 +461,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(6): Some(ScopeId(0))
@@ -496,9 +484,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(6): Some(ScopeId(0))
@@ -516,9 +501,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(6): Some(ScopeId(0))
@@ -530,9 +512,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(6): Some(ScopeId(0))
@@ -544,9 +523,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(5): Some(ScopeId(0))
@@ -590,9 +566,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(0))
@@ -604,9 +577,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -624,9 +594,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -734,9 +701,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(0))
@@ -748,9 +712,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -765,9 +726,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -845,9 +803,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -865,9 +820,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -931,9 +883,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))
@@ -951,9 +900,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
-rebuilt        : ScopeId(2): ScopeFlags(Function | Arrow)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(0))

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 103/116
+Passed: 103/117
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 103/116
 * regexp
 
 
-# babel-plugin-transform-class-properties (4/6)
+# babel-plugin-transform-class-properties (4/7)
 * private-loose-tagged-template/input.js
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -35,12 +35,32 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(0))
+
+* static-prop-initializer-strict-mode/input.js
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(8), ScopeId(14), ScopeId(17), ScopeId(20)]
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(8), ScopeId(14), ScopeId(17), ScopeId(20)]
+rebuilt        : ScopeId(1): []
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(2): Some(ScopeId(0))
+Scope parent mismatch:
+after transform: ScopeId(8): Some(ScopeId(1))
+rebuilt        : ScopeId(8): Some(ScopeId(0))
+Scope parent mismatch:
+after transform: ScopeId(14): Some(ScopeId(1))
+rebuilt        : ScopeId(14): Some(ScopeId(0))
+Scope parent mismatch:
+after transform: ScopeId(17): Some(ScopeId(1))
+rebuilt        : ScopeId(17): Some(ScopeId(0))
+Scope parent mismatch:
+after transform: ScopeId(20): Some(ScopeId(1))
+rebuilt        : ScopeId(20): Some(ScopeId(0))
 
 
 # babel-plugin-transform-async-to-generator (14/15)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-prop-initializer-strict-mode/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-prop-initializer-strict-mode/input.js
@@ -1,0 +1,47 @@
+// Just to make sure we're in sloppy mode. This is a syntax error in strict mode.
+delete x;
+
+class C {
+  static arrow = () => {
+    if (true) {
+      if (true) {
+        {
+          let f = function foo() {};
+        }
+      }
+    }
+    return () => {};
+  };
+
+  static fn = function() {
+    if (true) {
+      if (true) {
+        {
+          let f = function foo() {}
+        }
+      }
+    }
+    return () => {};
+  };
+
+  static arrowStrict = () => {
+    "use strict";
+    if (true) {}
+    return () => {};
+  };
+
+  static fnStrict = function() {
+    "use strict";
+    if (true) {}
+    return () => {};
+  };
+
+  static klass = class extends function() {} {
+    constructor() {}
+    method() {
+      if (true) {}
+      function foo() {}
+    }
+    [() => {}]() {}
+  };
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-prop-initializer-strict-mode/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-prop-initializer-strict-mode/output.js
@@ -1,0 +1,47 @@
+// Just to make sure we're in sloppy mode. This is a syntax error in strict mode.
+delete x;
+
+class C {}
+
+babelHelpers.defineProperty(C, "arrow", () => {
+  if (true) {
+    if (true) {
+      {
+        let f = function foo() {}
+      }
+    }
+  }
+  return () => {};
+});
+
+babelHelpers.defineProperty(C, "fn", function() {
+  if (true) {
+    if (true) {
+      {
+        let f = function foo() {}
+      }
+    }
+  }
+  return () => {};
+});
+
+babelHelpers.defineProperty(C, "arrowStrict", () => {
+  "use strict";
+  if (true) {}
+  return () => {};
+});
+
+babelHelpers.defineProperty(C, "fnStrict", function() {
+  "use strict";
+  if (true) {}
+  return () => {};
+});
+
+babelHelpers.defineProperty(C, "klass", class extends function() {} {
+  constructor() {}
+  method() {
+    if (true) {}
+    function foo() {}
+  }
+  [() => {}]() {}
+});


### PR DESCRIPTION
Code in static property initializers moves from inside the class to outside. If environment outside the class is not strict mode, then scopes within the initializer become sloppy mode. Update `ScopeFlags` for scopes in static prop initializers accordingly.

We're following Babel for now, but this isn't actually correct. The initializers should be wrapped in a strict mode IIFE to maintain their strict mode behavior. But at least semantic data is now correct for the output.
