### PR TITLE
fix(transformer/class-properties): panic when the callee or member is `ParenthesisExpression` or TS-syntax expressions.

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -1001,7 +1001,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
-        assert_expr_neither_parenthesis_nor_typescript_syntax(expr);
         match expr {
             Expression::PrivateFieldExpression(_) => {
                 Some(self.transform_private_field_expression_of_chain_expression(expr, ctx))
@@ -1015,7 +1014,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 self.transform_call_expression_of_chain_expression(call, ctx)
             }
             _ => {
-                assert_expr_neither_parenthesis_nor_typescript_syntax(expr);
+                assert_expr_neither_parenthesis_nor_typescript_syntax(expr, &self.ctx.source_path);
                 None
             }
         }
@@ -1126,7 +1125,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         let is_optional = member.optional();
-        let object = member.object_mut();
+        let object = member.object_mut().get_inner_expression_mut();
         let result = self.transform_chain_element_recursively(object, ctx)?;
         if is_optional && !object.is_identifier_reference() {
             // `o?.Foo.#self.self?.self.unicorn;` -> `(result ? void 0 : object)?.self.unicorn`
@@ -1320,7 +1319,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         let callee = &mut call.callee;
         let callee_member = callee.to_member_expression_mut();
         let is_optional_callee = callee_member.optional();
-        let object = callee_member.object_mut();
+        let object = callee_member.object_mut().get_inner_expression_mut();
 
         let context = if let Some(result) = self.transform_chain_element_recursively(object, ctx) {
             if is_optional_callee {
@@ -1609,7 +1608,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         object: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, Expression<'a>) {
-        assert_expr_neither_parenthesis_nor_typescript_syntax(&object);
+        assert_expr_neither_parenthesis_nor_typescript_syntax(&object, &self.ctx.source_path);
         self.ctx.duplicate_expression(object, false, ctx)
     }
 
@@ -1628,7 +1627,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         object: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, Expression<'a>, Expression<'a>) {
-        assert_expr_neither_parenthesis_nor_typescript_syntax(&object);
+        assert_expr_neither_parenthesis_nor_typescript_syntax(&object, &self.ctx.source_path);
         self.ctx.duplicate_expression_twice(object, false, ctx)
     }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -1,6 +1,8 @@
 //! ES2022: Class Properties
 //! Utility functions.
 
+use std::path::PathBuf;
+
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
@@ -55,9 +57,12 @@ pub(super) fn create_underscore_ident_name<'a>(ctx: &mut TraverseCtx<'a>) -> Ide
 }
 
 #[inline]
-pub(super) fn assert_expr_neither_parenthesis_nor_typescript_syntax(expr: &Expression) {
+pub(super) fn assert_expr_neither_parenthesis_nor_typescript_syntax(
+    expr: &Expression,
+    path: &PathBuf,
+) {
     debug_assert!(
         !(matches!(expr, Expression::ParenthesizedExpression(_)) || expr.is_typescript_syntax()),
-        "Should not be: {expr:?}",
+        "Should not be: {expr:?} in {path:?}",
     );
 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 105/117
+Passed: 106/120
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 105/117
 * regexp
 
 
-# babel-plugin-transform-class-properties (6/7)
+# babel-plugin-transform-class-properties (7/10)
 * private-loose-tagged-template/input.js
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -27,6 +27,16 @@ rebuilt        : ScopeId(2): [ScopeId(3)]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
+
+* typescript/optional-call/input.ts
+Symbol reference IDs mismatch for "X":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
+
+* typescript/optional-member/input.ts
+Symbol reference IDs mismatch for "X":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
 # babel-plugin-transform-async-to-generator (14/15)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-member-with-sequence/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-member-with-sequence/input.js
@@ -1,0 +1,8 @@
+class A {
+  static #a = 33;
+  b = 44;
+  method() {
+    (undefined, this)?.#a;
+    (undefined, this)?.b;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-member-with-sequence/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-member-with-sequence/output.js
@@ -1,0 +1,13 @@
+class A {
+  constructor() {
+    babelHelpers.defineProperty(this, "b", 44);
+  }
+  method() {
+    var _ref;
+    (_ref = (undefined, this)) === null || _ref === void 0 ? void 0 : babelHelpers.assertClassBrand(A, _ref, _a)._;
+    (undefined, this)?.b;
+  }
+}
+var _a = {
+  _: 33
+};

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-call/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-call/input.ts
@@ -1,0 +1,9 @@
+class X {
+  static #m = () => {};
+  method() {
+    const o = { X };
+    (o.X as typeof X).#m();
+    o.X!.#m();
+    o.X.#m();
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-call/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-call/output.js
@@ -1,0 +1,14 @@
+class X {
+  method() {
+    var _o$X, _o$X2, _o$X3;
+    const o = {
+      X
+    };
+    babelHelpers.assertClassBrand(X, _o$X = o.X, _m)._.call(_o$X);
+    babelHelpers.assertClassBrand(X, _o$X2 = o.X, _m)._.call(_o$X2);
+    babelHelpers.assertClassBrand(X, _o$X3 = o.X, _m)._.call(_o$X3);
+  }
+}
+var _m = {
+  _: () => {}
+};

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-member/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-member/input.ts
@@ -1,0 +1,9 @@
+class X {
+  static #a = 0;
+  method() {
+    const o = { X };
+    (o.X as typeof X).#a;
+    o.X!.#a;
+    o.X.#a;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-member/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/optional-member/output.js
@@ -1,0 +1,13 @@
+class X {
+  method() {
+    const o = {
+      X
+    };
+    babelHelpers.assertClassBrand(X, o.X, _a)._;
+    babelHelpers.assertClassBrand(X, o.X, _a)._;
+    babelHelpers.assertClassBrand(X, o.X, _a)._;
+  }
+}
+var _a = {
+  _: 0
+};

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-class-properties", "transform-typescript"]
+}


### PR DESCRIPTION
We need to call `get_inner_expression_mut` to get actual expressions that we need to deal with