### PR TITLE
fix(linter): Fix unicorn/prefer-query-selector to use the correct replacement for getElementsByClassName

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -3,7 +3,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::phf_map;
-use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, utils::is_node_value_not_dom_node, AstNode};
 
@@ -130,10 +129,12 @@ impl Rule for PreferQuerySelector {
                     let quotes_symbol = source_text.chars().next().unwrap();
                     let argument = match *cur_property_name {
                         "getElementById" => format!("#{literal_value}"),
-                        "getElementsByClassName" => format!(
-                            ".{}",
-                            Regex::new(r"\s+").unwrap().replace_all(literal_value, " .")
-                        ),
+                        "getElementsByClassName" => {
+                            format!(
+                                ".{}",
+                                literal_value.split_whitespace().collect::<Vec<_>>().join(" .")
+                            )
+                        }
                         _ => literal_value.to_string(),
                     };
                     let span = property_span.merge(&argument_expr.span());


### PR DESCRIPTION
Note: This uses a regex to replace multiple instances of whitespace with ` .`.  May not be the most performant, so if there's a simple alternative I can change to that instead.

cc @camc314, I know this was assigned to you but I just wanted to throw something quick together while I had a minute.  Feel free to use this, or decline it and write your own.

Fixes #7794.