### PR TITLE
fix(transformer/class-properties): unwrap failed when private field expression doesn't contain optional expression in `ChainExpression`

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 106/120
+Passed: 107/121
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 106/120
 * regexp
 
 
-# babel-plugin-transform-class-properties (7/10)
+# babel-plugin-transform-class-properties (8/11)
 * private-loose-tagged-template/input.js
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-call-with-non-optional-callee/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-call-with-non-optional-callee/input.js
@@ -1,0 +1,6 @@
+class A {
+  #a = {};
+  method() {
+    this.#a.get(message.id)?.(message);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-call-with-non-optional-callee/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-optional-call-with-non-optional-callee/output.js
@@ -1,0 +1,9 @@
+var _a = /*#__PURE__*/ new WeakMap();
+class A {
+  constructor() {
+    babelHelpers.classPrivateFieldInitSpec(this, _a, {});
+  }
+  method() {
+    babelHelpers.classPrivateFieldGet2(_a, this).get(message.id)?.(message);
+  }
+}


### PR DESCRIPTION
The root cause is due to transform wrongly a PrivateFieldExpression that doesn't contain any optional expression, so call `to_member_expression_mut` causes unwrap to fail.  I have fixed the incorrect transform and changed `to_member_expression_mut` to `as_member_expression_mut`.