### PR TITLE
refactor(transformer): handle `<CWD>` in test runner

### DIFF
--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -52,14 +52,10 @@ impl<'a> TransformCtx<'a> {
             .file_stem() // omit file extension
             .map_or_else(|| String::from("unknown"), |name| name.to_string_lossy().to_string());
 
-        let source_path = source_path
-            .strip_prefix(&options.cwd)
-            .map_or_else(|_| source_path.to_path_buf(), |p| Path::new("<CWD>").join(p));
-
         Self {
             errors: RefCell::new(vec![]),
             filename,
-            source_path,
+            source_path: source_path.to_path_buf(),
             source_type: SourceType::default(),
             source_text: "",
             module: options.env.module,

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -217,11 +217,17 @@ impl TestCase {
         };
 
         let source_text = fs::read_to_string(path).unwrap();
-
         let project_root = project_root();
         let mut options = transform_options.clone();
         options.helper_loader.mode = mode;
-        let mut driver = Driver::new(false, options).execute(&source_text, self.source_type, path);
+        let cwd_path = self
+            .options
+            .cwd
+            .as_ref()
+            .and_then(|cwd| path.strip_prefix(cwd).ok().map(|p| Path::new("<CWD>").join(p)))
+            .unwrap_or(path.clone());
+        let mut driver =
+            Driver::new(false, options).execute(&source_text, self.source_type, cwd_path.as_path());
         let errors = driver.errors();
         if !errors.is_empty() {
             let source = NamedSource::new(


### PR DESCRIPTION
We should move the handling of  `<CWD>` to the test runner because this is just only used in testing, and it causes us always get a path by `self.ctx.source_path` like `<CWD>/xxx/xxx.js`, we should get a real path for this.