### PR TITLE
refactor(transformer/class-properties): `#[inline(always)]` on `assert_expr_neither_parenthesis_nor_typescript_syntax`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -56,7 +56,9 @@ pub(super) fn create_underscore_ident_name<'a>(ctx: &mut TraverseCtx<'a>) -> Ide
     ctx.ast.identifier_name(SPAN, Atom::from("_"))
 }
 
-#[inline]
+// `#[inline(always)]` because this is a no-op in release mode
+#[expect(clippy::inline_always)]
+#[inline(always)]
 pub(super) fn assert_expr_neither_parenthesis_nor_typescript_syntax(
     expr: &Expression,
     path: &PathBuf,


### PR DESCRIPTION
Follow-on after #7795. Add `#[inline(always)]` to this function which is no-op in release mode, to make absolutely sure it gets optimized out in full.