### PR TITLE
refactor(transformer/class-properties): shorten code

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private.rs
@@ -961,11 +961,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             let mut chain_expr = Self::convert_chain_expression_to_expression(expr, ctx);
             let result = self
                 .transform_private_field_expression_of_chain_expression(&mut chain_expr, ctx)
-                .unwrap_or_else(|| {
-                    unreachable!(
-                        "The ChainExpression must contains at least one optional expression, so it never be `None` here."
-                    )
-                });
+                .expect("The ChainExpression must contain at least one optional expression, so it can never be `None` here.");
             Some((result, chain_expr))
         } else if let Some(result) = self.transform_chain_expression_element(element, ctx) {
             let chain_expr = Self::convert_chain_expression_to_expression(expr, ctx);


### PR DESCRIPTION
Follow-on after #7798. Pure refactor, just shorten code.

I *think* `expect` has same behavior as `unreachable!` in terms of making the compiler backtrack to try to prove the check can be elided. But in this case, I doubt it can prove it either way.