### PR TITLE
fix(semantic): missing reference when `export default` references a type alias binding

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1083,7 +1083,7 @@ fn test_namespaces() {
 
 #[test]
 fn test_type_aliases() {
-    let pass = vec![];
+    let pass = vec!["type Foo = string; export default Foo;"];
 
     let fail = vec![
         // usages within own declaration do not count

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1845,6 +1845,13 @@ impl<'a> SemanticBuilder<'a> {
         /* cfg */
 
         match kind {
+            AstKind::ExportDefaultDeclaration(decl) => {
+                // `export default Ident`
+                //                 ^^^^^ -> Can reference both type binding and value
+                if matches!(decl.declaration, ExportDefaultDeclarationKind::Identifier(_)) {
+                    self.current_reference_flags = ReferenceFlags::Read | ReferenceFlags::Type;
+                }
+            }
             AstKind::ExportNamedDeclaration(decl) => {
                 if decl.export_kind.is_type() {
                     self.current_reference_flags = ReferenceFlags::Type;
@@ -2033,7 +2040,8 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::TSTypeName(_) => {
                 self.current_reference_flags -= ReferenceFlags::Type;
             }
-            AstKind::ExportNamedDeclaration(_)
+            AstKind::ExportDefaultDeclaration(_)
+            | AstKind::ExportNamedDeclaration(_)
             | AstKind::TSTypeQuery(_)
             // Clear the reference flags that are set in AstKind::PropertySignature
             | AstKind::PropertyKey(_) => {

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 0,
+        "name": "A",
+        "node": "TSTypeAliasDeclaration",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "A",
+            "node_id": 6
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.ts
@@ -1,0 +1,2 @@
+type A = string;
+export default A;

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -574,6 +574,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Color":
+after transform: SymbolId(0) "Color"
+rebuilt        : <None>
+Reference flags mismatch for "Color":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Color"]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
 semantic error: Missing SymbolId: "D"
@@ -9306,6 +9315,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference flags mismatch for "Foo":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
 semantic error: Bindings mismatch:
@@ -9314,6 +9332,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference flags mismatch for "Foo":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
 semantic error: Bindings mismatch:
@@ -9507,6 +9534,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference flags mismatch for "Foo":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName.ts
 semantic error: Bindings mismatch:
@@ -23393,6 +23429,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "I":
+after transform: SymbolId(0) "I"
+rebuilt        : <None>
+Reference flags mismatch for "I":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["I"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsBundledOutput1.ts
 semantic error: Bindings mismatch:
@@ -37384,6 +37429,9 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "Op":
 after transform: SymbolId(0) "Op"
 rebuilt        : <None>
+Reference flags mismatch for "Op":
+after transform: ReferenceId(0): ReferenceFlags(Read)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Op"]
@@ -52439,6 +52487,9 @@ rebuilt        : ScopeId(1): []
 Reference symbol mismatch for "doc":
 after transform: SymbolId(0) "doc"
 rebuilt        : <None>
+Reference flags mismatch for "doc":
+after transform: ReferenceId(1): ReferenceFlags(Read)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
 Unresolved references mismatch:
 after transform: ["Document", "Element", "HTMLElement"]
 rebuilt        : ["HTMLElement", "doc"]
@@ -52453,6 +52504,9 @@ rebuilt        : ScopeId(1): []
 Reference symbol mismatch for "doc":
 after transform: SymbolId(0) "doc"
 rebuilt        : <None>
+Reference flags mismatch for "doc":
+after transform: ReferenceId(1): ReferenceFlags(Read)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
 Unresolved references mismatch:
 after transform: ["Document", "Element", "HTMLElement"]
 rebuilt        : ["HTMLElement", "doc"]
@@ -52464,6 +52518,9 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "val":
 after transform: SymbolId(0) "val"
 rebuilt        : <None>
+Reference flags mismatch for "val":
+after transform: ReferenceId(0): ReferenceFlags(Read)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["val"]


### PR DESCRIPTION
Fixes: #7809

`ExportNamedDecalration` and `ExportDefaultDeclaration` can reference both type binding and value, so we need to make sure the `ReferenceFlags` is `Read | Type`