### PR TITLE
perf(codegen): faster writing indentation

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -350,10 +350,7 @@ impl<'a> Codegen<'a> {
             self.print_next_indent_as_space = false;
             return;
         }
-        // SAFETY: this iterator only yields tabs, which are always valid ASCII characters.
-        unsafe {
-            self.code.print_bytes_unchecked(std::iter::repeat(b'\t').take(self.indent as usize));
-        }
+        self.code.print_indent(self.indent as usize);
     }
 
     #[inline]


### PR DESCRIPTION
Write indentation faster. Previously was writing indentation to buffer with a call to `memset`, which is relatively expensive. Where indentation `<= 16` (common case), write 16 tabs with a single 16-byte XMM write, which is faster.