### PR TITLE
refactor(ast)!: `span` field must be the first element

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1570,8 +1570,8 @@ pub struct BindingRestElement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct Function<'a> {
-    pub r#type: FunctionType,
     pub span: Span,
+    pub r#type: FunctionType,
     /// The function identifier. [`None`] for anonymous function expressions.
     pub id: Option<BindingIdentifier<'a>>,
     /// Is this a generator function?
@@ -1738,8 +1738,8 @@ pub struct YieldExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct Class<'a> {
-    pub r#type: ClassType,
     pub span: Span,
+    pub r#type: ClassType,
     /// Decorators applied to the class.
     ///
     /// Decorators are currently a stage 3 proposal. Oxc handles both TC39 and
@@ -1879,11 +1879,11 @@ pub enum ClassElement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct MethodDefinition<'a> {
+    pub span: Span,
     /// Method definition type
     ///
     /// This will always be true when an `abstract` modifier is used on the method.
     pub r#type: MethodDefinitionType,
-    pub span: Span,
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
     pub key: PropertyKey<'a>,
@@ -1918,8 +1918,8 @@ pub enum MethodDefinitionType {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct PropertyDefinition<'a> {
-    pub r#type: PropertyDefinitionType,
     pub span: Span,
+    pub r#type: PropertyDefinitionType,
     /// Decorators applied to the property.
     ///
     /// See [`Decorator`] for more information.
@@ -2140,8 +2140,8 @@ pub enum AccessorPropertyType {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ContentHash, ESTree)]
 pub struct AccessorProperty<'a> {
-    pub r#type: AccessorPropertyType,
     pub span: Span,
+    pub r#type: AccessorPropertyType,
     /// Decorators applied to the accessor property.
     ///
     /// See [`Decorator`] for more information.

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -165,8 +165,8 @@ impl<'a> AstBuilder<'a> {
         let params =
             self.formal_parameters(SPAN, FormalParameterKind::FormalParameter, self.vec(), NONE);
         let empty_function = self.function(
-            FunctionType::FunctionDeclaration,
             SPAN,
+            FunctionType::FunctionDeclaration,
             None,
             false,
             false,
@@ -249,8 +249,8 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> Box<'a, Function<'a>> {
         self.alloc_function_with_scope_id(
-            r#type,
             span,
+            r#type,
             id,
             false,
             false,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -543,8 +543,8 @@ const _: () = {
 
     assert!(size_of::<Function>() == 104usize);
     assert!(align_of::<Function>() == 8usize);
-    assert!(offset_of!(Function, r#type) == 0usize);
-    assert!(offset_of!(Function, span) == 4usize);
+    assert!(offset_of!(Function, span) == 0usize);
+    assert!(offset_of!(Function, r#type) == 8usize);
     assert!(offset_of!(Function, id) == 16usize);
     assert!(offset_of!(Function, generator) == 48usize);
     assert!(offset_of!(Function, r#async) == 49usize);
@@ -603,8 +603,8 @@ const _: () = {
 
     assert!(size_of::<Class>() == 160usize);
     assert!(align_of::<Class>() == 8usize);
-    assert!(offset_of!(Class, r#type) == 0usize);
-    assert!(offset_of!(Class, span) == 4usize);
+    assert!(offset_of!(Class, span) == 0usize);
+    assert!(offset_of!(Class, r#type) == 8usize);
     assert!(offset_of!(Class, decorators) == 16usize);
     assert!(offset_of!(Class, id) == 48usize);
     assert!(offset_of!(Class, type_parameters) == 80usize);
@@ -629,8 +629,8 @@ const _: () = {
 
     assert!(size_of::<MethodDefinition>() == 80usize);
     assert!(align_of::<MethodDefinition>() == 8usize);
-    assert!(offset_of!(MethodDefinition, r#type) == 0usize);
-    assert!(offset_of!(MethodDefinition, span) == 4usize);
+    assert!(offset_of!(MethodDefinition, span) == 0usize);
+    assert!(offset_of!(MethodDefinition, r#type) == 8usize);
     assert!(offset_of!(MethodDefinition, decorators) == 16usize);
     assert!(offset_of!(MethodDefinition, key) == 48usize);
     assert!(offset_of!(MethodDefinition, value) == 64usize);
@@ -646,8 +646,8 @@ const _: () = {
 
     assert!(size_of::<PropertyDefinition>() == 104usize);
     assert!(align_of::<PropertyDefinition>() == 8usize);
-    assert!(offset_of!(PropertyDefinition, r#type) == 0usize);
-    assert!(offset_of!(PropertyDefinition, span) == 4usize);
+    assert!(offset_of!(PropertyDefinition, span) == 0usize);
+    assert!(offset_of!(PropertyDefinition, r#type) == 8usize);
     assert!(offset_of!(PropertyDefinition, decorators) == 16usize);
     assert!(offset_of!(PropertyDefinition, key) == 48usize);
     assert!(offset_of!(PropertyDefinition, value) == 64usize);
@@ -686,8 +686,8 @@ const _: () = {
 
     assert!(size_of::<AccessorProperty>() == 104usize);
     assert!(align_of::<AccessorProperty>() == 8usize);
-    assert!(offset_of!(AccessorProperty, r#type) == 0usize);
-    assert!(offset_of!(AccessorProperty, span) == 4usize);
+    assert!(offset_of!(AccessorProperty, span) == 0usize);
+    assert!(offset_of!(AccessorProperty, r#type) == 8usize);
     assert!(offset_of!(AccessorProperty, decorators) == 16usize);
     assert!(offset_of!(AccessorProperty, key) == 48usize);
     assert!(offset_of!(AccessorProperty, value) == 64usize);
@@ -2105,8 +2105,8 @@ const _: () = {
 
     assert!(size_of::<Function>() == 60usize);
     assert!(align_of::<Function>() == 4usize);
-    assert!(offset_of!(Function, r#type) == 0usize);
-    assert!(offset_of!(Function, span) == 4usize);
+    assert!(offset_of!(Function, span) == 0usize);
+    assert!(offset_of!(Function, r#type) == 8usize);
     assert!(offset_of!(Function, id) == 12usize);
     assert!(offset_of!(Function, generator) == 32usize);
     assert!(offset_of!(Function, r#async) == 33usize);
@@ -2165,8 +2165,8 @@ const _: () = {
 
     assert!(size_of::<Class>() == 92usize);
     assert!(align_of::<Class>() == 4usize);
-    assert!(offset_of!(Class, r#type) == 0usize);
-    assert!(offset_of!(Class, span) == 4usize);
+    assert!(offset_of!(Class, span) == 0usize);
+    assert!(offset_of!(Class, r#type) == 8usize);
     assert!(offset_of!(Class, decorators) == 12usize);
     assert!(offset_of!(Class, id) == 28usize);
     assert!(offset_of!(Class, type_parameters) == 48usize);
@@ -2191,8 +2191,8 @@ const _: () = {
 
     assert!(size_of::<MethodDefinition>() == 48usize);
     assert!(align_of::<MethodDefinition>() == 4usize);
-    assert!(offset_of!(MethodDefinition, r#type) == 0usize);
-    assert!(offset_of!(MethodDefinition, span) == 4usize);
+    assert!(offset_of!(MethodDefinition, span) == 0usize);
+    assert!(offset_of!(MethodDefinition, r#type) == 8usize);
     assert!(offset_of!(MethodDefinition, decorators) == 12usize);
     assert!(offset_of!(MethodDefinition, key) == 28usize);
     assert!(offset_of!(MethodDefinition, value) == 36usize);
@@ -2208,8 +2208,8 @@ const _: () = {
 
     assert!(size_of::<PropertyDefinition>() == 60usize);
     assert!(align_of::<PropertyDefinition>() == 4usize);
-    assert!(offset_of!(PropertyDefinition, r#type) == 0usize);
-    assert!(offset_of!(PropertyDefinition, span) == 4usize);
+    assert!(offset_of!(PropertyDefinition, span) == 0usize);
+    assert!(offset_of!(PropertyDefinition, r#type) == 8usize);
     assert!(offset_of!(PropertyDefinition, decorators) == 12usize);
     assert!(offset_of!(PropertyDefinition, key) == 28usize);
     assert!(offset_of!(PropertyDefinition, value) == 36usize);
@@ -2248,8 +2248,8 @@ const _: () = {
 
     assert!(size_of::<AccessorProperty>() == 56usize);
     assert!(align_of::<AccessorProperty>() == 4usize);
-    assert!(offset_of!(AccessorProperty, r#type) == 0usize);
-    assert!(offset_of!(AccessorProperty, span) == 4usize);
+    assert!(offset_of!(AccessorProperty, span) == 0usize);
+    assert!(offset_of!(AccessorProperty, r#type) == 8usize);
     assert!(offset_of!(AccessorProperty, decorators) == 12usize);
     assert!(offset_of!(AccessorProperty, key) == 28usize);
     assert!(offset_of!(AccessorProperty, value) == 36usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -704,8 +704,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Class`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -718,8 +718,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn expression_class<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -736,8 +736,8 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Expression::ClassExpression(self.alloc(self.class(
-            r#type,
             span,
+            r#type,
             decorators,
             id,
             type_parameters,
@@ -777,8 +777,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Function`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -791,8 +791,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn expression_function<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -811,8 +811,8 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Expression::FunctionExpression(self.alloc(self.function(
-            r#type,
             span,
+            r#type,
             id,
             generator,
             r#async,
@@ -3609,8 +3609,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Function`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -3623,8 +3623,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn declaration_function<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -3643,8 +3643,8 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Declaration::FunctionDeclaration(self.alloc(self.function(
-            r#type,
             span,
+            r#type,
             id,
             generator,
             r#async,
@@ -3662,8 +3662,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Class`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -3676,8 +3676,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn declaration_class<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -3694,8 +3694,8 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Declaration::ClassDeclaration(self.alloc(self.class(
-            r#type,
             span,
+            r#type,
             decorators,
             id,
             type_parameters,
@@ -5262,8 +5262,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -5276,8 +5276,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn function<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -5296,8 +5296,8 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
-            r#type,
             span,
+            r#type,
             id,
             generator,
             r#async,
@@ -5316,8 +5316,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -5330,8 +5330,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_function<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -5351,8 +5351,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.function(
-                r#type,
                 span,
+                r#type,
                 id,
                 generator,
                 r#async,
@@ -5372,8 +5372,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function_with_scope_id`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -5387,8 +5387,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn function_with_scope_id<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -5408,8 +5408,8 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
-            r#type,
             span,
+            r#type,
             id,
             generator,
             r#async,
@@ -5428,8 +5428,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function_with_scope_id`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -5443,8 +5443,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_function_with_scope_id<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -5465,8 +5465,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.function_with_scope_id(
-                r#type,
                 span,
+                r#type,
                 id,
                 generator,
                 r#async,
@@ -5829,8 +5829,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -5843,8 +5843,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn class<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -5861,8 +5861,8 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Class {
-            r#type,
             span,
+            r#type,
             decorators,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -5881,8 +5881,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -5895,8 +5895,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_class<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -5914,8 +5914,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.class(
-                r#type,
                 span,
+                r#type,
                 decorators,
                 id,
                 type_parameters,
@@ -5935,8 +5935,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class_with_scope_id`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -5950,8 +5950,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn class_with_scope_id<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -5969,8 +5969,8 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Class {
-            r#type,
             span,
+            r#type,
             decorators,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -5989,8 +5989,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class_with_scope_id`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -6004,8 +6004,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_class_with_scope_id<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -6024,8 +6024,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.class_with_scope_id(
-                r#type,
                 span,
+                r#type,
                 decorators,
                 id,
                 type_parameters,
@@ -6090,8 +6090,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`MethodDefinition`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type: Method definition type
     /// - span: The [`Span`] covering this node
+    /// - r#type: Method definition type
     /// - decorators
     /// - key
     /// - value
@@ -6104,8 +6104,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn class_element_method_definition<T1>(
         self,
-        r#type: MethodDefinitionType,
         span: Span,
+        r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
@@ -6120,8 +6120,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, Function<'a>>>,
     {
         ClassElement::MethodDefinition(self.alloc(self.method_definition(
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value,
@@ -6139,8 +6139,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`PropertyDefinition`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration.
@@ -6156,8 +6156,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn class_element_property_definition<T1>(
         self,
-        r#type: PropertyDefinitionType,
         span: Span,
+        r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6175,8 +6175,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         ClassElement::PropertyDefinition(self.alloc(self.property_definition(
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value,
@@ -6197,8 +6197,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains an [`AccessorProperty`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the accessor property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration, if present.
@@ -6210,8 +6210,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn class_element_accessor_property<T1>(
         self,
-        r#type: AccessorPropertyType,
         span: Span,
+        r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6225,8 +6225,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         ClassElement::AccessorProperty(self.alloc(self.accessor_property(
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value,
@@ -6274,8 +6274,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_method_definition`] instead.
     ///
     /// ## Parameters
-    /// - r#type: Method definition type
     /// - span: The [`Span`] covering this node
+    /// - r#type: Method definition type
     /// - decorators
     /// - key
     /// - value
@@ -6288,8 +6288,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn method_definition<T1>(
         self,
-        r#type: MethodDefinitionType,
         span: Span,
+        r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
@@ -6304,8 +6304,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, Function<'a>>>,
     {
         MethodDefinition {
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value: value.into_in(self.allocator),
@@ -6323,8 +6323,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::method_definition`] instead.
     ///
     /// ## Parameters
-    /// - r#type: Method definition type
     /// - span: The [`Span`] covering this node
+    /// - r#type: Method definition type
     /// - decorators
     /// - key
     /// - value
@@ -6337,8 +6337,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_method_definition<T1>(
         self,
-        r#type: MethodDefinitionType,
         span: Span,
+        r#type: MethodDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
@@ -6354,8 +6354,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.method_definition(
-                r#type,
                 span,
+                r#type,
                 decorators,
                 key,
                 value,
@@ -6375,8 +6375,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_property_definition`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration.
@@ -6392,8 +6392,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn property_definition<T1>(
         self,
-        r#type: PropertyDefinitionType,
         span: Span,
+        r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6411,8 +6411,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         PropertyDefinition {
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value,
@@ -6433,8 +6433,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::property_definition`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration.
@@ -6450,8 +6450,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_property_definition<T1>(
         self,
-        r#type: PropertyDefinitionType,
         span: Span,
+        r#type: PropertyDefinitionType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6470,8 +6470,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.property_definition(
-                r#type,
                 span,
+                r#type,
                 decorators,
                 key,
                 value,
@@ -6745,8 +6745,8 @@ impl<'a> AstBuilder<'a> {
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_accessor_property`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the accessor property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration, if present.
@@ -6758,8 +6758,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn accessor_property<T1>(
         self,
-        r#type: AccessorPropertyType,
         span: Span,
+        r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6773,8 +6773,8 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         AccessorProperty {
-            r#type,
             span,
+            r#type,
             decorators,
             key,
             value,
@@ -6791,8 +6791,8 @@ impl<'a> AstBuilder<'a> {
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::accessor_property`] instead.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the accessor property.
     /// - key: The expression used to declare the property.
     /// - value: Initialized value in the declaration, if present.
@@ -6804,8 +6804,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_accessor_property<T1>(
         self,
-        r#type: AccessorPropertyType,
         span: Span,
+        r#type: AccessorPropertyType,
         decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
@@ -6820,8 +6820,8 @@ impl<'a> AstBuilder<'a> {
     {
         Box::new_in(
             self.accessor_property(
-                r#type,
                 span,
+                r#type,
                 decorators,
                 key,
                 value,
@@ -7423,8 +7423,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Function`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - id: The function identifier. [`None`] for anonymous function expressions.
     /// - generator: Is this a generator function?
     /// - r#async
@@ -7437,8 +7437,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn export_default_declaration_kind_function<T1, T2, T3, T4, T5>(
         self,
-        r#type: FunctionType,
         span: Span,
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
@@ -7457,8 +7457,8 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         ExportDefaultDeclarationKind::FunctionDeclaration(self.alloc(self.function(
-            r#type,
             span,
+            r#type,
             id,
             generator,
             r#async,
@@ -7476,8 +7476,8 @@ impl<'a> AstBuilder<'a> {
     /// This node contains a [`Class`] that will be stored in the memory arena.
     ///
     /// ## Parameters
-    /// - r#type
     /// - span: The [`Span`] covering this node
+    /// - r#type
     /// - decorators: Decorators applied to the class.
     /// - id: Class identifier, AKA the name
     /// - type_parameters
@@ -7490,8 +7490,8 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn export_default_declaration_kind_class<T1, T2, T3>(
         self,
-        r#type: ClassType,
         span: Span,
+        r#type: ClassType,
         decorators: Vec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
@@ -7508,8 +7508,8 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         ExportDefaultDeclarationKind::ClassDeclaration(self.alloc(self.class(
-            r#type,
             span,
+            r#type,
             decorators,
             id,
             type_parameters,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -1903,8 +1903,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
     type Cloned = Function<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Function {
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             generator: CloneIn::clone_in(&self.generator, allocator),
             r#async: CloneIn::clone_in(&self.r#async, allocator),
@@ -2011,8 +2011,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
     type Cloned = Class<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Class {
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -2072,8 +2072,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
     type Cloned = MethodDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MethodDefinition {
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -2101,8 +2101,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
     type Cloned = PropertyDefinition<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PropertyDefinition {
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -2204,8 +2204,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
     type Cloned = AccessorProperty<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AccessorProperty {
-            r#type: CloneIn::clone_in(&self.r#type, allocator),
             span: CloneIn::clone_in(&self.span, allocator),
+            r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1357,8 +1357,8 @@ impl Serialize for BindingRestElement<'_> {
 impl Serialize for Function<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("generator", &self.generator)?;
         map.serialize_entry("async", &self.r#async)?;
@@ -1470,8 +1470,8 @@ impl Serialize for YieldExpression<'_> {
 impl Serialize for Class<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("typeParameters", &self.type_parameters)?;
@@ -1523,8 +1523,8 @@ impl Serialize for ClassElement<'_> {
 impl Serialize for MethodDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("key", &self.key)?;
         map.serialize_entry("value", &self.value)?;
@@ -1556,8 +1556,8 @@ impl Serialize for MethodDefinitionType {
 impl Serialize for PropertyDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("key", &self.key)?;
         map.serialize_entry("value", &self.value)?;
@@ -1664,8 +1664,8 @@ impl Serialize for AccessorPropertyType {
 impl Serialize for AccessorProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("key", &self.key)?;
         map.serialize_entry("value", &self.value)?;

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -91,8 +91,8 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         self.ast.class_element_property_definition(
-            property.r#type,
             property.span,
+            property.r#type,
             self.ast.vec(),
             property.key.clone_in(self.ast.allocator),
             value,
@@ -117,8 +117,8 @@ impl<'a> IsolatedDeclarations<'a> {
         let function = &definition.value;
 
         let value = self.ast.alloc_function(
-            FunctionType::TSEmptyBodyFunctionExpression,
             function.span,
+            FunctionType::TSEmptyBodyFunctionExpression,
             function.id.clone_in(self.ast.allocator),
             false,
             false,
@@ -131,8 +131,8 @@ impl<'a> IsolatedDeclarations<'a> {
         );
 
         self.ast.class_element_method_definition(
-            definition.r#type,
             definition.span,
+            definition.r#type,
             self.ast.vec(),
             definition.key.clone_in(self.ast.allocator),
             value,
@@ -155,8 +155,8 @@ impl<'a> IsolatedDeclarations<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a> {
         self.ast.class_element_property_definition(
-            r#type,
             span,
+            r#type,
             self.ast.vec(),
             key,
             None,
@@ -183,8 +183,8 @@ impl<'a> IsolatedDeclarations<'a> {
         };
         let key = self.ast.property_key_identifier_name(SPAN, ident_name);
         Some(self.ast.class_element_property_definition(
-            PropertyDefinitionType::PropertyDefinition,
             param.span,
+            PropertyDefinitionType::PropertyDefinition,
             self.ast.vec(),
             key,
             None,
@@ -488,8 +488,8 @@ impl<'a> IsolatedDeclarations<'a> {
 
                     // FIXME: missing many fields
                     let new_element = self.ast.class_element_accessor_property(
-                        property.r#type,
                         property.span,
+                        property.r#type,
                         self.ast.vec(),
                         property.key.clone_in(self.ast.allocator),
                         None,
@@ -519,7 +519,7 @@ impl<'a> IsolatedDeclarations<'a> {
             let r#type = PropertyDefinitionType::PropertyDefinition;
             let decorators = self.ast.vec();
             let element = self.ast.class_element_property_definition(
-                r#type, SPAN, decorators, ident, None, false, false, false, false, false, false,
+                SPAN, r#type, decorators, ident, None, false, false, false, false, false, false,
                 false, NONE, None,
             );
 
@@ -529,8 +529,8 @@ impl<'a> IsolatedDeclarations<'a> {
         let body = self.ast.class_body(decl.body.span, elements);
 
         Some(self.ast.alloc_class(
-            decl.r#type,
             decl.span,
+            decl.r#type,
             self.ast.vec(),
             decl.id.clone_in(self.ast.allocator),
             decl.type_parameters.clone_in(self.ast.allocator),

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -26,8 +26,8 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             let params = self.transform_formal_parameters(&func.params);
             Some(self.ast.alloc_function(
-                func.r#type,
                 func.span,
+                func.r#type,
                 func.id.clone_in(self.ast.allocator),
                 false,
                 false,

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -95,8 +95,8 @@ impl<'a> ParserImpl<'a> {
         );
 
         Ok(self.ast.alloc_class(
-            r#type,
             self.end_span(start_span),
+            r#type,
             decorators,
             id,
             type_parameters,
@@ -430,8 +430,8 @@ impl<'a> ParserImpl<'a> {
             MethodDefinitionType::MethodDefinition
         };
         Ok(self.ast.class_element_method_definition(
-            r#type,
             self.end_span(span),
+            r#type,
             decorators,
             key,
             value,
@@ -471,8 +471,8 @@ impl<'a> ParserImpl<'a> {
             PropertyDefinitionType::PropertyDefinition
         };
         Ok(self.ast.class_element_property_definition(
-            r#type,
             self.end_span(span),
+            r#type,
             decorators,
             key,
             value,
@@ -519,8 +519,8 @@ impl<'a> ParserImpl<'a> {
 
         let decorators = self.consume_decorators();
         Ok(self.ast.class_element_accessor_property(
-            r#type,
             self.end_span(span),
+            r#type,
             decorators,
             key,
             value,

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -170,8 +170,8 @@ impl<'a> ParserImpl<'a> {
         );
 
         Ok(self.ast.alloc_function(
-            function_type,
             self.end_span(span),
+            function_type,
             id,
             generator,
             r#async,

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -558,8 +558,8 @@ impl<'a> ArrowFunctionConverter<'a> {
         }
 
         Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
-            FunctionType::FunctionExpression,
             arrow_function_expr.span,
+            FunctionType::FunctionExpression,
             None,
             false,
             arrow_function_expr.r#async,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -586,8 +586,8 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             FunctionType::FunctionExpression
         };
         ctx.ast.alloc_function_with_scope_id(
-            r#type,
             SPAN,
+            r#type,
             id,
             false,
             false,

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -151,15 +151,15 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         stmts.extend(exprs_into_stmts(inits, ctx));
 
         let ctor = ClassElement::MethodDefinition(ctx.ast.alloc_method_definition(
-            MethodDefinitionType::MethodDefinition,
             SPAN,
+            MethodDefinitionType::MethodDefinition,
             ctx.ast.vec(),
             PropertyKey::StaticIdentifier(
                 ctx.ast.alloc_identifier_name(SPAN, Atom::from("constructor")),
             ),
             ctx.ast.alloc_function_with_scope_id(
-                FunctionType::FunctionExpression,
                 SPAN,
+                FunctionType::FunctionExpression,
                 None,
                 false,
                 false,
@@ -426,8 +426,8 @@ impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
         let body_stmts = ctx.ast.vec_from_iter(exprs_into_stmts(inits, ctx).chain([return_stmt]));
         // `function() { <inits>; return this; }`
         Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
-            FunctionType::FunctionExpression,
             SPAN,
+            FunctionType::FunctionExpression,
             None,
             false,
             false,

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -110,8 +110,8 @@ impl ClassStaticBlock {
         let key = ctx.ast.property_key_private_identifier(SPAN, key);
 
         ctx.ast.class_element_property_definition(
-            PropertyDefinitionType::PropertyDefinition,
             block.span,
+            PropertyDefinitionType::PropertyDefinition,
             ctx.ast.vec(),
             key,
             Some(expr),

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -566,8 +566,8 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
             let function = Argument::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
-                FunctionType::FunctionExpression,
                 SPAN,
+                FunctionType::FunctionExpression,
                 None,
                 false,
                 false,

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -100,8 +100,8 @@ impl<'a> TypeScriptEnum<'a> {
         let statements = self.transform_ts_enum_members(&mut decl.members, &param_binding, ctx);
         let body = ast.alloc_function_body(decl.span, ast.vec(), statements);
         let callee = Expression::FunctionExpression(ctx.ast.alloc_function_with_scope_id(
-            FunctionType::FunctionExpression,
             SPAN,
+            FunctionType::FunctionExpression,
             None,
             false,
             false,

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -6501,8 +6501,8 @@ impl<'a, 't> GetAddress for BindingRestElementWithoutArgument<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_FUNCTION_TYPE: usize = offset_of!(Function, r#type);
 pub(crate) const OFFSET_FUNCTION_SPAN: usize = offset_of!(Function, span);
+pub(crate) const OFFSET_FUNCTION_TYPE: usize = offset_of!(Function, r#type);
 pub(crate) const OFFSET_FUNCTION_ID: usize = offset_of!(Function, id);
 pub(crate) const OFFSET_FUNCTION_GENERATOR: usize = offset_of!(Function, generator);
 pub(crate) const OFFSET_FUNCTION_ASYNC: usize = offset_of!(Function, r#async);
@@ -6523,13 +6523,13 @@ pub struct FunctionWithoutId<'a, 't>(
 
 impl<'a, 't> FunctionWithoutId<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -6611,13 +6611,13 @@ pub struct FunctionWithoutTypeParameters<'a, 't>(
 
 impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -6699,13 +6699,13 @@ pub struct FunctionWithoutThisParam<'a, 't>(
 
 impl<'a, 't> FunctionWithoutThisParam<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -6787,13 +6787,13 @@ pub struct FunctionWithoutParams<'a, 't>(
 
 impl<'a, 't> FunctionWithoutParams<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -6875,13 +6875,13 @@ pub struct FunctionWithoutReturnType<'a, 't>(
 
 impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -6963,13 +6963,13 @@ pub struct FunctionWithoutBody<'a, 't>(
 
 impl<'a, 't> FunctionWithoutBody<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
     }
 
     #[inline]
@@ -7613,8 +7613,8 @@ impl<'a, 't> GetAddress for YieldExpressionWithoutArgument<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_CLASS_TYPE: usize = offset_of!(Class, r#type);
 pub(crate) const OFFSET_CLASS_SPAN: usize = offset_of!(Class, span);
+pub(crate) const OFFSET_CLASS_TYPE: usize = offset_of!(Class, r#type);
 pub(crate) const OFFSET_CLASS_DECORATORS: usize = offset_of!(Class, decorators);
 pub(crate) const OFFSET_CLASS_ID: usize = offset_of!(Class, id);
 pub(crate) const OFFSET_CLASS_TYPE_PARAMETERS: usize = offset_of!(Class, type_parameters);
@@ -7636,13 +7636,13 @@ pub struct ClassWithoutDecorators<'a, 't>(
 
 impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -7719,13 +7719,13 @@ pub struct ClassWithoutId<'a, 't>(pub(crate) *const Class<'a>, pub(crate) Phanto
 
 impl<'a, 't> ClassWithoutId<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -7805,13 +7805,13 @@ pub struct ClassWithoutTypeParameters<'a, 't>(
 
 impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -7890,13 +7890,13 @@ pub struct ClassWithoutSuperClass<'a, 't>(
 
 impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -7976,13 +7976,13 @@ pub struct ClassWithoutSuperTypeParameters<'a, 't>(
 
 impl<'a, 't> ClassWithoutSuperTypeParameters<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -8061,13 +8061,13 @@ pub struct ClassWithoutImplements<'a, 't>(
 
 impl<'a, 't> ClassWithoutImplements<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -8143,13 +8143,13 @@ pub struct ClassWithoutBody<'a, 't>(pub(crate) *const Class<'a>, pub(crate) Phan
 
 impl<'a, 't> ClassWithoutBody<'a, 't> {
     #[inline]
-    pub fn r#type(self) -> &'t ClassType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
     }
 
     #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
+    pub fn r#type(self) -> &'t ClassType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE) as *const ClassType) }
     }
 
     #[inline]
@@ -8246,8 +8246,8 @@ impl<'a, 't> GetAddress for ClassBodyWithoutBody<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_METHOD_DEFINITION_TYPE: usize = offset_of!(MethodDefinition, r#type);
 pub(crate) const OFFSET_METHOD_DEFINITION_SPAN: usize = offset_of!(MethodDefinition, span);
+pub(crate) const OFFSET_METHOD_DEFINITION_TYPE: usize = offset_of!(MethodDefinition, r#type);
 pub(crate) const OFFSET_METHOD_DEFINITION_DECORATORS: usize =
     offset_of!(MethodDefinition, decorators);
 pub(crate) const OFFSET_METHOD_DEFINITION_KEY: usize = offset_of!(MethodDefinition, key);
@@ -8270,16 +8270,16 @@ pub struct MethodDefinitionWithoutDecorators<'a, 't>(
 
 impl<'a, 't> MethodDefinitionWithoutDecorators<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t MethodDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_TYPE)
                 as *const MethodDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8350,16 +8350,16 @@ pub struct MethodDefinitionWithoutKey<'a, 't>(
 
 impl<'a, 't> MethodDefinitionWithoutKey<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t MethodDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_TYPE)
                 as *const MethodDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8431,16 +8431,16 @@ pub struct MethodDefinitionWithoutValue<'a, 't>(
 
 impl<'a, 't> MethodDefinitionWithoutValue<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t MethodDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_TYPE)
                 as *const MethodDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8502,8 +8502,8 @@ impl<'a, 't> GetAddress for MethodDefinitionWithoutValue<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_PROPERTY_DEFINITION_TYPE: usize = offset_of!(PropertyDefinition, r#type);
 pub(crate) const OFFSET_PROPERTY_DEFINITION_SPAN: usize = offset_of!(PropertyDefinition, span);
+pub(crate) const OFFSET_PROPERTY_DEFINITION_TYPE: usize = offset_of!(PropertyDefinition, r#type);
 pub(crate) const OFFSET_PROPERTY_DEFINITION_DECORATORS: usize =
     offset_of!(PropertyDefinition, decorators);
 pub(crate) const OFFSET_PROPERTY_DEFINITION_KEY: usize = offset_of!(PropertyDefinition, key);
@@ -8536,16 +8536,16 @@ pub struct PropertyDefinitionWithoutDecorators<'a, 't>(
 
 impl<'a, 't> PropertyDefinitionWithoutDecorators<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t PropertyDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE)
                 as *const PropertyDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8631,16 +8631,16 @@ pub struct PropertyDefinitionWithoutKey<'a, 't>(
 
 impl<'a, 't> PropertyDefinitionWithoutKey<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t PropertyDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE)
                 as *const PropertyDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8727,16 +8727,16 @@ pub struct PropertyDefinitionWithoutValue<'a, 't>(
 
 impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t PropertyDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE)
                 as *const PropertyDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8822,16 +8822,16 @@ pub struct PropertyDefinitionWithoutTypeAnnotation<'a, 't>(
 
 impl<'a, 't> PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t PropertyDefinitionType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE)
                 as *const PropertyDefinitionType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -8941,8 +8941,8 @@ impl<'a, 't> GetAddress for StaticBlockWithoutBody<'a, 't> {
     }
 }
 
-pub(crate) const OFFSET_ACCESSOR_PROPERTY_TYPE: usize = offset_of!(AccessorProperty, r#type);
 pub(crate) const OFFSET_ACCESSOR_PROPERTY_SPAN: usize = offset_of!(AccessorProperty, span);
+pub(crate) const OFFSET_ACCESSOR_PROPERTY_TYPE: usize = offset_of!(AccessorProperty, r#type);
 pub(crate) const OFFSET_ACCESSOR_PROPERTY_DECORATORS: usize =
     offset_of!(AccessorProperty, decorators);
 pub(crate) const OFFSET_ACCESSOR_PROPERTY_KEY: usize = offset_of!(AccessorProperty, key);
@@ -8964,16 +8964,16 @@ pub struct AccessorPropertyWithoutDecorators<'a, 't>(
 
 impl<'a, 't> AccessorPropertyWithoutDecorators<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t AccessorPropertyType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE)
                 as *const AccessorPropertyType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -9039,16 +9039,16 @@ pub struct AccessorPropertyWithoutKey<'a, 't>(
 
 impl<'a, 't> AccessorPropertyWithoutKey<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t AccessorPropertyType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE)
                 as *const AccessorPropertyType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -9115,16 +9115,16 @@ pub struct AccessorPropertyWithoutValue<'a, 't>(
 
 impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t AccessorPropertyType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE)
                 as *const AccessorPropertyType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
     }
 
     #[inline]
@@ -9190,16 +9190,16 @@ pub struct AccessorPropertyWithoutTypeAnnotation<'a, 't>(
 
 impl<'a, 't> AccessorPropertyWithoutTypeAnnotation<'a, 't> {
     #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
+    }
+
+    #[inline]
     pub fn r#type(self) -> &'t AccessorPropertyType {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE)
                 as *const AccessorPropertyType)
         }
-    }
-
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_SPAN) as *const Span) }
     }
 
     #[inline]

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -195,6 +195,19 @@ fn lower_ast_enum(it @ rust::Enum { item, meta }: &rust::Enum, ctx: &EarlyCtx) -
 }
 
 fn lower_ast_struct(it @ rust::Struct { item, meta }: &rust::Struct, ctx: &EarlyCtx) -> StructDef {
+    // If the struct contains a `span` field, it must be the first field for consistency, and also
+    // small performance improvement from byte ordering.
+    if item
+        .fields
+        .iter()
+        .map(|field| field.ident.as_ref().unwrap().to_string())
+        .position(|ident| ident == "span")
+        .filter(|i| *i != 0)
+        .is_some()
+    {
+        panic!("First field of `{}` must be `span`.", it.item.ident);
+    }
+
     let (size_64, align_64, offsets_64) = meta
         .layout_64
         .clone()


### PR DESCRIPTION
For consistency. And maybe a small performance improvement when enum
bytes are aligned.