### PR TITLE
fix(transformer/class-properties): create temp vars in correct scope

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -316,10 +316,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                     // Create binding for private property key
                     if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
                         // Note: Current scope is outside class.
-                        let binding = ctx.generate_uid_in_current_scope(
-                            ident.name.as_str(),
-                            SymbolFlags::FunctionScopedVariable,
-                        );
+                        let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
                         private_props.insert(
                             ident.name.clone(),
                             PrivateProp { binding, is_static: prop.r#static },

--- a/crates/oxc_transformer/src/es2022/class_properties/class_bindings.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_bindings.rs
@@ -1,4 +1,4 @@
-use oxc_syntax::symbol::{SymbolFlags, SymbolId};
+use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::{BoundIdentifier, TraverseCtx};
 
 /// Store for bindings for class.
@@ -98,6 +98,6 @@ impl<'a> ClassBindings<'a> {
         // TODO(improve-on-babel): If class name var isn't mutated, no need for temp var for
         // class declaration. Can just use class binding.
         let name = name_binding.map_or("Class", |binding| binding.name.as_str());
-        ctx.generate_uid_in_current_scope(name, SymbolFlags::FunctionScopedVariable)
+        ctx.generate_uid_in_current_hoist_scope(name)
     }
 }

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 578/927
+Passed: 579/927
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (192/264)
+# babel-plugin-transform-class-properties (193/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -400,14 +400,11 @@ x Output mismatch
 
 * private-loose/nested-class-extends-computed-redeclared/input.js
 Bindings mismatch:
-after transform: ScopeId(2): ["Nested", "_foo2"]
+after transform: ScopeId(2): ["Nested", "_foo2", "_foo3"]
 rebuilt        : ScopeId(3): ["Nested", "_foo2", "_foo3", "_this$foo"]
 Bindings mismatch:
-after transform: ScopeId(3): ["_foo3", "_this$foo"]
+after transform: ScopeId(3): ["_this$foo"]
 rebuilt        : ScopeId(4): []
-Symbol scope ID mismatch for "_foo3":
-after transform: SymbolId(5): ScopeId(3)
-rebuilt        : SymbolId(2): ScopeId(3)
 Symbol scope ID mismatch for "_this$foo":
 after transform: SymbolId(6): ScopeId(3)
 rebuilt        : SymbolId(3): ScopeId(3)
@@ -504,20 +501,6 @@ x Output mismatch
 
 * regression/7951/input.mjs
 x Output mismatch
-
-* regression/8882/input.js
-Bindings mismatch:
-after transform: ScopeId(0): ["classes"]
-rebuilt        : ScopeId(0): ["_A", "_bar", "classes"]
-Bindings mismatch:
-after transform: ScopeId(2): ["_A", "_bar", "_i"]
-rebuilt        : ScopeId(2): ["_i"]
-Symbol scope ID mismatch for "_A":
-after transform: SymbolId(4): ScopeId(2)
-rebuilt        : SymbolId(2): ScopeId(0)
-Symbol scope ID mismatch for "_bar":
-after transform: SymbolId(3): ScopeId(2)
-rebuilt        : SymbolId(3): ScopeId(0)
 
 
 # babel-plugin-transform-nullish-coalescing-operator (5/12)


### PR DESCRIPTION
Create `var` temp vars in current *hoist* scope, not current scope.