### PR TITLE
fix(transformer/class-properties): no `raw` for generated `StringLiteral`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/supers.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/supers.rs
@@ -32,11 +32,8 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let property = &member.property;
-        let property = ctx.ast.expression_string_literal(
-            property.span,
-            property.name.clone(),
-            Some(property.name.clone()),
-        );
+        let property =
+            ctx.ast.expression_string_literal(property.span, property.name.clone(), None);
         self.create_super_prop_get(member.span, property, ctx)
     }
 


### PR DESCRIPTION
Follow-on after #7815. Generated `StringLiteral`s should have `raw: None`.