### PR TITLE
test(transformer/replace-global-defines): remove panicking test

### DIFF
--- a/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
@@ -283,10 +283,3 @@ log(__MEMBER__);
     let snapshot = visualizer.into_visualizer_text();
     insta::assert_snapshot!("test_sourcemap", snapshot);
 }
-
-#[test]
-#[should_panic(expected = "")]
-fn test_complex() {
-    let config = ReplaceGlobalDefinesConfig::new(&[("__DEF__", "((() => {})())")]).unwrap();
-    test("__DEF__", "1", config.clone());
-}


### PR DESCRIPTION
Follow-on after #7811. Remove the panicking test. It *does* currently cause a panic if replacement contains scopes (e.g. `() => 123`) but that's a bug. So we shouldn't have a test saying that it *should* panic.