### PR TITLE
refactor(ast): use exhaustive match for `Argument` to `ArrayExpressionElement` conversion

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -321,10 +321,9 @@ impl ArrayExpressionElement<'_> {
 
 impl<'a> From<Argument<'a>> for ArrayExpressionElement<'a> {
     fn from(argument: Argument<'a>) -> Self {
-        if let Argument::SpreadElement(spread) = argument {
-            ArrayExpressionElement::SpreadElement(spread)
-        } else {
-            ArrayExpressionElement::from(argument.into_expression())
+        match argument {
+            Argument::SpreadElement(spread) => Self::SpreadElement(spread),
+            match_expression!(Argument) => Self::from(argument.into_expression()),
         }
     }
 }


### PR DESCRIPTION
Follow-on after #7830. Refactor.

Use an exhaustive match in implementation of `From<Argument<'a>> for ArrayExpressionElement<'a>`.

At present this change makes no difference. But the reason I feel an exhaustive match is preferable here is that if we add a variant to `Argument` enum later, then this match will be missing an arm to handle that variant, and compiler will refuse to compile until we deal with it.

Whereas before this PR, compiler would not complain, but instead it'd be a runtime panic when `into_expression` discovers that the new `Argument` variant is not an `Expression`.