### PR TITLE
refactor(semantic): use `Expression::is_super`

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -975,8 +975,8 @@ fn super_private(span: Span) -> OxcDiagnostic {
 
 pub fn check_member_expression(member_expr: &MemberExpression, ctx: &SemanticBuilder<'_>) {
     if let MemberExpression::PrivateFieldExpression(private_expr) = member_expr {
-        // super.#m
-        if let Expression::Super(_) = &private_expr.object {
+        // `super.#m`
+        if private_expr.object.is_super() {
             ctx.error(super_private(private_expr.span));
         }
     }


### PR DESCRIPTION
Shorten code by using `Expression::is_super`, which was introduced in #7831.