### PR TITLE
refactor(transformer): use `Expression::is_super`

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -630,16 +630,17 @@ impl<'a> ArrowFunctionConverter<'a> {
         let mut property = "";
         let init = match expr.to_member_expression_mut() {
             MemberExpression::ComputedMemberExpression(computed_member) => {
-                if !matches!(computed_member.object, Expression::Super(_)) {
+                if !computed_member.object.is_super() {
                     return None;
                 }
+
                 // The property will as a parameter to pass to the new arrow function.
                 // `super[property]` to `_superprop_get(property)`
                 argument = Some(ctx.ast.move_expression(&mut computed_member.expression));
                 ctx.ast.move_expression(&mut computed_member.object)
             }
             MemberExpression::StaticMemberExpression(static_member) => {
-                if !matches!(static_member.object, Expression::Super(_)) {
+                if !static_member.object.is_super() {
                     return None;
                 }
 
@@ -741,10 +742,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     ) -> Option<Expression<'a>> {
         // Check if the left of the assignment is a `super` member expression.
         if self.super_methods.is_none()
-            || !assignment
-                .left
-                .as_member_expression()
-                .is_some_and(|m| matches!(m.object(), Expression::Super(_)))
+            || !assignment.left.as_member_expression().is_some_and(|m| m.object().is_super())
         {
             return None;
         }

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -595,7 +595,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
                             binding.to_maybe_bound_identifier()
                         });
                     self.set_binding_context(binding);
-                } else if matches!(object, Expression::Super(_)) {
+                } else if object.is_super() {
                     self.set_this_context();
                 }
             }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -495,7 +495,7 @@ impl<'a, 'c> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, 'c> {
     #[inline]
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         if let Expression::CallExpression(call_expr) = expr {
-            if let Expression::Super(_) = &call_expr.callee {
+            if call_expr.callee.is_super() {
                 // Walk `CallExpression`'s arguments here rather than falling through to `walk_expression`
                 // below to avoid infinite loop as `super()` gets visited over and over
                 self.visit_arguments(&mut call_expr.arguments);
@@ -610,7 +610,7 @@ impl<'a, 'c> ConstructorBodySuperReplacer<'a, 'c> {
                 // We can avoid a nested `_super` function for this common case.
                 if let Statement::ExpressionStatement(expr_stmt) = &*stmt {
                     if let Expression::CallExpression(call_expr) = &expr_stmt.expression {
-                        if let Expression::Super(_) = &call_expr.callee {
+                        if call_expr.callee.is_super() {
                             let insert_location =
                                 InstanceInitsInsertLocation::ExistingConstructor(index + 1);
                             return (self.constructor_scope_id, insert_location);


### PR DESCRIPTION
Shorten code by using `Expression::is_super`, which was introduced in #7831.