### PR TITLE
refactor(transformer/class-properties): re-use existing `Vec`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/supers.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/supers.rs
@@ -98,9 +98,8 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         arguments: &mut ArenaVec<'a, Argument<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let owned_arguments = ctx.ast.move_vec(arguments);
-        let elements =
-            ctx.ast.vec_from_iter(owned_arguments.into_iter().map(ArrayExpressionElement::from));
+        let elements = arguments.drain(..).map(ArrayExpressionElement::from);
+        let elements = ctx.ast.vec_from_iter(elements);
         let array = ctx.ast.expression_array(SPAN, elements, None);
         arguments.push(Argument::from(array));
     }


### PR DESCRIPTION
Follow-on after #7831.

Previously this code was:

1. Create a new empty `Vec` (in `move_vec` call).
2. Consume the old `Vec` and create a new `Vec<ArrayExpressionElement>`.
3. Push to the empty `Vec` created in step 1.

Instead:

1. Drain the old `Vec` and create a new `Vec<ArrayExpressionElement>`.
2. The old `Vec` is now empty, but still holds an allocation if it wasn't empty before.
3. Push to the old `Vec` (re-using the existing allocation).

i.e. We create 1 less `Vec`, and re-use an existing allocation if possible.
