### PR TITLE
refactor(transformer/class-properties): reduce visibility of method

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/supers.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/supers.rs
@@ -94,7 +94,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     }
 
     /// [A, B, C] -> [[A, B, C]]
-    pub(super) fn transform_super_call_expression_arguments(
+    fn transform_super_call_expression_arguments(
         arguments: &mut ArenaVec<'a, Argument<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {


### PR DESCRIPTION
Follow-on after #7831. `transform_super_call_expression_arguments` is only used within this file, so does not need to be `pub(super)`.