### PR TITLE
fix(cfg): include export default code in CFG instructions

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -12,7 +12,7 @@ impl<'a> AstKind<'a> {
                     | Self::DebuggerStatement(_) | Self::EmptyStatement(_) | Self::ExpressionStatement(_)
                     | Self::LabeledStatement(_) | Self::ReturnStatement(_) | Self::SwitchStatement(_)
                     | Self::ThrowStatement(_) | Self::TryStatement(_) | Self::WithStatement(_)
-                    | Self::IfStatement(_) | Self::VariableDeclaration(_))
+                    | Self::IfStatement(_) | Self::VariableDeclaration(_) | Self::ExportDefaultDeclaration(_))
     }
 
     #[rustfmt::skip]

--- a/crates/oxc_semantic/tests/integration/snapshots/function_as_expression.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/function_as_expression.snap
@@ -33,7 +33,7 @@ bb6: {
 }
 
 bb7: {
-
+	statement
 }
 
 bb8: {
@@ -172,7 +172,8 @@ ExpressionStatement" shape = box]
     5 [ label = "bb5" shape = box]
     6 [ label = "bb6
 return" shape = box]
-    7 [ label = "bb7" shape = box]
+    7 [ label = "bb7
+ExportDefaultDeclaration" shape = box]
     8 [ label = "bb8" shape = box]
     9 [ label = "bb9
 return" shape = box]


### PR DESCRIPTION
Previously any instructions happening inside of the expression passed to `export default` were invisible in the CFG.

Example:

```
// Uncommenting this line makes the call to bar() disappear from the
// CFG view of the program:
// export default
bar();
```