### PR TITLE
refactor(semantic, syntax, wasm): remove `#![allow(non_snake_case)]`

### DIFF
--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,6 +1,3 @@
-// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
-
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)] // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -1,8 +1,6 @@
 //! ECMAScript operators.
 //!
 //! Not all operators are punctuation - some, such as `delete`, are keywords.
-// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
 
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -1,6 +1,3 @@
-// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
-
 mod options;
 
 use std::{

--- a/wasm/parser/src/lib.rs
+++ b/wasm/parser/src/lib.rs
@@ -1,5 +1,3 @@
-// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
 #![allow(clippy::needless_pass_by_value)]
 
 use oxc::{allocator::Allocator, parser::Parser, span::SourceType};


### PR DESCRIPTION
`#![allow(non_snake_case)]` was required in files using `#[derive(Tsify)]`, as a bug in Rust Analyser caused erroneous warnings. This appears to be fixed now, so we can remove these `#![allow]` attributes.