### PR TITLE
refactor(semantic)!: remove `SymbolTable::rename` method

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -102,11 +102,6 @@ impl SymbolTable {
 
     /// Rename a symbol.
     #[inline]
-    pub fn rename(&mut self, symbol_id: SymbolId, new_name: CompactStr) {
-        self.names[symbol_id] = new_name;
-    }
-
-    #[inline]
     pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactStr) {
         self.names[symbol_id] = name;
     }

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -905,7 +905,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: CompactStr, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.symbols().get_scope_id(symbol_id);
-        ctx.symbols_mut().rename(symbol_id, name.clone());
+        ctx.symbols_mut().set_name(symbol_id, name.clone());
         ctx.scopes_mut().rename_binding(scope_id, "arguments", name);
     }
 


### PR DESCRIPTION
Remove `SymbolTable::rename` method. We also have `SymbolTable::set_name` method which does the same thing.