### PR TITLE
refactor(semantic): `SymbolTable::set_name` return old name

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]
@@ -101,9 +103,11 @@ impl SymbolTable {
     }
 
     /// Rename a symbol.
+    ///
+    /// Returns the old name.
     #[inline]
-    pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactStr) {
-        self.names[symbol_id] = name;
+    pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactStr) -> CompactStr {
+        mem::replace(&mut self.names[symbol_id], name)
     }
 
     /// Get the [`SymbolFlags`] for a symbol, which describe how the symbol is declared.


### PR DESCRIPTION
`SymbolTable::set_name` return old symbol name. `set_name` is marked `#[inline]`, so where the caller does not use the old name, getting it should be optimized out by the compiler. So it makes the method more flexible, at no cost.