### PR TITLE
feat(traverse): add `TraverseScoping::rename_symbol` method

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -905,8 +905,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: CompactStr, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.symbols().get_scope_id(symbol_id);
-        ctx.symbols_mut().set_name(symbol_id, name.clone());
-        ctx.scopes_mut().rename_binding(scope_id, symbol_id, "arguments", name);
+        ctx.rename_symbol(symbol_id, scope_id, name);
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -589,6 +589,21 @@ impl<'a> TraverseCtx<'a> {
     pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
         self.scoping.delete_reference_for_identifier(ident);
     }
+
+    /// Rename symbol.
+    ///
+    /// Preserves original order of bindings for scope.
+    ///
+    /// The following must be true for successful operation:
+    /// * Binding exists in specified scope for `symbol_id`.
+    /// * No binding already exists in scope for `new_name`.
+    ///
+    /// Panics in debug mode if either of the above are not satisfied.
+    ///
+    /// This is a shortcut for `ctx.scoping.rename_symbol`.
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: CompactStr) {
+        self.scoping.rename_symbol(symbol_id, scope_id, new_name);
+    }
 }
 
 // Methods used internally within crate

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -362,6 +362,22 @@ impl TraverseScoping {
     pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
         self.delete_reference(ident.reference_id(), &ident.name);
     }
+
+    /// Rename symbol.
+    ///
+    /// Preserves original order of bindings for scope.
+    ///
+    /// The following must be true for successful operation:
+    /// * Binding exists in specified scope for `symbol_id`.
+    /// * No binding already exists in scope for `new_name`.
+    ///
+    /// Panics in debug mode if either of the above are not satisfied.
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: CompactStr) {
+        // Rename symbol
+        let old_name = self.symbols.set_name(symbol_id, new_name.clone());
+        // Rename binding
+        self.scopes.rename_binding(scope_id, symbol_id, &old_name, new_name);
+    }
 }
 
 // Methods used internally within crate


### PR DESCRIPTION
Add `TraverseScoping::rename_symbol` method. This renames the symbol, and also the binding for that symbol.