### PR TITLE
fix(transformer/class-properties): fix symbol clashes in instance prop initializers

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -3,8 +3,14 @@
 
 use std::cell::Cell;
 
+use rustc_hash::FxHashMap;
+
 use oxc_ast::{ast::*, visit::Visit};
-use oxc_syntax::scope::{ScopeFlags, ScopeId};
+use oxc_span::Atom;
+use oxc_syntax::{
+    scope::{ScopeFlags, ScopeId},
+    symbol::SymbolId,
+};
 use oxc_traverse::TraverseCtx;
 
 use super::ClassProperties;
@@ -24,13 +30,24 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     }
 }
 
-/// Visitor to change parent scope of first-level scopes in instance property initializer.
+// TODO: If no `constructor_scope_id`, then don't need to traverse beyond first-level scope,
+// as all we need to do is update scopes. Add a faster visitor for this more limited traversal.
+
+/// Visitor to change parent scope of first-level scopes in instance property initializer,
+/// and find any `IdentifierReference`s which would be shadowed by bindings in constructor,
+/// once initializer moves into constructor body.
 struct InstanceInitializerVisitor<'a, 'v> {
     /// Incremented when entering a scope, decremented when exiting it.
     /// Parent `ScopeId` should be updated when `scope_depth == 0`.
     scope_depth: u32,
     /// Parent scope
     parent_scope_id: ScopeId,
+    /// Constructor scope, if need to check for clashing bindings with constructor.
+    /// `None` if constructor is newly created, or inits are being inserted in `_super` function
+    /// outside class, because in those cases there are no bindings which can clash.
+    constructor_scope_id: Option<ScopeId>,
+    /// Clashing symbols
+    clashing_constructor_symbols: &'v mut FxHashMap<SymbolId, Atom<'a>>,
     /// `TraverseCtx` object.
     ctx: &'v mut TraverseCtx<'a>,
 }
@@ -40,24 +57,21 @@ impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
         class_properties: &'v mut ClassProperties<'a, '_>,
         ctx: &'v mut TraverseCtx<'a>,
     ) -> Self {
-        let parent_scope_id = class_properties.instance_inits_scope_id;
-        Self { scope_depth: 0, parent_scope_id, ctx }
+        Self {
+            scope_depth: 0,
+            parent_scope_id: class_properties.instance_inits_scope_id,
+            constructor_scope_id: class_properties.instance_inits_constructor_scope_id,
+            clashing_constructor_symbols: &mut class_properties.clashing_constructor_symbols,
+            ctx,
+        }
     }
 }
 
 impl<'a, 'v> Visit<'a> for InstanceInitializerVisitor<'a, 'v> {
     /// Update parent scope for first level of scopes.
-    /// Convert scope to sloppy mode if `self.make_sloppy_mode == true`.
     fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
-        let scope_id = scope_id.get().unwrap();
-
-        // TODO: Not necessary to do this check for all scopes.
-        // In JS, only `Function`, `ArrowFunctionExpression` or `Class` can be the first-level scope,
-        // as all other types which have a scope are statements or `StaticBlock` which would need to be
-        // inside a function or class. But some TS types with scopes could be first level via
-        // e.g. `TaggedTemplateExpression::type_parameters`, which contains `TSType`.
-        // Not sure if that matters though, as they'll be stripped out anyway by TS transform.
         if self.scope_depth == 0 {
+            let scope_id = scope_id.get().unwrap();
             self.reparent_scope(scope_id);
         }
         self.scope_depth += 1;
@@ -66,10 +80,27 @@ impl<'a, 'v> Visit<'a> for InstanceInitializerVisitor<'a, 'v> {
     fn leave_scope(&mut self) {
         self.scope_depth -= 1;
     }
+
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        let Some(constructor_scope_id) = self.constructor_scope_id else { return };
+
+        // TODO: It would be ideal if could get reference `&Bindings` for constructor
+        // in `InstanceInitializerVisitor::new` rather than indexing into `ScopeTree::bindings`
+        // with same `ScopeId` every time here, but `ScopeTree` doesn't allow that, and we also
+        // take a `&mut ScopeTree` in `reparent_scope`, so borrow-checker doesn't allow that.
+        let Some(symbol_id) = self.ctx.scopes().get_binding(constructor_scope_id, &ident.name)
+        else {
+            return;
+        };
+
+        // TODO: Optimization: Exit if reference is bound to symbol within initializer
+
+        self.clashing_constructor_symbols.entry(symbol_id).or_insert(ident.name.clone());
+    }
 }
 
 impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
-    /// Update parent of scope to scope above class.
+    /// Update parent of scope.
     fn reparent_scope(&mut self, scope_id: ScopeId) {
         self.ctx.scopes_mut().change_parent_id(scope_id, Some(self.parent_scope_id));
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -145,13 +145,14 @@
 //! * Class properties TC39 proposal: <https://github.com/tc39/proposal-class-fields>
 
 use indexmap::IndexMap;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::Deserialize;
 
 use oxc_allocator::{Address, GetAddress};
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::NonEmptyStack;
-use oxc_syntax::scope::ScopeId;
+use oxc_span::Atom;
+use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::TransformCtx;
@@ -220,6 +221,12 @@ pub struct ClassProperties<'a, 'ctx> {
     temp_var_is_created: bool,
     /// Scope that instance init initializers will be inserted into
     instance_inits_scope_id: ScopeId,
+    /// `ScopeId` of class constructor, if instance init initializers will be inserted into constructor.
+    /// Used for checking for variable name clashes.
+    /// e.g. `let x; class C { prop = x; constructor(x) {} }` - `x` in constructor needs to be renamed
+    instance_inits_constructor_scope_id: Option<ScopeId>,
+    /// `SymbolId`s in constructor which clash with instance prop initializers
+    clashing_constructor_symbols: FxHashMap<SymbolId, Atom<'a>>,
     /// Expressions to insert before class
     insert_before: Vec<Expression<'a>>,
     /// Expressions to insert after class expression
@@ -252,7 +259,9 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             class_bindings: ClassBindings::default(),
             temp_var_is_created: false,
             instance_inits_scope_id: ScopeId::new(0),
+            instance_inits_constructor_scope_id: None,
             // `Vec`s and `FxHashMap`s which are reused for every class being transformed
+            clashing_constructor_symbols: FxHashMap::default(),
             insert_before: vec![],
             insert_after_exprs: vec![],
             insert_after_stmts: vec![],

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 582/927
+Passed: 593/927
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (194/264)
+# babel-plugin-transform-class-properties (205/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -295,16 +295,10 @@ x Output mismatch
 * assumption-setPublicClassFields/computed/input.js
 x Output mismatch
 
-* assumption-setPublicClassFields/constructor-collision/input.js
-x Output mismatch
-
 * assumption-setPublicClassFields/static-infer-name/input.js
 x Output mismatch
 
 * assumption-setPublicClassFields/static-super-loose/input.js
-x Output mismatch
-
-* assumption-setPublicClassFields/super-with-collision/input.js
 x Output mismatch
 
 * class-name-tdz/general/input.js
@@ -339,12 +333,6 @@ x Output mismatch
 x Output mismatch
 
 * private/class-shadow-builtins/input.mjs
-x Output mismatch
-
-* private/constructor-collision/input.js
-x Output mismatch
-
-* private/extracted-this/input.js
 x Output mismatch
 
 * private/nested-class-computed-redeclared/input.js
@@ -384,12 +372,6 @@ x Output mismatch
 x Output mismatch
 
 * private-loose/class-shadow-builtins/input.mjs
-x Output mismatch
-
-* private-loose/constructor-collision/input.js
-x Output mismatch
-
-* private-loose/extracted-this/input.js
 x Output mismatch
 
 * private-loose/nested-class-computed-redeclared/input.js
@@ -463,19 +445,10 @@ x Output mismatch
 * public/computed/input.js
 x Output mismatch
 
-* public/constructor-collision/input.js
-x Output mismatch
-
 * public/delete-super-property/input.js
 x Output mismatch
 
-* public/extracted-this/input.js
-x Output mismatch
-
 * public/static-infer-name/input.js
-x Output mismatch
-
-* public/super-with-collision/input.js
 x Output mismatch
 
 * public-loose/class-shadow-builtins/input.mjs
@@ -484,16 +457,10 @@ x Output mismatch
 * public-loose/computed/input.js
 x Output mismatch
 
-* public-loose/constructor-collision/input.js
-x Output mismatch
-
 * public-loose/static-infer-name/input.js
 x Output mismatch
 
 * public-loose/static-super/input.js
-x Output mismatch
-
-* public-loose/super-with-collision/input.js
 x Output mismatch
 
 * regression/6153/input.js

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 189 of 215 (87.91%)
+Passed: 191 of 215 (88.84%)
 
 Failures:
 
@@ -23,14 +23,6 @@ Unexpected token `[`. Expected * for generator, private key, identifier or async
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-decorator-exec.test.js
 AssertionError: expected undefined to be 'hello' // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-decorator-exec.test.js:22:28
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-constructor-collision-exec.test.js
-AssertionError: expected undefined to be 'bar' // Object.is equality
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-constructor-collision-exec.test.js:18:19
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js
-AssertionError: expected undefined to be 'bar' // Object.is equality
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-constructor-collision-exec.test.js:21:19
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-computed-redeclared-exec.test.js
 Private field '#foo' must be declared in an enclosing class


### PR DESCRIPTION
Instance property initializers are moved into constructor. If symbols they reference are shadowed within constructor, rename those symbols.

Input:

```js
class C {
  prop = foo();
  constructor(foo) {
    console.log(foo);
  }
}
```

Output:

```js
class C {
  constructor(_foo) { // <-- renamed
    this.prop = foo(); // <-- moved into constructor
    console.log(_foo); // <-- renamed
  }
}
```