### PR TITLE
test(transformer): skip test which uses filesystem under miri

### DIFF
--- a/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
@@ -237,6 +237,7 @@ console.log(
     );
 }
 
+#[cfg(not(miri))]
 #[test]
 fn test_sourcemap() {
     let config = ReplaceGlobalDefinesConfig::new(&[


### PR DESCRIPTION
Miri does not support filesystem operations. Skip this test which loads snapshot from disk when running under Miri.