### PR TITLE
fix(linter): false positive in `jsx-a11y/label-has-associated-control`

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -206,10 +206,12 @@ impl Rule for LabelHasAssociatedControl {
             return;
         };
 
-        if let Some(element_type) = get_element_type(ctx, &element.opening_element) {
-            if self.label_components.binary_search(&element_type.into()).is_err() {
-                return;
-            }
+        let Some(element_type) = get_element_type(ctx, &element.opening_element) else {
+            return;
+        };
+
+        if self.label_components.binary_search(&element_type.into()).is_err() {
+            return;
         }
 
         let has_html_for = has_jsx_prop(&element.opening_element, "htmlFor").is_some();
@@ -915,6 +917,8 @@ fn test() {
             }])),
             None,
         ),
+        // Issue: <https://github.com/oxc-project/oxc/issues/7849>
+        ("<FilesContext.Provider value={{ addAlert, cwdInfo }} />", None, None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
closes #7849

This is essentially because `get_element_type` does not support recognizing tag names like `<a.b />`. I'm unsure whether we should support it.