### PR TITLE
style(ast_tools): reformat macro

### DIFF
--- a/tasks/ast_tools/src/logger.rs
+++ b/tasks/ast_tools/src/logger.rs
@@ -11,13 +11,13 @@ pub(super) fn __internal_log_enable() -> bool {
 }
 
 macro_rules! log {
-        ($fmt:literal $(, $args:expr)*) => {
-            if $crate::logger::__internal_log_enable() {
-                print!($fmt$(, $args)*);
-                std::io::Write::flush(&mut std::io::stdout()).unwrap();
-            }
+    ($fmt:literal $(, $args:expr)*) => {
+        if $crate::logger::__internal_log_enable() {
+            print!($fmt$(, $args)*);
+            std::io::Write::flush(&mut std::io::stdout()).unwrap();
         }
     }
+}
 
 macro_rules! log_success {
     () => {


### PR DESCRIPTION
Fix indentation in macro definition.