### PR TITLE
feat(semantic): re-export all flags and ID types

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -12,7 +12,10 @@ use oxc_ast::{
 };
 use oxc_cfg::ControlFlowGraph;
 use oxc_span::{GetSpan, SourceType, Span};
+// Re-export flags and ID types
 pub use oxc_syntax::{
+    node::{NodeFlags, NodeId},
+    reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -38,8 +41,8 @@ use class::ClassTable;
 pub use crate::{
     builder::{SemanticBuilder, SemanticBuilderReturn},
     jsdoc::{JSDoc, JSDocFinder, JSDocTag},
-    node::{AstNode, AstNodes, NodeId},
-    reference::{Reference, ReferenceFlags, ReferenceId},
+    node::{AstNode, AstNodes},
+    reference::Reference,
     scope::ScopeTree,
     stats::Stats,
     symbol::{IsGlobalReference, SymbolTable},


### PR DESCRIPTION
`oxc_semantic` already re-exports `ScopeId`, `ScopeFlags`, `SymbolId` and `SymbolFlags` from `oxc_syntax`. It seems inconsistent that it doesn't also re-export `ReferenceId`, `ReferenceFlags`, `NodeId` and `NodeFlags` too. Do that.