### PR TITLE
refactor(semantic): import flags and ID types from `oxc_syntax`

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -5,12 +5,12 @@ use std::ptr;
 use oxc_ast::{ast::*, AstKind};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
 use oxc_span::{GetSpan, SourceType};
-
-use crate::{
+use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
-    SemanticBuilder,
 };
+
+use crate::SemanticBuilder;
 
 pub(crate) trait Binder<'a> {
     #[allow(unused_variables)]

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -9,6 +9,12 @@ use oxc_cfg::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Atom, CompactStr, SourceType, Span};
+use oxc_syntax::{
+    node::{NodeFlags, NodeId},
+    reference::{ReferenceFlags, ReferenceId},
+    scope::{ScopeFlags, ScopeId},
+    symbol::{SymbolFlags, SymbolId},
+};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -18,11 +24,11 @@ use crate::{
     diagnostics::redeclaration,
     jsdoc::JSDocBuilder,
     label::UnusedLabels,
-    node::{AstNodes, NodeFlags, NodeId},
-    reference::{Reference, ReferenceFlags, ReferenceId},
-    scope::{Bindings, ScopeFlags, ScopeId, ScopeTree},
+    node::AstNodes,
+    reference::Reference,
+    scope::{Bindings, ScopeTree},
     stats::Stats,
-    symbol::{SymbolFlags, SymbolId, SymbolTable},
+    symbol::SymbolTable,
     unresolved_stack::UnresolvedReferencesStack,
     JSDocFinder, Semantic,
 };

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -5,11 +5,12 @@ use oxc_span::{GetSpan, ModuleKind, Span};
 use oxc_syntax::{
     number::NumberBase,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
+    scope::ScopeFlags,
 };
 use phf::{phf_set, Set};
 use rustc_hash::FxHashMap;
 
-use crate::{builder::SemanticBuilder, diagnostics::redeclaration, scope::ScopeFlags, AstNode};
+use crate::{builder::SemanticBuilder, diagnostics::redeclaration, AstNode};
 
 pub fn check_duplicate_class_elements(ctx: &SemanticBuilder<'_>) {
     let classes = &ctx.class_table_builder.classes;

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,9 +1,10 @@
 use oxc_index::IndexVec;
 use oxc_span::{CompactStr, Span};
-use oxc_syntax::class::{ClassId, ElementId, ElementKind};
+use oxc_syntax::{
+    class::{ClassId, ElementId, ElementKind},
+    node::NodeId,
+};
 use rustc_hash::FxHashMap;
-
-use crate::node::NodeId;
 
 #[derive(Debug)]
 pub struct Element {

--- a/crates/oxc_semantic/src/label.rs
+++ b/crates/oxc_semantic/src/label.rs
@@ -1,4 +1,4 @@
-use crate::NodeId;
+use oxc_syntax::node::NodeId;
 
 #[derive(Debug)]
 pub struct LabeledScope<'a> {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -2,9 +2,10 @@ use oxc_ast::AstKind;
 use oxc_cfg::BlockNodeId;
 use oxc_index::IndexVec;
 use oxc_span::GetSpan;
-pub use oxc_syntax::node::{NodeFlags, NodeId};
-
-use crate::scope::ScopeId;
+use oxc_syntax::{
+    node::{NodeFlags, NodeId},
+    scope::ScopeId,
+};
 
 /// Semantic node contains all the semantic information about an ast node.
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,10 +1,8 @@
-pub use oxc_syntax::reference::{ReferenceFlags, ReferenceId};
+use oxc_syntax::{node::NodeId, reference::ReferenceFlags, symbol::SymbolId};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]
 use tsify::Tsify;
-
-use crate::{symbol::SymbolId, NodeId};
 
 /// Describes where and how a Symbol is used in the AST.
 ///

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -3,11 +3,13 @@ use std::mem;
 use indexmap::IndexMap;
 use oxc_index::IndexVec;
 use oxc_span::CompactStr;
-use oxc_syntax::reference::ReferenceId;
-pub use oxc_syntax::scope::{ScopeFlags, ScopeId};
+use oxc_syntax::{
+    node::NodeId,
+    reference::ReferenceId,
+    scope::{ScopeFlags, ScopeId},
+    symbol::SymbolId,
+};
 use rustc_hash::{FxBuildHasher, FxHashMap};
-
-use crate::{symbol::SymbolId, NodeId};
 
 type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -3,7 +3,9 @@ use std::mem;
 use oxc_ast::ast::{Expression, IdentifierReference};
 use oxc_index::IndexVec;
 use oxc_span::{CompactStr, Span};
-pub use oxc_syntax::{
+use oxc_syntax::{
+    node::NodeId,
+    reference::ReferenceId,
     scope::ScopeId,
     symbol::{RedeclarationId, SymbolFlags, SymbolId},
 };
@@ -12,10 +14,7 @@ use serde::Serialize;
 #[cfg(feature = "serialize")]
 use tsify::Tsify;
 
-use crate::{
-    node::NodeId,
-    reference::{Reference, ReferenceId},
-};
+use crate::reference::Reference;
 
 #[cfg(feature = "serialize")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]


### PR DESCRIPTION
`oxc_semantic` had a bit of a mess of modules importing and re-exporting symbols from `oxc_syntax` all over the place. I assume this is a leftover from when our crates were structured differently.

Make this consistent by always importing `oxc_syntax`'s symbols from `oxc_syntax`, and only re-export them from the crate root.