### PR TITLE
fix(tasks/lint_rules): fix regex for syncing vitest rules

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -152,7 +152,7 @@ exports.syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
   // };
   // ```
   const vitestCompatibleRules = vitestCompatibleRulesFile.match(
-    /const VITEST_COMPATIBLE_JEST_RULES.+phf_set! {([^}]+)/s,
+    /const VITEST_COMPATIBLE_JEST_RULES[^.]+phf_set! {([^}]+)/s,
   )?.[1];
   if (!vitestCompatibleRules) {
     throw new Error('Failed to find the list of vitest-compatible rules');


### PR DESCRIPTION
output:

~/dev/oxc$ node tasks/lint_rules/ --target vitest
👀 promise/spec-only is implemented but not found in their rules
👀 unicorn/consistent-existence-index-check is implemented but not found in their rules
👀 unicorn/prefer-math-min-max is implemented but not found in their rules

> [!WARNING]
> This comment is maintained by CI. Do not edit this comment directly.
> To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules

This is tracking issue for `eslint-plugin-vitest`.


There are 51(+ 1 deprecated) rules.

- 1/8 recommended rules are remaining as TODO
- 30/43 not recommended rules are remaining as TODO


To get started, run the following command:

```sh
just new-vitest-rule <RULE_NAME>
```

Then register the rule in `crates/oxc_linter/src/rules.rs` and also `declare_all_lint_rules` at the bottom.


## Recommended rules

<details open>
<summary>
  ✨: 7, 🚫: 0 / total: 8
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
| ✨ | vitest/no-identical-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md |
| ✨ | vitest/expect-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/expect-expect.md |
| ✨ | vitest/no-commented-out-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md |
| ✨ | vitest/no-import-node-test | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-import-node-test.md |
|  | vitest/valid-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md |
| ✨ | vitest/valid-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-expect.md |
| ✨ | vitest/require-local-test-context-for-concurrent-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-local-test-context-for-concurrent-snapshots.md |
| ✨ | vitest/valid-describe-callback | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/valid-describe-callback.md |

✨ = Implemented, 🚫 = No need to implement

</details>


## Not recommended rules

<details open>
<summary>
  ✨: 13, 🚫: 0 / total: 43
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | vitest/prefer-lowercase-title | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-lowercase-title.md |
|  | vitest/max-nested-describe | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md |
| ✨ | vitest/no-focused-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md |
| ✨ | vitest/no-conditional-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-tests.md |
| ✨ | vitest/consistent-test-it | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md |
|  | vitest/prefer-to-be | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be.md |
|  | vitest/no-hooks | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md |
|  | vitest/no-restricted-vi-methods | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md |
|  | vitest/consistent-test-filename | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md |
|  | vitest/max-expects | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md |
| ✨ | vitest/no-alias-methods | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-alias-methods.md |
| ✨ | vitest/no-conditional-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md |
| ✨ | vitest/no-conditional-in-test | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md |
| ✨ | vitest/no-disabled-tests | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md |
|  | vitest/no-duplicate-hooks | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md |
|  | vitest/no-large-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-large-snapshots.md |
|  | vitest/no-interpolation-in-snapshots | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md |
|  | vitest/no-mocks-import | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md |
|  | vitest/no-restricted-matchers | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md |
|  | vitest/no-standalone-expect | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md |
| ✨ | vitest/no-test-prefixes | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md |
|  | vitest/no-test-return-statement | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-test-return-statement.md |
|  | vitest/prefer-called-with | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md |
| ✨ | vitest/prefer-to-be-falsy | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-falsy.md |
| ✨ | vitest/prefer-to-be-object | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-object.md |
| ✨ | vitest/prefer-to-be-truthy | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-truthy.md |
|  | vitest/prefer-to-have-length | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md |
|  | vitest/prefer-equality-matcher | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md |
|  | vitest/prefer-strict-equal | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-equal.md |
|  | vitest/prefer-expect-resolves | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md |
| ✨ | vitest/prefer-each | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md |
|  | vitest/prefer-hooks-on-top | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md |
| ✨ | vitest/prefer-hooks-in-order | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md |
|  | vitest/prefer-mock-promise-shorthand | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md |
|  | vitest/prefer-snapshot-hint | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-snapshot-hint.md |
|  | vitest/require-top-level-describe | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md |
|  | vitest/require-to-throw-message | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md |
|  | vitest/require-hook | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-hook.md |
|  | vitest/prefer-todo | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md |
|  | vitest/prefer-spy-on | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-spy-on.md |
|  | vitest/prefer-comparison-matcher | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-comparison-matcher.md |
|  | vitest/prefer-to-contain | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-contain.md |
|  | vitest/prefer-expect-assertions | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md |

✨ = Implemented, 🚫 = No need to implement

</details>


## Deprecated rules

<details >
<summary>
  ✨: 0, 🚫: 0 / total: 1
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | vitest/no-done-callback | https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md |

✨ = Implemented, 🚫 = No need to implement

</details>
