### PR TITLE
fix(tools): `just submodules` update transformer test fixtures

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 54a8389fa31ce4fd18b0335b05832dc1ad3cc21f
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 37fd1774d13ef68abcc03775ceef0a91f87a57d7
+  just update-transformer-fixtures
 
 # Install git pre-commit to format files
 install-hook:
@@ -133,10 +134,9 @@ autoinherit:
 test-transform *args='':
   cargo run -p oxc_transform_conformance -- --exec {{args}}
 
-# Update transformer conformance test fixtures, including overrides.
-# `just submodules` also does this, but this runs faster. Useful when working on transformer.
+# Update transformer conformance test fixtures
 update-transformer-fixtures:
-  cd tasks/coverage/babel && git reset --hard HEAD && git clean -f -q
+  cd tasks/coverage/babel; git reset --hard HEAD; git clean -f -q
   node tasks/transform_conformance/update_fixtures.mjs
 
 # Install wasm-pack


### PR DESCRIPTION
`just submodules` run `just update-transformer-fixtures`. Otherwise after updating submodules, transformer tests will break. Most people won't know that they need to run `just update-transformer-fixtures` too.

Also make `just update-transformer-fixtures` work on Windows.