### PR TITLE
refactor(linter): move rule "no-restricted-imports" to nursery

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -69,7 +69,7 @@ declare_oxc_lint!(
     /// export { foo } from "bar";
     /// ```
     NoRestrictedImports,
-    style,
+    nursery,
 );
 
 impl Rule for NoRestrictedImports {


### PR DESCRIPTION
many options are not supported:

https://github.com/oxc-project/oxc/issues/7810#issuecomment-2543182046