### PR TITLE
perf(transformer/class-properties): fast path for instance prop initializer scope re-parenting

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 110/124
+Passed: 110/125
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,24 @@ Passed: 110/124
 * regexp
 
 
-# babel-plugin-transform-class-properties (11/13)
+# babel-plugin-transform-class-properties (11/14)
+* instance-prop-initializer-no-existing-constructor/input.js
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Constructor)
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(14): ScopeFlags(StrictMode | Constructor)
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(15): ScopeFlags(StrictMode | Constructor)
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(16): ScopeFlags(StrictMode | Constructor)
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(21): ScopeFlags(StrictMode | Constructor)
+
 * typescript/optional-call/input.ts
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/instance-prop-initializer-no-existing-constructor/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/instance-prop-initializer-no-existing-constructor/input.js
@@ -1,0 +1,33 @@
+class C {
+  function = function() {};
+  functions = [
+    function() {
+      function foo() {}
+    },
+    function() {
+      function foo() {}
+    }
+  ];
+  arrow = () => {};
+  arrows = [() => () => {}, () => () => {}];
+  klass = class {};
+  classExtends = class extends class {} {};
+  classes = [
+    class {
+      method() {
+        class D {}
+      }
+      method2() {
+        class E {}
+      }
+    },
+    class {
+      method() {
+        class D {}
+      }
+      method2() {
+        class E {}
+      }
+    }
+  ];
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/instance-prop-initializer-no-existing-constructor/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/instance-prop-initializer-no-existing-constructor/output.js
@@ -1,0 +1,29 @@
+class C {
+  constructor() {
+    babelHelpers.defineProperty(this, "function", function() {});
+    babelHelpers.defineProperty(this, "functions", [function() {
+      function foo() {}
+    }, function() {
+      function foo() {}
+    }]);
+    babelHelpers.defineProperty(this, "arrow", () => {});
+    babelHelpers.defineProperty(this, "arrows", [() => () => {}, () => () => {}]);
+    babelHelpers.defineProperty(this, "klass", class {});
+    babelHelpers.defineProperty(this, "classExtends", class extends class {} {});
+    babelHelpers.defineProperty(this, "classes", [class {
+      method() {
+        class D {}
+      }
+      method2() {
+        class E {}
+      }
+    }, class {
+      method() {
+        class D {}
+      }
+      method2() {
+        class E {}
+      }
+    }]);
+  }
+}


### PR DESCRIPTION
Add a fast path for inserting instance property initializers into constructor, when no existing constructor or constructor has no bindings. This should be reasonably common.

The `Scope flags mismatch` errors are due to #7900.
