### PR TITLE
perf(ast): faster `Comment::is_jsdoc`

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -104,9 +104,10 @@ impl Comment {
     /// Returns `true` if this comment is a JSDoc comment. Implies `is_leading`
     /// and `is_block`.
     pub fn is_jsdoc(&self, source_text: &str) -> bool {
-        self.is_leading()
-            && self.is_block()
-            && self.content_span().source_text(source_text).starts_with('*')
+        self.is_leading() && self.is_block() && {
+            let span = self.content_span();
+            !span.is_empty() && source_text.as_bytes()[span.start as usize] == b'*'
+        }
     }
 
     /// Legal comments


### PR DESCRIPTION
Small optimization. 

Replace string slice + `starts_with` (at least 3 x bounds checks + 2 x UTF8 character boundary checks) with a single byte read (1 x bounds check).