### PR TITLE
feat(mangler): mangle top level variables

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -6,7 +6,7 @@ use oxc_span::CompactStr;
 
 type Slot = usize;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct MangleOptions {
     pub top_level: bool,
     pub debug: bool,

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -38,6 +38,8 @@ fn main() -> std::io::Result<()> {
 fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let mangler = Mangler::new().with_options(MangleOptions { debug, top_level: source_type.is_module() }).build(&ret.program);
+    let mangler = Mangler::new()
+        .with_options(MangleOptions { debug, top_level: source_type.is_module() })
+        .build(&ret.program);
     CodeGenerator::new().with_mangler(Some(mangler)).build(&ret.program).code
 }

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -38,6 +38,6 @@ fn main() -> std::io::Result<()> {
 fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let mangler = Mangler::new().with_options(MangleOptions { debug }).build(&ret.program);
+    let mangler = Mangler::new().with_options(MangleOptions { debug, top_level: source_type.is_module() }).build(&ret.program);
     CodeGenerator::new().with_mangler(Some(mangler)).build(&ret.program).code
 }

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{CodeGenerator, CodegenOptions};
+use oxc_mangler::MangleOptions;
 use oxc_minifier::{CompressOptions, Minifier, MinifierOptions};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -47,7 +48,10 @@ fn minify(
 ) -> String {
     let ret = Parser::new(allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let options = MinifierOptions { mangle, compress: CompressOptions::default() };
+    let options = MinifierOptions {
+        mangle: mangle.then(MangleOptions::default),
+        compress: CompressOptions::default(),
+    };
     let ret = Minifier::new(options).build(allocator, &mut program);
     CodeGenerator::new()
         .with_options(CodegenOptions { minify: nospace, ..CodegenOptions::default() })

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -14,16 +14,17 @@ use oxc_ast::ast::Program;
 use oxc_mangler::Mangler;
 
 pub use crate::{ast_passes::CompressorPass, compressor::Compressor, options::CompressOptions};
+pub use oxc_mangler::MangleOptions;
 
 #[derive(Debug, Clone, Copy)]
 pub struct MinifierOptions {
-    pub mangle: bool,
+    pub mangle: Option<MangleOptions>,
     pub compress: CompressOptions,
 }
 
 impl Default for MinifierOptions {
     fn default() -> Self {
-        Self { mangle: true, compress: CompressOptions::default() }
+        Self { mangle: Some(MangleOptions::default()), compress: CompressOptions::default() }
     }
 }
 
@@ -42,8 +43,10 @@ impl Minifier {
 
     pub fn build<'a>(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
         Compressor::new(allocator, self.options.compress).build(program);
-        // TODO: pass top_level to mangler
-        let mangler = self.options.mangle.then(|| Mangler::default().build(program));
+        let mangler = self
+            .options
+            .mangle
+            .map(|options| Mangler::default().with_options(options).build(program));
         MinifierReturn { mangler }
     }
 }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -42,6 +42,7 @@ impl Minifier {
 
     pub fn build<'a>(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
         Compressor::new(allocator, self.options.compress).build(program);
+        // TODO: pass top_level to mangler
         let mangler = self.options.mangle.then(|| Mangler::default().build(program));
         MinifierReturn { mangler }
     }

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -2,16 +2,16 @@ use std::fmt::Write;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::CodeGenerator;
-use oxc_mangler::Mangler;
+use oxc_mangler::{MangleOptions, Mangler};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-fn mangle(source_text: &str) -> String {
+fn mangle(source_text: &str, top_level: bool) -> String {
     let allocator = Allocator::default();
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = ret.program;
-    let mangler = Mangler::new().build(&program);
+    let mangler = Mangler::new().with_options(MangleOptions { debug: false, top_level }).build(&program);
     CodeGenerator::new().with_mangler(Some(mangler)).build(&program).code
 }
 
@@ -25,9 +25,17 @@ fn mangler() {
         "import { x } from 's'; export { x }",
         "function _ (exports) { Object.defineProperty(exports, '__esModule', { value: true }) }",
     ];
+    let top_level_cases = [
+        "function foo(a) {a}",
+    ];
 
-    let snapshot = cases.into_iter().fold(String::new(), |mut w, case| {
-        write!(w, "{case}\n{}\n", mangle(case)).unwrap();
+    let mut snapshot = String::new();
+    cases.into_iter().fold(&mut snapshot, |w, case| {
+        write!(w, "{case}\n{}\n", mangle(case, false)).unwrap();
+        w
+    });
+    top_level_cases.into_iter().fold(&mut snapshot, |w, case| {
+        write!(w, "{case}\n{}\n", mangle(case, true)).unwrap();
         w
     });
 

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -11,7 +11,8 @@ fn mangle(source_text: &str, top_level: bool) -> String {
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = ret.program;
-    let mangler = Mangler::new().with_options(MangleOptions { debug: false, top_level }).build(&program);
+    let mangler =
+        Mangler::new().with_options(MangleOptions { debug: false, top_level }).build(&program);
     CodeGenerator::new().with_mangler(Some(mangler)).build(&program).code
 }
 
@@ -25,9 +26,7 @@ fn mangler() {
         "import { x } from 's'; export { x }",
         "function _ (exports) { Object.defineProperty(exports, '__esModule', { value: true }) }",
     ];
-    let top_level_cases = [
-        "function foo(a) {a}",
-    ];
+    let top_level_cases = ["function foo(a) {a}"];
 
     let mut snapshot = String::new();
     cases.into_iter().fold(&mut snapshot, |w, case| {

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -30,3 +30,8 @@ function _ (exports) { Object.defineProperty(exports, '__esModule', { value: tru
 function _(exports) {
 	Object.defineProperty(exports, "__esModule", { value: true });
 }
+
+function foo(a) {a}
+function a(b) {
+	b;
+}

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -13,8 +13,7 @@ use oxc::{
     allocator::Allocator,
     ast::{ast::Program, Comment as OxcComment, CommentKind, Visit},
     codegen::{CodeGenerator, CodegenOptions},
-    mangler::MangleOptions,
-    minifier::{CompressOptions, Minifier, MinifierOptions},
+    minifier::{CompressOptions, Minifier, MinifierOptions, MangleOptions},
     parser::{ParseOptions, Parser, ParserReturn},
     semantic::{
         dot::{DebugDot, DebugDotContext},

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -13,7 +13,7 @@ use oxc::{
     allocator::Allocator,
     ast::{ast::Program, Comment as OxcComment, CommentKind, Visit},
     codegen::{CodeGenerator, CodegenOptions},
-    minifier::{CompressOptions, Minifier, MinifierOptions, MangleOptions},
+    minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions},
     parser::{ParseOptions, Parser, ParserReturn},
     semantic::{
         dot::{DebugDot, DebugDotContext},

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -13,6 +13,7 @@ use oxc::{
     allocator::Allocator,
     ast::{ast::Program, Comment as OxcComment, CommentKind, Visit},
     codegen::{CodeGenerator, CodegenOptions},
+    mangler::MangleOptions,
     minifier::{CompressOptions, Minifier, MinifierOptions},
     parser::{ParseOptions, Parser, ParserReturn},
     semantic::{
@@ -269,7 +270,7 @@ impl Oxc {
         {
             let compress_options = minifier_options.compress_options.unwrap_or_default();
             let options = MinifierOptions {
-                mangle: minifier_options.mangle.unwrap_or_default(),
+                mangle: minifier_options.mangle.unwrap_or_default().then(MangleOptions::default),
                 compress: if minifier_options.compress.unwrap_or_default() {
                     CompressOptions {
                         drop_console: compress_options.drop_console,

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
-use oxc_minifier::{CompressOptions, Minifier, MinifierOptions};
+use oxc_minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -14,10 +14,12 @@ pub fn minify(filename: String, source_text: String) -> String {
 
     let mut program = Parser::new(&allocator, &source_text, source_type).parse().program;
 
-    let mangler =
-        Minifier::new(MinifierOptions { mangle: true, compress: CompressOptions::default() })
-            .build(&allocator, &mut program)
-            .mangler;
+    let mangler = Minifier::new(MinifierOptions {
+        mangle: Some(MangleOptions::default()),
+        compress: CompressOptions::default(),
+    })
+    .build(&allocator, &mut program)
+    .mangler;
 
     Codegen::new()
         .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -183,7 +183,7 @@ impl Test262RuntimeCase {
         }
 
         let mangler = if minify {
-            Minifier::new(MinifierOptions { mangle: false, ..MinifierOptions::default() })
+            Minifier::new(MinifierOptions { mangle: None, ..MinifierOptions::default() })
                 .build(&allocator, &mut program)
                 .mangler
         } else {

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -8,7 +8,7 @@ use flate2::{write::GzEncoder, Compression};
 use humansize::{format_size, DECIMAL};
 use oxc_allocator::Allocator;
 use oxc_codegen::{CodeGenerator, CodegenOptions};
-use oxc_minifier::{CompressOptions, Minifier, MinifierOptions};
+use oxc_minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_tasks_common::{project_root, TestFile, TestFiles};
@@ -115,7 +115,10 @@ pub fn run() -> Result<(), io::Error> {
 
 fn minify_twice(file: &TestFile) -> String {
     let source_type = SourceType::from_path(&file.file_name).unwrap();
-    let options = MinifierOptions { mangle: true, compress: CompressOptions::default() };
+    let options = MinifierOptions {
+        mangle: Some(MangleOptions::default()),
+        compress: CompressOptions::default(),
+    };
     let source_text1 = minify(&file.source_text, source_type, options);
     let source_text2 = minify(&source_text1, source_type, options);
     assert!(source_text1 == source_text2, "Minification failed for {}", &file.file_name);


### PR DESCRIPTION
Adds `top_level` option which is similar to [terser's `toplevel` option](https://terser.org/docs/cli-usage/#cli-mangle-options).