### PR TITLE
feat(minifier): fold bitwise operation

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 173.90 kB  | 61.61 kB   | 59.82 kB   | 19.55 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 92.61 kB   | 90.07 kB   | 32.27 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 92.60 kB   | 90.07 kB   | 32.26 kB   | 31.95 kB   | jquery.js 
 
 342.15 kB  | 121.79 kB  | 118.14 kB  | 44.59 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 73.37 kB   | 72.48 kB   | 26.13 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 276.22 kB  | 270.13 kB  | 91.15 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 276.15 kB  | 270.13 kB  | 91.13 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 467.14 kB  | 458.89 kB  | 126.74 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 662.69 kB  | 646.76 kB  | 164.02 kB  | 163.73 kB  | three.js  
+1.25 MB    | 662.53 kB  | 646.76 kB  | 163.97 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 740.94 kB  | 724.14 kB  | 181.49 kB  | 181.07 kB  | victory.js
+2.14 MB    | 740.87 kB  | 724.14 kB  | 181.46 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.02 MB    | 1.01 MB    | 332.09 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.02 MB    | 1.01 MB    | 332.10 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.39 MB    | 2.31 MB    | 496.17 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.56 MB    | 3.49 MB    | 911.37 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.55 MB    | 3.49 MB    | 910.45 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
This PR implements constant evaluation for bitwise operations (`&`, `|`, `^`).

I wanted to play around with the minifier a bit 🙂