### PR TITLE
feat(transformer/class-properties): do not create temp var for template literal computed key

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
@@ -112,6 +112,12 @@ fn key_needs_temp_var(key: &Expression, ctx: &TraverseCtx) -> bool {
         | Expression::BigIntLiteral(_)
         | Expression::RegExpLiteral(_)
         | Expression::StringLiteral(_) => false,
+        // Template literal cannot have side effects if it has no expressions.
+        // If it *does* have expressions, but they're all literals, then also cannot have side effects,
+        // but don't bother checking for that as it shouldn't occur in real world code.
+        // Why would you write "`x${9}z`" when you can just write "`x9z`"?
+        // Note: "`x${foo}`" *can* have side effects if `foo` is an object with a `valueOf` method.
+        Expression::TemplateLiteral(lit) => !lit.expressions.is_empty(),
         // `IdentifierReference`s can have side effects if is unbound.
         //
         // If var is mutated, it also needs a temp var, because of cases like


### PR DESCRIPTION
Do not create temp var for computed key which is `TemplateLiteral` with no expressions. Evaluating such a template literal cannot have side effects.

```js
class C {
  [`foo`] = 1;
}
```

But this *can* have side effects:

```js
class C {
  [`foo${bar}`] = 1;
}
```