### PR TITLE
perf(sourcemap): improve perf of `search_original_line_and_column`

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -142,7 +142,7 @@ impl SourcemapBuilder {
         // This is a hot path. When building sourcemaps, typically, positions are accessed in increasing order.
         // e.g. if the last call to this function looked at position `n`, the next call will likely be for `n+1`.
         if position >= lines[idx].byte_offset_to_start_of_line {
-            let cap = (idx + 20).min(lines.len() - 1);
+            let cap = (idx + 16).min(lines.len() - 1);
             while idx + 1 < cap && lines[idx + 1].byte_offset_to_start_of_line <= position {
                 idx += 1;
             }
@@ -152,7 +152,7 @@ impl SourcemapBuilder {
                     .saturating_sub(1);
             }
         } else {
-            let cap = idx.saturating_sub(20);
+            let cap = idx.saturating_sub(16);
             while idx > cap && lines[idx].byte_offset_to_start_of_line > position {
                 idx -= 1;
             }

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,4 +1,8 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    cmp::{max, min},
+    path::Path,
+    sync::Arc,
+};
 
 use nonmax::NonMaxU32;
 use oxc_index::{Idx, IndexVec};
@@ -168,8 +172,8 @@ impl SourcemapBuilder {
         let lines = &self.line_offset_tables.lines;
         let mut idx = self.last_line_lookup;
 
-        let cap = (idx + 16).min(lines.len() - 1);
-        idx = (idx + 1).min(cap);
+        let cap = min(idx + 16, lines.len() - 1);
+        idx = min(idx + 1, cap);
         while idx < cap && lines[idx].byte_offset_to_start_of_line <= position {
             idx += 1;
         }
@@ -188,7 +192,7 @@ impl SourcemapBuilder {
         let mut idx = self.last_line_lookup;
 
         let cap = idx.saturating_sub(16);
-        idx = idx.saturating_sub(1).max(cap);
+        idx = max(idx.saturating_sub(1), cap);
         while idx > cap && lines[idx].byte_offset_to_start_of_line > position {
             idx -= 1;
         }

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -136,7 +136,7 @@ impl SourcemapBuilder {
 
     #[allow(clippy::cast_possible_truncation)]
     fn search_original_line_and_column(&mut self, position: u32) -> (u32, u32) {
-        let original_line = self.search_line_index(position);
+        let original_line = self.search_original_line(position);
 
         // Store line index as starting point for next search
         self.last_line_lookup = original_line;
@@ -153,7 +153,7 @@ impl SourcemapBuilder {
         (original_line as u32, original_column)
     }
 
-    fn search_line_index(&mut self, position: u32) -> usize {
+    fn search_original_line(&mut self, position: u32) -> usize {
         let lines = &self.line_offset_tables.lines;
         let mut idx = self.last_line_lookup;
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -136,13 +136,12 @@ impl SourcemapBuilder {
 
     #[allow(clippy::cast_possible_truncation)]
     fn search_original_line_and_column(&mut self, position: u32) -> (u32, u32) {
-        let idx = self.search_line_index(position);
+        let original_line = self.search_line_index(position);
 
-        self.last_line_lookup = idx;
+        // Store line index as starting point for next search
+        self.last_line_lookup = original_line;
 
-        let lines = &self.line_offset_tables.lines;
-
-        let line = &lines[idx];
+        let line = &self.line_offset_tables.lines[original_line];
         let mut original_column = position - line.byte_offset_to_start_of_line;
         if let Some(column_offsets_id) = line.column_offsets_id {
             let column_offsets = &self.line_offset_tables.column_offsets[column_offsets_id];
@@ -151,7 +150,7 @@ impl SourcemapBuilder {
                     [(original_column - column_offsets.byte_offset_to_first) as usize];
             }
         }
-        (idx as u32, original_column)
+        (original_line as u32, original_column)
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -153,7 +153,7 @@ impl SourcemapBuilder {
         (original_line as u32, original_column)
     }
 
-    fn search_original_line(&mut self, position: u32) -> usize {
+    fn search_original_line(&self, position: u32) -> usize {
         let lines = &self.line_offset_tables.lines;
         let mut idx = self.last_line_lookup;
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -157,6 +157,13 @@ impl SourcemapBuilder {
         (original_line as u32, original_column)
     }
 
+    /// Find line index for byte index `position`, using line offset table.
+    ///
+    /// Usually output code is roughly in same order as it was in original source,
+    /// so line will be close to the line found in last call to this function.
+    ///
+    /// So do fast linear search first over a few lines, and fallback to slower binary search
+    /// if this doesn't find the line.
     fn search_original_line(&self, position: u32) -> usize {
         let lines = &self.line_offset_tables.lines;
         let idx = self.last_line_lookup;

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -343,7 +343,8 @@ impl SourcemapBuilder {
 
         if position >= lines[idx].byte_offset_to_start_of_line {
             let cap = (idx + 16).min(lines.len() - 1);
-            while idx + 1 < cap && lines[idx + 1].byte_offset_to_start_of_line <= position {
+            idx = (idx + 1).min(cap);
+            while idx < cap && lines[idx].byte_offset_to_start_of_line <= position {
                 idx += 1;
             }
             if lines[idx].byte_offset_to_start_of_line > position {
@@ -353,6 +354,7 @@ impl SourcemapBuilder {
             }
         } else {
             let cap = idx.saturating_sub(16);
+            idx = idx.saturating_sub(1).max(cap);
             while idx > cap && lines[idx].byte_offset_to_start_of_line > position {
                 idx -= 1;
             }

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::print_stdout)]
-use std::{hint::black_box, path::Path};
+use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_codegen::{CodeGenerator, CodegenOptions};
+use oxc_codegen::CodeGenerator;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -19,7 +19,7 @@ fn main() {
         args.opt_value_from_str("--babel-options").unwrap_or(None);
     let targets: Option<String> = args.opt_value_from_str("--targets").unwrap_or(None);
     let target: Option<String> = args.opt_value_from_str("--target").unwrap_or(None);
-    let name = args.free_from_str().unwrap_or_else(|_| "checker.ts".to_string());
+    let name = args.free_from_str().unwrap_or_else(|_| "test.js".to_string());
 
     let path = Path::new(&name);
     let source_text =
@@ -37,8 +37,8 @@ fn main() {
         }
     }
 
-    //println!("Original:\n");
-    //println!("{source_text}\n");
+    println!("Original:\n");
+    println!("{source_text}\n");
 
     let mut program = ret.program;
 
@@ -72,8 +72,6 @@ fn main() {
         TransformOptions::enable_all()
     };
 
-    //    dbg!(&transform_options);
-
     transform_options.helper_loader.mode = HelperLoaderMode::External;
 
     let ret = Transformer::new(&allocator, path, &transform_options).build_with_symbols_and_scopes(
@@ -89,17 +87,8 @@ fn main() {
             println!("{error:?}");
         }
     }
-    let start = std::time::Instant::now();
 
-    let printed = CodeGenerator::new()
-        .with_options(CodegenOptions {
-            source_map_path: Some(path.to_path_buf()),
-            ..CodegenOptions::default()
-        })
-        .build(&program)
-        .code;
-
-    black_box(printed);
-
-    println!("Time: {:?}", start.elapsed());
+    let printed = CodeGenerator::new().build(&program).code;
+    println!("Transformed:\n");
+    println!("{printed}");
 }


### PR DESCRIPTION
this seems to show a decent speed up on perf.
the thinking behind this change is:
 1. subsequent calls to `search_original_line_and_column` will **never** look at back at lines it has already searched
 2. binary search is faster in this case as typically `idx` is only increased by a small amount

Given this, we can skip checking a bunch of lines (that will never return true) improving performance.

This is a very hot path. 


```
$ hyperfine --warmup=3 ./target/release-with-debug/examples/sourcemap-main ./target/release-with-debug/examples/sourcemap
Benchmark 1: ./target/release-with-debug/examples/sourcemap-main
  Time (mean ± σ):      79.5 ms ±   5.5 ms    [User: 65.1 ms, System: 12.2 ms]
  Range (min … max):    76.8 ms … 111.7 ms    37 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./target/release-with-debug/examples/sourcemap
  Time (mean ± σ):      72.9 ms ±   0.9 ms    [User: 59.2 ms, System: 12.2 ms]
  Range (min … max):    70.6 ms …  75.0 ms    40 runs
 
Summary
  ./target/release-with-debug/examples/sourcemap ran
    1.09 ± 0.08 times faster than ./target/release-with-debug/examples/sourcemap-main
```