### PR TITLE
fix(mangler): keep exported symbols for `top_level: true`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "oxc_index",
  "oxc_semantic",
  "oxc_span",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -26,3 +26,4 @@ oxc_ast = { workspace = true }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+rustc-hash = { workspace = true }

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -26,7 +26,13 @@ fn mangler() {
         "import { x } from 's'; export { x }",
         "function _ (exports) { Object.defineProperty(exports, '__esModule', { value: true }) }",
     ];
-    let top_level_cases = ["function foo(a) {a}"];
+    let top_level_cases = [
+        "function foo(a) {a}",
+        "export function foo() {}; foo()",
+        "export default function foo() {}; foo()",
+        "export const foo = 1; foo",
+        "const foo = 1; foo; export { foo }",
+    ];
 
     let mut snapshot = String::new();
     cases.into_iter().fold(&mut snapshot, |w, case| {

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -37,10 +37,9 @@ function a(b) {
 }
 
 export function foo() {}; foo()
-function a() {}
+export function foo() {}
 ;
-a();
-export { a as foo };
+foo();
 
 export default function foo() {}; foo()
 export default function a() {}
@@ -48,9 +47,8 @@ export default function a() {}
 a();
 
 export const foo = 1; foo
-export const a = 1;
-a;
-export { a as foo };
+export const foo = 1;
+foo;
 
 const foo = 1; foo; export { foo }
 const a = 1;

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -35,3 +35,24 @@ function foo(a) {a}
 function a(b) {
 	b;
 }
+
+export function foo() {}; foo()
+function a() {}
+;
+a();
+export { a as foo };
+
+export default function foo() {}; foo()
+export default function a() {}
+;
+a();
+
+export const foo = 1; foo
+export const a = 1;
+a;
+export { a as foo };
+
+const foo = 1; foo; export { foo }
+const a = 1;
+a;
+export { a as foo };


### PR DESCRIPTION
~~I'm not going to work on a fix for a while so feel free to fix it if anyone wants to work on it.~~

Exported symbols are now not mangled.
