### PR TITLE
fix(semantic): remove inherting `ScopeFlags::Modifiers` from parent scope

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -41,8 +41,19 @@ impl Rule for NoSetterReturn {
         let AstKind::ReturnStatement(stmt) = node.kind() else {
             return;
         };
-        if stmt.argument.is_some() && ctx.scopes().get_flags(node.scope_id()).is_set_accessor() {
-            ctx.diagnostic(no_setter_return_diagnostic(stmt.span));
+        if stmt.argument.is_none() {
+            return;
+        }
+
+        for scope_id in ctx.scopes().ancestors(node.scope_id()) {
+            let flags = ctx.scopes().get_flags(scope_id);
+            if flags.is_set_accessor() {
+                ctx.diagnostic(no_setter_return_diagnostic(stmt.span));
+            } else if flags.is_function() {
+                break;
+            } else {
+                continue;
+            }
         }
     }
 }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -143,21 +143,9 @@ impl ScopeTree {
     }
 
     /// Get [`ScopeFlags`] for a new child scope under `parent_scope_id`.
-    pub fn get_new_scope_flags(
-        &self,
-        mut flags: ScopeFlags,
-        parent_scope_id: ScopeId,
-    ) -> ScopeFlags {
+    pub fn get_new_scope_flags(&self, flags: ScopeFlags, parent_scope_id: ScopeId) -> ScopeFlags {
         // https://tc39.es/ecma262/#sec-strict-mode-code
-        let parent_scope_flags = self.get_flags(parent_scope_id);
-        flags |= parent_scope_flags & ScopeFlags::StrictMode;
-
-        // inherit flags for non-function scopes
-        if !flags.contains(ScopeFlags::Function) {
-            flags |= parent_scope_flags & ScopeFlags::Modifiers;
-        }
-
-        flags
+        flags | self.get_flags(parent_scope_id) & ScopeFlags::StrictMode
     }
 
     #[inline]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -54767,7 +54767,7 @@ Bindings mismatch:
 after transform: ScopeId(32): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(24): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(32): ScopeFlags(StrictMode | Constructor)
+after transform: ScopeId(32): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(24): ScopeFlags(StrictMode | Function)
 Bindings mismatch:
 after transform: ScopeId(34): ["C", "E"]
@@ -54785,7 +54785,7 @@ Bindings mismatch:
 after transform: ScopeId(38): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(30): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(38): ScopeFlags(StrictMode | GetAccessor)
+after transform: ScopeId(38): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(30): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 110/125
+Passed: 111/125
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,24 +16,7 @@ Passed: 110/125
 * regexp
 
 
-# babel-plugin-transform-class-properties (11/14)
-* instance-prop-initializer-no-existing-constructor/input.js
-Scope flags mismatch:
-after transform: ScopeId(12): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Constructor)
-Scope flags mismatch:
-after transform: ScopeId(13): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(14): ScopeFlags(StrictMode | Constructor)
-Scope flags mismatch:
-after transform: ScopeId(14): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(15): ScopeFlags(StrictMode | Constructor)
-Scope flags mismatch:
-after transform: ScopeId(15): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(16): ScopeFlags(StrictMode | Constructor)
-Scope flags mismatch:
-after transform: ScopeId(20): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(21): ScopeFlags(StrictMode | Constructor)
-
+# babel-plugin-transform-class-properties (12/14)
 * typescript/optional-call/input.ts
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]


### PR DESCRIPTION
close: #7900

After #4283 changed, we don't need to inherit `ScopeFlags` from the `constructor`, `set`, `get` anymore, I think this is a logic of forgetting to remove