### PR TITLE
refactor(semantic): remove `ScopeFlags::Modifiers`

### DIFF
--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -74,7 +74,6 @@ bitflags! {
         const SetAccessor      = 1 << 8;
         const CatchClause      = 1 << 9;
         const Var = Self::Top.bits() | Self::Function.bits() | Self::ClassStaticBlock.bits() | Self::TsModuleBlock.bits();
-        const Modifiers = Self::Constructor.bits() | Self::GetAccessor.bits() | Self::SetAccessor.bits();
     }
 }
 


### PR DESCRIPTION
#7932 removed the only usage of `ScopeFlags::Modifiers`. So we don't need it any more. Remove it.