### PR TITLE
fix(wasm): use `ScopeTree`'s flags rather than `enter_scope`'s flags parameter

### DIFF
--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -378,8 +378,9 @@ impl Oxc {
         }
 
         impl Visit<'_> for ScopesTextWriter<'_> {
-            fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
+            fn enter_scope(&mut self, _: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
                 let scope_id = scope_id.get().unwrap();
+                let flags = self.scopes.get_flags(scope_id);
                 self.write_line(format!("Scope {} ({flags:?}) {{", scope_id.index()));
                 self.indent_in();
 


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/issues/7900#issuecomment-2545374960