### PR TITLE
test(transformer/class-properties): add static super tagged template test

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 112/126
+Passed: 112/127
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,10 @@ Passed: 112/126
 * regexp
 
 
-# babel-plugin-transform-class-properties (13/15)
+# babel-plugin-transform-class-properties (13/16)
+* static-super-tagged-template/input.js
+x Output mismatch
+
 * typescript/optional-call/input.ts
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,4 +2,10 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 3 of 3 (100.00%)
+Passed: 3 of 4 (75.00%)
+
+Failures:
+
+./fixtures/oxc/babel-plugin-transform-class-properties-test-fixtures-static-super-tagged-template-exec.test.js
+AssertionError: expected undefined to be [Function C] // Object.is equality
+    at ./tasks/transform_conformance/fixtures/oxc/babel-plugin-transform-class-properties-test-fixtures-static-super-tagged-template-exec.test.js:15:17

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/exec.js
@@ -1,0 +1,11 @@
+class S {
+  static method() {
+    return this;
+  }
+}
+
+class C extends S {
+  static prop = super.method`xyz`;
+}
+
+expect(C.prop).toBe(C);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/input.js
@@ -1,0 +1,11 @@
+class S {
+  static method() {
+    return this;
+  }
+}
+
+class C extends S {
+  static prop = super.method`xyz`;
+}
+
+expect(C.prop).toBe(C);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-tagged-template/output.js
@@ -1,0 +1,13 @@
+var _C;
+
+class S {
+  static method() {
+    return this;
+  }
+}
+
+class C extends S {}
+_C = C;
+babelHelpers.defineProperty(C, "prop", babelHelpers.superPropGet(_C, "method", _C).bind(_C)`xyz`);
+
+expect(C.prop).toBe(C);


### PR DESCRIPTION
I just found that we don't need to transform `TaggedTemplateExpression` because its `tag` can be transformed by `transform_static_member_expression` and `transform_computed_member_expression`
