### PR TITLE
refactor(transformer/class-properties): methods take `&self` where possible

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -418,7 +418,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     #[inline]
     #[expect(clippy::needless_pass_by_value)]
     fn transform_static_assignment_expression(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         prop_binding: BoundIdentifier<'a>,
         class_binding: BoundIdentifier<'a>,
@@ -577,7 +577,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     #[inline]
     #[expect(clippy::needless_pass_by_value)]
     fn transform_instance_assignment_expression(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         prop_binding: BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,


### PR DESCRIPTION
These 2 methods don't need to take `&mut self`.