### PR TITLE
feat(span): add `impl From<ArenaString> for Atom`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -84,7 +84,7 @@ impl<'a> AstBuilder<'a> {
     /// Allocate an [`Atom`] from a string slice.
     #[inline]
     pub fn atom(self, value: &str) -> Atom<'a> {
-        Atom::from(String::from_str_in(value, self.allocator).into_bump_str())
+        Atom::from_in(value, self.allocator)
     }
 
     /// # SAFETY

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -73,7 +73,7 @@ impl<'alloc> FromIn<'alloc, &Atom<'alloc>> for Atom<'alloc> {
 
 impl<'alloc> FromIn<'alloc, &str> for Atom<'alloc> {
     fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {
-        Self::from(oxc_allocator::String::from_str_in(s, allocator).into_bump_str())
+        Self::from(oxc_allocator::String::from_str_in(s, allocator))
     }
 }
 
@@ -98,6 +98,12 @@ impl<'alloc> FromIn<'alloc, Cow<'_, str>> for Atom<'alloc> {
 impl<'a> From<&'a str> for Atom<'a> {
     fn from(s: &'a str) -> Self {
         Self(s)
+    }
+}
+
+impl<'alloc> From<oxc_allocator::String<'alloc>> for Atom<'alloc> {
+    fn from(s: oxc_allocator::String<'alloc>) -> Self {
+        Self::from(s.into_bump_str())
     }
 }
 

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -298,7 +298,7 @@ impl<'a> HelperLoaderStore<'a> {
         source.push_str(&self.module_name);
         source.push_str("/helpers/");
         source.push_str(helper_name);
-        Atom::from(source.into_bump_str())
+        Atom::from(source)
     }
 
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -269,7 +269,7 @@ impl<'a> Keys<'a> {
         let mut key = ArenaString::with_capacity_in(num_str.len() + 1, ctx.ast.allocator);
         key.push('_');
         key.push_str(num_str);
-        let key = Atom::from(key.into_bump_str());
+        let key = Atom::from(key);
 
         self.numbered.push(&key.as_str()[1..]);
 


### PR DESCRIPTION
Add conversion method from `oxc_allocator::String` to `Atom`. This is a zero-cost conversion, because the string is already in the arena.