### PR TITLE
feat(ast): add `AstBuilder::atom_from_cow`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -6,7 +6,7 @@
 )]
 #![warn(missing_docs)]
 
-use std::mem;
+use std::{borrow::Cow, mem};
 
 use oxc_allocator::{Allocator, Box, FromIn, String, Vec};
 use oxc_span::{Atom, GetSpan, Span, SPAN};
@@ -85,6 +85,20 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn atom(self, value: &str) -> Atom<'a> {
         Atom::from_in(value, self.allocator)
+    }
+
+    /// Convert a [`Cow<'a, str>`] to an [`Atom<'a>`].
+    ///
+    /// If the `Cow` borrows a string from arena, returns an `Atom` which references that same string,
+    /// without allocating a new one.
+    ///
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Atom`.
+    #[inline]
+    pub fn atom_from_cow(self, value: &Cow<'a, str>) -> Atom<'a> {
+        match value {
+            Cow::Borrowed(s) => Atom::from(*s),
+            Cow::Owned(s) => self.atom(s),
+        }
     }
 
     /// # SAFETY


### PR DESCRIPTION
Various methods e.g. `PropertyKey::static_name` return a `Cow<'a, str>`.

When we need to create an `Atom` from such a `Cow`, we can avoid reallocating the string into arena again if the `Cow` already borrows an arena string. The `Atom` can reference that same string, rather than making another copy of it in arena.

Add `AstBuilder::atom_from_cow` method for this purpose.