### PR TITLE
refactor(transformer/class-properties): simplify logic for when to create temp binding

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -257,17 +257,20 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 .insert_many_after(&stmt_address, self.insert_after_stmts.drain(..));
         }
 
-        // Update class bindings prior to traversing class body and insertion of statements/expressions
-        // before/after the class. See comments on `ClassBindings`.
+        // Flag that static private fields should be transpiled using name binding,
+        // while traversing class body.
+        //
         // Static private fields reference class name (not temp var) in class declarations.
         // `class Class { static #prop; method() { return obj.#prop; } }`
         // -> `method() { return _assertClassBrand(Class, obj, _prop)._; }`
         // (note `Class` in `_assertClassBrand(Class, ...)`, not `_Class`)
-        // So set "temp" binding to actual class name while visiting class body.
+        //
+        // Also see comments on `ClassBindings`.
+        //
         // Note: If declaration is `export default class {}` with no name, and class has static props,
         // then class has had name binding created already in `transform_class`.
         // So name binding is always `Some`.
-        class_details.bindings.temp = class_details.bindings.name.clone();
+        class_details.bindings.static_private_fields_use_temp = false;
     }
 
     /// `_classPrivateFieldLooseKey("prop")`

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -88,7 +88,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 Self::create_underscore_member_expression(prop_ident, span, ctx)
             } else {
                 // `_assertClassBrand(Class, object, _prop)._`
-                let class_binding = class_bindings.get_or_init_temp_binding(ctx);
+                let class_binding = class_bindings.get_or_init_static_binding(ctx);
                 let class_ident = class_binding.create_read_expression(ctx);
 
                 self.create_assert_class_brand_underscore(
@@ -282,7 +282,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                     Self::create_underscore_member_expression(prop_ident, field_expr.span, ctx);
                 (callee, object)
             } else {
-                let class_binding = class_bindings.get_or_init_temp_binding(ctx);
+                let class_binding = class_bindings.get_or_init_static_binding(ctx);
                 let class_ident = class_binding.create_read_expression(ctx);
 
                 // Make 2 copies of `object`
@@ -383,7 +383,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             // for shortcut/no shortcut and do the "can we shortcut?" check here.
             // Then only create temp var for the "no shortcut" branch, and clone the resulting binding
             // before passing it to the "no shortcut" method. What a palaver!
-            let class_binding = class_bindings.get_or_init_temp_binding(ctx);
+            let class_binding = class_bindings.get_or_init_static_binding(ctx);
             let class_binding = class_binding.clone();
             let class_symbol_id = class_bindings.name_symbol_id();
 
@@ -792,7 +792,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 let get_expr = Self::create_underscore_member_expression(prop_ident, SPAN, ctx);
                 (get_expr, object, None)
             } else {
-                let class_binding = class_bindings.get_or_init_temp_binding(ctx);
+                let class_binding = class_bindings.get_or_init_static_binding(ctx);
                 let class_ident = class_binding.create_read_expression(ctx);
                 let class_ident2 = class_binding.create_read_expression(ctx);
 

--- a/crates/oxc_transformer/src/es2022/class_properties/supers.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/supers.rs
@@ -137,7 +137,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         is_callee: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let temp_binding = self.current_class_mut().bindings.get_or_init_temp_binding(ctx);
+        let temp_binding = self.current_class_mut().bindings.get_or_init_static_binding(ctx);
 
         let ident1 = Argument::from(temp_binding.create_read_expression(ctx));
         let ident2 = Argument::from(temp_binding.create_read_expression(ctx));


### PR DESCRIPTION
Remove the hack of overwriting temp binding with name binding before traversing class body. Instead decide which binding to use in `ClassBindings::get_or_init_static_binding` based on a flag.

This less performant than what we had before. But it simplifies some confusing logic, and prepares the ground for changes to come where we'll need to duck in and out of static context repeatedly while traversing the class body.