### PR TITLE
fix(transformer/class-properties): do not transform `super.prop` in nested method within static prop initializer

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 111/125
+Passed: 112/126
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 111/125
 * regexp
 
 
-# babel-plugin-transform-class-properties (12/14)
+# babel-plugin-transform-class-properties (13/15)
 * typescript/optional-call/input.ts
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(16)]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-static-prop-initializer/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-static-prop-initializer/input.js
@@ -1,0 +1,37 @@
+class C {
+  static prop = () => {
+    // Transform
+    super.prop;
+    super[prop];
+    super.prop();
+    super[prop]();
+
+    const obj = {
+      method() {
+        // Don't transform
+        super.prop;
+        super[prop];
+        super.prop();
+        super[prop]();
+      }
+    };
+
+    class Inner {
+      method() {
+        // Don't transform
+        super.prop;
+        super[prop];
+        super.prop();
+        super[prop]();
+      }
+
+      static staticMethod() {
+        // Don't transform
+        super.prop;
+        super[prop];
+        super.prop();
+        super[prop]();
+      }
+    }
+  };
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-static-prop-initializer/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-static-prop-initializer/output.js
@@ -1,0 +1,38 @@
+var _C;
+class C {}
+_C = C;
+babelHelpers.defineProperty(C, "prop", () => {
+  // Transform
+  babelHelpers.superPropGet(_C, "prop", _C);
+  babelHelpers.superPropGet(_C, prop, _C);
+  babelHelpers.superPropGet(_C, "prop", _C, 2)([]);
+  babelHelpers.superPropGet(_C, prop, _C, 2)([]);
+
+  const obj = {
+    method() {
+      // Don't transform
+      super.prop;
+      super[prop];
+      super.prop();
+      super[prop]();
+    }
+  };
+
+  class Inner {
+    method() {
+      // Don't transform
+      super.prop;
+      super[prop];
+      super.prop();
+      super[prop]();
+    }
+
+    static staticMethod() {
+      // Don't transform
+      super.prop;
+      super[prop];
+      super.prop();
+      super[prop]();
+    }
+  }
+});


### PR DESCRIPTION
Don't transform `super` in static property initializers if it's nested in another method, so is a *different* `super`.

```js
class C {
  static prop = () => {
    const object = {
      method() {
        // `super` here refers to prototype of `object`, not class `C`
        return super.foo;
      }
    };
  };
}
```