### PR TITLE
refactor(transformer/class-properties): remove `move_expression`s

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -24,10 +24,10 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         // Get value
-        let value = match &mut prop.value {
-            Some(value) => {
-                self.transform_instance_initializer(value, ctx);
-                ctx.ast.move_expression(value)
+        let value = match prop.value.take() {
+            Some(mut value) => {
+                self.transform_instance_initializer(&mut value, ctx);
+                value
             }
             None => ctx.ast.void_0(SPAN),
         };
@@ -90,10 +90,10 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     ) {
         // Get value, and transform it to replace `this` with reference to class name,
         // and transform class fields (`object.#prop`)
-        let value = match &mut prop.value {
-            Some(value) => {
-                self.transform_static_initializer(value, ctx);
-                ctx.ast.move_expression(value)
+        let value = match prop.value.take() {
+            Some(mut value) => {
+                self.transform_static_initializer(&mut value, ctx);
+                value
             }
             None => ctx.ast.void_0(SPAN),
         };


### PR DESCRIPTION
Remove 2 x `move_expression` calls by taking value from `Option` instead. This avoids allocating dummy `Expression`s into arena.