### PR TITLE
refactor(transformer/class-properties): store `is_declaration` only on `ClassDetails`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -455,7 +455,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         // TODO: If static block transform is not enabled, it's possible to construct the class
         // within the static block `class C { static { new C() } }` and that'd run before `_super`
         // is defined. So it needs to go before the class, not after, in that case.
-        let init = if self.is_declaration {
+        let init = if self.current_class().is_declaration {
             Some(super_func)
         } else {
             let assignment = create_assignment(super_binding, super_func, ctx);

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -218,8 +218,6 @@ pub struct ClassProperties<'a, 'ctx> {
 
     // State during transform of class
     //
-    /// `true` for class declaration, `false` for class expression
-    is_declaration: bool,
     /// `true` if temp var for class has been inserted
     temp_var_is_created: bool,
     /// Scope that instance init initializers will be inserted into
@@ -258,7 +256,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             classes_stack: ClassesStack::default(),
             class_expression_addresses_stack: NonEmptyStack::new(Address::DUMMY),
             // Temporary values - overwritten when entering class
-            is_declaration: false,
             temp_var_is_created: false,
             instance_inits_scope_id: ScopeId::new(0),
             instance_inits_constructor_scope_id: None,


### PR DESCRIPTION
`is_declaration` was stored in 2 places. Only store it in `ClassDetails` struct.