### PR TITLE
refactor(transformer/class-properties): store `temp_var_is_created` on `ClassBindings`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -141,7 +141,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         let class_expr = ctx.ast.move_expression(expr);
         if let Some(binding) = &class_details.bindings.temp {
             // Insert `var _Class` statement, if it wasn't already in `transform_class`
-            if !self.temp_var_is_created {
+            if !class_details.bindings.temp_var_is_created {
                 self.ctx.var_declarations.insert_var(binding, ctx);
             }
 
@@ -191,7 +191,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             // Binding for class name is required
             if let Some(ident) = &class.id {
                 // Insert `var _Class` statement, if it wasn't already in `transform_class`
-                if !self.temp_var_is_created {
+                if !class_details.bindings.temp_var_is_created {
                     self.ctx.var_declarations.insert_var(temp_binding, ctx);
                 }
 
@@ -373,7 +373,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         let mut class_name_binding = class.id.as_ref().map(BoundIdentifier::from_binding_ident);
 
         let need_temp_var = has_static_prop && (!is_declaration || class.id.is_none());
-        self.temp_var_is_created = need_temp_var;
 
         let class_temp_binding = if need_temp_var {
             let temp_binding = ClassBindings::create_temp_binding(class_name_binding.as_ref(), ctx);
@@ -393,7 +392,8 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             None
         };
 
-        let class_bindings = ClassBindings::new(class_name_binding, class_temp_binding);
+        let class_bindings =
+            ClassBindings::new(class_name_binding, class_temp_binding, need_temp_var);
 
         // Add entry to `classes_stack`
         self.classes_stack.push(ClassDetails {

--- a/crates/oxc_transformer/src/es2022/class_properties/class_bindings.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_bindings.rs
@@ -45,6 +45,8 @@ pub(super) struct ClassBindings<'a> {
     /// `true` if should use temp binding for references to class in transpiled static private fields,
     /// `false` if can use name binding
     pub static_private_fields_use_temp: bool,
+    /// `true` if temp var for class has been inserted
+    pub temp_var_is_created: bool,
 }
 
 impl<'a> ClassBindings<'a> {
@@ -52,8 +54,14 @@ impl<'a> ClassBindings<'a> {
     pub fn new(
         name_binding: Option<BoundIdentifier<'a>>,
         temp_binding: Option<BoundIdentifier<'a>>,
+        temp_var_is_created: bool,
     ) -> Self {
-        Self { name: name_binding, temp: temp_binding, static_private_fields_use_temp: true }
+        Self {
+            name: name_binding,
+            temp: temp_binding,
+            static_private_fields_use_temp: true,
+            temp_var_is_created,
+        }
     }
 
     /// Get `SymbolId` of name binding.

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -218,8 +218,6 @@ pub struct ClassProperties<'a, 'ctx> {
 
     // State during transform of class
     //
-    /// `true` if temp var for class has been inserted
-    temp_var_is_created: bool,
     /// Scope that instance init initializers will be inserted into
     instance_inits_scope_id: ScopeId,
     /// `ScopeId` of class constructor, if instance init initializers will be inserted into constructor.
@@ -256,7 +254,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             classes_stack: ClassesStack::default(),
             class_expression_addresses_stack: NonEmptyStack::new(Address::DUMMY),
             // Temporary values - overwritten when entering class
-            temp_var_is_created: false,
             instance_inits_scope_id: ScopeId::new(0),
             instance_inits_constructor_scope_id: None,
             // `Vec`s and `FxHashMap`s which are reused for every class being transformed


### PR DESCRIPTION
Move `temp_var_is_created` from main `ClassProperties` object to `ClassBindings`. It makes more sense there.