### PR TITLE
fix(transformer/class-properties): run other transforms on static properties, static blocks, and computed keys

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -10,7 +10,7 @@ use oxc_syntax::{
     scope::ScopeFlags,
     symbol::{SymbolFlags, SymbolId},
 };
-use oxc_traverse::{BoundIdentifier, TraverseCtx};
+use oxc_traverse::{Ancestor, BoundIdentifier, TraverseCtx};
 
 use crate::{common::helper_loader::Helper, TransformCtx};
 
@@ -20,74 +20,465 @@ use super::{
     ClassBindings, ClassDetails, ClassProperties, FxIndexMap, PrivateProp,
 };
 
+// TODO(improve-on-babel): If outer scope is sloppy mode, all code which is moved to outside
+// the class should be wrapped in an IIFE with `'use strict'` directive. Babel doesn't do this.
+
+// TODO: If static blocks transform is disabled, it's possible to get incorrect execution order.
+// ```js
+// class C {
+//     static x = console.log('x');
+//     static {
+//         console.log('block');
+//     }
+//     static y = console.log('y');
+// }
+// ```
+// This logs "x", "block", "y". But in transformed output it'd be "block", "x", "y".
+// Maybe force transform of static blocks if any static properties?
+// Or alternatively could insert static property initializers into static blocks.
+
 impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
-    /// Transform class expression.
-    // `#[inline]` so that compiler sees that `expr` is an `Expression::ClassExpression`.
-    // Main guts of transform is broken out into `transform_class_expression_start` and
-    // `transform_class_expression_finish` to keep this function as small as possible.
-    // Want it to be inlined into `enter_expression` and for `enter_expression` to be inlined into parent.
-    #[inline]
-    pub(super) fn transform_class_expression(
+    /// Perform first phase of transformation of class.
+    ///
+    /// This is the only entry point into the transform upon entering class body.
+    ///
+    /// First we check if any transforms are necessary, and exit if not.
+    ///
+    /// If transform is required:
+    /// * Build a hashmap of private property keys.
+    /// * Push `ClassDetails` containing info about the class to `classes_stack`.
+    /// * Extract instance property initializers (public or private) from class body and insert into
+    ///   class constructor.
+    /// * Temporarily replace computed keys of instance properties with assignments to temp vars.
+    ///   `class C { [foo()] = 123; }` -> `class C { [_foo = foo()]; }`
+    pub(super) fn transform_class_body_on_entry(
+        &mut self,
+        body: &mut ClassBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        // Ignore TS class declarations
+        // TODO: Is this correct?
+        let Ancestor::ClassBody(class) = ctx.parent() else { unreachable!() };
+        if *class.declare() {
+            return;
+        }
+
+        // Get basic details about class
+        let is_declaration = match ctx.ancestor(1) {
+            Ancestor::ExportDefaultDeclarationDeclaration(_)
+            | Ancestor::ExportNamedDeclarationDeclaration(_) => true,
+            grandparent => grandparent.is_parent_of_statement(),
+        };
+
+        let mut class_name_binding = class.id().as_ref().map(BoundIdentifier::from_binding_ident);
+        let class_scope_id = class.scope_id().get().unwrap();
+        let has_super_class = class.super_class().is_some();
+
+        // Check if class has any properties or statick blocks, and locate constructor (if class has one)
+        let mut instance_prop_count = 0;
+        let mut has_static_prop = false;
+        let mut has_static_block = false;
+        // TODO: Store `FxIndexMap`s in a pool and re-use them
+        let mut private_props = FxIndexMap::default();
+        let mut constructor = None;
+        for element in body.body.iter_mut() {
+            match element {
+                ClassElement::PropertyDefinition(prop) => {
+                    // TODO: Throw error if property has decorators
+
+                    // Create binding for private property key
+                    if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
+                        // Note: Current scope is outside class.
+                        let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
+                        private_props.insert(
+                            ident.name.clone(),
+                            PrivateProp { binding, is_static: prop.r#static },
+                        );
+                    }
+
+                    if prop.r#static {
+                        has_static_prop = true;
+                    } else {
+                        instance_prop_count += 1;
+                    }
+
+                    continue;
+                }
+                ClassElement::StaticBlock(_) => {
+                    // Static block only necessitates transforming class if it's being transformed
+                    if self.transform_static_blocks {
+                        has_static_block = true;
+                        continue;
+                    }
+                }
+                ClassElement::MethodDefinition(method) => {
+                    if method.kind == MethodDefinitionKind::Constructor
+                        && method.value.body.is_some()
+                    {
+                        constructor = Some(method);
+                    }
+                }
+                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {
+                    // TODO: Need to handle these?
+                }
+            }
+        }
+
+        // Exit if nothing to transform
+        if instance_prop_count == 0 && !has_static_prop && !has_static_block {
+            self.classes_stack.push(ClassDetails::empty(is_declaration));
+            return;
+        }
+
+        // Initialize class binding vars.
+        // Static prop in class expression or anonymous `export default class {}` always require
+        // temp var for class. Static prop in class declaration doesn't.
+        let need_temp_var = has_static_prop && (!is_declaration || class_name_binding.is_none());
+
+        let outer_hoist_scope_id = ctx.current_hoist_scope_id();
+        let class_temp_binding = if need_temp_var {
+            let temp_binding = ClassBindings::create_temp_binding(
+                class_name_binding.as_ref(),
+                outer_hoist_scope_id,
+                ctx,
+            );
+            if is_declaration {
+                // Anonymous `export default class {}`. Set class name binding to temp var.
+                // Actual class name will be set to this later.
+                class_name_binding = Some(temp_binding.clone());
+            } else {
+                // Create temp var `var _Class;` statement.
+                // TODO(improve-on-babel): Inserting the temp var `var _Class` statement here is only
+                // to match Babel's output. It'd be simpler just to insert it at the end and get rid of
+                // `temp_var_is_created` that tracks whether it's done already or not.
+                self.ctx.var_declarations.insert_var(&temp_binding, ctx);
+            }
+            Some(temp_binding)
+        } else {
+            None
+        };
+
+        let static_private_fields_use_temp = !is_declaration;
+        let class_bindings = ClassBindings::new(
+            class_name_binding,
+            class_temp_binding,
+            outer_hoist_scope_id,
+            static_private_fields_use_temp,
+            need_temp_var,
+        );
+
+        // Add entry to `classes_stack`
+        self.classes_stack.push(ClassDetails {
+            is_declaration,
+            is_transform_required: true,
+            private_props: if private_props.is_empty() { None } else { Some(private_props) },
+            bindings: class_bindings,
+        });
+
+        // Exit if no instance properties (public or private)
+        if instance_prop_count == 0 {
+            return;
+        }
+
+        // Determine where to insert instance property initializers in constructor
+        let instance_inits_insert_location = if let Some(constructor) = constructor {
+            // Existing constructor
+            let constructor = constructor.value.as_mut();
+            if has_super_class {
+                let (insert_scopes, insert_location) =
+                    Self::replace_super_in_constructor(constructor, ctx);
+                self.instance_inits_scope_id = insert_scopes.insert_in_scope_id;
+                self.instance_inits_constructor_scope_id = insert_scopes.constructor_scope_id;
+                insert_location
+            } else {
+                let constructor_scope_id = constructor.scope_id();
+                self.instance_inits_scope_id = constructor_scope_id;
+                // Only record `constructor_scope_id` if constructor's scope has some bindings.
+                // If it doesn't, no need to check for shadowed symbols in instance prop initializers,
+                // because no bindings to clash with.
+                self.instance_inits_constructor_scope_id =
+                    if ctx.scopes().get_bindings(constructor_scope_id).is_empty() {
+                        None
+                    } else {
+                        Some(constructor_scope_id)
+                    };
+                InstanceInitsInsertLocation::ExistingConstructor(0)
+            }
+        } else {
+            // No existing constructor - create scope for one
+            let constructor_scope_id = ctx.scopes_mut().add_scope(
+                Some(class_scope_id),
+                NodeId::DUMMY,
+                ScopeFlags::Function | ScopeFlags::Constructor | ScopeFlags::StrictMode,
+            );
+            self.instance_inits_scope_id = constructor_scope_id;
+            self.instance_inits_constructor_scope_id = None;
+            InstanceInitsInsertLocation::NewConstructor
+        };
+
+        // Extract instance properties initializers.
+        //
+        // We leave the properties themselves in place, but take the initializers.
+        // `class C { prop = 123; }` -> `class { prop; }`
+        // Leave them in place to avoid shifting up all the elements twice.
+        // We already have to do that in exit phase, so better to do it all at once.
+        //
+        // Also replace any instance property computed keys with an assignment to temp var.
+        // `class C { [foo()] = 123; }` -> `class C { [_foo = foo()]; }`
+        // Those assignments will be moved to before class in exit phase of the transform.
+        // -> `_foo = foo(); class C {}`
+        let mut instance_inits = Vec::with_capacity(instance_prop_count);
+        let mut constructor = None;
+        for element in body.body.iter_mut() {
+            #[expect(clippy::match_same_arms)]
+            match element {
+                ClassElement::PropertyDefinition(prop) => {
+                    if !prop.r#static {
+                        self.convert_instance_property(prop, &mut instance_inits, ctx);
+                    }
+                }
+                ClassElement::MethodDefinition(method) => {
+                    if method.kind == MethodDefinitionKind::Constructor
+                        && method.value.body.is_some()
+                    {
+                        constructor = Some(method.value.as_mut());
+                    }
+                }
+                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {
+                    // TODO: Need to handle these?
+                }
+                ClassElement::StaticBlock(_) => {}
+            }
+        }
+
+        // Insert instance initializers into constructor.
+        // Create a constructor if there isn't one.
+        match instance_inits_insert_location {
+            InstanceInitsInsertLocation::NewConstructor => {
+                self.insert_constructor(body, instance_inits, has_super_class, ctx);
+            }
+            InstanceInitsInsertLocation::ExistingConstructor(stmt_index) => {
+                self.insert_inits_into_constructor_as_statements(
+                    constructor.as_mut().unwrap(),
+                    instance_inits,
+                    stmt_index,
+                    ctx,
+                );
+            }
+            InstanceInitsInsertLocation::SuperFnInsideConstructor(super_binding) => {
+                self.create_super_function_inside_constructor(
+                    constructor.as_mut().unwrap(),
+                    instance_inits,
+                    &super_binding,
+                    ctx,
+                );
+            }
+            InstanceInitsInsertLocation::SuperFnOutsideClass(super_binding) => {
+                self.create_super_function_outside_constructor(instance_inits, &super_binding, ctx);
+            }
+        }
+    }
+
+    /// Transform class declaration on exit.
+    ///
+    /// This is the exit phase of the transform. Only applies to class *declarations*.
+    /// Class *expressions* are handled in [`ClassProperties::transform_class_expression_on_exit`] below.
+    /// Both functions do much the same, `transform_class_expression_on_exit` inserts items as expressions,
+    /// whereas here we insert as statements.
+    ///
+    /// At this point, other transforms have had a chance to run on the class body, so we can move
+    /// parts of the code out to before/after the class now.
+    ///
+    /// * Transform static properties and insert after class.
+    /// * Transform static blocks and insert after class.
+    /// * Extract computed key assignments and insert them before class.
+    /// * Remove all properties and static blocks from class body.
+    ///
+    /// Items needing insertion before/after class are inserted as statements.
+    ///
+    /// `class C { static [foo()] = 123; static { bar(); } }`
+    /// -> `_foo = foo(); class C {}; C[_foo] = 123; bar();`
+    pub(super) fn transform_class_declaration_on_exit(
+        &mut self,
+        class: &mut Class<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        // Ignore TS class declarations
+        // TODO: Is this correct?
+        if class.declare {
+            return;
+        }
+
+        // Leave class expressions to `transform_class_expression_on_exit`
+        let class_details = self.current_class_mut();
+        if !class_details.is_declaration {
+            return;
+        }
+
+        // Finish transform
+        if class_details.is_transform_required {
+            self.transform_class_declaration_on_exit_impl(class, ctx);
+        } else {
+            debug_assert!(class_details.bindings.temp.is_none());
+        }
+
+        // Pop off stack. We're done!
+        self.classes_stack.pop();
+    }
+
+    fn transform_class_declaration_on_exit_impl(
+        &mut self,
+        class: &mut Class<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        // Static properties and static blocks
+        self.current_class_mut().bindings.static_private_fields_use_temp = true;
+
+        // Transform static properties, remove static and instance properties, and move computed keys
+        // to before class
+        self.transform_class_elements(class, ctx);
+
+        // Insert temp var for class if required. Name class if required.
+        let class_details = self.classes_stack.last_mut();
+        if let Some(temp_binding) = &class_details.bindings.temp {
+            // Binding for class name is required
+            if let Some(ident) = &class.id {
+                // Insert `var _Class` statement, if it wasn't already in entry phase
+                if !class_details.bindings.temp_var_is_created {
+                    self.ctx.var_declarations.insert_var(temp_binding, ctx);
+                }
+
+                // Insert `_Class = Class` after class.
+                // TODO(improve-on-babel): Could just insert `var _Class = Class;` after class,
+                // rather than separate `var _Class` declaration.
+                let class_name =
+                    BoundIdentifier::from_binding_ident(ident).create_read_expression(ctx);
+                let expr = create_assignment(temp_binding, class_name, ctx);
+                let stmt = ctx.ast.statement_expression(SPAN, expr);
+                self.insert_after_stmts.insert(0, stmt);
+            } else {
+                // Class must be default export `export default class {}`, as all other class declarations
+                // always have a name. Set class name.
+                *ctx.symbols_mut().get_flags_mut(temp_binding.symbol_id) = SymbolFlags::Class;
+                class.id = Some(temp_binding.create_binding_identifier(ctx));
+            }
+        }
+
+        // Insert statements before/after class
+        let stmt_address = match ctx.parent() {
+            parent @ (Ancestor::ExportDefaultDeclarationDeclaration(_)
+            | Ancestor::ExportNamedDeclarationDeclaration(_)) => parent.address(),
+            // `Class` is always stored in a `Box`, so has a stable memory location
+            _ => Address::from_ptr(class),
+        };
+
+        if !self.insert_before.is_empty() {
+            self.ctx.statement_injector.insert_many_before(
+                &stmt_address,
+                exprs_into_stmts(self.insert_before.drain(..), ctx),
+            );
+        }
+
+        if let Some(private_props) = &class_details.private_props {
+            if self.private_fields_as_properties {
+                self.ctx.statement_injector.insert_many_before(
+                    &stmt_address,
+                    private_props.iter().map(|(name, prop)| {
+                        // `var _prop = _classPrivateFieldLooseKey("prop");`
+                        let value = Self::create_private_prop_key_loose(name, self.ctx, ctx);
+                        create_variable_declaration(&prop.binding, value, ctx)
+                    }),
+                );
+            } else {
+                // TODO: Only call `insert_many_before` if some private *instance* props
+                let mut weakmap_symbol_id = None;
+                self.ctx.statement_injector.insert_many_before(
+                    &stmt_address,
+                    private_props.values().filter_map(|prop| {
+                        if prop.is_static {
+                            return None;
+                        }
+
+                        // `var _prop = new WeakMap();`
+                        let value = create_new_weakmap(&mut weakmap_symbol_id, ctx);
+                        Some(create_variable_declaration(&prop.binding, value, ctx))
+                    }),
+                );
+            }
+        }
+
+        if !self.insert_after_stmts.is_empty() {
+            self.ctx
+                .statement_injector
+                .insert_many_after(&stmt_address, self.insert_after_stmts.drain(..));
+        }
+    }
+
+    /// Transform class expression on exit.
+    ///
+    /// This is the exit phase of the transform. Only applies to class *expressions*.
+    /// Class *expressions* are handled in [`ClassProperties::transform_class_declaration_on_exit`] above.
+    /// Both functions do much the same, `transform_class_declaration_on_exit` inserts items as statements,
+    /// whereas here we insert as expressions.
+    ///
+    /// At this point, other transforms have had a chance to run on the class body, so we can move
+    /// parts of the code out to before/after the class now.
+    ///
+    /// * Transform static properties and insert after class.
+    /// * Transform static blocks and insert after class.
+    /// * Extract computed key assignments and insert them before class.
+    /// * Remove all properties and static blocks from class body.
+    ///
+    /// Items needing insertion before/after class are inserted as expressions around, surrounding class
+    /// in a [`SequenceExpression`].
+    ///
+    /// `let C = class { static [foo()] = 123; static { bar(); } };`
+    /// -> `let C = (_foo = foo(), _Class = class {}, _Class[_foo] = 123, bar(), _Class);`
+    pub(super) fn transform_class_expression_on_exit(
         &mut self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         let Expression::ClassExpression(class) = expr else { unreachable!() };
 
-        let class_address = class.address();
-        let expr_count = self.transform_class_expression_start(class, class_address, ctx);
-        if expr_count > 0 {
-            self.transform_class_expression_finish(expr, expr_count, ctx);
+        // Ignore TS class declarations
+        // TODO: Is this correct?
+        if class.declare {
+            return;
         }
+
+        // Finish transform
+        let class_details = self.current_class();
+        if class_details.is_transform_required {
+            self.transform_class_expression_on_exit_impl(expr, ctx);
+        } else {
+            debug_assert!(class_details.bindings.temp.is_none());
+        }
+
+        // Pop off stack. We're done!
+        self.classes_stack.pop();
     }
 
-    fn transform_class_expression_start(
-        &mut self,
-        class: &mut Class<'a>,
-        class_address: Address,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> usize {
-        // Check this class isn't being visited twice
-        if *self.class_expression_addresses_stack.last() == class_address {
-            // This class has already been transformed, and we're now encountering it again
-            // in the sequence expression which was substituted for it. So don't transform it again!
-            // Returning 0 tells `enter_expression` not to call `transform_class_expression_finish` either.
-            self.class_expression_addresses_stack.pop();
-            return 0;
-        }
-
-        self.transform_class(class, false, ctx);
-
-        // Return number of expressions to be inserted before/after the class
-        let mut expr_count = self.insert_before.len() + self.insert_after_exprs.len();
-        if let Some(private_props) = &self.current_class().private_props {
-            expr_count += private_props.len();
-        }
-
-        if expr_count > 0 {
-            // We're going to replace class expression with a sequence expression
-            // `(..., _C = class C {}, ..., _C)`, so this class will be visited again.
-            // Store the `Address` of class in stack. This will cause bail-out when we re-visit it.
-            self.class_expression_addresses_stack.push(class_address);
-        }
-
-        expr_count
-    }
-
-    /// Insert expressions before/after the class.
-    /// `C = class { [x()] = 1; static y = 2 };`
-    /// -> `C = (_x = x(), _Class = class C { constructor() { this[_x] = 1; } }, _Class.y = 2, _Class)`
-    fn transform_class_expression_finish(
+    fn transform_class_expression_on_exit_impl(
         &mut self,
         expr: &mut Expression<'a>,
-        mut expr_count: usize,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        let Expression::ClassExpression(class) = expr else { unreachable!() };
+
+        // Transform static properties, remove static and instance properties, and move computed keys
+        // to before class
+        self.transform_class_elements(class, ctx);
+
+        // Insert expressions before / after class.
+        // `C = class { [x()] = 1; static y = 2 };`
+        // -> `C = (_x = x(), _Class = class C { constructor() { this[_x] = 1; } }, _Class.y = 2, _Class)`
+
         // TODO: Name class if had no name, and name is statically knowable (as in example above).
         // If class name shadows var which is referenced within class, rename that var.
         // `var C = class { prop = C }; var C2 = C;`
         // -> `var _C = class C { constructor() { this.prop = _C; } }; var C2 = _C;`
-        // This is really difficult as need to rename all references too to that binding too,
+        // This is really difficult as need to rename all references to that binding too,
         // which can be very far above the class in AST, when it's a `var`.
         // Maybe for now only add class name if it doesn't shadow a var used within class?
 
@@ -95,6 +486,17 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         // Or maybe should store count and increment it when create private static props?
         // They're probably pretty rare, so it'll be rarely used.
         let class_details = self.classes_stack.last();
+
+        let mut expr_count = self.insert_before.len() + self.insert_after_exprs.len();
+        if let Some(private_props) = &class_details.private_props {
+            expr_count += private_props.len();
+        }
+
+        // Exit if no expressions to insert before or after class
+        if expr_count == 0 {
+            return;
+        }
+
         expr_count += 1 + usize::from(class_details.bindings.temp.is_some());
 
         let mut exprs = ctx.ast.vec_with_capacity(expr_count);
@@ -140,7 +542,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         // Insert class + static property assignments + static blocks
         let class_expr = ctx.ast.move_expression(expr);
         if let Some(binding) = &class_details.bindings.temp {
-            // Insert `var _Class` statement, if it wasn't already in `transform_class`
+            // Insert `var _Class` statement, if it wasn't already in entry phase
             if !class_details.bindings.temp_var_is_created {
                 self.ctx.var_declarations.insert_var(binding, ctx);
             }
@@ -165,108 +567,88 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             exprs.push(class_expr);
         }
 
+        debug_assert!(exprs.len() > 1);
+        debug_assert!(exprs.len() <= expr_count);
+
         *expr = ctx.ast.expression_sequence(SPAN, exprs);
     }
 
-    /// Transform class declaration.
-    pub(super) fn transform_class_declaration(
-        &mut self,
-        class: &mut Class<'a>,
-        stmt_address: Address,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        // Ignore TS class declarations
-        // TODO: Is this correct?
-        // TODO: If remove this check, remove from `transform_class_on_exit` too.
-        if class.declare {
-            return;
-        }
-
-        self.transform_class(class, true, ctx);
-
-        // TODO: Run other transforms on inserted statements. How?
-
-        let class_details = self.classes_stack.last_mut();
-        if let Some(temp_binding) = &class_details.bindings.temp {
-            // Binding for class name is required
-            if let Some(ident) = &class.id {
-                // Insert `var _Class` statement, if it wasn't already in `transform_class`
-                if !class_details.bindings.temp_var_is_created {
-                    self.ctx.var_declarations.insert_var(temp_binding, ctx);
+    /// Transform class elements.
+    ///
+    /// This is part of the exit phase of transform, performed on both class declarations
+    /// and class expressions.
+    ///
+    /// At this point, other transforms have had a chance to run on the class body, so we can move
+    /// parts of the code out to before/after the class now.
+    ///
+    /// * Transform static properties and insert after class.
+    /// * Transform static blocks and insert after class.
+    /// * Extract computed key assignments and insert them before class.
+    /// * Remove all properties and static blocks from class body.
+    fn transform_class_elements(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        class.body.body.retain_mut(|element| {
+            match element {
+                ClassElement::PropertyDefinition(prop) => {
+                    if prop.r#static {
+                        self.convert_static_property(prop, ctx);
+                    } else if prop.computed {
+                        self.extract_instance_prop_computed_key(prop, ctx);
+                    }
+                    return false;
                 }
-
-                // Insert `_Class = Class` after class.
-                // TODO(improve-on-babel): Could just insert `var _Class = Class;` after class,
-                // rather than separate `var _Class` declaration.
-                let class_name =
-                    BoundIdentifier::from_binding_ident(ident).create_read_expression(ctx);
-                let expr = create_assignment(temp_binding, class_name, ctx);
-                let stmt = ctx.ast.statement_expression(SPAN, expr);
-                self.insert_after_stmts.insert(0, stmt);
-            } else {
-                // Class must be default export `export default class {}`, as all other class declarations
-                // always have a name. Set class name.
-                *ctx.symbols_mut().get_flags_mut(temp_binding.symbol_id) = SymbolFlags::Class;
-                class.id = Some(temp_binding.create_binding_identifier(ctx));
+                ClassElement::StaticBlock(block) => {
+                    if self.transform_static_blocks {
+                        self.convert_static_block(block, ctx);
+                        return false;
+                    }
+                }
+                ClassElement::MethodDefinition(method) => {
+                    self.substitute_temp_var_for_method_computed_key(method, ctx);
+                }
+                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {
+                    // TODO: Need to handle these?
+                }
             }
+
+            true
+        });
+    }
+
+    /// Flag that static private fields should be transpiled using temp binding,
+    /// while in this static property or static block.
+    ///
+    /// We turn `static_private_fields_use_temp` on and off when entering exiting static context.
+    ///
+    /// Static private fields reference class name (not temp var) in class declarations.
+    /// `class Class { static #privateProp; method() { return obj.#privateProp; } }`
+    /// -> `method() { return _assertClassBrand(Class, obj, _privateProp)._; }`
+    ///                                         ^^^^^
+    ///
+    /// But in static properties and static blocks, they use the temp var.
+    /// `class Class { static #privateProp; static publicProp = obj.#privateProp; }`
+    /// -> `Class.publicProp = _assertClassBrand(_Class, obj, _privateProp)._`
+    ///                                          ^^^^^^
+    ///
+    /// Also see comments on `ClassBindings`.
+    ///
+    /// Note: If declaration is `export default class {}` with no name, and class has static props,
+    /// then class has had name binding created already in `transform_class`.
+    /// So name binding is always `Some`.
+    pub(super) fn flag_entering_static_property_or_block(&mut self) {
+        // No need to check if class is a declaration, because `static_private_fields_use_temp`
+        // is always `true` for class expressions anyway
+        self.current_class_mut().bindings.static_private_fields_use_temp = true;
+    }
+
+    /// Flag that static private fields should be transpiled using name binding again
+    /// as we're exiting this static property or static block.
+    /// (see [`ClassProperties::flag_entering_static_property_or_block`])
+    pub(super) fn flag_exiting_static_property_or_block(&mut self) {
+        // Flag that transpiled static private props use name binding in class declarations
+        let class_details = self.current_class_mut();
+        if class_details.is_declaration {
+            class_details.bindings.static_private_fields_use_temp = false;
         }
-
-        // Insert expressions before/after class
-        if !self.insert_before.is_empty() {
-            self.ctx.statement_injector.insert_many_before(
-                &stmt_address,
-                exprs_into_stmts(self.insert_before.drain(..), ctx),
-            );
-        }
-
-        if let Some(private_props) = &class_details.private_props {
-            if self.private_fields_as_properties {
-                self.ctx.statement_injector.insert_many_before(
-                    &stmt_address,
-                    private_props.iter().map(|(name, prop)| {
-                        // `var _prop = _classPrivateFieldLooseKey("prop");`
-                        let value = Self::create_private_prop_key_loose(name, self.ctx, ctx);
-                        create_variable_declaration(&prop.binding, value, ctx)
-                    }),
-                );
-            } else {
-                // TODO: Only call `insert_many_before` if some private *instance* props
-                let mut weakmap_symbol_id = None;
-                self.ctx.statement_injector.insert_many_before(
-                    &stmt_address,
-                    private_props.values().filter_map(|prop| {
-                        if prop.is_static {
-                            return None;
-                        }
-
-                        // `var _prop = new WeakMap();`
-                        let value = create_new_weakmap(&mut weakmap_symbol_id, ctx);
-                        Some(create_variable_declaration(&prop.binding, value, ctx))
-                    }),
-                );
-            }
-        }
-
-        if !self.insert_after_stmts.is_empty() {
-            self.ctx
-                .statement_injector
-                .insert_many_after(&stmt_address, self.insert_after_stmts.drain(..));
-        }
-
-        // Flag that static private fields should be transpiled using name binding,
-        // while traversing class body.
-        //
-        // Static private fields reference class name (not temp var) in class declarations.
-        // `class Class { static #prop; method() { return obj.#prop; } }`
-        // -> `method() { return _assertClassBrand(Class, obj, _prop)._; }`
-        // (note `Class` in `_assertClassBrand(Class, ...)`, not `_Class`)
-        //
-        // Also see comments on `ClassBindings`.
-        //
-        // Note: If declaration is `export default class {}` with no name, and class has static props,
-        // then class has had name binding created already in `transform_class`.
-        // So name binding is always `Some`.
-        class_details.bindings.static_private_fields_use_temp = false;
     }
 
     /// `_classPrivateFieldLooseKey("prop")`
@@ -287,224 +669,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         )
     }
 
-    /// Main guts of the transform.
-    fn transform_class(
-        &mut self,
-        class: &mut Class<'a>,
-        is_declaration: bool,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        // TODO(improve-on-babel): If outer scope is sloppy mode, all code which is moved to outside
-        // the class should be wrapped in an IIFE with `'use strict'` directive. Babel doesn't do this.
-
-        // TODO: If static blocks transform is disabled, it's possible to get incorrect execution order.
-        // ```js
-        // class C {
-        //     static x = console.log('x');
-        //     static {
-        //         console.log('block');
-        //     }
-        //     static y = console.log('y');
-        // }
-        // ```
-        // This logs "x", "block", "y". But in transformed output it'd be "block", "x", "y".
-        // Maybe force transform of static blocks if any static properties?
-        // Or alternatively could insert static property initializers into static blocks.
-
-        // Check if class has any properties and get index of constructor (if class has one)
-        let mut instance_prop_count = 0;
-        let mut has_static_prop = false;
-        let mut has_static_block = false;
-        // TODO: Store `FxIndexMap`s in a pool and re-use them
-        let mut private_props = FxIndexMap::default();
-        let mut constructor = None;
-        for element in class.body.body.iter_mut() {
-            match element {
-                ClassElement::PropertyDefinition(prop) => {
-                    // TODO: Throw error if property has decorators
-
-                    // Create binding for private property key
-                    if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
-                        // Note: Current scope is outside class.
-                        let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
-                        private_props.insert(
-                            ident.name.clone(),
-                            PrivateProp { binding, is_static: prop.r#static },
-                        );
-                    }
-
-                    if prop.r#static {
-                        has_static_prop = true;
-                    } else {
-                        instance_prop_count += 1;
-                    }
-
-                    continue;
-                }
-                ClassElement::StaticBlock(_) => {
-                    // Static block only necessitates transforming class if it's being transformed
-                    if self.transform_static_blocks {
-                        has_static_block = true;
-                        continue;
-                    }
-                }
-                ClassElement::MethodDefinition(method) => {
-                    if method.kind == MethodDefinitionKind::Constructor
-                        && method.value.body.is_some()
-                    {
-                        constructor = Some(method);
-                    }
-                }
-                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {
-                    // TODO: Need to handle these?
-                }
-            }
-        }
-
-        // Exit if nothing to transform
-        if instance_prop_count == 0 && !has_static_prop && !has_static_block {
-            self.classes_stack.push(ClassDetails::default());
-            return;
-        }
-
-        // Initialize class binding vars.
-        // Static prop in class expression or anonymous `export default class {}` always require
-        // temp var for class. Static prop in class declaration doesn't.
-        let mut class_name_binding = class.id.as_ref().map(BoundIdentifier::from_binding_ident);
-
-        let need_temp_var = has_static_prop && (!is_declaration || class.id.is_none());
-
-        let class_temp_binding = if need_temp_var {
-            let temp_binding = ClassBindings::create_temp_binding(class_name_binding.as_ref(), ctx);
-            if is_declaration {
-                // Anonymous `export default class {}`. Set class name binding to temp var.
-                // Actual class name will be set to this later.
-                class_name_binding = Some(temp_binding.clone());
-            } else {
-                // Create temp var `var _Class;` statement.
-                // TODO(improve-on-babel): Inserting the temp var `var _Class` statement here is only
-                // to match Babel's output. It'd be simpler just to insert it at the end and get rid of
-                // `temp_var_is_created` that tracks whether it's done already or not.
-                self.ctx.var_declarations.insert_var(&temp_binding, ctx);
-            }
-            Some(temp_binding)
-        } else {
-            None
-        };
-
-        let class_bindings =
-            ClassBindings::new(class_name_binding, class_temp_binding, need_temp_var);
-
-        // Add entry to `classes_stack`
-        self.classes_stack.push(ClassDetails {
-            is_declaration,
-            private_props: if private_props.is_empty() { None } else { Some(private_props) },
-            bindings: class_bindings,
-        });
-
-        // Determine where to insert instance property initializers in constructor
-        let instance_inits_insert_location = if instance_prop_count == 0 {
-            // No instance prop initializers to insert
-            None
-        } else if let Some(constructor) = constructor {
-            // Existing constructor
-            let constructor = constructor.value.as_mut();
-            if class.super_class.is_some() {
-                let (insert_scopes, insert_location) =
-                    Self::replace_super_in_constructor(constructor, ctx);
-                self.instance_inits_scope_id = insert_scopes.insert_in_scope_id;
-                self.instance_inits_constructor_scope_id = insert_scopes.constructor_scope_id;
-                Some(insert_location)
-            } else {
-                let constructor_scope_id = constructor.scope_id();
-                self.instance_inits_scope_id = constructor_scope_id;
-                // Only record `constructor_scope_id` if constructor's scope has some bindings.
-                // If it doesn't, no need to check for shadowed symbols in instance prop initializers,
-                // because no bindings to clash with.
-                self.instance_inits_constructor_scope_id =
-                    if ctx.scopes().get_bindings(constructor_scope_id).is_empty() {
-                        None
-                    } else {
-                        Some(constructor_scope_id)
-                    };
-                Some(InstanceInitsInsertLocation::ExistingConstructor(0))
-            }
-        } else {
-            // No existing constructor - create scope for one
-            let constructor_scope_id = ctx.scopes_mut().add_scope(
-                Some(class.scope_id()),
-                NodeId::DUMMY,
-                ScopeFlags::Function | ScopeFlags::Constructor | ScopeFlags::StrictMode,
-            );
-            self.instance_inits_scope_id = constructor_scope_id;
-            self.instance_inits_constructor_scope_id = None;
-            Some(InstanceInitsInsertLocation::NewConstructor)
-        };
-
-        // Extract properties and static blocks from class body + substitute computed method keys
-        let mut instance_inits = Vec::with_capacity(instance_prop_count);
-        let mut constructor_index = 0;
-        let mut index_not_including_removed = 0;
-        class.body.body.retain_mut(|element| {
-            match element {
-                ClassElement::PropertyDefinition(prop) => {
-                    if prop.r#static {
-                        self.convert_static_property(prop, ctx);
-                    } else {
-                        self.convert_instance_property(prop, &mut instance_inits, ctx);
-                    }
-                    return false;
-                }
-                ClassElement::StaticBlock(block) => {
-                    if self.transform_static_blocks {
-                        self.convert_static_block(block, ctx);
-                        return false;
-                    }
-                }
-                ClassElement::MethodDefinition(method) => {
-                    if method.kind == MethodDefinitionKind::Constructor {
-                        if method.value.body.is_some() {
-                            constructor_index = index_not_including_removed;
-                        }
-                    } else {
-                        self.substitute_temp_var_for_method_computed_key(method, ctx);
-                    }
-                }
-                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {
-                    // TODO: Need to handle these?
-                }
-            }
-
-            index_not_including_removed += 1;
-
-            true
-        });
-
-        // Insert instance initializers into constructor, or create constructor if there is none
-        if let Some(instance_inits_insert_location) = instance_inits_insert_location {
-            self.insert_instance_inits(
-                class,
-                instance_inits,
-                &instance_inits_insert_location,
-                constructor_index,
-                ctx,
-            );
-        }
-    }
-
-    /// Pop from private props stack.
-    // `#[inline]` because this is function is so small
-    #[inline]
-    pub(super) fn transform_class_on_exit(&mut self, class: &Class) {
-        // Ignore TS class declarations
-        // TODO: Is this correct?
-        if class.declare {
-            return;
-        }
-
-        self.classes_stack.pop();
-    }
-
     /// Insert an expression after the class.
     pub(super) fn insert_expr_after_class(
         &mut self,
@@ -522,6 +686,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 /// Create `new WeakMap()` expression.
 ///
 /// Takes an `&mut Option<Option<SymbolId>>` which is updated after looking up the binding for `WeakMap`.
+///
 /// * `None` = Not looked up yet.
 /// * `Some(None)` = Has been looked up, and `WeakMap` is unbound.
 /// * `Some(Some(symbol_id))` = Has been looked up, and `WeakMap` has a local binding.

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -97,8 +97,6 @@
 //!
 //! ## Implementation
 //!
-//! WORK IN PROGRESS. INCOMPLETE.
-//!
 //! ### Reference implementation
 //!
 //! Implementation based on [@babel/plugin-transform-class-properties](https://babel.dev/docs/babel-plugin-transform-class-properties).
@@ -115,13 +113,65 @@
 //!
 //! Transform happens in 3 phases:
 //!
-//! 1. Check if class contains properties or static blocks, to determine if any transform is necessary
-//!    (in [`ClassProperties::transform_class`]).
-//! 2. Extract class property declarations and static blocks from class and insert in class constructor
-//!    (instance properties) or before/after the class (static properties + static blocks)
-//!    (in [`ClassProperties::transform_class`]).
-//! 3. Transform private property usages (`this.#prop`)
-//!    (in [`ClassProperties::transform_private_field_expression`] and other visitors).
+//! 1. On entering class body:
+//!    ([`ClassProperties::transform_class_body_on_entry`])
+//!    * Check if class contains properties or static blocks, to determine if any transform is necessary.
+//!      Exit if nothing to do.
+//!    * Build a hashmap of private property keys.
+//!    * Extract instance property initializers (public or private) from class body and insert into
+//!      class constructor.
+//!    * Temporarily replace computed keys of instance properties with assignments to temp vars.
+//!      `class C { [foo()] = 123; }` -> `class C { [_foo = foo()]; }`
+//!
+//! 2. During traversal of class body:
+//!    ([`ClassProperties::transform_private_field_expression`] and other visitors)
+//!    * Transform private fields (`this.#foo`).
+//!
+//! 3. On exiting class:
+//!    ([`ClassProperties::transform_class_declaration_on_exit`] and [`ClassProperties::transform_class_expression_on_exit`])
+//!    * Transform static properties, and static blocks.
+//!    * Move assignments to temp vars which were inserted in computed keys for in phase 1 to before class.
+//!    * Create temp vars for computed method keys if required.
+//!    * Insert statements before/after class declaration / expressions before/after class expression.
+//!
+//! The reason for doing transform in 3 phases is that everything needs to stay within the class body
+//! while main traverse executes, so that other transforms have a chance to run on that code.
+//!
+//! Static property initializers, static blocks, and computed keys move to outside the class eventually,
+//! but we move them in the final exit phase, so they get transformed first.
+//! Additionally, any private fields (`this.#prop`) in these parts are also transformed in the main traverse
+//! by this transform.
+//!
+//! However, we can't leave *everything* until the exit phase because:
+//!
+//! 1. We need to compile a list of private properties before main traversal.
+//! 2. Instance property initializers need to move into the class constructor, and if we don't do that
+//!    before the main traversal of class body, then other transforms running on instance property
+//!    initializers will create temp vars outside the class, when they should be in constructor.
+//!
+//! Note: We execute the entry phase on entering class *body*, not class, because private properties
+//! defined in a class only affect the class body, and not the `extends` clause.
+//! By only pushing details of the class to the stack when entering class *body*, we avoid any class
+//! fields in the `extends` clause being incorrectly resolved to private properties defined in that class,
+//! as `extends` clause is visited before class body.
+//!
+//! ### Structures
+//!
+//! Transform stores 2 sets of state:
+//!
+//! 1. Details about classes in a stack of `ClassDetails` - `classes_stack`.
+//!    This stack is pushed to when entering class body, and popped when exiting class.
+//!    This contains data which is used in both the enter and exit phases.
+//! 2. A set of properties - `insert_before` etc.
+//!    These properties are only used in *either* enter or exit phase.
+//!    State cannot be shared between enter and exit phases in these properties, as they'll get clobbered
+//!    if there's a nested class within this one.
+//!
+//! We don't store all state in `ClassDetails` as a performance optimization.
+//! It reduces the size of `ClassDetails` which has be repeatedly pushed and popped from stack,
+//! and allows reusing same `Vec`s and `FxHashMap`s for each class, rather than creating new each time.
+//!
+//! ### Files
 //!
 //! Implementation is split into several files:
 //!
@@ -151,9 +201,7 @@ use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::Deserialize;
 
-use oxc_allocator::{Address, GetAddress};
 use oxc_ast::ast::*;
-use oxc_data_structures::stack::NonEmptyStack;
 use oxc_span::Atom;
 use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 use oxc_traverse::{Traverse, TraverseCtx};
@@ -189,43 +237,49 @@ pub struct ClassPropertiesOptions {
 ///
 /// [module docs]: self
 pub struct ClassProperties<'a, 'ctx> {
-    // Options
+    // ----- Options -----
     //
-    /// If `true`, set properties with `=`, instead of `_defineProperty` helper.
+    /// If `true`, set properties with `=`, instead of `_defineProperty` helper (loose option).
     set_public_class_fields: bool,
-    /// If `true`, record private properties as string keys
+    /// If `true`, store private properties as normal properties as string keys (loose option).
     private_fields_as_properties: bool,
     /// If `true`, transform static blocks.
     transform_static_blocks: bool,
 
     ctx: &'ctx TransformCtx<'a>,
 
-    // State during whole AST
+    // ----- State used during all phases of transform -----
     //
     /// Stack of classes.
     /// Pushed to when entering a class, popped when exiting.
-    // TODO: The way stack is used is not perfect, because pushing to/popping from it in
-    // `enter_expression` / `exit_expression`. If another transform replaces the class,
-    // then stack will get out of sync.
-    // TODO: Should push to the stack only when entering class body, because `#x` in class `extends`
-    // clause resolves to `#x` in *outer* class, not the current class.
+    ///
+    /// The way stack is used is not perfect, because pushing to/popping from it in
+    /// `enter_class_body` / `exit_expression`. If another transform replaces/removes the class
+    /// in an earlier `exit_expression` visitor, then stack will get out of sync.
+    /// I (@overlookmotel) don't think there's a solution to this, and I don't think any other
+    /// transforms will remove a class expression in this way, so should be OK.
+    /// This problem only affects class expressions. Class declarations aren't affected,
+    /// as their exit-phase transform happens in `exit_class`.
     classes_stack: ClassesStack<'a>,
 
-    /// Addresses of class expressions being processed, to prevent same class being visited twice.
-    /// Have to use a stack because the revisit doesn't necessarily happen straight after the first visit.
-    /// e.g. `c = class C { [class D {}] = 1; }` -> `c = (_D = class D {}, class C { ... })`
-    class_expression_addresses_stack: NonEmptyStack<Address>,
-
-    // State during transform of class
+    // ----- State used only during enter phase -----
     //
-    /// Scope that instance init initializers will be inserted into
+    /// Scope that instance property initializers will be inserted into.
+    /// This is usually class constructor, but can also be a `_super` function which is created.
     instance_inits_scope_id: ScopeId,
-    /// `ScopeId` of class constructor, if instance init initializers will be inserted into constructor.
+    /// Scope of class constructor, if instance property initializers will be inserted into constructor.
     /// Used for checking for variable name clashes.
-    /// e.g. `let x; class C { prop = x; constructor(x) {} }` - `x` in constructor needs to be renamed
+    /// e.g. `class C { prop = x(); constructor(x) {} }`
+    /// - `x` in constructor needs to be renamed when `x()` is moved into constructor body.
+    /// `None` if class has no existing constructor, as then there can't be any clashes.
     instance_inits_constructor_scope_id: Option<ScopeId>,
-    /// `SymbolId`s in constructor which clash with instance prop initializers
+    /// Symbols in constructor which clash with instance prop initializers.
+    /// Keys are symbols' IDs.
+    /// Values are initially the original name of binding, later on the name of new UID name.
     clashing_constructor_symbols: FxHashMap<SymbolId, Atom<'a>>,
+
+    // ----- State used only during exit phase -----
+    //
     /// Expressions to insert before class
     insert_before: Vec<Expression<'a>>,
     /// Expressions to insert after class expression
@@ -235,6 +289,7 @@ pub struct ClassProperties<'a, 'ctx> {
 }
 
 impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+    /// Create `ClassProperties` transformer
     pub fn new(
         options: ClassPropertiesOptions,
         transform_static_blocks: bool,
@@ -251,8 +306,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             private_fields_as_properties,
             transform_static_blocks,
             ctx,
-            classes_stack: ClassesStack::default(),
-            class_expression_addresses_stack: NonEmptyStack::new(Address::DUMMY),
+            classes_stack: ClassesStack::new(),
             // Temporary values - overwritten when entering class
             instance_inits_scope_id: ScopeId::new(0),
             instance_inits_constructor_scope_id: None,
@@ -266,16 +320,26 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 }
 
 impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
-    // `#[inline]` because this is a hot path
+    fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.transform_class_body_on_entry(body, ctx);
+    }
+
+    fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.transform_class_declaration_on_exit(class, ctx);
+    }
+
+    // `#[inline]` for fast exit for expressions which are not `Class`es
+    #[inline]
+    fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if matches!(expr, Expression::ClassExpression(_)) {
+            self.transform_class_expression_on_exit(expr, ctx);
+        }
+    }
+
+    // `#[inline]` for fast exit for expressions which are not any of the transformed types
     #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // IMPORTANT: If add any other visitors here to handle private fields,
-        // also need to add them to visitor in `static_prop.rs`.
         match expr {
-            // `class {}`
-            Expression::ClassExpression(_) => {
-                self.transform_class_expression(expr, ctx);
-            }
             // `object.#prop`
             Expression::PrivateFieldExpression(_) => {
                 self.transform_private_field_expression(expr, ctx);
@@ -308,7 +372,7 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
         }
     }
 
-    // `#[inline]` because this is a hot path
+    // `#[inline]` for fast exit for assignment targets which are not private fields (rare case)
     #[inline]
     fn enter_assignment_target(
         &mut self,
@@ -318,37 +382,31 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
         self.transform_assignment_target(target, ctx);
     }
 
-    // `#[inline]` because this is a hot path
-    #[inline]
-    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        match stmt {
-            // `class C {}`
-            Statement::ClassDeclaration(class) => {
-                let stmt_address = class.address();
-                self.transform_class_declaration(class, stmt_address, ctx);
-            }
-            // `export class C {}`
-            Statement::ExportNamedDeclaration(decl) => {
-                let stmt_address = decl.address();
-                if let Some(Declaration::ClassDeclaration(class)) = &mut decl.declaration {
-                    self.transform_class_declaration(class, stmt_address, ctx);
-                }
-            }
-            // `export default class {}`
-            Statement::ExportDefaultDeclaration(decl) => {
-                let stmt_address = decl.address();
-                if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &mut decl.declaration
-                {
-                    self.transform_class_declaration(class, stmt_address, ctx);
-                }
-            }
-            _ => {}
+    fn enter_property_definition(
+        &mut self,
+        prop: &mut PropertyDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        if prop.r#static {
+            self.flag_entering_static_property_or_block();
         }
     }
 
-    // `#[inline]` because `transform_class_on_exit` is so small
-    #[inline]
-    fn exit_class(&mut self, class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
-        self.transform_class_on_exit(class);
+    fn exit_property_definition(
+        &mut self,
+        prop: &mut PropertyDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        if prop.r#static {
+            self.flag_exiting_static_property_or_block();
+        }
+    }
+
+    fn enter_static_block(&mut self, _block: &mut StaticBlock<'a>, _ctx: &mut TraverseCtx<'a>) {
+        self.flag_entering_static_property_or_block();
+    }
+
+    fn exit_static_block(&mut self, _block: &mut StaticBlock<'a>, _ctx: &mut TraverseCtx<'a>) {
+        self.flag_exiting_static_property_or_block();
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1439,8 +1439,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         }
     }
 
-    // Note: This is also called by visitor in `static_prop.rs`
-    pub(super) fn transform_unary_expression_impl(
+    fn transform_unary_expression_impl(
         &mut self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/es2022/mod.rs
+++ b/crates/oxc_transformer/src/es2022/mod.rs
@@ -43,14 +43,16 @@ impl<'a, 'ctx> Traverse<'a> for ES2022<'a, 'ctx> {
         }
     }
 
-    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(class_properties) = &mut self.class_properties {
-            class_properties.enter_statement(stmt, ctx);
+            class_properties.exit_expression(expr, ctx);
         }
     }
 
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        if let Some(class_static_block) = &mut self.class_static_block {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.enter_class_body(body, ctx);
+        } else if let Some(class_static_block) = &mut self.class_static_block {
             class_static_block.enter_class_body(body, ctx);
         }
     }
@@ -68,6 +70,38 @@ impl<'a, 'ctx> Traverse<'a> for ES2022<'a, 'ctx> {
     ) {
         if let Some(class_properties) = &mut self.class_properties {
             class_properties.enter_assignment_target(target, ctx);
+        }
+    }
+
+    fn enter_property_definition(
+        &mut self,
+        prop: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.enter_property_definition(prop, ctx);
+        }
+    }
+
+    fn exit_property_definition(
+        &mut self,
+        prop: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.exit_property_definition(prop, ctx);
+        }
+    }
+
+    fn enter_static_block(&mut self, block: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.enter_static_block(block, ctx);
+        }
+    }
+
+    fn exit_static_block(&mut self, block: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.exit_static_block(block, ctx);
         }
     }
 }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -262,10 +262,12 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
 
     fn enter_static_block(&mut self, block: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {
         self.common.enter_static_block(block, ctx);
+        self.x2_es2022.enter_static_block(block, ctx);
     }
 
     fn exit_static_block(&mut self, block: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {
         self.common.exit_static_block(block, ctx);
+        self.x2_es2022.exit_static_block(block, ctx);
     }
 
     fn enter_ts_module_declaration(
@@ -294,6 +296,7 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
 
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x1_jsx.exit_expression(expr, ctx);
+        self.x2_es2022.exit_expression(expr, ctx);
         self.x2_es2018.exit_expression(expr, ctx);
         self.x2_es2017.exit_expression(expr, ctx);
         self.common.exit_expression(expr, ctx);
@@ -438,6 +441,15 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_property_definition(def, ctx);
         }
+        self.x2_es2022.enter_property_definition(def, ctx);
+    }
+
+    fn exit_property_definition(
+        &mut self,
+        def: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x2_es2022.exit_property_definition(def, ctx);
     }
 
     fn enter_accessor_property(
@@ -518,7 +530,6 @@ impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_statement(stmt, ctx);
         }
-        self.x2_es2022.enter_statement(stmt, ctx);
         self.x2_es2018.enter_statement(stmt, ctx);
     }
 

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -7,21 +7,16 @@ class Foo {
     });
   }
   test() {
-    var _foo2;
     let _this$foo;
-    var _foo3 = babelHelpers.classPrivateFieldLooseKey("foo");
-    class Nested extends (_foo2 = babelHelpers.classPrivateFieldLooseKey("foo"), _this$foo = babelHelpers.classPrivateFieldLooseBase(this, _foo2)[_foo2], class {
+    var _foo2 = babelHelpers.classPrivateFieldLooseKey("foo");
+    class Nested extends (_this$foo = babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo], class {
       constructor() {
-        Object.defineProperty(this, _foo2, {
-          writable: true,
-          value: 2
-        });
         this[_this$foo] = 2;
       }
     }) {
       constructor(..._args) {
         super(..._args);
-        Object.defineProperty(this, _foo3, {
+        Object.defineProperty(this, _foo2, {
           writable: true,
           value: 3
         });

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -1,0 +1,22 @@
+var _foo = new WeakMap();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateFieldInitSpec(this, _foo, 1);
+  }
+  test() {
+    var _foo2;
+    let _this$foo;
+    var _foo3 = new WeakMap();
+    class Nested extends (_foo2 = new WeakMap(), _this$foo = babelHelpers.classPrivateFieldGet2(_foo2, this), class {
+      constructor() {
+        babelHelpers.classPrivateFieldInitSpec(this, _foo2, 2);
+        babelHelpers.defineProperty(this, _this$foo, 2);
+      }
+    }) {
+      constructor(..._args) {
+        super(..._args);
+        babelHelpers.classPrivateFieldInitSpec(this, _foo3, 3);
+      }
+    }
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -1,0 +1,20 @@
+var _foo = new WeakMap();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateFieldInitSpec(this, _foo, 1);
+  }
+  test() {
+    let _this$foo;
+    var _foo2 = new WeakMap();
+    class Nested extends (_this$foo = babelHelpers.classPrivateFieldGet2(_foo, this), class {
+      constructor() {
+        babelHelpers.defineProperty(this, _this$foo, 2);
+      }
+    }) {
+      constructor(..._args) {
+        super(..._args);
+        babelHelpers.classPrivateFieldInitSpec(this, _foo2, 3);
+      }
+    }
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 593/927
+Passed: 599/927
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -276,7 +276,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (205/264)
+# babel-plugin-transform-class-properties (211/264)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -335,15 +335,6 @@ x Output mismatch
 * private/class-shadow-builtins/input.mjs
 x Output mismatch
 
-* private/nested-class-computed-redeclared/input.js
-x Output mismatch
-
-* private/nested-class-extends-computed/input.js
-x Output mismatch
-
-* private/nested-class-extends-computed-redeclared/input.js
-x Output mismatch
-
 * private/optional-chain-cast-to-boolean/input.js
 x Output mismatch
 
@@ -373,23 +364,6 @@ x Output mismatch
 
 * private-loose/class-shadow-builtins/input.mjs
 x Output mismatch
-
-* private-loose/nested-class-computed-redeclared/input.js
-x Output mismatch
-
-* private-loose/nested-class-extends-computed/input.js
-x Output mismatch
-
-* private-loose/nested-class-extends-computed-redeclared/input.js
-Bindings mismatch:
-after transform: ScopeId(2): ["Nested", "_foo2", "_foo3"]
-rebuilt        : ScopeId(3): ["Nested", "_foo2", "_foo3", "_this$foo"]
-Bindings mismatch:
-after transform: ScopeId(3): ["_this$foo"]
-rebuilt        : ScopeId(4): []
-Symbol scope ID mismatch for "_this$foo":
-after transform: SymbolId(6): ScopeId(3)
-rebuilt        : SymbolId(3): ScopeId(3)
 
 * private-loose/optional-chain-before-member-call/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 191 of 215 (88.84%)
+Passed: 195 of 215 (90.70%)
 
 Failures:
 
@@ -23,16 +23,6 @@ Unexpected token `[`. Expected * for generator, private key, identifier or async
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-decorator-exec.test.js
 AssertionError: expected undefined to be 'hello' // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-nested-class-super-property-in-decorator-exec.test.js:22:28
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-computed-redeclared-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js
-AssertionError: expected [Function] to not throw an error but 'TypeError: attempted to use private f…' was thrown
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1438:21)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-nested-class-extends-computed-exec.test.js:36:9
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-optional-chain-in-function-param-with-transform-exec.test.js
 TypeError: Cannot convert undefined or null to object
@@ -61,16 +51,6 @@ TypeError: Cannot read properties of undefined (reading 'bind')
 TypeError: Cannot read properties of undefined (reading 'bind')
     at Foo.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-with-transform-exec.test.js:20:59)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-loose-parenthesized-optional-member-call-with-transform-exec.test.js:78:12
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-computed-redeclared-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-extends-computed-exec.test.js
-AssertionError: expected [Function] to not throw an error but 'TypeError: Private element is not pre…' was thrown
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1438:21)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-nested-class-extends-computed-exec.test.js:31:9
 
 ./fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-private-static-shadow-exec.test.js
 TypeError: e.has is not a function

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 116/132
+Passed: 116/133
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,36 @@ Passed: 116/132
 * regexp
 
 
-# babel-plugin-transform-class-properties (17/21)
+# babel-plugin-transform-class-properties (17/22)
+* interaction-with-other-transforms/input.js
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "C2", "_ref", "_ref2"]
+rebuilt        : ScopeId(0): ["C", "C2", "_a", "_e", "_g", "_ref", "_ref2"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_a", "_e", "_g"]
+rebuilt        : ScopeId(1): []
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(6)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(3): ScopeFlags(Function | Arrow)
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(1))
+rebuilt        : ScopeId(3): Some(ScopeId(0))
+Symbol scope ID mismatch for "_a":
+after transform: SymbolId(4): ScopeId(1)
+rebuilt        : SymbolId(0): ScopeId(0)
+Symbol scope ID mismatch for "_e":
+after transform: SymbolId(5): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+Symbol scope ID mismatch for "_g":
+after transform: SymbolId(6): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(0)
+
 * static-super-assignment-target/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/input.js
@@ -1,0 +1,16 @@
+class C {
+  [a ?? b] = c ?? d;
+  static [e ?? f] = g ?? h;
+  static {
+    i ?? j;
+  }
+}
+
+class C2 extends S {
+  prop = k ?? l;
+  constructor() {
+    if (true) {
+      super();
+    }
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    "transform-class-static-block",
+    "transform-nullish-coalescing-operator"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/interaction-with-other-transforms/output.js
@@ -1,0 +1,28 @@
+var _a, _e, _g;
+let _ref, _ref2;
+
+_ref = (_a = a) !== null && _a !== void 0 ? _a : b;
+_ref2 = (_e = e) !== null && _e !== void 0 ? _e : f;
+class C {
+  constructor() {
+    var _c;
+    babelHelpers.defineProperty(this, _ref, (_c = c) !== null && _c !== void 0 ? _c : d);
+  }
+}
+babelHelpers.defineProperty(C, _ref2, (_g = g) !== null && _g !== void 0 ? _g : h);
+(() => {
+  var _i;
+  (_i = i) !== null && _i !== void 0 ? _i : j;
+})();
+
+class C2 extends S {
+  constructor() {
+    var _super = (..._args) => {
+      var _k;
+      return super(..._args), babelHelpers.defineProperty(this, "prop", (_k = k) !== null && _k !== void 0 ? _k : l), this;
+    };
+    if (true) {
+      _super();
+    }
+  }
+}


### PR DESCRIPTION
Large re-architecting of class properties transform. Split transform into 3 phases:

1. Transform instance properties when entering class.
2. Transform private fields during traversal of class body.
3. Transform static properties and static blocks when exiting class.

This ensures that code which has to be moved outside of the class (static property initializers, static blocks, computed keys) can get transformed by other transforms before they're moved out.

Also fixes a problem where we previously registered private properties too early - on entering the class, rather than the class *body*, so private fields in `extends` clause of a nested class were misinterpretted.