### PR TITLE
refactor(semantic): remove resetting `current_reference_flags` in visit functions

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -854,8 +854,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         self.visit_assignment_target(&expr.left);
 
-        self.current_reference_flags = ReferenceFlags::empty();
-
         /* cfg  */
         let cfg_ixs = control_flow!(self, |cfg| {
             if expr.operator.is_logical() {
@@ -1764,7 +1762,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         //    ^      ^ We always treat `a` as Read and Write reference,
         self.current_reference_flags = ReferenceFlags::read_write();
         self.visit_simple_assignment_target(&it.argument);
-        self.current_reference_flags = ReferenceFlags::empty();
         self.leave_node(kind);
     }
 


### PR DESCRIPTION
We have reset current_reference_flags after resolving reference flags in https://github.com/oxc-project/oxc/pull/7923, so that we don't need to set it to empty in another place.