### PR TITLE
test(semantic): add a test for catch parameters reference

### DIFF
--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.js
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.js
@@ -1,0 +1,9 @@
+let a = 0, A = 0;
+try { } catch (
+  { a = A,
+//      ^ is referenced to parent scope's `A`
+    b = a }
+//      ^ is referenced to parameter `a`
+) {
+  let A = 0 ;
+}

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.snap
@@ -1,0 +1,87 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/js/try-catch/parameters.js
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "BlockStatement",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "BlockStatement",
+            "symbols": [
+              {
+                "flags": "SymbolFlags(BlockScopedVariable | CatchVariable)",
+                "id": 2,
+                "name": "a",
+                "node": "CatchParameter",
+                "references": [
+                  {
+                    "flags": "ReferenceFlags(Read)",
+                    "id": 1,
+                    "name": "a",
+                    "node_id": 22
+                  }
+                ]
+              },
+              {
+                "flags": "SymbolFlags(BlockScopedVariable | CatchVariable)",
+                "id": 3,
+                "name": "b",
+                "node": "CatchParameter",
+                "references": []
+              },
+              {
+                "flags": "SymbolFlags(BlockScopedVariable)",
+                "id": 4,
+                "name": "A",
+                "node": "VariableDeclarator(A)",
+                "references": []
+              }
+            ]
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | CatchClause)",
+        "id": 2,
+        "node": "CatchClause",
+        "symbols": []
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(BlockScopedVariable)",
+        "id": 0,
+        "name": "a",
+        "node": "VariableDeclarator(a)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable)",
+        "id": 1,
+        "name": "A",
+        "node": "VariableDeclarator(A)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 0,
+            "name": "A",
+            "node_id": 17
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
I am trying to clean up Semantic, just found that we can remove this code without any test failing, but it should fail in that test case I added.
 https://github.com/oxc-project/oxc/blob/1082868855ba67b03a5bd03211f1b23262976410/crates/oxc_semantic/src/builder.rs#L2085-L2087