### PR TITLE
feat(transformer/class-properties): transform super assignment expressions within static prop initializer

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -159,6 +159,7 @@ pub enum Helper {
     ClassPrivateFieldLooseKey,
     ClassPrivateFieldLooseBase,
     SuperPropGet,
+    SuperPropSet,
 }
 
 impl Helper {
@@ -183,6 +184,7 @@ impl Helper {
             Self::ClassPrivateFieldLooseKey => "classPrivateFieldLooseKey",
             Self::ClassPrivateFieldLooseBase => "classPrivateFieldLooseBase",
             Self::SuperPropGet => "superPropGet",
+            Self::SuperPropSet => "superPropSet",
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1608,7 +1608,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     /// * Anything else `foo()` -> `_foo = foo()`, `_foo`
     ///
     /// Returns 2 `Expression`s. The first must be inserted into output first.
-    fn duplicate_object(
+    pub(super) fn duplicate_object(
         &self,
         object: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 112/127
+Passed: 113/128
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 112/127
 * regexp
 
 
-# babel-plugin-transform-class-properties (13/16)
+# babel-plugin-transform-class-properties (14/17)
 * static-super-tagged-template/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/input.js
@@ -1,0 +1,50 @@
+const ident = "A";
+
+class Outer {
+  static B = () => {
+    // Transform
+    super.A = 1;
+    super.A += 1;
+    super.A -= 1;
+    super.A &&= 1;
+    super.A ||= 1;
+
+    super[ident] = 1;
+    super[ident] += 1;
+    super[ident] -= 1;
+    super[ident] &&= 1;
+    super[ident] ||= 1;
+
+    class Inner {
+      method() {
+        // Don't transform
+        super.A = 1;
+        super.A += 1;
+        super.A -= 1;
+        super.A &&= 1;
+        super.A ||= 1;
+
+        super[ident] = 1;
+        super[ident] += 1;
+        super[ident] -= 1;
+        super[ident] &&= 1;
+        super[ident] ||= 1;
+      }
+
+      static staticMethod() {
+        // Don't transform
+        super.A = 1;
+        super.A += 1;
+        super.A -= 1;
+        super.A &&= 1;
+        super.A ||= 1;
+
+        super[ident] = 1;
+        super[ident] += 1;
+        super[ident] -= 1;
+        super[ident] &&= 1;
+        super[ident] ||= 1;
+      }
+    }
+  };
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/output.js
@@ -1,0 +1,53 @@
+var _Outer;
+
+const ident = "A";
+
+class Outer {}
+
+_Outer = Outer;
+babelHelpers.defineProperty(Outer, "B", () => {
+  // Transform
+  babelHelpers.superPropSet(_Outer, "A", 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, "A", babelHelpers.superPropGet(_Outer, "A", _Outer) + 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, "A", babelHelpers.superPropGet(_Outer, "A", _Outer) - 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, "A", _Outer) && babelHelpers.superPropSet(_Outer, "A", 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, "A", _Outer) || babelHelpers.superPropSet(_Outer, "A", 1, _Outer, 1);
+
+  babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, ident, babelHelpers.superPropGet(_Outer, ident, _Outer) + 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, ident, babelHelpers.superPropGet(_Outer, ident, _Outer) - 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, ident, _Outer) && babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, ident, _Outer) || babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
+
+  class Inner {
+    method() {
+      // Don't transform
+      super.A = 1;
+      super.A += 1;
+      super.A -= 1;
+      super.A &&= 1;
+      super.A ||= 1;
+
+      super[ident] = 1;
+      super[ident] += 1;
+      super[ident] -= 1;
+      super[ident] &&= 1;
+      super[ident] ||= 1;
+    }
+
+    static staticMethod() {
+      // Don't transform
+      super.A = 1;
+      super.A += 1;
+      super.A -= 1;
+      super.A &&= 1;
+      super.A ||= 1;
+
+      super[ident] = 1;
+      super[ident] += 1;
+      super[ident] -= 1;
+      super[ident] &&= 1;
+      super[ident] ||= 1;
+    }
+  }
+});


### PR DESCRIPTION
Alternative of #7956 and #7959. Unlike the previous method, adapting duplicating the same logic rather than making the same logic transform function to be generic