### PR TITLE
test(transformer/class-properties): more testing for assignment to `super[prop]`

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/input.js
@@ -1,4 +1,4 @@
-const ident = "A";
+let bound = "A";
 
 class Outer {
   static B = () => {
@@ -9,11 +9,17 @@ class Outer {
     super.A &&= 1;
     super.A ||= 1;
 
-    super[ident] = 1;
-    super[ident] += 1;
-    super[ident] -= 1;
-    super[ident] &&= 1;
-    super[ident] ||= 1;
+    super[bound] = 1;
+    super[bound] += 1;
+    super[bound] -= 1;
+    super[bound] &&= 1;
+    super[bound] ||= 1;
+
+    super[unbound] = 1;
+    super[unbound] += 1;
+    super[unbound] -= 1;
+    super[unbound] &&= 1;
+    super[unbound] ||= 1;
 
     class Inner {
       method() {
@@ -24,11 +30,17 @@ class Outer {
         super.A &&= 1;
         super.A ||= 1;
 
-        super[ident] = 1;
-        super[ident] += 1;
-        super[ident] -= 1;
-        super[ident] &&= 1;
-        super[ident] ||= 1;
+        super[bound] = 1;
+        super[bound] += 1;
+        super[bound] -= 1;
+        super[bound] &&= 1;
+        super[bound] ||= 1;
+
+        super[unbound] = 1;
+        super[unbound] += 1;
+        super[unbound] -= 1;
+        super[unbound] &&= 1;
+        super[unbound] ||= 1;
       }
 
       static staticMethod() {
@@ -39,11 +51,17 @@ class Outer {
         super.A &&= 1;
         super.A ||= 1;
 
-        super[ident] = 1;
-        super[ident] += 1;
-        super[ident] -= 1;
-        super[ident] &&= 1;
-        super[ident] ||= 1;
+        super[bound] = 1;
+        super[bound] += 1;
+        super[bound] -= 1;
+        super[bound] &&= 1;
+        super[bound] ||= 1;
+
+        super[unbound] = 1;
+        super[unbound] += 1;
+        super[unbound] -= 1;
+        super[unbound] &&= 1;
+        super[unbound] ||= 1;
       }
     }
   };

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-expression/output.js
@@ -1,6 +1,6 @@
-var _Outer;
+var _unbound, _unbound2, _unbound3, _unbound4, _Outer;
 
-const ident = "A";
+let bound = "A";
 
 class Outer {}
 
@@ -13,11 +13,17 @@ babelHelpers.defineProperty(Outer, "B", () => {
   babelHelpers.superPropGet(_Outer, "A", _Outer) && babelHelpers.superPropSet(_Outer, "A", 1, _Outer, 1);
   babelHelpers.superPropGet(_Outer, "A", _Outer) || babelHelpers.superPropSet(_Outer, "A", 1, _Outer, 1);
 
-  babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
-  babelHelpers.superPropSet(_Outer, ident, babelHelpers.superPropGet(_Outer, ident, _Outer) + 1, _Outer, 1);
-  babelHelpers.superPropSet(_Outer, ident, babelHelpers.superPropGet(_Outer, ident, _Outer) - 1, _Outer, 1);
-  babelHelpers.superPropGet(_Outer, ident, _Outer) && babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
-  babelHelpers.superPropGet(_Outer, ident, _Outer) || babelHelpers.superPropSet(_Outer, ident, 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, bound, 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, bound, babelHelpers.superPropGet(_Outer, bound, _Outer) + 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, bound, babelHelpers.superPropGet(_Outer, bound, _Outer) - 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, bound, _Outer) && babelHelpers.superPropSet(_Outer, bound, 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, bound, _Outer) || babelHelpers.superPropSet(_Outer, bound, 1, _Outer, 1);
+
+  babelHelpers.superPropSet(_Outer, unbound, 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, _unbound = unbound, babelHelpers.superPropGet(_Outer, _unbound, _Outer) + 1, _Outer, 1);
+  babelHelpers.superPropSet(_Outer, _unbound2 = unbound, babelHelpers.superPropGet(_Outer, _unbound2, _Outer) - 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, _unbound3 = unbound, _Outer) && babelHelpers.superPropSet(_Outer, _unbound3, 1, _Outer, 1);
+  babelHelpers.superPropGet(_Outer, _unbound4 = unbound, _Outer) || babelHelpers.superPropSet(_Outer, _unbound4, 1, _Outer, 1);
 
   class Inner {
     method() {
@@ -28,11 +34,17 @@ babelHelpers.defineProperty(Outer, "B", () => {
       super.A &&= 1;
       super.A ||= 1;
 
-      super[ident] = 1;
-      super[ident] += 1;
-      super[ident] -= 1;
-      super[ident] &&= 1;
-      super[ident] ||= 1;
+      super[bound] = 1;
+      super[bound] += 1;
+      super[bound] -= 1;
+      super[bound] &&= 1;
+      super[bound] ||= 1;
+
+      super[unbound] = 1;
+      super[unbound] += 1;
+      super[unbound] -= 1;
+      super[unbound] &&= 1;
+      super[unbound] ||= 1;
     }
 
     static staticMethod() {
@@ -43,11 +55,17 @@ babelHelpers.defineProperty(Outer, "B", () => {
       super.A &&= 1;
       super.A ||= 1;
 
-      super[ident] = 1;
-      super[ident] += 1;
-      super[ident] -= 1;
-      super[ident] &&= 1;
-      super[ident] ||= 1;
+      super[bound] = 1;
+      super[bound] += 1;
+      super[bound] -= 1;
+      super[bound] &&= 1;
+      super[bound] ||= 1;
+
+      super[unbound] = 1;
+      super[unbound] += 1;
+      super[unbound] -= 1;
+      super[unbound] &&= 1;
+      super[unbound] ||= 1;
     }
   }
 });


### PR DESCRIPTION
Amend test added in #7991 to test transform of `super[prop] = value` where `prop` is not bound.

We should ideally have the `_unbound` temp vars *inside* the arrow function rather than outside, as Babel does, but that's not possible with our double-visitor scheme at present, and I think current output will operate correctly anyway.

Probably these temp vars could be hoisted even higher up - to very top level of the file, even if the class and `super[prop]` were deeply nested in many functions - and it'd still be correct. That'd be good for transformer performance as less `var` statements to insert, and also slightly smaller output size - less `var`s in code. But I don't know if that would be worse for runtime performance, as it makes the arrow function more impure. 🤔