### PR TITLE
refactor(transformer/class-properties): do not pass `ScopeId` into `insert_instance_inits`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -486,7 +486,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 class,
                 instance_inits,
                 &instance_inits_insert_location,
-                self.instance_inits_scope_id,
                 constructor_index,
                 ctx,
             );


### PR DESCRIPTION
No need to pass this var through various functions, as they already have access to `self` to get it itself.