### PR TITLE
refactor(transformer/class-properties): use `temp_var_name_base` to generate temp var names for `super` transform

### DIFF
--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-update-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-update-expression/output.js
@@ -1,4 +1,4 @@
-var _super$A, _super$A2, _super$A3, _super$A4, _super$A5, _super$A6, _super$bound, _super$bound2, _super$bound3, _super$bound4, _super$bound5, _super$bound6, _super$unbound, _unbound, _super$unbound2, _super$unbound3, _unbound2, _super$unbound4, _super$unbound5, _unbound3, _super$unbound6, _unbound4, _Outer;
+var _super$A, _super$A2, _super$A3, _super$A4, _super$A5, _super$A6, _super$bound, _super$bound2, _super$bound3, _super$bound4, _super$bound5, _super$bound6, _unbound, _super$unbound, _super$unbound2, _unbound2, _super$unbound3, _super$unbound4, _unbound3, _super$unbound5, _unbound4, _super$unbound6, _Outer;
 
 let bound = "A";
 


### PR DESCRIPTION
Follow-on after #7997.

Generate "base name" for temp var using `temp_var_name_base` and then create the 2 temp bindings from it.

This is a bit more efficient than creating 2nd temp binding from name of the first temp binding, because the first binding's name has `_` added to start, and may have digits on the end, which have to be trimmed off again. Whereas the "base name" is ready to go.

Incidentally, changing the timing of when temp bindings are created also aligns output with Babel.