### PR TITLE
test(transformer/class-properties): failing test for `super.prop` as assignment target

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 114/129
+Passed: 114/130
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,10 @@ Passed: 114/129
 * regexp
 
 
-# babel-plugin-transform-class-properties (15/18)
+# babel-plugin-transform-class-properties (15/19)
+* static-super-assignment-target/input.js
+x Output mismatch
+
 * static-super-tagged-template/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-target/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-target/input.js
@@ -1,0 +1,21 @@
+let bound = "A";
+
+class Outer {
+  static prop = () => {
+    [super.prop] = [];
+    [super[bound]] = [];
+    [super[unbound]] = [];
+
+    [...super.prop] = [];
+    [...super[bound]] = [];
+    [...super[unbound]] = [];
+
+    ({x: super.prop} = {});
+    ({x: super[bound]} = {});
+    ({x: super[unbound]} = {});
+
+    ({...super.prop} = {});
+    ({...super[bound]} = {});
+    ({...super[unbound]} = {});
+  };
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-target/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/static-super-assignment-target/output.js
@@ -1,0 +1,11 @@
+// We don't know what correct output for this should be.
+//
+// Babel doesn't support this, but ESBuild does.
+//
+// We'd need to add a new helper function to support this.
+
+class Outer {}
+
+babelHelpers.defineProperty(Outer, "prop", () => {
+  // ?????
+});


### PR DESCRIPTION
Add failing test for syntax we can't support yet.