### PR TITLE
refactor(language_server)!: use `.oxlintrc.json` when no config path provided

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -55,7 +55,7 @@ struct Options {
 
 impl Default for Options {
     fn default() -> Self {
-        Self { enable: true, run: Run::default(), config_path: ".eslintrc".into() }
+        Self { enable: true, run: Run::default(), config_path: ".oxlintrc.json".into() }
     }
 }
 


### PR DESCRIPTION
Will break for other IDEs when they do not self provide an default value 