### PR TITLE
feat(transformer/class-properties): exit faster from super replacement visitor

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 114/130
+Passed: 116/132
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,7 @@ Passed: 114/130
 * regexp
 
 
-# babel-plugin-transform-class-properties (15/19)
+# babel-plugin-transform-class-properties (17/21)
 * static-super-assignment-target/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-missing/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-missing/input.js
@@ -1,0 +1,6 @@
+class C extends S {
+  prop = 1;
+  constructor() {
+    return {};
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-missing/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-missing/output.js
@@ -1,0 +1,6 @@
+class C extends S {
+  constructor() {
+    var _super = (..._args) => (super(..._args), babelHelpers.defineProperty(this, "prop", 1), this);
+    return {};
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-nested/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-nested/input.js
@@ -1,0 +1,46 @@
+class C extends S {
+  prop = 1;
+  constructor() {
+    // Insert prop initializer after `super()`
+    super();
+    this.self = this;
+  }
+}
+
+class C2 extends S {
+  prop = 1;
+  constructor() {
+    class Inner extends S {
+      constructor() {
+        // Don't transform - different `super`
+        super();
+      }
+    }
+
+    // Insert prop initializer after `super()`
+    super();
+    this.self = this;
+  }
+}
+
+class C3 extends S {
+  prop = 1;
+  constructor() {
+    if (condition) {
+      // Transform to `_super()`
+      super(1, 2);
+      return this;
+    }
+
+    // Transform to `_super()`
+    super(3, 4);
+
+    if (condition2) {
+      // Don't transform
+      super(5, 6);
+    }
+
+    // Don't transform
+    super(7, 8);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-nested/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/super-in-constructor-nested/output.js
@@ -1,0 +1,47 @@
+class C extends S {
+  constructor() {
+    // Insert prop initializer after `super()`
+    super();
+    babelHelpers.defineProperty(this, "prop", 1);
+    this.self = this;
+  }
+}
+
+class C2 extends S {
+  constructor() {
+    class Inner extends S {
+      constructor() {
+        // Don't transform - different `super`
+        super();
+      }
+    }
+
+    // Insert prop initializer after `super()`
+    super();
+    babelHelpers.defineProperty(this, "prop", 1);
+    this.self = this;
+  }
+}
+
+class C3 extends S {
+  constructor() {
+    var _super = (..._args) => (super(..._args), babelHelpers.defineProperty(this, "prop", 1), this);
+
+    if (condition) {
+      // Transform to `_super()`
+      _super(1, 2);
+      return this;
+    }
+
+    // Transform to `_super()`
+    _super(3, 4);
+
+    if (condition2) {
+      // Don't transform
+      super(5, 6);
+    }
+
+    // Don't transform
+    super(7, 8);
+  }
+}


### PR DESCRIPTION
When inserting instance property initializers into class constructor, need to search for and transform `super()`. Exit that visit earlier in some cases, for better performance and smaller output.