### PR TITLE
refactor(linter): remove unused `with_rules` and `set_rule` methods

### DIFF
--- a/crates/oxc_linter/src/config/flat.rs
+++ b/crates/oxc_linter/src/config/flat.rs
@@ -70,13 +70,6 @@ impl ConfigStore {
         Self { cache, base, overrides }
     }
 
-    /// Set the base rules, replacing all existing rules.
-    #[cfg(test)]
-    #[inline]
-    pub fn set_rules(&mut self, new_rules: Vec<RuleWithSeverity>) {
-        self.base.rules = Arc::from(new_rules.into_boxed_slice());
-    }
-
     pub fn number_of_rules(&self) -> usize {
         self.base.rules.len()
     }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -79,13 +79,6 @@ impl Linter {
         Self { options, config }
     }
 
-    #[cfg(test)]
-    #[must_use]
-    pub fn with_rules(mut self, rules: Vec<RuleWithSeverity>) -> Self {
-        self.config.set_rules(rules);
-        self
-    }
-
     /// Set the kind of auto fixes to apply.
     ///
     /// # Example


### PR DESCRIPTION
this method is unused, hence it makes sense to remove.
furthermore, keeping it makes it tricky to work the nested config stuff