### PR TITLE
refactor(linter): remove unused `set_rules` method

### DIFF
--- a/crates/oxc_linter/src/config/flat.rs
+++ b/crates/oxc_linter/src/config/flat.rs
@@ -70,13 +70,6 @@ impl ConfigStore {
         Self { cache, base, overrides }
     }
 
-    /// Set the base rules, replacing all existing rules.
-    #[cfg(test)]
-    #[inline]
-    pub fn set_rules(&mut self, new_rules: Vec<RuleWithSeverity>) {
-        self.base.rules = Arc::from(new_rules.into_boxed_slice());
-    }
-
     pub fn number_of_rules(&self) -> usize {
         self.base.rules.len()
     }


### PR DESCRIPTION
this method is unused, hence it makes sense to remove.
furthermore, keeping it makes it tricky to work the nested config stuff