### PR TITLE
refactor(linter): refactor `LintBuilder` to prep for nested configs

### DIFF
--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
 
-use oxc_linter::{FixKind, Linter};
+use oxc_linter::{ConfigStoreBuilder, FixKind, LintOptions, Linter};
 
 use crate::linter::error_with_position::DiagnosticReport;
 use crate::linter::isolated_lint_handler::IsolatedLintHandler;
@@ -13,7 +13,9 @@ pub struct ServerLinter {
 
 impl ServerLinter {
     pub fn new() -> Self {
-        let linter = Linter::default().with_fix(FixKind::SafeFix);
+        let config_store =
+            ConfigStoreBuilder::default().build().expect("Failed to build config store");
+        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
         Self { linter: Arc::new(linter) }
     }
 

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 mod categories;
+mod config_builder;
 mod config_store;
 mod env;
 mod globals;
@@ -9,6 +10,7 @@ mod oxlintrc;
 mod plugins;
 mod rules;
 mod settings;
+pub use config_builder::{ConfigBuilderError, ConfigStoreBuilder};
 pub use config_store::ConfigStore;
 pub(crate) use config_store::ResolvedLinterState;
 pub use env::OxlintEnv;
@@ -20,7 +22,7 @@ pub use rules::{ESLintRule, OxlintRules};
 pub use settings::{jsdoc::JSDocPluginSettings, OxlintSettings};
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct LintConfig {
+pub struct LintConfig {
     pub(crate) plugins: LintPlugins,
     pub(crate) settings: OxlintSettings,
     /// Environments enable and disable collections of global variables.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -4,7 +4,6 @@
 mod tester;
 
 mod ast_util;
-mod builder;
 mod config;
 mod context;
 mod disable_directives;
@@ -29,23 +28,22 @@ use oxc_semantic::{AstNode, Semantic};
 use rules::RULES;
 
 pub use crate::{
-    builder::{LinterBuilder, LinterBuilderError},
-    config::{ESLintRule, LintPlugins, Oxlintrc},
+    config::{
+        ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintPlugins, Oxlintrc,
+    },
     context::LintContext,
     fixer::FixKind,
     frameworks::FrameworkFlags,
     module_record::ModuleRecord,
+    options::LintOptions,
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
 };
 use crate::{
-    config::{
-        ConfigStore, LintConfig, OxlintEnv, OxlintGlobals, OxlintSettings, ResolvedLinterState,
-    },
+    config::{LintConfig, OxlintEnv, OxlintGlobals, OxlintSettings, ResolvedLinterState},
     context::ContextHost,
     fixer::{Fixer, Message},
-    options::LintOptions,
     rules::RuleEnum,
     table::RuleTable,
     utils::iter_possible_jest_call_node,
@@ -68,14 +66,8 @@ pub struct Linter {
     config: ConfigStore,
 }
 
-impl Default for Linter {
-    fn default() -> Self {
-        LinterBuilder::default().build()
-    }
-}
-
 impl Linter {
-    pub(crate) fn new(options: LintOptions, config: ConfigStore) -> Self {
+    pub fn new(options: LintOptions, config: ConfigStore) -> Self {
         Self { options, config }
     }
 
@@ -101,10 +93,6 @@ impl Linter {
 
     pub fn number_of_rules(&self) -> usize {
         self.config.number_of_rules()
-    }
-
-    pub(crate) fn rules(&self) -> &Arc<[RuleWithSeverity]> {
-        self.config.rules()
     }
 
     pub fn run<'a>(

--- a/crates/oxc_linter/src/options/mod.rs
+++ b/crates/oxc_linter/src/options/mod.rs
@@ -9,7 +9,7 @@ use crate::{fixer::FixKind, FrameworkFlags};
 /// Subset of options used directly by the linter.
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq))]
-pub(crate) struct LintOptions {
+pub struct LintOptions {
     pub fix: FixKind,
     pub framework_hints: FrameworkFlags,
 }

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Write};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{rules::RULES, Linter, RuleCategory, RuleFixMeta};
+use crate::{rules::RULES, RuleCategory, RuleFixMeta};
 
 pub struct RuleTable {
     pub sections: Vec<RuleTableSection>,
@@ -34,8 +34,11 @@ impl Default for RuleTable {
 
 impl RuleTable {
     pub fn new() -> Self {
-        let default_rules =
-            Linter::default().rules().iter().map(|rule| rule.name()).collect::<FxHashSet<&str>>();
+        let default_rules = RULES
+            .iter()
+            .filter(|rule| rule.category() == RuleCategory::Correctness)
+            .map(super::rules::RuleEnum::name)
+            .collect::<FxHashSet<&str>>();
 
         let mut rows = RULES
             .iter()
@@ -82,7 +85,7 @@ impl RuleTable {
         })
         .collect::<Vec<_>>();
 
-        RuleTable { total, sections, turned_on_by_default_count: default_rules.len() }
+        RuleTable { total, sections, turned_on_by_default_count: 123 }
     }
 }
 

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -24,7 +24,7 @@ use oxc::{
     transformer::{TransformOptions, Transformer},
 };
 use oxc_index::Idx;
-use oxc_linter::{Linter, ModuleRecord};
+use oxc_linter::{ConfigStoreBuilder, LintOptions, Linter, ModuleRecord};
 use oxc_prettier::{Prettier, PrettierOptions};
 
 use crate::options::{OxcOptions, OxcRunOptions};
@@ -309,8 +309,13 @@ impl Oxc {
         if run_options.lint.unwrap_or_default() && self.diagnostics.borrow().is_empty() {
             let semantic_ret = SemanticBuilder::new().with_cfg(true).build(program);
             let semantic = Rc::new(semantic_ret.semantic);
-            let linter_ret =
-                Linter::default().run(path, Rc::clone(&semantic), Arc::clone(module_record));
+            let lint_config =
+                ConfigStoreBuilder::default().build().expect("Failed to build config store");
+            let linter_ret = Linter::new(LintOptions::default(), lint_config).run(
+                path,
+                Rc::clone(&semantic),
+                Arc::clone(module_record),
+            );
             let diagnostics = linter_ret.into_iter().map(|e| e.error).collect();
             self.save_diagnostics(diagnostics);
         }

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -2,7 +2,7 @@ use std::{env, path::Path, rc::Rc, sync::Arc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{FixKind, LinterBuilder, ModuleRecord};
+use oxc_linter::{ConfigStoreBuilder, FixKind, LintOptions, Linter, ModuleRecord};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -39,7 +39,9 @@ fn bench_linter(criterion: &mut Criterion) {
             let semantic = semantic_ret.semantic;
             let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record, &semantic));
             let semantic = Rc::new(semantic);
-            let linter = LinterBuilder::all().with_fix(FixKind::All).build();
+            let lint_config =
+                ConfigStoreBuilder::all().build().expect("Failed to build config store");
+            let linter = Linter::new(LintOptions::default(), lint_config).with_fix(FixKind::All);
             b.iter(|| linter.run(path, Rc::clone(&semantic), Arc::clone(&module_record)));
         });
     }


### PR DESCRIPTION
More simplification/preparations for nested configurations:

1. renames `LinterBuilder` to `ConfigStoreBuilder`
2. moves the `options` logic out of `LintBuilder` 
3. make `ConfigStoreBuilder::build()` return a result (currently always returns OK, but it will return errors when nested config is implemented

The next steps to implement nested config which i hope to do in the next week are:
1. refactor the `from_oxlintrc` to accept a file path
2. introduce a new method on `ConfigStoreBuilder` (name TBC) that walks all child directories, collecting `.oxlintrc` files. these will be put into `ConfigStore` as a hash map of path > config.