### PR TITLE
refactor(transformer/class-properties): do not take mut ref when immut ref will do

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -310,7 +310,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         }
 
         // Leave class expressions to `transform_class_expression_on_exit`
-        let class_details = self.current_class_mut();
+        let class_details = self.current_class();
         if !class_details.is_declaration {
             return;
         }


### PR DESCRIPTION
Tiny refactor. Not need to take a `&mut` when a `&` will do.