### PR TITLE
fix(transformer/class-properties): correctly resolve private fields pointing to private accessors

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -41,11 +41,17 @@ pub(super) struct PrivateProp<'a> {
     pub binding: BoundIdentifier<'a>,
     pub is_static: bool,
     pub is_method: bool,
+    pub is_accessor: bool,
 }
 
 impl<'a> PrivateProp<'a> {
-    pub fn new(binding: BoundIdentifier<'a>, is_static: bool, is_method: bool) -> Self {
-        Self { binding, is_static, is_method }
+    pub fn new(
+        binding: BoundIdentifier<'a>,
+        is_static: bool,
+        is_method: bool,
+        is_accessor: bool,
+    ) -> Self {
+        Self { binding, is_static, is_method, is_accessor }
     }
 }
 
@@ -111,6 +117,7 @@ impl<'a> ClassesStack<'a> {
                         class_bindings: &mut class.bindings,
                         is_static: prop.is_static,
                         is_method: prop.is_method,
+                        is_accessor: prop.is_accessor,
                         is_declaration: class.is_declaration,
                     };
                 }
@@ -133,6 +140,8 @@ pub(super) struct ResolvedPrivateProp<'a, 'b> {
     pub is_static: bool,
     /// `true` if is a private method
     pub is_method: bool,
+    /// `true` if is a private accessor property
+    pub is_accessor: bool,
     /// `true` if class which defines this property is a class declaration
     pub is_declaration: bool,
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -53,10 +53,11 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             class_bindings,
             is_static,
             is_method,
+            is_accessor,
             is_declaration,
         } = self.classes_stack.find_private_prop(&field_expr.field);
 
-        if is_method {
+        if is_method || is_accessor {
             // TODO: Should not consume existing `PrivateFieldExpression` and then create a new one
             // which is identical to the original
             return Expression::PrivateFieldExpression(field_expr);
@@ -184,10 +185,10 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 
         if self.private_fields_as_properties {
             // `object.#prop(arg)` -> `_classPrivateFieldLooseBase(object, _prop)[_prop](arg)`
-            let ResolvedPrivateProp { prop_binding, is_method, .. } =
+            let ResolvedPrivateProp { prop_binding, is_method, is_accessor, .. } =
                 self.classes_stack.find_private_prop(&field_expr.field);
 
-            if is_method {
+            if is_method || is_accessor {
                 return;
             }
 
@@ -262,10 +263,11 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             class_bindings,
             is_static,
             is_method,
+            is_accessor,
             is_declaration,
         } = self.classes_stack.find_private_prop(&field_expr.field);
 
-        if is_method {
+        if is_method || is_accessor {
             return None;
         };
 
@@ -367,10 +369,11 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             class_bindings,
             is_static,
             is_method,
+            is_accessor,
             is_declaration,
         } = self.classes_stack.find_private_prop(&field_expr.field);
 
-        if is_method {
+        if is_method || is_accessor {
             return;
         };
 
@@ -752,10 +755,11 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             class_bindings,
             is_static,
             is_method,
+            is_accessor,
             is_declaration,
         } = self.classes_stack.find_private_prop(&field_expr.field);
 
-        if is_method {
+        if is_method || is_accessor {
             return;
         };
 
@@ -1547,10 +1551,10 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             // //                                               ^^^^^^^^^^^^^
             // ```
             // But this is not needed, so we omit it.
-            let ResolvedPrivateProp { prop_binding, is_method, .. } =
+            let ResolvedPrivateProp { prop_binding, is_method, is_accessor, .. } =
                 self.classes_stack.find_private_prop(&field_expr.field);
 
-            if is_method {
+            if is_method || is_accessor {
                 return None;
             }
 


### PR DESCRIPTION
We don't transform private accessors yet, but include them in private property resolution.

This fixes some panics in TS conformance tests which use private accessors.