### PR TITLE
feat(ast): add `Expression::into_inner_expression`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -188,6 +188,24 @@ impl<'a> Expression<'a> {
     }
 
     #[allow(missing_docs)]
+    #[must_use]
+    pub fn into_inner_expression(self) -> Expression<'a> {
+        let mut expr = self;
+        loop {
+            expr = match expr {
+                Expression::ParenthesizedExpression(e) => e.unbox().expression,
+                Expression::TSAsExpression(e) => e.unbox().expression,
+                Expression::TSSatisfiesExpression(e) => e.unbox().expression,
+                Expression::TSInstantiationExpression(e) => e.unbox().expression,
+                Expression::TSNonNullExpression(e) => e.unbox().expression,
+                Expression::TSTypeAssertion(e) => e.unbox().expression,
+                _ => break,
+            };
+        }
+        expr
+    }
+
+    #[allow(missing_docs)]
     pub fn get_inner_expression(&self) -> &Expression<'a> {
         let mut expr = self;
         loop {


### PR DESCRIPTION
Add `Expression::into_inner_expression`. Does the same as `get_inner_expression` and `get_inner_expression_mut`, but operates on an owned `Expression`.