### PR TITLE
fix(transformer/class-properties): unwrap parenthesised expressions

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -523,7 +523,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
                 AssignmentTarget::PrivateFieldExpression(field_expr) => field_expr.unbox(),
                 _ => unreachable!(),
             };
-            let object = field_expr.object;
+            let object = field_expr.object.into_inner_expression();
 
             let class_ident = class_binding.create_read_expression(ctx);
             let value = ctx.ast.move_expression(&mut assign_expr.right);
@@ -621,7 +621,9 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         };
         let AssignmentExpression { span, operator, right: value, left } = assign_expr;
         let object = match left {
-            AssignmentTarget::PrivateFieldExpression(field_expr) => field_expr.unbox().object,
+            AssignmentTarget::PrivateFieldExpression(field_expr) => {
+                field_expr.unbox().object.into_inner_expression()
+            }
             _ => unreachable!(),
         };
 
@@ -787,7 +789,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 
         // TODO(improve-on-babel): Could avoid `move_expression` here and replace `update_expr.argument` instead.
         // Only doing this first to match the order Babel creates temp vars.
-        let object = ctx.ast.move_expression(&mut field_expr.object);
+        let object = ctx.ast.move_expression(field_expr.object.get_inner_expression_mut());
 
         if is_static {
             // If `object` is reference to class name, and class is declaration, use shortcuts:

--- a/crates/oxc_transformer/src/es2022/class_properties/supers.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/supers.rs
@@ -214,7 +214,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
         };
         let AssignmentExpression { span, operator, right: value, left } = assign_expr.unbox();
         let AssignmentTarget::ComputedMemberExpression(member) = left else { unreachable!() };
-        let property = member.unbox().expression;
+        let property = member.unbox().expression.into_inner_expression();
         *expr =
             self.transform_super_assignment_expression_impl(span, operator, property, value, ctx);
     }
@@ -420,7 +420,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 
         let temp_var_name_base = get_var_name_from_node(member.as_ref());
 
-        let property = ctx.ast.move_expression(&mut member.expression);
+        let property = ctx.ast.move_expression(member.expression.get_inner_expression_mut());
 
         *expr = self.transform_super_update_expression_impl(
             &temp_var_name_base,


### PR DESCRIPTION
Unwrap parenthesised expressions everywhere where we call `duplicate_object`.

This fixes panics in conformance tests.