### PR TITLE
feat(napi/parser): add `crate-type: "lib"`

### DIFF
--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -16,7 +16,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 test = false
 doctest = false
 


### PR DESCRIPTION
The rolldown need export it to instead of `rollup/parseAst`, ref https://rollupjs.org/javascript-api/#accessing-the-parser