### PR TITLE
chore(linter): use `assert_eq!` instead of `assert!`

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -57,7 +57,7 @@ fn size_asserts() {
     // `RuleEnum` runs in a really tight loop, make sure it is small for CPU cache.
     // A reduction from 168 bytes to 16 results 15% performance improvement.
     // See codspeed in https://github.com/oxc-project/oxc/pull/1783
-    assert!(std::mem::size_of::<RuleEnum>() == 16);
+    assert_eq!(size_of::<RuleEnum>(), 16);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This ensures that both the expected and actual values are printed in the log when the test fails.