### PR TITLE
chore(ast): use `assert_eq!` instead of `assert!` (`crates/oxc_ast/src/lib.rs`)

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -119,18 +119,18 @@ fn size_asserts() {
 
     use crate::ast;
 
-    assert!(size_of::<ast::Statement>() == 16);
-    assert!(size_of::<ast::Expression>() == 16);
-    assert!(size_of::<ast::Declaration>() == 16);
-    assert!(size_of::<ast::BindingPatternKind>() == 16);
-    assert!(size_of::<ast::ModuleDeclaration>() == 16);
-    assert!(size_of::<ast::ClassElement>() == 16);
-    assert!(size_of::<ast::ExportDefaultDeclarationKind>() == 16);
-    assert!(size_of::<ast::AssignmentTargetPattern>() == 16);
-    assert!(size_of::<ast::AssignmentTargetMaybeDefault>() == 16);
-    assert!(size_of::<ast::AssignmentTargetProperty>() == 16);
-    assert!(size_of::<ast::TSLiteral>() == 16);
-    assert!(size_of::<ast::TSType>() == 16);
+    assert_eq!(size_of::<ast::Statement>(), 16);
+    assert_eq!(size_of::<ast::Expression>(), 16);
+    assert_eq!(size_of::<ast::Declaration>(), 16);
+    assert_eq!(size_of::<ast::BindingPatternKind>(), 16);
+    assert_eq!(size_of::<ast::ModuleDeclaration>(), 16);
+    assert_eq!(size_of::<ast::ClassElement>(), 16);
+    assert_eq!(size_of::<ast::ExportDefaultDeclarationKind>(), 16);
+    assert_eq!(size_of::<ast::AssignmentTargetPattern>(), 16);
+    assert_eq!(size_of::<ast::AssignmentTargetMaybeDefault>(), 16);
+    assert_eq!(size_of::<ast::AssignmentTargetProperty>(), 16);
+    assert_eq!(size_of::<ast::TSLiteral>(), 16);
+    assert_eq!(size_of::<ast::TSType>(), 16);
 }
 
 #[test]


### PR DESCRIPTION
related to https://github.com/oxc-project/oxc/pull/8124