### PR TITLE
chore(semantic): use `assert_eq!` instead of `assert!` (`crates/oxc_semantic/src/lib.rs`)

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
         let allocator = Allocator::default();
         let source_type: SourceType = SourceType::default().with_typescript(true);
         let semantic = get_semantic(&allocator, source, source_type);
-        assert!(semantic.symbols().references.len() == 1);
+        assert_eq!(semantic.symbols().references.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
related to https://github.com/oxc-project/oxc/pull/8124