### PR TITLE
feat(transformer/class-properties): transform static/instance accessor methods

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -161,6 +161,8 @@ pub enum Helper {
     ClassPrivateFieldLooseBase,
     SuperPropGet,
     SuperPropSet,
+    ReadOnlyError,
+    WriteOnlyError,
 }
 
 impl Helper {
@@ -187,6 +189,8 @@ impl Helper {
             Self::ClassPrivateFieldLooseBase => "classPrivateFieldLooseBase",
             Self::SuperPropGet => "superPropGet",
             Self::SuperPropSet => "superPropSet",
+            Self::ReadOnlyError => "readOnlyError",
+            Self::WriteOnlyError => "writeOnlyError",
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -40,18 +40,33 @@ impl<'a> ClassDetails<'a> {
 pub(super) struct PrivateProp<'a> {
     pub binding: BoundIdentifier<'a>,
     pub is_static: bool,
-    pub is_method: bool,
+    pub method_kind: Option<MethodDefinitionKind>,
     pub is_accessor: bool,
+    // For accessor methods, they have two bindings,
+    // one for getter and another for setter.
+    pub binding2: Option<BoundIdentifier<'a>>,
 }
 
 impl<'a> PrivateProp<'a> {
     pub fn new(
         binding: BoundIdentifier<'a>,
         is_static: bool,
-        is_method: bool,
+        method_kind: Option<MethodDefinitionKind>,
         is_accessor: bool,
     ) -> Self {
-        Self { binding, is_static, is_method, is_accessor }
+        Self { binding, is_static, method_kind, is_accessor, binding2: None }
+    }
+
+    pub fn is_method(&self) -> bool {
+        self.method_kind.is_some()
+    }
+
+    pub fn is_accessor(&self) -> bool {
+        self.is_accessor || self.method_kind.is_some_and(|kind| kind.is_accessor())
+    }
+
+    pub fn set_binding2(&mut self, binding: BoundIdentifier<'a>) {
+        self.binding2 = Some(binding);
     }
 }
 
@@ -101,36 +116,120 @@ impl<'a> ClassesStack<'a> {
         self.stack.last_mut()
     }
 
-    /// Lookup details of private property referred to by `ident`.
-    pub fn find_private_prop<'b>(
+    fn lookup_private_prop<
+        'b,
+        Ret,
+        RetFn: Fn(&'b PrivateProp<'a>, &'b mut ClassBindings<'a>, bool) -> Ret,
+    >(
         &'b mut self,
         ident: &PrivateIdentifier<'a>,
-    ) -> ResolvedPrivateProp<'a, 'b> {
+        ret_fn: RetFn,
+    ) -> Ret {
         // Check for binding in closest class first, then enclosing classes.
         // We skip the first, because this is a `NonEmptyStack` with dummy first entry.
         // TODO: Check there are tests for bindings in enclosing classes.
         for class in self.stack[1..].iter_mut().rev() {
             if let Some(private_props) = &mut class.private_props {
                 if let Some(prop) = private_props.get(&ident.name) {
-                    return ResolvedPrivateProp {
-                        prop_binding: &prop.binding,
-                        class_bindings: &mut class.bindings,
-                        is_static: prop.is_static,
-                        is_method: prop.is_method,
-                        is_accessor: prop.is_accessor,
-                        is_declaration: class.is_declaration,
-                    };
+                    return ret_fn(prop, &mut class.bindings, class.is_declaration);
                 }
             }
         }
-
         unreachable!();
+    }
+
+    /// Lookup details of private property referred to by `ident`.
+    pub fn find_private_prop<'b>(
+        &'b mut self,
+        ident: &PrivateIdentifier<'a>,
+    ) -> ResolvedPrivateProp<'a, 'b> {
+        self.lookup_private_prop(ident, move |prop, class_bindings, is_declaration| {
+            ResolvedPrivateProp {
+                prop_binding: &prop.binding,
+                class_bindings,
+                is_static: prop.is_static,
+                is_method: prop.is_method(),
+                is_accessor: prop.is_accessor(),
+                is_declaration,
+            }
+        })
+    }
+
+    /// Lookup details of readable private property referred to by `ident`.
+    pub fn find_readable_private_prop<'b>(
+        &'b mut self,
+        ident: &PrivateIdentifier<'a>,
+    ) -> Option<ResolvedPrivateProp<'a, 'b>> {
+        self.lookup_private_prop(ident, move |prop, class_bindings, is_declaration| {
+            let prop_binding = if matches!(prop.method_kind, Some(MethodDefinitionKind::Set)) {
+                prop.binding2.as_ref()
+            } else {
+                Some(&prop.binding)
+            };
+            prop_binding.map(|prop_binding| ResolvedPrivateProp {
+                prop_binding,
+                class_bindings,
+                is_static: prop.is_static,
+                is_method: prop.is_method(),
+                is_accessor: prop.is_accessor(),
+                is_declaration,
+            })
+        })
+    }
+
+    /// Lookup details of writeable private property referred to by `ident`.
+    /// Returns `Some` if it refers to a private prop and setter method
+    pub fn find_writeable_private_prop<'b>(
+        &'b mut self,
+        ident: &PrivateIdentifier<'a>,
+    ) -> Option<ResolvedPrivateProp<'a, 'b>> {
+        self.lookup_private_prop(ident, move |prop, class_bindings, is_declaration| {
+            let prop_binding = if matches!(prop.method_kind, Some(MethodDefinitionKind::Set) | None)
+            {
+                Some(&prop.binding)
+            } else {
+                prop.binding2.as_ref()
+            };
+            prop_binding.map(|prop_binding| ResolvedPrivateProp {
+                prop_binding,
+                class_bindings,
+                is_static: prop.is_static,
+                is_method: prop.is_method(),
+                is_accessor: prop.is_accessor(),
+                is_declaration,
+            })
+        })
+    }
+
+    /// Look up details of the private property referred to by ident and it can either be read or written.
+    pub fn find_get_set_private_prop<'b>(
+        &'b mut self,
+        ident: &PrivateIdentifier<'a>,
+    ) -> ResolvedGetSetPrivateProp<'a, 'b> {
+        self.lookup_private_prop(ident, move |prop, class_bindings, is_declaration| {
+            let (get_binding, set_binding) = match prop.method_kind {
+                Some(MethodDefinitionKind::Set) => (prop.binding2.as_ref(), Some(&prop.binding)),
+                Some(_) => (Some(&prop.binding), prop.binding2.as_ref()),
+                _ => (Some(&prop.binding), Some(&prop.binding)),
+            };
+            ResolvedGetSetPrivateProp {
+                get_binding,
+                set_binding,
+                class_bindings,
+                is_static: prop.is_static,
+                is_method: prop.is_method(),
+                is_accessor: prop.is_accessor(),
+                is_declaration,
+            }
+        })
     }
 }
 
 /// Details of a private property resolved for a private field.
 ///
-/// This is the return value of [`ClassesStack::find_private_prop`].
+/// This is the return value of [`ClassesStack::find_private_prop`],
+/// [`ClassesStack::find_readable_private_prop`] and
+/// [`ClassesStack::find_writeable_private_prop`].
 pub(super) struct ResolvedPrivateProp<'a, 'b> {
     /// Binding for temp var representing the property
     pub prop_binding: &'b BoundIdentifier<'a>,
@@ -138,9 +237,32 @@ pub(super) struct ResolvedPrivateProp<'a, 'b> {
     pub class_bindings: &'b mut ClassBindings<'a>,
     /// `true` if is a static property
     pub is_static: bool,
-    /// `true` if is a private method
+    /// `true` if is a private method or accessor property
     pub is_method: bool,
-    /// `true` if is a private accessor property
+    /// `true` if is a private accessor property or [`PrivateProp::method_kind`] is
+    /// `Some(MethodDefinitionKind::Get)` or `Some(MethodDefinitionKind::Set)`
+    pub is_accessor: bool,
+    /// `true` if class which defines this property is a class declaration
+    pub is_declaration: bool,
+}
+
+/// Details of a private property resolved for a private field.
+///
+/// This is the return value of [`ClassesStack::find_get_set_private_prop`].
+pub(super) struct ResolvedGetSetPrivateProp<'a, 'b> {
+    /// Binding for temp var representing the property or getter method
+    pub get_binding: Option<&'b BoundIdentifier<'a>>,
+    /// Binding for temp var representing the property or setter method
+    pub set_binding: Option<&'b BoundIdentifier<'a>>,
+    /// Bindings for class name and temp var for class
+    pub class_bindings: &'b mut ClassBindings<'a>,
+    /// `true` if is a static property
+    pub is_static: bool,
+    /// `true` if is a private method or accessor property
+    pub is_method: bool,
+    /// `true` if is a private accessor property or [`PrivateProp::method_kind`] is
+    /// `Some(MethodDefinitionKind::Get)` or `Some(MethodDefinitionKind::Set)`
+    #[expect(unused)]
     pub is_accessor: bool,
     /// `true` if class which defines this property is a class declaration
     pub is_declaration: bool,

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use oxc_ast::ast::*;
+use oxc_ast::{ast::*, NONE};
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::{BoundIdentifier, TraverseCtx};
@@ -80,4 +80,38 @@ pub(super) fn create_prototype_member<'a>(
     let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
     let static_member = ctx.ast.member_expression_static(SPAN, object, property, false);
     Expression::from(static_member)
+}
+
+/// `object` -> `object.call`.
+pub(super) fn create_member_callee<'a>(
+    object: Expression<'a>,
+    property: &'static str,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
+    Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
+}
+
+/// `object` -> `object.bind(this)`.
+pub(super) fn create_bind_call<'a>(
+    callee: Expression<'a>,
+    this: Expression<'a>,
+    span: Span,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let callee = create_member_callee(callee, "bind", ctx);
+    let arguments = ctx.ast.vec1(Argument::from(this));
+    ctx.ast.expression_call(span, callee, NONE, arguments, false)
+}
+
+/// `object` -> `object.call(...arguments)`.
+pub(super) fn create_call_call<'a>(
+    callee: Expression<'a>,
+    this: Expression<'a>,
+    span: Span,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let callee = create_member_callee(callee, "call", ctx);
+    let arguments = ctx.ast.vec1(Argument::from(this));
+    ctx.ast.expression_call(span, callee, NONE, arguments, false)
 }

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/arguments/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/arguments/output.js
@@ -1,0 +1,23 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, "top secret string");
+    this.publicField = "not secret string";
+  }
+  publicGetPrivateField() {
+    return _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this));
+  }
+  publicSetPrivateField(newValue) {
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = newValue;
+  }
+}
+function _get_privateFieldValue() {
+  expect(arguments.length).toBe(0);
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+function _set_privateFieldValue(newValue) {
+  expect(arguments.length).toBe(1);
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/basic/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/basic/output.js
@@ -1,0 +1,21 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, "top secret string");
+    this.publicField = "not secret string";
+  }
+  publicGetPrivateField() {
+    return _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this));
+  }
+  publicSetPrivateField(newValue) {
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = newValue;
+  }
+}
+function _get_privateFieldValue() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/class-binding/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/class-binding/output.js
@@ -1,0 +1,11 @@
+var _A;
+var _A_brand = new WeakSet();
+class A {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _A_brand);
+  }
+}
+_A = A;
+function _get_getA() {
+  return _A;
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/destructuring/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/destructuring/output.js
@@ -1,0 +1,12 @@
+var _A_brand = new WeakSet();
+class A {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _A_brand);
+  }
+  m() {
+    [babelHelpers.toSetter(_set_setter.bind(babelHelpers.assertClassBrand(_A_brand, this)))._] = [1];
+    [(this, babelHelpers.readOnlyError("#getter"))._] = [1];
+  }
+}
+function _set_setter(v) {}
+function _get_getter() {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/get-only-setter/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/get-only-setter/output.js
@@ -1,0 +1,12 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, 0);
+    this.publicField = (this, babelHelpers.writeOnlyError("#privateFieldValue"));
+  }
+}
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/preserve-comments/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/preserve-comments/output.js
@@ -1,0 +1,10 @@
+var _C_brand = new WeakSet();
+class C {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _C_brand);
+  }
+}
+function _get_a() {
+  return 42;
+}
+function _set_a(v) {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/reassignment/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/reassignment/output.js
@@ -1,0 +1,15 @@
+let results = [];
+var _Foo_brand = new WeakSet();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo_brand);
+    this.self, results.push(2), babelHelpers.readOnlyError("#privateFieldValue");
+  }
+  get self() {
+    results.push(1);
+    return this;
+  }
+}
+function _get_privateFieldValue() {
+  return 42;
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/set-only-getter/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/set-only-getter/output.js
@@ -1,0 +1,18 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  get self() {
+    this.counter++;
+    return this;
+  }
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, 0);
+    babelHelpers.defineProperty(this, "counter", 0);
+    this.self, 1([(this.self, babelHelpers.readOnlyError("#privateFieldValue"))._] = [1]), babelHelpers.readOnlyError("#privateFieldValue");
+  }
+}
+function _get_privateFieldValue() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+const cl = new Cl();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/tagged-template/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/tagged-template/output.js
@@ -1,0 +1,11 @@
+var _Foo_brand = new WeakSet();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo_brand);
+    _get_tag.call(babelHelpers.assertClassBrand(_Foo_brand, this)).bind(this)``;
+  }
+}
+function _get_tag() {
+  return () => this;
+}
+new Foo();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/updates-bigint/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/updates-bigint/output.js
@@ -1,0 +1,40 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, "top secret string");
+    this.publicField = "not secret string";
+  }
+  publicGetPrivateField() {
+    return _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this));
+  }
+  publicSetPrivateField(newValue) {
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = newValue;
+  }
+  get publicFieldValue() {
+    return this.publicField;
+  }
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+  testUpdates() {
+    var _this$privateFieldVal, _this$privateFieldVal2, _this$privateFieldVal3;
+    babelHelpers.classPrivateFieldSet2(_privateField, this, 0n);
+    this.publicField = 0n;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = (_set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), (_this$privateFieldVal = _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)), _this$privateFieldVal2 = _this$privateFieldVal++, _this$privateFieldVal)), _this$privateFieldVal2);
+    this.publicFieldValue = this.publicFieldValue++;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), (_this$privateFieldVal3 = _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)), ++_this$privateFieldVal3));
+    ++this.publicFieldValue;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)) + 1n);
+    this.publicFieldValue += 1n;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = -(_get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)) ** _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)));
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+}
+function _get_privateFieldValue() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/updates/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/accessors/updates/output.js
@@ -1,0 +1,40 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, "top secret string");
+    this.publicField = "not secret string";
+  }
+  publicGetPrivateField() {
+    return _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this));
+  }
+  publicSetPrivateField(newValue) {
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = newValue;
+  }
+  get publicFieldValue() {
+    return this.publicField;
+  }
+  set publicFieldValue(newValue) {
+    this.publicField = newValue;
+  }
+  testUpdates() {
+    var _this$privateFieldVal, _this$privateFieldVal2, _this$privateFieldVal3;
+    babelHelpers.classPrivateFieldSet2(_privateField, this, 0);
+    this.publicField = 0;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = (_set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), (_this$privateFieldVal = _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)), _this$privateFieldVal2 = _this$privateFieldVal++, _this$privateFieldVal)), _this$privateFieldVal2);
+    this.publicFieldValue = this.publicFieldValue++;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), (_this$privateFieldVal3 = _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)), ++_this$privateFieldVal3));
+    ++this.publicFieldValue;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this), _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)) + 1);
+    this.publicFieldValue += 1;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(babelHelpers.assertClassBrand(_Cl_brand, this)))._ = -(_get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)) ** _get_privateFieldValue.call(babelHelpers.assertClassBrand(_Cl_brand, this)));
+    this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
+  }
+}
+function _get_privateFieldValue() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+function _set_privateFieldValue(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/duplicated-names/get-set/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/duplicated-names/get-set/output.js
@@ -1,0 +1,14 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, 0);
+  }
+}
+function _get_getSet() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}
+function _set_getSet(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/duplicated-names/set-get/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/duplicated-names/set-get/output.js
@@ -1,0 +1,14 @@
+var _privateField = new WeakMap();
+var _Cl_brand = new WeakSet();
+class Cl {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Cl_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _privateField, 0);
+  }
+}
+function _set_getSet(newValue) {
+  babelHelpers.classPrivateFieldSet2(_privateField, this, newValue);
+}
+function _get_getSet() {
+  return babelHelpers.classPrivateFieldGet2(_privateField, this);
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/misc/multiple/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/misc/multiple/output.js
@@ -1,0 +1,16 @@
+var _A_brand = new WeakSet();
+class A {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _A_brand);
+    babelHelpers.assertClassBrand(_A_brand, this, _method).call(this);
+    _get_getter.call(babelHelpers.assertClassBrand(_A_brand, this));
+    babelHelpers.toSetter(_set_setter.bind(babelHelpers.assertClassBrand(_A_brand, this)))._ = 1;
+    _get_getset.call(babelHelpers.assertClassBrand(_A_brand, this));
+    babelHelpers.toSetter(_set_getset.bind(babelHelpers.assertClassBrand(_A_brand, this)))._ = 2;
+  }
+}
+function _method() {}
+function _get_getter() {}
+function _set_setter(v) {}
+function _get_getset() {}
+function _set_getset(v) {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/basic/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/basic/output.js
@@ -1,0 +1,15 @@
+class Cl {
+  static getValue() {
+    return _get_privateStaticFieldValue.call(Cl);
+  }
+  static setValue() {
+    babelHelpers.toSetter(_set_privateStaticFieldValue.bind(Cl))._ = "dank";
+  }
+}
+function _get_privateStaticFieldValue() {
+  return _PRIVATE_STATIC_FIELD._;
+}
+function _set_privateStaticFieldValue(newValue) {
+  _PRIVATE_STATIC_FIELD._ = `Updated: ${newValue}`;
+}
+var _PRIVATE_STATIC_FIELD = { _: "top secret string" };

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/destructure-set/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/destructure-set/output.js
@@ -1,0 +1,10 @@
+class C {
+  constructor() {
+    [babelHelpers.toSetter(_set_p.bind(C))._] = [0];
+  }
+}
+function _set_p(v) {
+  _q._ = v;
+}
+var _q = { _: void 0 };
+new C();

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/preserve-comments/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/preserve-comments/output.js
@@ -1,0 +1,5 @@
+class C {}
+function _get_a() {
+  return 42;
+}
+function _set_a(v) {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/tagged-template/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/tagged-template/output.js
@@ -1,0 +1,11 @@
+class Foo {
+  static test() {
+    const receiver = _get_tag.call(babelHelpers.assertClassBrand(Foo, this)).bind(this)``;
+    expect(receiver).toBe(this);
+  }
+}
+function _get_tag() {
+  return function() {
+    return this;
+  };
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/updates/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-methods/test/fixtures/static-accessors/updates/output.js
@@ -1,0 +1,35 @@
+class Cl {
+  static publicGetPrivateField() {
+    return _get_privateFieldValue.call(Cl);
+  }
+  static publicSetPrivateField(newValue) {
+    babelHelpers.toSetter(_set_privateFieldValue.bind(Cl))._ = newValue;
+  }
+  static get publicFieldValue() {
+    return Cl.publicField;
+  }
+  static set publicFieldValue(newValue) {
+    Cl.publicField = newValue;
+  }
+  static testUpdates() {
+    var _Cl$privateFieldValue, _Cl$privateFieldValue2, _Cl$privateFieldValue3;
+    _privateField._ = 0;
+    Cl.publicField = 0;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(Cl))._ = (_set_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl), (_Cl$privateFieldValue = _get_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl)), _Cl$privateFieldValue2 = _Cl$privateFieldValue++, _Cl$privateFieldValue)), _Cl$privateFieldValue2);
+    Cl.publicFieldValue = Cl.publicFieldValue++;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl), (_Cl$privateFieldValue3 = _get_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl)), ++_Cl$privateFieldValue3));
+    ++Cl.publicFieldValue;
+    _set_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl), _get_privateFieldValue.call(babelHelpers.assertClassBrand(Cl, Cl)) + 1);
+    Cl.publicFieldValue += 1;
+    babelHelpers.toSetter(_set_privateFieldValue.bind(Cl))._ = -(_get_privateFieldValue.call(Cl) ** _get_privateFieldValue.call(Cl));
+    Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
+  }
+}
+function _get_privateFieldValue() {
+  return _privateField._;
+}
+function _set_privateFieldValue(newValue) {
+  _privateField._ = newValue;
+}
+var _privateField = { _: "top secret string" };
+babelHelpers.defineProperty(Cl, "publicField", "not secret string");

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 641/1095
+Passed: 661/1095
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -467,39 +467,11 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-private-methods (26/148)
-* accessors/arguments/input.js
-x Output mismatch
-
-* accessors/basic/input.js
-x Output mismatch
-
-* accessors/class-binding/input.js
-x Output mismatch
-
-* accessors/destructuring/input.js
-x Output mismatch
-
-* accessors/get-only-setter/input.js
-x Output mismatch
-
-* accessors/preserve-comments/input.js
-x Output mismatch
-
-* accessors/reassignment/input.js
-x Output mismatch
-
-* accessors/set-only-getter/input.js
-x Output mismatch
-
+# babel-plugin-transform-private-methods (46/148)
 * accessors/tagged-template/input.js
-x Output mismatch
-
-* accessors/updates/input.js
-x Output mismatch
-
-* accessors/updates-bigint/input.js
-x Output mismatch
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Arrow)
+rebuilt        : ScopeId(4): ScopeFlags(Function | Arrow)
 
 * accessors-loose/basic/input.js
 x Output mismatch
@@ -559,24 +531,6 @@ x Output mismatch
 x Output mismatch
 
 * assumption-constantSuper/private-method-super/input.js
-x Output mismatch
-
-* duplicated-names/get-set/input.js
-x Output mismatch
-
-* duplicated-names/set-get/input.js
-x Output mismatch
-
-* misc/multiple/input.js
-x Output mismatch
-
-* private-method/destructuring/input.js
-x Output mismatch
-
-* private-method/read-only/input.js
-x Output mismatch
-
-* private-method/reassignment/input.js
 x Output mismatch
 
 * private-method/super/input.js
@@ -791,26 +745,16 @@ x Output mismatch
 * private-static-method-privateFieldsAsSymbols/this/input.js
 x Output mismatch
 
-* static-accessors/basic/input.js
-x Output mismatch
-
-* static-accessors/destructure-set/input.js
-x Output mismatch
-
 * static-accessors/get-only-setter/input.js
-x Output mismatch
-
-* static-accessors/preserve-comments/input.js
 x Output mismatch
 
 * static-accessors/set-only-getter/input.js
 x Output mismatch
 
 * static-accessors/tagged-template/input.js
-x Output mismatch
-
-* static-accessors/updates/input.js
-x Output mismatch
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 
 * static-accessors-loose/basic/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 252 of 362 (69.61%)
+Passed: 283 of 362 (78.18%)
 
 Failures:
 
@@ -112,24 +112,6 @@ TypeError: Cannot read properties of undefined (reading 'x')
     at Foo.test (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-loose-exec.test.js:25:63)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-general-parenthesized-expression-member-call-loose-exec.test.js:68:12
 
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-arguments-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-basic-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-class-binding-exec.test.js
-AssertionError: expected [Function _get_getA] to be [Function A] // Object.is equality
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-class-binding-exec.test.js:22:26
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-get-only-setter-exec.test.js
-AssertionError: expected function to throw an error, but it didn't
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-get-only-setter-exec.test.js:14:77)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-get-only-setter-exec.test.js:20:13
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-helper-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-basic-exec.test.js
 ReferenceError: _Cl_brand is not defined
     at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-basic-exec.test.js:10:38)
@@ -142,8 +124,8 @@ ReferenceError: _A_brand is not defined
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-get-only-setter-exec.test.js
 ReferenceError: _Cl_brand is not defined
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-get-only-setter-exec.test.js:10:38)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-get-only-setter-exec.test.js:21:13
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-get-only-setter-exec.test.js:11:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-get-only-setter-exec.test.js:22:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-helper-exec.test.js
 ReferenceError: _Cl_brand is not defined
@@ -156,11 +138,13 @@ AssertionError: expected +0 to be 1 // Object.is equality
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-set-only-getter-exec.test.js
 ReferenceError: _Cl_brand is not defined
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-set-only-getter-exec.test.js:10:38)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-set-only-getter-exec.test.js:22:13
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-set-only-getter-exec.test.js:11:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-set-only-getter-exec.test.js:23:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
+ReferenceError: _Cl_brand is not defined
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-updates-exec.test.js:10:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-loose-updates-exec.test.js:49:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-basic-exec.test.js
 ReferenceError: _Cl_brand is not defined
@@ -174,8 +158,8 @@ ReferenceError: _A_brand is not defined
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js
 ReferenceError: _Cl_brand is not defined
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:10:38)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:21:13
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:11:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:22:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-helper-exec.test.js
 ReferenceError: _Cl_brand is not defined
@@ -184,50 +168,19 @@ ReferenceError: _Cl_brand is not defined
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-set-only-getter-exec.test.js
 ReferenceError: _Cl_brand is not defined
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-set-only-getter-exec.test.js:10:38)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-set-only-getter-exec.test.js:22:13
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-set-only-getter-exec.test.js:11:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-set-only-getter-exec.test.js:23:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-basic-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-class-binding-exec.test.js
-AssertionError: expected [Function _get_getA] to be [Function A] // Object.is equality
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-class-binding-exec.test.js:22:26
+ReferenceError: _Cl_brand is not defined
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-updates-exec.test.js:10:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsProperties-updates-exec.test.js:49:13
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js
-AssertionError: expected [Function _set_privateFieldValue] to be undefined
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1236:20)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:14:71)
+TypeError: "#privateFieldValue" is write-only
+    at _writeOnlyError (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/writeOnlyError.js:2:9)
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:14:18)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:20:13
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-helper-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-set-only-getter-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-privateFieldsAsSymbols-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-reassignment-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-set-only-getter-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-updates-bigint-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-accessors-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-context-exec.test.js
-Private field '#getStatus' must be declared in an enclosing class
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-assignment-exec.test.js
 ReferenceError: _Foo_brand is not defined
@@ -302,15 +255,6 @@ ReferenceError: _Cl_brand is not defined
 ReferenceError: _Sub_brand is not defined
     at new Sub (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-super-exec.test.js:16:38)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-super-exec.test.js:29:9
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsSymbols-context-exec.test.js
-Private field '#getStatus' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-read-only-exec.test.js
-Private field '#method' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-reassignment-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-loose-basic-exec.test.js
 TypeError: attempted to use private field on non-instance
@@ -396,36 +340,17 @@ TypeError: attempted to use private field on non-instance
     at Function.extract (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-privateFieldsAsProperties-this-exec.test.js:17:12)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-privateFieldsAsProperties-this-exec.test.js:27:25
 
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-privateFieldsAsSymbols-reassignment-exec.test.js
-Private field '#privateStaticMethod' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-read-only-exec.test.js
-Private field '#method' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-reassignment-exec.test.js
-Private field '#privateStaticMethod' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-access-in-static-field-initializer-exec.test.js
-Private field '#p' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-basic-exec.test.js
-Private field '#privateStaticFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-destructure-set-exec.test.js
-Private field '#p' must be declared in an enclosing class
-
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-get-only-setter-exec.test.js
-AssertionError: expected [Function _set_privateStaticFieldValue] to be undefined
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1236:20)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-get-only-setter-exec.test.js:13:42
+TypeError: "#privateStaticFieldValue" is write-only
+    at _writeOnlyError (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/writeOnlyError.js:2:9)
+    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-get-only-setter-exec.test.js:7:15)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-get-only-setter-exec.test.js:14:12
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-access-in-static-field-initializer-exec.test.js
 TypeError: attempted to use private field on non-instance
     at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
     at new C (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-access-in-static-field-initializer-exec.test.js:12:9)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-access-in-static-field-initializer-exec.test.js:18:11
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-access-in-static-field-initializer-exec.test.js:21:11
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-access-in-static-field-initializer-exec.test.js:24:4
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-basic-exec.test.js
@@ -441,19 +366,22 @@ TypeError: attempted to use private field on non-instance
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-destructure-set-exec.test.js:22:2
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-get-only-setter-exec.test.js
-TypeError: attempted to use private field on non-instance
-    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
-    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-get-only-setter-exec.test.js:10:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-get-only-setter-exec.test.js:21:12
+TypeError: "#privateStaticFieldValue" is write-only
+    at _writeOnlyError (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/writeOnlyError.js:2:9)
+    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-get-only-setter-exec.test.js:11:15)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-get-only-setter-exec.test.js:22:12
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
+TypeError: attempted to use private field on non-instance
+    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
+    at Function.testUpdates (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-updates-exec.test.js:24:4)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-loose-updates-exec.test.js:47:5
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-access-in-static-field-initializer-exec.test.js
 TypeError: attempted to use private field on non-instance
     at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
     at new C (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-access-in-static-field-initializer-exec.test.js:12:9)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-access-in-static-field-initializer-exec.test.js:18:11
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-access-in-static-field-initializer-exec.test.js:21:11
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-access-in-static-field-initializer-exec.test.js:24:4
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-basic-exec.test.js
@@ -469,41 +397,22 @@ TypeError: attempted to use private field on non-instance
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-destructure-set-exec.test.js:22:2
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js
-TypeError: attempted to use private field on non-instance
-    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
-    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:10:11)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:21:12
+TypeError: "#privateStaticFieldValue" is write-only
+    at _writeOnlyError (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/writeOnlyError.js:2:9)
+    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:11:15)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-get-only-setter-exec.test.js:22:12
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-access-in-static-field-initializer-exec.test.js
-Private field '#p' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-basic-exec.test.js
-Private field '#privateStaticFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-destructure-set-exec.test.js
-Private field '#p' must be declared in an enclosing class
+TypeError: attempted to use private field on non-instance
+    at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
+    at Function.testUpdates (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-updates-exec.test.js:25:4)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsProperties-updates-exec.test.js:48:5
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js
-AssertionError: expected [Function _set_privateStaticFieldValue] to be undefined
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1236:20)
-    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
-    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
-    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:13:42
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-set-only-getter-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-set-only-getter-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-updates-exec.test.js
-Private field '#privateFieldValue' must be declared in an enclosing class
+TypeError: "#privateStaticFieldValue" is write-only
+    at _writeOnlyError (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/writeOnlyError.js:2:9)
+    at Function.getPrivateStaticFieldValue (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:7:15)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:14:12
 
 ./fixtures/babel/babel-preset-env-test-fixtures-plugins-integration-issue-15170-exec.test.js
 AssertionError: expected [Function] to not throw an error but 'ReferenceError: x is not defined' was thrown


### PR DESCRIPTION
This PR supports transforming private `getter` or `setter` methods, and the output is a little different from Babel's output, For example:

Input:
```js
class Cls {
  #prop = 0;

  get #accessor() {
    return this.#prop;
  }
  set #accessor(v) {
    console.log(arguments);
    this.#prop = v;
  }

  constructor() {
    console.log(this.#accessor)
    [this.#accessor] = [1];
  }
}
```

[Babel's output](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYGwhgzhAEDCIwN4ChrQMQAcBOB7T0AvNAAwDcyq0A5gKYAuGYwwtUu2AFAJTQpppsDAK7YAdtHoALAJYQAdFjyYKaAL5UIDJizYQOnAG69-A4LjH6QteSFzVOYbNWEBbWmPoRuqgdLmKOPhE0Ia-GlTmlvTYwsD0BiZUaFFWNnYO_grozKzs2NzJ0ADaWYq5ehwAuiHFAIxV4cgaQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=script&lineWrap=true&presets=&prettier=false&targets=&version=7.26.4&externalPlugins=%40babel%2Fplugin-transform-class-properties%407.25.9%2C%40babel%2Fplugin-transform-private-methods%407.25.9%2C%40babel%2Fplugin-external-helpers%407.25.9&assumptions=%7B%7D):
```js
var _prop = new WeakMap();
var _Cls_brand = new WeakSet();
class Cls {
  constructor() {
    babelHelpers.classPrivateMethodInitSpec(this, _Cls_brand);
    babelHelpers.classPrivateFieldInitSpec(this, _prop, 0);
    console.log(babelHelpers.classPrivateGetter(_Cls_brand, this, _get_accessor));
    [babelHelpers.classPrivateGetter(_Cls_brand, this, _get_accessor)] = [1];
  }
}
function _get_accessor(_this) {
  return babelHelpers.classPrivateFieldGet(_prop, _this);
}
function _set_accessor(_this2, v) {
  var _arguments = [].slice.call(arguments, 1);
  console.log(_arguments);
  babelHelpers.classPrivateFieldSet(_prop, _this2, v);
}
```

Oxc's output:
```js
var _prop = new WeakMap();
var _Cls_brand = new WeakSet();
class Cls {
        constructor() {
                babelHelpers.classPrivateMethodInitSpec(this, _Cls_brand);
                babelHelpers.classPrivateFieldInitSpec(this, _prop, 0);
                console.log(_get_accessor.call(babelHelpers.assertClassBrand(_Cls_brand, this)));
                [babelHelpers.toSetter(_set_accessor.bind(babelHelpers.assertClassBrand(_Cls_brand, this)), [])._] = [1];
        }
}
function _get_accessor() {
        return babelHelpers.classPrivateFieldGet2(_prop, this);
}
function _set_accessor(v) {
        console.log(arguments);
        babelHelpers.classPrivateFieldSet2(_prop, this, v);
}
```

### Main difference
```diff
// Babel
+ console.log(babelHelpers.classPrivateGetter(_Cls_brand, this, _get_accessor));
+ [babelHelpers.classPrivateGetter(_Cls_brand, this, _get_accessor)] = [1];

+ function _get_accessor(_this) {
+   return babelHelpers.classPrivateFieldGet(_prop, _this);
+ }

+ function _set_accessor(_this2, v) {
+   var _arguments = [].slice.call(arguments, 1);
+   console.log(_arguments);
+   babelHelpers.classPrivateFieldSet(_prop, _this2, v);
+ }

// Oxc
-  console.log(_get_accessor.call(babelHelpers.assertClassBrand(_Cls_brand, this)));- - 
-  [babelHelpers.toSetter(_set_accessor.bind(babelHelpers.assertClassBrand(_Cls_brand, this)), [])._] = [1];

- function _get_accessor() {
-   return babelHelpers.classPrivateFieldGet2(_prop, this);
- }

- function _set_accessor(v) {
-   console.log(arguments);
-   babelHelpers.classPrivateFieldSet2(_prop, this, v);
- }
```

From the main differences, we can see that Babel handles `getter` and `setter` methods using `classPrivateGetter` and `classPrivateSetter` helper functions, which causes all use `this` and `arguments` needs to rewrite to use a temp var instead in `getter` and `setter` methods. This is unnecessary and is not an efficient transformation for us.

Instead, I adapt binding a `this` instead of passing in `this`, this way we don't need to rewrite anything. We can't control the `helper` library for now, so I just transformed the AST to bind `this`, in the future, we can create a helper function to do the same thing.