### PR TITLE
fix(ecmascript): incorrect `to_int_32` value for Infinity

### DIFF
--- a/crates/oxc_ecmascript/src/to_int_32.rs
+++ b/crates/oxc_ecmascript/src/to_int_32.rs
@@ -56,8 +56,8 @@ impl ToInt32 for f64 {
 
         let number = *self;
 
+        // NOTE: this also matches with negative zero
         if !number.is_finite() || number == 0.0 {
-            // NOTE: this matches with negative zero
             return 0;
         }
 

--- a/crates/oxc_ecmascript/src/to_int_32.rs
+++ b/crates/oxc_ecmascript/src/to_int_32.rs
@@ -56,6 +56,10 @@ impl ToInt32 for f64 {
 
         let number = *self;
 
+        if !number.is_finite() || number == 0.0 { // NOTE: this matches with negative zero
+            return 0;
+        }
+
         if number.is_finite() && number <= f64::from(i32::MAX) && number >= f64::from(i32::MIN) {
             let i = number as i32;
             if f64::from(i) == number {

--- a/crates/oxc_ecmascript/src/to_int_32.rs
+++ b/crates/oxc_ecmascript/src/to_int_32.rs
@@ -56,7 +56,8 @@ impl ToInt32 for f64 {
 
         let number = *self;
 
-        if !number.is_finite() || number == 0.0 { // NOTE: this matches with negative zero
+        if !number.is_finite() || number == 0.0 {
+            // NOTE: this matches with negative zero
             return 0;
         }
 

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -1505,9 +1505,9 @@ mod test {
 
     #[test]
     fn test_fold_left_child_op() {
-        test_same("x & infinity & 2"); // FIXME: want x & 0
-        test_same("x - infinity - 2"); // FIXME: want "x-infinity"
-        test_same("x - 1 + infinity");
+        test("x & Infinity & 2", "x & 0");
+        test_same("x - Infinity - 2"); // FIXME: want "x-Infinity"
+        test_same("x - 1 + Infinity");
         test_same("x - 2 + 1");
         test_same("x - 2 + 3");
         test_same("1 + x - 2 + 1");


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-toint32
Infinity should return `0` when passed to `ToInt32` abstract operation.
