### PR TITLE
fix(linter): false positiver in private member expr in oxc/const-comparison

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -415,9 +415,11 @@ fn test() {
         "status_code > 500 && foo() && bar || status_code < 400;",
         // oxc specific
         "a < b",
+        "a.b.c < b.b.c",
         "a <= b",
         "a > b",
         "a >= b",
+        "class Foo { #a; #b; constructor() { this.#a = 1; }; test() { return this.#a > this.#b } }",
     ];
 
     let fail = vec![
@@ -500,10 +502,12 @@ fn test() {
         "a <= a",
         "a > a",
         "a >= a",
+        "a.b.c >= a.b.c",
         "a == b && a == b",
         "a == b || a == b",
         "!foo && !foo",
         "!foo || !foo",
+        "class Foo { #a; #b; constructor() { this.#a = 1; }; test() { return this.#a > this.#a } }",
     ];
 
     Tester::new(ConstComparisons::NAME, ConstComparisons::CATEGORY, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/oxc_const_comparisons.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_const_comparisons.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-snapshot_kind: text
 ---
   ⚠ oxc(const-comparisons): Unexpected constant comparison
    ╭─[const_comparisons.tsx:1:1]
@@ -264,6 +263,13 @@ snapshot_kind: text
    ╰────
   help: Because `a` will always be equal to itself
 
+  ⚠ oxc(const-comparisons): This comparison will always evaluate to true
+   ╭─[const_comparisons.tsx:1:1]
+ 1 │ a.b.c >= a.b.c
+   · ──────────────
+   ╰────
+  help: Because `a.b.c` will always be equal to itself
+
   ⚠ oxc(const-comparisons): Both sides of the logical operator are the same
    ╭─[const_comparisons.tsx:1:1]
  1 │ a == b && a == b
@@ -299,3 +305,10 @@ snapshot_kind: text
    ·   ╰── If this expression evaluates to true
    ╰────
   help: This logical expression will always evaluate to the same value as the expression itself.
+
+  ⚠ oxc(const-comparisons): This comparison will always evaluate to false
+   ╭─[const_comparisons.tsx:1:69]
+ 1 │ class Foo { #a; #b; constructor() { this.#a = 1; }; test() { return this.#a > this.#a } }
+   ·                                                                     ─────────────────
+   ╰────
+  help: Because `this.#a` will never be greater than itself

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -274,7 +274,16 @@ pub fn is_same_member_expression(
         (Some(_), None) | (None, Some(_)) => {
             return false;
         }
-        _ => {}
+        (None, None) => {
+            if let (
+                MemberExpression::PrivateFieldExpression(left),
+                MemberExpression::PrivateFieldExpression(right),
+            ) = (left, right)
+            {
+                return left.field.name == right.field.name
+                    && is_same_expression(&left.object, &right.object, ctx);
+            }
+        }
     }
 
     if let (


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/8163