### PR TITLE
perf(linter): run rules which require typescript syntax only when source type is actually typescript

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -118,6 +118,10 @@ impl Rule for ConsistentGenericConstructors {
                 .unwrap_or_default(),
         }))
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 impl ConsistentGenericConstructors {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -140,6 +140,10 @@ impl Rule for NoEmptyObjectType {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn check_interface_declaration(

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -113,6 +113,10 @@ impl Rule for NoMisusedNew {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -76,6 +76,10 @@ impl Rule for NoUnsafeFunctionType {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn handle_function_type<'a>(identifier: &'a IdentifierReference<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -99,6 +99,10 @@ impl Rule for NoWrapperObjectTypes {
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]


### PR DESCRIPTION
there are some typescript rules which could be applied to javascript too. 
These are the rules which diagnostic reports are only possible in typescript