### PR TITLE
feat(linter): add jsx-a11y/no-noninteractive-tabindex rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -410,6 +410,7 @@ mod jsx_a11y {
     pub mod no_aria_hidden_on_focusable;
     pub mod no_autofocus;
     pub mod no_distracting_elements;
+    pub mod no_noninteractive_tabindex;
     pub mod no_redundant_roles;
     pub mod prefer_tag_over_role;
     pub mod role_has_required_aria_props;
@@ -745,6 +746,7 @@ oxc_macros::declare_all_lint_rules! {
     jsx_a11y::lang,
     jsx_a11y::media_has_caption,
     jsx_a11y::mouse_events_have_key_events,
+    jsx_a11y::no_noninteractive_tabindex,
     jsx_a11y::no_access_key,
     jsx_a11y::no_aria_hidden_on_focusable,
     jsx_a11y::no_autofocus,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -1,11 +1,17 @@
-use oxc_ast::{ast::{JSXAttributeItem, JSXAttributeValue}, AstKind};
+use oxc_ast::{
+    ast::{JSXAttributeItem, JSXAttributeValue},
+    AstKind,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactStr, Span};
+use oxc_span::Span;
 use phf::phf_set;
 
 use crate::{
-    context::LintContext, rule::Rule, utils::{get_element_type, has_jsx_prop_ignore_case}, AstNode
+    context::LintContext,
+    rule::Rule,
+    utils::{get_element_type, has_jsx_prop_ignore_case},
+    AstNode,
 };
 
 fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
@@ -24,11 +30,11 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Tab key navigation should be limited to elements on the page that can be interacted with. 
-    /// Thus it is not necessary to add a tabindex to items in an unordered list, for example, 
-    /// to make them navigable through assistive technology. 
-    /// 
-    /// These applications already afford page traversal mechanisms based on the HTML of the page. 
+    /// Tab key navigation should be limited to elements on the page that can be interacted with.
+    /// Thus it is not necessary to add a tabindex to items in an unordered list, for example,
+    /// to make them navigable through assistive technology.
+    ///
+    /// These applications already afford page traversal mechanisms based on the HTML of the page.
     /// Generally, we should try to reduce the size of the page's tab ring rather than increasing it.
     ///
     /// ### Examples
@@ -65,14 +71,16 @@ const INTERACTIVE_HTML_ELEMENTS: phf::set::Set<&'static str> = phf_set! {
 const INTERACTIVE_HTML_ROLES: phf::set::Set<&'static str> = phf_set! {
     "button", "checkbox", "gridcell", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "textbox"
 };
- 
+
 impl Rule for NoNoninteractiveTabindex {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };
 
-        if let Some(JSXAttributeItem::Attribute(tabindex_attr)) = has_jsx_prop_ignore_case(jsx_el, "tabIndex") {
+        if let Some(JSXAttributeItem::Attribute(tabindex_attr)) =
+            has_jsx_prop_ignore_case(jsx_el, "tabIndex")
+        {
             if let Some(JSXAttributeValue::StringLiteral(tabindex)) = &tabindex_attr.value {
                 if tabindex.value == "-1" {
                     return;
@@ -84,10 +92,14 @@ impl Rule for NoNoninteractiveTabindex {
                     return;
                 }
 
-                if let Some(JSXAttributeItem::Attribute(role_attr)) = has_jsx_prop_ignore_case(jsx_el, "role") {
+                if let Some(JSXAttributeItem::Attribute(role_attr)) =
+                    has_jsx_prop_ignore_case(jsx_el, "role")
+                {
                     if let Some(JSXAttributeValue::StringLiteral(role)) = &role_attr.value {
                         if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str()) {
-                            ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
+                            ctx.diagnostic(no_noninteractive_tabindex_diagnostic(
+                                tabindex_attr.span,
+                            ));
                         }
                     } else {
                         ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
@@ -97,7 +109,6 @@ impl Rule for NoNoninteractiveTabindex {
                 }
             }
         }
-
     }
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -30,7 +30,11 @@ pub struct NoNoninteractiveTabindex {
 
 impl Default for NoNoninteractiveTabindex {
     fn default() -> Self {
-        Self {roles: vec![CompactStr::new("tabpanel")], allow_expression_values: true, tags: vec![]}
+        Self {
+            roles: vec![CompactStr::new("tabpanel")],
+            allow_expression_values: true,
+            tags: vec![],
+        }
     }
 }
 
@@ -107,14 +111,17 @@ impl Rule for NoNoninteractiveTabindex {
                 if let Some(JSXAttributeItem::Attribute(role_attr)) =
                     has_jsx_prop_ignore_case(jsx_el, "role")
                 {
-                    if self.allow_expression_values {return;}
+                    if self.allow_expression_values {
+                        return;
+                    }
 
                     println!("role_attr: {role_attr:?}");
                     if let Some(JSXAttributeValue::StringLiteral(role)) = &role_attr.value {
                         println!("role: {role:?}");
 
-
-                        if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str()) && !self.roles.contains(&CompactStr::new(role.value.as_str())) {
+                        if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str())
+                            && !self.roles.contains(&CompactStr::new(role.value.as_str()))
+                        {
                             ctx.diagnostic(no_noninteractive_tabindex_diagnostic(
                                 tabindex_attr.span,
                             ));
@@ -137,17 +144,23 @@ impl Rule for NoNoninteractiveTabindex {
                 roles: config
                     .get("roles")
                     .and_then(serde_json::Value::as_array)
-                    .map_or(default.roles, |v|  v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()),
+                    .map_or(default.roles, |v| {
+                        v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
+                    }),
                 tags: config
-                .get("tags")
-                .and_then(serde_json::Value::as_array)
-                .map_or(default.tags, |v|  v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()),
-                allow_expression_values:  config.get("allow_expression_values").and_then(serde_json::Value::as_bool).unwrap_or(default.allow_expression_values)
+                    .get("tags")
+                    .and_then(serde_json::Value::as_array)
+                    .map_or(default.tags, |v| {
+                        v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
+                    }),
+                allow_expression_values: config
+                    .get("allow_expression_values")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(default.allow_expression_values),
             }
         } else {
             default
         }
-        
     }
 }
 
@@ -177,8 +190,14 @@ fn test() {
     ];
 
     let fail = vec![
-        (r#"<div role="tabpanel" tabIndex="0" />"#, Some(serde_json::json!([{ "roles": [], "allowExpressionValues": false }]))),
-        (r#"<div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;"#, Some(serde_json::json!([{ "roles": [], "allowExpressionValues": false }]))),
+        (
+            r#"<div role="tabpanel" tabIndex="0" />"#,
+            Some(serde_json::json!([{ "roles": [], "allowExpressionValues": false }])),
+        ),
+        (
+            r#"<div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "roles": [], "allowExpressionValues": false }])),
+        ),
         (
             r#"<div role={BUTTON} onClick={() => {}} tabIndex="0" />;"#,
             Some(serde_json::json!([{ "allowExpressionValues": false }])),

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -86,8 +86,9 @@ const INTERACTIVE_HTML_ELEMENTS: phf::set::Set<&'static str> = phf_set! {
 };
 
 // https://w3c.github.io/aria/#widget_roles
+// NOTE: "tabpanel" should be here, but adding it makes the unit tests for the jsx-a11y plugin fail.
 const INTERACTIVE_HTML_ROLES: phf::set::Set<&'static str> = phf_set! {
-    "button", "checkbox", "gridcell", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "scrollbar", "searchbox", "separator", "slider", "spinbutton", "switch", "tab", "tabpanel", "textbox", "treeitem"
+    "button", "checkbox", "gridcell", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "scrollbar", "searchbox", "separator", "slider", "spinbutton", "switch", "tab", "textbox", "treeitem"
 };
 
 impl Rule for NoNoninteractiveTabindex {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -33,12 +33,11 @@ struct NoNoninteractiveTabindexConfig {
 
 impl Default for NoNoninteractiveTabindex {
     fn default() -> Self {
-        Self (
-            Box::new(NoNoninteractiveTabindexConfig{ roles: vec![CompactStr::new("tabpanel")],
+        Self(Box::new(NoNoninteractiveTabindexConfig {
+            roles: vec![CompactStr::new("tabpanel")],
             allow_expression_values: true,
             tags: vec![],
-        })
-    )
+        }))
     }
 }
 
@@ -110,20 +109,14 @@ impl Rule for NoNoninteractiveTabindex {
                     return;
                 }
 
-                println!("component: {component}");
-
                 if let Some(JSXAttributeItem::Attribute(role_attr)) =
                     has_jsx_prop_ignore_case(jsx_el, "role")
                 {
-                    println!("allow_expression_values: {}", self.0.allow_expression_values);
                     if self.0.allow_expression_values {
                         return;
                     }
 
-                    println!("role_attr: {role_attr:?}");
                     if let Some(JSXAttributeValue::StringLiteral(role)) = &role_attr.value {
-                        println!("role: {role:?}");
-
                         if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str())
                             && !self.0.roles.contains(&CompactStr::new(role.value.as_str()))
                         {
@@ -145,8 +138,8 @@ impl Rule for NoNoninteractiveTabindex {
         let default = Self::default();
 
         if let Some(config) = value.get(0) {
-            Self (
-                Box::new(NoNoninteractiveTabindexConfig {roles: config
+            Self(Box::new(NoNoninteractiveTabindexConfig {
+                roles: config
                     .get("roles")
                     .and_then(serde_json::Value::as_array)
                     .map_or(default.0.roles, |v| {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -144,25 +144,25 @@ impl Rule for NoNoninteractiveTabindex {
         let Some(config) = value.get(0) else {
             return default;
         };
-        
-            Self(Box::new(NoNoninteractiveTabindexConfig {
-                roles: config
-                    .get("roles")
-                    .and_then(serde_json::Value::as_array)
-                    .map_or(default.0.roles, |v| {
-                        v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
-                    }),
-                tags: config
-                    .get("tags")
-                    .and_then(serde_json::Value::as_array)
-                    .map_or(default.0.tags, |v| {
-                        v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
-                    }),
-                allow_expression_values: config
-                    .get("allowExpressionValues")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(default.0.allow_expression_values),
-            }))
+
+        Self(Box::new(NoNoninteractiveTabindexConfig {
+            roles: config
+                .get("roles")
+                .and_then(serde_json::Value::as_array)
+                .map_or(default.0.roles, |v| {
+                    v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
+                }),
+            tags: config
+                .get("tags")
+                .and_then(serde_json::Value::as_array)
+                .map_or(default.0.tags, |v| {
+                    v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
+                }),
+            allow_expression_values: config
+                .get("allowExpressionValues")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(default.0.allow_expression_values),
+        }))
     }
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -85,8 +85,8 @@ const INTERACTIVE_HTML_ELEMENTS: phf::set::Set<&'static str> = phf_set! {
     "a", "audio", "button", "details", "embed", "iframe", "img", "input", "label", "select", "textarea", "video"
 };
 
-// https://w3c.github.io/aria/#widget_roles
-// NOTE: "tabpanel" should be here, but adding it makes the unit tests for the jsx-a11y plugin fail.
+// https://www.w3.org/TR/wai-aria/#widget_roles
+// NOTE: "tabpanel" is not included here because it's technically a section role. It can optionally be considered interactive within the context of a tablist, because its visibility is dynamically controlled by an element with the "tab" aria role. It's included in the recommended jsx-a11y config for this reason.
 const INTERACTIVE_HTML_ROLES: phf::set::Set<&'static str> = phf_set! {
     "button", "checkbox", "gridcell", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "scrollbar", "searchbox", "separator", "slider", "spinbutton", "switch", "tab", "textbox", "treeitem"
 };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 
 fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("tabIndex should only be declared on interactive elements")
         .with_help("tabIndex attribute should be removed")
         .with_label(span)

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -1,0 +1,93 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+    AstNode,
+};
+
+fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNoninteractiveTabindex;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    NoNoninteractiveTabindex,
+    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+
+    pending  // TODO: describe fix capabilities. Remove if no fix can be done,
+             // keep at 'pending' if you think one could be added but don't know how.
+             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+);
+
+impl Rule for NoNoninteractiveTabindex {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"<div role="tabpanel" tabIndex="0" />"#, None),
+        (r#"<div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;"#, None),
+        (
+            r#"<div role={BUTTON} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": true }])),
+        ),
+        (
+            r#"<div role={isButton ? "button" : "link"} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": true }])),
+        ),
+        (
+            r#"<div role={isButton ? "button" : LINK} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": true }])),
+        ),
+        (
+            r#"<div role={isButton ? BUTTON : LINK} onClick={() => {}} tabIndex="0"/>;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        (r#"<div role="tabpanel" tabIndex="0" />"#, None),
+        (r#"<div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;"#, None),
+        (
+            r#"<div role={BUTTON} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": false }])),
+        ),
+        (
+            r#"<div role={isButton ? "button" : "link"} onClick={() => {}} tabIndex="0" />;"#,
+            Some(serde_json::json!([{ "allowExpressionValues": false }])),
+        ),
+    ];
+
+    Tester::new(NoNoninteractiveTabindex::NAME, NoNoninteractiveTabindex::CATEGORY, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -133,17 +133,7 @@ impl Rule for NoNoninteractiveTabindex {
             if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str())
                 && !self.0.roles.contains(&CompactStr::new(role.value.as_str()))
             {
-                        ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                        ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                    }
-                } else {
-                    ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                }
                 ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                    }
-                } else {
-                    ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                }
             }
         }
     }
@@ -151,7 +141,10 @@ impl Rule for NoNoninteractiveTabindex {
     fn from_configuration(value: serde_json::Value) -> Self {
         let default = Self::default();
 
-        if let Some(config) = value.get(0) {
+        let Some(config) = value.get(0) else {
+            return default;
+        };
+        
             Self(Box::new(NoNoninteractiveTabindexConfig {
                 roles: config
                     .get("roles")
@@ -170,9 +163,6 @@ impl Rule for NoNoninteractiveTabindex {
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(default.0.allow_expression_values),
             }))
-        } else {
-            default
-        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -102,39 +102,40 @@ impl Rule for NoNoninteractiveTabindex {
             return;
         };
 
-        if let Some(JSXAttributeValue::StringLiteral(tabindex)) = &tabindex_attr.value {
-            if tabindex.value == "-1" {
-                return;
-            }
+        let Some(JSXAttributeValue::StringLiteral(tabindex)) = &tabindex_attr.value else {
+            return;
+        };
 
-            let component = &get_element_type(ctx, jsx_el);
+        if tabindex.value == "-1" {
+            return;
+        }
 
-            if INTERACTIVE_HTML_ELEMENTS.contains(component) {
-                return;
-            }
+        let component = &get_element_type(ctx, jsx_el);
 
-            let Some(JSXAttributeItem::Attribute(role_attr)) =
-                has_jsx_prop_ignore_case(jsx_el, "role")
-            else {
-                // if the component is not an interactive element and has no role, the tabindex is invalid.
-                ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                return;
-            };
+        if INTERACTIVE_HTML_ELEMENTS.contains(component) {
+            return;
+        }
 
-            if self.0.allow_expression_values {
-                return;
-            }
+        let Some(JSXAttributeItem::Attribute(role_attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
+        else {
+            // if the component is not an interactive element and has no role, the tabindex is invalid.
+            ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
+            return;
+        };
 
-            let Some(JSXAttributeValue::StringLiteral(role)) = &role_attr.value else {
-                ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-                return;
-            };
+        if self.0.allow_expression_values {
+            return;
+        }
 
-            if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str())
-                && !self.0.roles.contains(&CompactStr::new(role.value.as_str()))
-            {
-                ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
-            }
+        let Some(JSXAttributeValue::StringLiteral(role)) = &role_attr.value else {
+            ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
+            return;
+        };
+
+        if !INTERACTIVE_HTML_ROLES.contains(role.value.as_str())
+            && !self.0.roles.contains(&CompactStr::new(role.value.as_str()))
+        {
+            ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));
         }
     }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -16,8 +16,8 @@ use crate::{
 
 fn no_noninteractive_tabindex_diagnostic(span: Span) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Tabindex should only be declared on interactive elements")
-        .with_help("Tabindex attribute should be removed")
+    OxcDiagnostic::warn("tabIndex should only be declared on interactive elements")
+        .with_help("tabIndex attribute should be removed")
         .with_label(span)
 }
 
@@ -111,6 +111,7 @@ impl Rule for NoNoninteractiveTabindex {
                 if let Some(JSXAttributeItem::Attribute(role_attr)) =
                     has_jsx_prop_ignore_case(jsx_el, "role")
                 {
+                    println!("allow_expression_values: {}", self.allow_expression_values);
                     if self.allow_expression_values {
                         return;
                     }
@@ -154,7 +155,7 @@ impl Rule for NoNoninteractiveTabindex {
                         v.iter().map(|v| CompactStr::new(v.as_str().unwrap())).collect()
                     }),
                 allow_expression_values: config
-                    .get("allow_expression_values")
+                    .get("allowExpressionValues")
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(default.allow_expression_values),
             }

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+snapshot_kind: text
+---
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+   ╭─[no_noninteractive_tabindex.tsx:1:22]
+ 1 │ <div role="tabpanel" tabIndex="0" />
+   ·                      ────────────
+   ╰────
+  help: Tabindex attribute should be removed
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+   ╭─[no_noninteractive_tabindex.tsx:1:44]
+ 1 │ <div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;
+   ·                                            ────────────
+   ╰────
+  help: Tabindex attribute should be removed
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+   ╭─[no_noninteractive_tabindex.tsx:1:39]
+ 1 │ <div role={BUTTON} onClick={() => {}} tabIndex="0" />;
+   ·                                       ────────────
+   ╰────
+  help: Tabindex attribute should be removed
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+   ╭─[no_noninteractive_tabindex.tsx:1:61]
+ 1 │ <div role={isButton ? "button" : "link"} onClick={() => {}} tabIndex="0" />;
+   ·                                                             ────────────
+   ╰────
+  help: Tabindex attribute should be removed

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_tabindex.snap
@@ -2,30 +2,30 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:22]
  1 │ <div role="tabpanel" tabIndex="0" />
    ·                      ────────────
    ╰────
-  help: Tabindex attribute should be removed
+  help: tabIndex attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:44]
  1 │ <div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;
    ·                                            ────────────
    ╰────
-  help: Tabindex attribute should be removed
+  help: tabIndex attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:39]
  1 │ <div role={BUTTON} onClick={() => {}} tabIndex="0" />;
    ·                                       ────────────
    ╰────
-  help: Tabindex attribute should be removed
+  help: tabIndex attribute should be removed
 
-  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): Tabindex should only be declared on interactive elements
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-tabindex): tabIndex should only be declared on interactive elements
    ╭─[no_noninteractive_tabindex.tsx:1:61]
  1 │ <div role={isButton ? "button" : "link"} onClick={() => {}} tabIndex="0" />;
    ·                                                             ────────────
    ╰────
-  help: Tabindex attribute should be removed
+  help: tabIndex attribute should be removed


### PR DESCRIPTION
This PR implements the [jsx-a11y/no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/91e39b45ade789c86ae14df869a86b0ea468ed95/docs/rules/no-noninteractive-tabindex.md) rule. 

I set the default values as the ones that are in the recommended config.

I used this [html spec section](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) to source the interactive elements.

The interactive roles came from [this article in the MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles).