### PR TITLE
feat(minifier): change `foo?.['bar']` to `foo?.bar`

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/mod.rs
+++ b/crates/oxc_minifier/src/ast_passes/mod.rs
@@ -166,6 +166,14 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         self.x4_peephole_substitute_alternate_syntax.exit_property_key(key, ctx);
     }
 
+    fn exit_member_expression(
+        &mut self,
+        expr: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x4_peephole_substitute_alternate_syntax.exit_member_expression(expr, ctx);
+    }
+
     fn exit_catch_clause(&mut self, catch: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x4_peephole_substitute_alternate_syntax.exit_catch_clause(catch, ctx);
     }

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 173.90 kB  | 60.15 kB   | 59.82 kB   | 19.50 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 90.56 kB   | 90.07 kB   | 32.18 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 90.54 kB   | 90.07 kB   | 32.17 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 118.53 kB  | 118.14 kB  | 44.56 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 118.53 kB  | 118.14 kB  | 44.55 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 71.98 kB   | 72.48 kB   | 26.19 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 71.97 kB   | 72.48 kB   | 26.19 kB   | 26.20 kB   | lodash.js 
 
 555.77 kB  | 273.85 kB  | 270.13 kB  | 91.17 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 460.99 kB  | 458.89 kB  | 126.92 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 460.99 kB  | 458.89 kB  | 126.91 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 653.54 kB  | 646.76 kB  | 164.04 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 727.90 kB  | 724.14 kB  | 180.39 kB  | 181.07 kB  | victory.js
+2.14 MB    | 727.17 kB  | 724.14 kB  | 180.34 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 332.29 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 332.27 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.32 MB    | 2.31 MB    | 493.24 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.32 MB    | 2.31 MB    | 493.10 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.51 MB    | 3.49 MB    | 910.88 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.51 MB    | 3.49 MB    | 910.40 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
ChainExpression's `expression` field is `ChainElement` and not `Expression` so the previous code did not run for optional chainings.