### PR TITLE
fix(minifier): minify string `PropertyKey`

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/mod.rs
+++ b/crates/oxc_minifier/src/ast_passes/mod.rs
@@ -269,6 +269,10 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn exit_call_expression(&mut self, expr: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x3_peephole_substitute_alternate_syntax.exit_call_expression(expr, ctx);
     }
+
+    fn exit_property_key(&mut self, key: &mut PropertyKey<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x3_peephole_substitute_alternate_syntax.exit_property_key(key, ctx);
+    }
 }
 
 pub struct DeadCodeElimination {

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 173.90 kB  | 60.16 kB   | 59.82 kB   | 19.48 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 90.70 kB   | 90.07 kB   | 32.21 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 90.57 kB   | 90.07 kB   | 32.18 kB   | 31.95 kB   | jquery.js 
 
 342.15 kB  | 118.59 kB  | 118.14 kB  | 44.53 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 72.49 kB   | 72.48 kB   | 26.22 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 72.02 kB   | 72.48 kB   | 26.18 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 274.10 kB  | 270.13 kB  | 91.25 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 273.89 kB  | 270.13 kB  | 91.18 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 461.05 kB  | 458.89 kB  | 126.89 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 461.04 kB  | 458.89 kB  | 126.89 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 656.99 kB  | 646.76 kB  | 164.18 kB  | 163.73 kB  | three.js  
+1.25 MB    | 656.62 kB  | 646.76 kB  | 164.13 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 728.22 kB  | 724.14 kB  | 180.43 kB  | 181.07 kB  | victory.js
+2.14 MB    | 727.99 kB  | 724.14 kB  | 180.35 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 332.24 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.34 MB    | 2.31 MB    | 493.51 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.32 MB    | 2.31 MB    | 493.24 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.51 MB    | 3.49 MB    | 910.84 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.51 MB    | 3.49 MB    | 910.83 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
#8169 added `if self.in_fixed_loop` in `try_compress_property_key`. Because `exit_property_key` was not called for `PeepholeOptimizations`, `try_compress_property_key` was never called.

refs #8147
