### PR TITLE
fix(editor/vscode): set minimum supported ver. to `^1.93.0`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate", "helpers:pinGitHubActionDigests"],
-  "ignorePaths": [
-    "crates/oxc_linter/fixtures/**"
-  ]
+  "ignorePaths": ["crates/oxc_linter/fixtures/**"],
+  "ignoreDeps": ["@types/vscode"]
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -22,7 +22,7 @@
     "oxc"
   ],
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.93.0"
   },
   "sponsor": {
     "url": "https://github.com/sponsors/boshen"
@@ -146,7 +146,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.0.0",
-    "@types/vscode": "1.96.0",
+    "@types/vscode": "1.93.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^22.0.0
         version: 22.10.2
       '@types/vscode':
-        specifier: 1.96.0
-        version: 1.96.0
+        specifier: 1.93.0
+        version: 1.93.0
       '@vscode/test-cli':
         specifier: ^0.0.10
         version: 0.0.10
@@ -1304,8 +1304,8 @@ packages:
   '@types/node@22.10.2':
     resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
 
-  '@types/vscode@1.96.0':
-    resolution: {integrity: sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==}
+  '@types/vscode@1.93.0':
+    resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -4020,7 +4020,7 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/vscode@1.96.0': {}
+  '@types/vscode@1.93.0': {}
 
   '@types/wrap-ansi@3.0.0': {}
 


### PR DESCRIPTION
Hi,

I'm using Cursor which is based on VSCode `1.93` at the moment of this PR. And i've faced with an issue when i can't install latest version of oxc vscode plugin - by default plugin marketplace offers me `v0.0.1` and via `Install Specific Version` i can install only `v0.10.3` while latest is `v0.15.3`. No idea when Cursor will update its version.
There's no issue with VSCode, only Cursor.

After downgrading minimum version, Cursor allowed me to install plugin that i compiled by myself, everything seem to be working.

Not sure about how is usually contributions made here so correct me if i miss something