### PR TITLE
fix(codegen): source map builder panicked because it attempted to subtract with overflow in `search_original_line_and_column`

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use nonmax::NonMaxU32;
 use oxc_index::{Idx, IndexVec};
@@ -235,9 +235,7 @@ impl SourcemapBuilder {
         let lines = &self.line_offset_tables.lines;
         let mut idx = self.last_line_lookup as usize;
 
-        let cap = idx.saturating_sub(16);
-        idx = max(idx.saturating_sub(1), cap);
-        while idx > cap && lines[idx].byte_offset_to_start_of_line > position {
+        while lines[idx].byte_offset_to_start_of_line > position {
             idx -= 1;
         }
 


### PR DESCRIPTION
See: https://github.com/oxc-project/monitor-oxc/actions/runs/12531534720/job/34949348092
Related: #7926 

This line causes panic.
https://github.com/oxc-project/oxc/blob/46fc1a8b7d26f1971d1809d68060cb0259dc4b53/crates/oxc_codegen/src/sourcemap_builder.rs#L147-L148

￼After investigation, I found that the root cause was the code removed in this PR. I don’t understand what the code was used for, but it was obviously wrong. Because `idx` is always smaller than `cap`


