### PR TITLE
feat(semantic): allow getting mutable reference to symbols table

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -163,6 +163,11 @@ impl<'a> Semantic<'a> {
         &self.symbols
     }
 
+    /// Get a mutable reference to the [`SymbolTable`].
+    pub fn symbols_mut(&mut self) -> &mut SymbolTable {
+        &mut self.symbols
+    }
+
     pub fn unused_labels(&self) -> &Vec<NodeId> {
         &self.unused_labels
     }


### PR DESCRIPTION
Seems like the only way to get a mutable reference to the `SymbolTable` inside `Semantic` right now is with `into_symbol_table_and_scope_tree`, but that drops other useful info.

Since `scopes_mut` exists I figure this would be reasonable too?

Reason I'm requesting this is I have a project where I need to fill in some symbols `oxc_semantic` doesn't yet pick up on (like function overloads, `declare`'d symbols) and this would be the cleanest way to do it.