### PR TITLE
feat(linter): add `statement_span` to `ModuleRecord/ImportEntry`

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::Path,
     rc::Rc,
     sync::{Arc, OnceLock},
 };
@@ -38,56 +38,57 @@ impl IsolatedLintHandler {
         path: &Path,
         content: Option<String>,
     ) -> Option<Vec<DiagnosticReport>> {
-        if Self::should_lint_path(path) {
-            Some(self.lint_path(path, content).map_or(vec![], |(p, errors)| {
-                let mut diagnostics: Vec<DiagnosticReport> =
-                    errors.into_iter().map(|e| e.into_diagnostic_report(&p)).collect();
-                // a diagnostics connected from related_info to original diagnostic
-                let mut inverted_diagnostics = vec![];
-                for d in &diagnostics {
-                    let Some(ref related_info) = d.diagnostic.related_information else {
-                        continue;
-                    };
-                    let related_information = Some(vec![DiagnosticRelatedInformation {
-                        location: lsp_types::Location {
-                            uri: lsp_types::Url::from_file_path(path).unwrap(),
-                            range: d.diagnostic.range,
-                        },
-                        message: "original diagnostic".to_string(),
-                    }]);
-                    for r in related_info {
-                        if r.location.range == d.diagnostic.range {
-                            continue;
-                        }
-                        inverted_diagnostics.push(DiagnosticReport {
-                            diagnostic: lsp_types::Diagnostic {
-                                range: r.location.range,
-                                severity: Some(DiagnosticSeverity::HINT),
-                                code: None,
-                                message: r.message.clone(),
-                                source: d.diagnostic.source.clone(),
-                                code_description: None,
-                                related_information: related_information.clone(),
-                                tags: None,
-                                data: None,
-                            },
-                            fixed_content: None,
-                        });
-                    }
-                }
-                diagnostics.append(&mut inverted_diagnostics);
-                diagnostics
-            }))
-        } else {
-            None
+        if !Self::should_lint_path(path) {
+            return None;
         }
+
+        Some(self.lint_path(path, content).map_or(vec![], |errors| {
+            let mut diagnostics: Vec<DiagnosticReport> =
+                errors.into_iter().map(|e| e.into_diagnostic_report(&path.to_path_buf())).collect();
+
+            // a diagnostics connected from related_info to original diagnostic
+            let mut inverted_diagnostics = vec![];
+            for d in &diagnostics {
+                let Some(ref related_info) = d.diagnostic.related_information else {
+                    continue;
+                };
+                let related_information = Some(vec![DiagnosticRelatedInformation {
+                    location: lsp_types::Location {
+                        uri: lsp_types::Url::from_file_path(path).unwrap(),
+                        range: d.diagnostic.range,
+                    },
+                    message: "original diagnostic".to_string(),
+                }]);
+                for r in related_info {
+                    if r.location.range == d.diagnostic.range {
+                        continue;
+                    }
+                    inverted_diagnostics.push(DiagnosticReport {
+                        diagnostic: lsp_types::Diagnostic {
+                            range: r.location.range,
+                            severity: Some(DiagnosticSeverity::HINT),
+                            code: None,
+                            message: r.message.clone(),
+                            source: d.diagnostic.source.clone(),
+                            code_description: None,
+                            related_information: related_information.clone(),
+                            tags: None,
+                            data: None,
+                        },
+                        fixed_content: None,
+                    });
+                }
+            }
+            diagnostics.append(&mut inverted_diagnostics);
+            diagnostics
+        }))
     }
 
     fn lint_path(
         &self,
         path: &Path,
         source_text: Option<String>,
-    ) -> Option<(PathBuf, Vec<ErrorWithPosition>)> {
+    ) -> Option<Vec<ErrorWithPosition>> {
         if !Loader::can_load(path) {
             debug!("extension not supported yet.");
             return None;
@@ -170,12 +171,10 @@ impl IsolatedLintHandler {
                     ErrorReport { error: Error::from(msg.error), fixed_content }
                 })
                 .collect::<Vec<ErrorReport>>();
-            let (_, errors_with_position) =
-                Self::wrap_diagnostics(path, &source_text, reports, start);
-            diagnostics.extend(errors_with_position);
+            diagnostics.extend(Self::wrap_diagnostics(path, &source_text, reports, start));
         }
 
-        Some((path.to_path_buf(), diagnostics))
+        Some(diagnostics)
     }
 
     fn should_lint_path(path: &Path) -> bool {
@@ -194,9 +193,10 @@ impl IsolatedLintHandler {
         source_text: &str,
         reports: Vec<ErrorReport>,
         start: u32,
-    ) -> (PathBuf, Vec<ErrorWithPosition>) {
+    ) -> Vec<ErrorWithPosition> {
         let source = Arc::new(NamedSource::new(path.to_string_lossy(), source_text.to_owned()));
-        let diagnostics = reports
+
+        reports
             .into_iter()
             .map(|report| {
                 ErrorWithPosition::new(
@@ -206,7 +206,6 @@ impl IsolatedLintHandler {
                     start as usize,
                 )
             })
-            .collect();
-        (path.to_path_buf(), diagnostics)
+            .collect()
     }
 }

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -156,6 +156,16 @@ impl<'a> From<&oxc_syntax::module_record::NameSpan<'a>> for NameSpan {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportEntry {
+    /// Span of the import statement.
+    /// 
+    /// ## Examples
+    /// 
+    /// ```ts
+    /// import { foo } from "mod";
+    /// ^^^^^^^^^^^^^^^^^^^^^^^^^
+    /// ```
+    pub statement_span: Span,
+
     /// String value of the ModuleSpecifier of the ImportDeclaration.
     ///
     /// ## Examples
@@ -212,6 +222,7 @@ pub struct ImportEntry {
 impl<'a> From<&oxc_syntax::module_record::ImportEntry<'a>> for ImportEntry {
     fn from(other: &oxc_syntax::module_record::ImportEntry<'a>) -> Self {
         Self {
+            statement_span: other.statement_span,
             module_request: NameSpan::from(&other.module_request),
             import_name: ImportImportName::from(&other.import_name),
             local_name: NameSpan::from(&other.local_name),

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -157,9 +157,9 @@ impl<'a> From<&oxc_syntax::module_record::NameSpan<'a>> for NameSpan {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportEntry {
     /// Span of the import statement.
-    /// 
+    ///
     /// ## Examples
-    /// 
+    ///
     /// ```ts
     /// import { foo } from "mod";
     /// ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Probably a breaking change. 

this is needed for the diagnostic in `no-restricted-imports`: https://github.com/oxc-project/oxc/pull/8113

you can see the eslint expection here:
https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-restricted-imports.js#L487-L517