### PR TITLE
feat(transformer/class-properties): transform private in expression

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -163,6 +163,7 @@ pub enum Helper {
     SuperPropSet,
     ReadOnlyError,
     WriteOnlyError,
+    CheckInRHS,
 }
 
 impl Helper {
@@ -191,6 +192,7 @@ impl Helper {
             Self::SuperPropSet => "superPropSet",
             Self::ReadOnlyError => "readOnlyError",
             Self::WriteOnlyError => "writeOnlyError",
+            Self::CheckInRHS => "checkInRHS",
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -368,6 +368,10 @@ impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
             Expression::TaggedTemplateExpression(_) => {
                 self.transform_tagged_template_expression(expr, ctx);
             }
+            // "#prop in object"
+            Expression::PrivateInExpression(_) => {
+                self.transform_private_in_expression(expr, ctx);
+            }
             _ => {}
         }
     }

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/private/accessor/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/private/accessor/output.js
@@ -1,0 +1,10 @@
+var _Foo_brand = new WeakSet();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo_brand);
+  }
+  test(other) {
+    return _Foo_brand.has(babelHelpers.checkInRHS(other));
+  }
+}
+function _get_foo() {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/private/static-accessor/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/private/static-accessor/output.js
@@ -1,0 +1,6 @@
+class Foo {
+  test(other) {
+    return babelHelpers.checkInRHS(other) === Foo;
+  }
+}
+function _get_foo() {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/accessor/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/accessor/output.js
@@ -1,0 +1,10 @@
+var _Foo_brand = new WeakSet();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo_brand);
+  }
+  test(other) {
+    return _Foo_brand.has(babelHelpers.checkInRHS(other));
+  }
+}
+function _get_foo() {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/half-constructed-instance/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/half-constructed-instance/output.js
@@ -1,0 +1,20 @@
+var _F_brand = new WeakSet();
+var _x = new WeakMap();
+var _y = new WeakMap();
+class F {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _F_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _y, (() => {
+      throw "error";
+    })());
+  }
+  m() {
+    _F_brand.has(babelHelpers.checkInRHS(this));
+    _x.has(babelHelpers.checkInRHS(this));
+    _y.has(babelHelpers.checkInRHS(this));
+    _F_brand.has(babelHelpers.checkInRHS(this));
+  }
+}
+function _get_w() {}
+function _z() {}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/static-accessor/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-private-property-in-object/test/fixtures/to-native-fields/static-accessor/output.js
@@ -1,0 +1,6 @@
+class Foo {
+  test(other) {
+    return babelHelpers.checkInRHS(other) === Foo;
+  }
+}
+function _get_foo() {}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 661/1154
+Passed: 686/1154
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -811,7 +811,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-private-property-in-object (0/59)
+# babel-plugin-transform-private-property-in-object (25/59)
 * assumption-privateFieldsAsProperties/accessor/input.js
 x Output mismatch
 
@@ -872,36 +872,6 @@ x Output mismatch
 * assumption-privateFieldsAsSymbols/static-method/input.js
 x Output mismatch
 
-* private/accessor/input.js
-x Output mismatch
-
-* private/field/input.js
-x Output mismatch
-
-* private/method/input.js
-x Output mismatch
-
-* private/native-classes/input.js
-x Output mismatch
-
-* private/nested-class/input.js
-x Output mismatch
-
-* private/nested-class-other-redeclared/input.js
-x Output mismatch
-
-* private/nested-class-redeclared/input.js
-x Output mismatch
-
-* private/static-accessor/input.js
-x Output mismatch
-
-* private/static-field/input.js
-x Output mismatch
-
-* private/static-method/input.js
-x Output mismatch
-
 * private/static-shadow/input.js
 x Output mismatch
 
@@ -912,9 +882,6 @@ x Output mismatch
 x Output mismatch
 
 * private-loose/method/input.js
-x Output mismatch
-
-* private-loose/native-classes/input.js
 x Output mismatch
 
 * private-loose/nested-class/input.js
@@ -938,49 +905,7 @@ x Output mismatch
 * private-loose/static-shadow/input.js
 x Output mismatch
 
-* to-native-fields/accessor/input.js
-x Output mismatch
-
 * to-native-fields/class-expression-in-default-param/input.js
-x Output mismatch
-
-* to-native-fields/class-expression-instance/input.js
-x Output mismatch
-
-* to-native-fields/class-expression-static/input.js
-x Output mismatch
-
-* to-native-fields/field/input.js
-x Output mismatch
-
-* to-native-fields/half-constructed-instance/input.js
-x Output mismatch
-
-* to-native-fields/half-constructed-static/input.js
-x Output mismatch
-
-* to-native-fields/method/input.js
-x Output mismatch
-
-* to-native-fields/multiple-checks/input.js
-x Output mismatch
-
-* to-native-fields/nested-class/input.js
-x Output mismatch
-
-* to-native-fields/nested-class-other-redeclared/input.js
-x Output mismatch
-
-* to-native-fields/nested-class-redeclared/input.js
-x Output mismatch
-
-* to-native-fields/static-accessor/input.js
-x Output mismatch
-
-* to-native-fields/static-field/input.js
-x Output mismatch
-
-* to-native-fields/static-method/input.js
 x Output mismatch
 
 * to-native-fields/static-shadow/input.js

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 283 of 374 (75.67%)
+Passed: 291 of 374 (77.81%)
 
 Failures:
 
@@ -78,9 +78,6 @@ AssertionError: expected '_Class' to be 'Foo' // Object.is equality
 AssertionError: expected '_Class' to be 'Foo' // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-properties-test-fixtures-public-static-infer-name-exec.test.js:9:19
 
-./fixtures/babel/babel-plugin-transform-class-static-block-test-fixtures-integration-loose-private-in-exec.test.js
-Private field '#bar' must be declared in an enclosing class
-
 ./fixtures/babel/babel-plugin-transform-class-static-block-test-fixtures-integration-loose-private-methods-access-exec.test.js
 TypeError: attempted to use private field on non-instance
     at _classPrivateFieldBase (./node_modules/.pnpm/@babel+runtime@7.26.0/node_modules/@babel/runtime/helpers/classPrivateFieldLooseBase.js:2:44)
@@ -90,9 +87,6 @@ TypeError: attempted to use private field on non-instance
 ./fixtures/babel/babel-plugin-transform-class-static-block-test-fixtures-integration-new-target-exec.test.js
 AssertionError: expected [Function Base] to be undefined // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-class-static-block-test-fixtures-integration-new-target-exec.test.js:10:29
-
-./fixtures/babel/babel-plugin-transform-class-static-block-test-fixtures-integration-private-in-exec.test.js
-Private field '#bar' must be declared in an enclosing class
 
 ./fixtures/babel/babel-plugin-transform-optional-chaining-test-fixtures-assumption-noDocumentAll-parenthesized-expression-member-call-exec.test.js
 TypeError: Cannot read properties of undefined (reading 'x')
@@ -415,40 +409,32 @@ TypeError: "#privateStaticFieldValue" is write-only
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-static-accessors-privateFieldsAsSymbols-get-only-setter-exec.test.js:14:12
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsProperties-method-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsProperties-rhs-not-object-exec.test.js
-Private field '#p' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsSymbols-method-exec.test.js
-Private field '#foo' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsSymbols-rhs-not-object-exec.test.js
-Private field '#p' must be declared in an enclosing class
+ReferenceError: _Foo_brand is not defined
+    at new Foo (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsProperties-method-exec.test.js:8:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-assumption-privateFieldsAsProperties-method-exec.test.js:19:13
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-rhs-not-object-exec.test.js
-Private field '#p' must be declared in an enclosing class
+AssertionError: expected [Function] to throw error including 'right-hand side of \'in\' should be a…' but got '_Class_brand is not defined'
+    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:1438:21)
+    at Proxy.<anonymous> (./node_modules/.pnpm/@vitest+expect@2.1.2/node_modules/@vitest/expect/dist/index.js:923:17)
+    at Proxy.methodWrapper (./node_modules/.pnpm/chai@5.1.2/node_modules/chai/chai.js:1610:25)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-rhs-not-object-exec.test.js:176:5
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js
-Private field '#x' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-rhs-not-object-exec.test.js
-Private field '#p' must be declared in an enclosing class
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-loose-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js
-Private field '#x' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-half-constructed-instance-exec.test.js
-Private field '#w' must be declared in an enclosing class
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-private-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-half-constructed-static-exec.test.js
-Private field '#w' must be declared in an enclosing class
-
-./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-rhs-not-object-exec.test.js
-Private field '#p' must be declared in an enclosing class
+AssertionError: expected true to be false // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-half-constructed-static-exec.test.js:29:15
 
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js
-Private field '#x' must be declared in an enclosing class
+AssertionError: expected 2 to be 5 // Object.is equality
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:18:25
 
 ./fixtures/babel/babel-preset-env-test-fixtures-plugins-integration-issue-15170-exec.test.js
 AssertionError: expected [Function] to not throw an error but 'ReferenceError: x is not defined' was thrown


### PR DESCRIPTION
This PR support transforms `#prop in object` in class-properties to cover https://www.npmjs.com/package/@babel/plugin-transform-private-property-in-object  plugin does