### PR TITLE
fix(linter): fix `ignorePattern` config for windows 

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -282,6 +282,7 @@ impl LintRunner {
     }
 }
 
+#[cfg(test)]
 mod test {
     use std::{env, path::MAIN_SEPARATOR_STR};
 

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     io::BufWriter,
-    path::{Path, PathBuf, MAIN_SEPARATOR_STR},
+    path::{Path, PathBuf},
     time::Instant,
 };
 
@@ -72,16 +72,6 @@ impl Runner for LintRunner {
             paths.retain(|p| if p.is_dir() { true } else { !ignore.matched(p, false).is_ignore() });
         }
 
-        // Append cwd to all paths
-        paths = paths
-            .into_iter()
-            .map(|x| {
-                let mut path_with_cwd = self.cwd.clone();
-                path_with_cwd.push(x);
-                path_with_cwd
-            })
-            .collect();
-
         if paths.is_empty() {
             // If explicit paths were provided, but all have been
             // filtered, return early.
@@ -115,8 +105,10 @@ impl Runner for LintRunner {
         }
 
         let mut oxlintrc = config_search_result.unwrap();
+        let oxlint_wd = oxlintrc.path.parent().unwrap_or(&self.cwd).to_path_buf();
+        println!("Using configuration file: {:?}", oxlint_wd);
 
-        let paths = Walk::new(&oxlintrc.path, &paths, &ignore_options, &oxlintrc.ignore_patterns)
+        let paths = Walk::new(&oxlint_wd, &paths, &ignore_options, &oxlintrc.ignore_patterns)
             .with_extensions(Extensions(extensions))
             .paths();
 

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -116,13 +116,7 @@ impl Runner for LintRunner {
 
         let mut oxlintrc = config_search_result.unwrap();
 
-        let ignore_paths = oxlintrc
-            .ignore_patterns
-            .iter()
-            .map(|value| PathBuf::from(value.replace('/', MAIN_SEPARATOR_STR)))
-            .collect::<Vec<_>>();
-
-        let paths = Walk::new(&paths, &ignore_options, &ignore_paths)
+        let paths = Walk::new(&oxlintrc.path, &paths, &ignore_options, &oxlintrc.ignore_patterns)
             .with_extensions(Extensions(extensions))
             .paths();
 
@@ -696,7 +690,6 @@ mod test {
         // Apply fix to the file.
         let _ = test(args);
         assert_eq!(fs::read_to_string(file).unwrap().replace("\r\n", "\n"), "\n");
-
 
         // File should not be modified if no fix is applied.
         let modified_before = fs::metadata(file).unwrap().modified().unwrap();

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -116,7 +116,6 @@ impl Runner for LintRunner {
 
         let mut oxlintrc = config_search_result.unwrap();
         let oxlint_wd = oxlintrc.path.parent().unwrap_or(&self.cwd).to_path_buf();
-        println!("Using configuration file: {:?}", oxlint_wd);
 
         let paths = Walk::new(&oxlint_wd, &paths, &ignore_options, &oxlintrc.ignore_patterns)
             .with_extensions(Extensions(extensions))
@@ -281,6 +280,7 @@ impl LintRunner {
         Oxlintrc::from_file(&config_path).or_else(|_| Ok(Oxlintrc::default()))
     }
 }
+
 mod test {
     use std::{env, path::MAIN_SEPARATOR_STR};
 

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -56,10 +56,7 @@ impl ignore::ParallelVisitor for WalkCollector {
         match entry {
             Ok(entry) => {
                 if Walk::is_wanted_entry(&entry, &self.extensions) {
-                    println!("Processing entry: {:?}", entry.path()); // Debug output
                     self.paths.push(entry.path().to_path_buf().into_boxed_path());
-                } else {
-                    println!("Ignoring entry: {:?}", entry.path()); // Debug output
                 }
                 ignore::WalkState::Continue
             }
@@ -106,7 +103,7 @@ impl Walk {
 
             if !config_ignore_patterns.is_empty() {
                 for pattern in config_ignore_patterns {
-                    let pattern = format!("!{}", pattern);
+                    let pattern = format!("!{pattern}");
                     override_builder.add(&pattern).unwrap();
                 }
             }

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -56,7 +56,10 @@ impl ignore::ParallelVisitor for WalkCollector {
         match entry {
             Ok(entry) => {
                 if Walk::is_wanted_entry(&entry, &self.extensions) {
+                    println!("Processing entry: {:?}", entry.path()); // Debug output
                     self.paths.push(entry.path().to_path_buf().into_boxed_path());
+                } else {
+                    println!("Ignoring entry: {:?}", entry.path()); // Debug output
                 }
                 ignore::WalkState::Continue
             }
@@ -64,14 +67,14 @@ impl ignore::ParallelVisitor for WalkCollector {
         }
     }
 }
-
 impl Walk {
     /// Will not canonicalize paths.
     /// # Panics
     pub fn new(
+        current_path: &PathBuf,
         paths: &[PathBuf],
         options: &IgnoreOptions,
-        config_ignore_patterns: &[PathBuf],
+        config_ignore_patterns: &Vec<String>,
     ) -> Self {
         assert!(!paths.is_empty(), "At least one path must be provided to Walk::new");
 
@@ -91,7 +94,7 @@ impl Walk {
         if !options.no_ignore {
             inner.add_custom_ignore_filename(&options.ignore_path);
 
-            let mut override_builder = OverrideBuilder::new(Path::new("/"));
+            let mut override_builder = OverrideBuilder::new(current_path);
             if !options.ignore_pattern.is_empty() {
                 for pattern in &options.ignore_pattern {
                     // Meaning of ignore pattern is reversed
@@ -103,7 +106,7 @@ impl Walk {
 
             if !config_ignore_patterns.is_empty() {
                 for pattern in config_ignore_patterns {
-                    let pattern = format!("!{}", pattern.to_str().unwrap());
+                    let pattern = format!("!{}", pattern);
                     override_builder.add(&pattern).unwrap();
                 }
             }
@@ -148,7 +151,7 @@ impl Walk {
 
 #[cfg(test)]
 mod test {
-    use std::{env, ffi::OsString};
+    use std::{env, ffi::OsString, path::PathBuf};
 
     use super::{Extensions, Walk};
     use crate::cli::IgnoreOptions;
@@ -164,7 +167,7 @@ mod test {
             symlinks: false,
         };
 
-        let mut paths = Walk::new(&fixtures, &ignore_options, &[])
+        let mut paths = Walk::new(&PathBuf::from("/"), &fixtures, &ignore_options, &vec![])
             .with_extensions(Extensions(["js", "vue"].to_vec()))
             .paths()
             .into_iter()

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::Path,
     rc::Rc,
     sync::{Arc, OnceLock},
 };
@@ -38,56 +38,57 @@ impl IsolatedLintHandler {
         path: &Path,
         content: Option<String>,
     ) -> Option<Vec<DiagnosticReport>> {
-        if Self::should_lint_path(path) {
-            Some(self.lint_path(path, content).map_or(vec![], |(p, errors)| {
-                let mut diagnostics: Vec<DiagnosticReport> =
-                    errors.into_iter().map(|e| e.into_diagnostic_report(&p)).collect();
-                // a diagnostics connected from related_info to original diagnostic
-                let mut inverted_diagnostics = vec![];
-                for d in &diagnostics {
-                    let Some(ref related_info) = d.diagnostic.related_information else {
-                        continue;
-                    };
-                    let related_information = Some(vec![DiagnosticRelatedInformation {
-                        location: lsp_types::Location {
-                            uri: lsp_types::Url::from_file_path(path).unwrap(),
-                            range: d.diagnostic.range,
-                        },
-                        message: "original diagnostic".to_string(),
-                    }]);
-                    for r in related_info {
-                        if r.location.range == d.diagnostic.range {
-                            continue;
-                        }
-                        inverted_diagnostics.push(DiagnosticReport {
-                            diagnostic: lsp_types::Diagnostic {
-                                range: r.location.range,
-                                severity: Some(DiagnosticSeverity::HINT),
-                                code: None,
-                                message: r.message.clone(),
-                                source: d.diagnostic.source.clone(),
-                                code_description: None,
-                                related_information: related_information.clone(),
-                                tags: None,
-                                data: None,
-                            },
-                            fixed_content: None,
-                        });
-                    }
-                }
-                diagnostics.append(&mut inverted_diagnostics);
-                diagnostics
-            }))
-        } else {
-            None
+        if !Self::should_lint_path(path) {
+            return None;
         }
+
+        Some(self.lint_path(path, content).map_or(vec![], |errors| {
+            let mut diagnostics: Vec<DiagnosticReport> =
+                errors.into_iter().map(|e| e.into_diagnostic_report(&path.to_path_buf())).collect();
+
+            // a diagnostics connected from related_info to original diagnostic
+            let mut inverted_diagnostics = vec![];
+            for d in &diagnostics {
+                let Some(ref related_info) = d.diagnostic.related_information else {
+                    continue;
+                };
+                let related_information = Some(vec![DiagnosticRelatedInformation {
+                    location: lsp_types::Location {
+                        uri: lsp_types::Url::from_file_path(path).unwrap(),
+                        range: d.diagnostic.range,
+                    },
+                    message: "original diagnostic".to_string(),
+                }]);
+                for r in related_info {
+                    if r.location.range == d.diagnostic.range {
+                        continue;
+                    }
+                    inverted_diagnostics.push(DiagnosticReport {
+                        diagnostic: lsp_types::Diagnostic {
+                            range: r.location.range,
+                            severity: Some(DiagnosticSeverity::HINT),
+                            code: None,
+                            message: r.message.clone(),
+                            source: d.diagnostic.source.clone(),
+                            code_description: None,
+                            related_information: related_information.clone(),
+                            tags: None,
+                            data: None,
+                        },
+                        fixed_content: None,
+                    });
+                }
+            }
+            diagnostics.append(&mut inverted_diagnostics);
+            diagnostics
+        }))
     }
 
     fn lint_path(
         &self,
         path: &Path,
         source_text: Option<String>,
-    ) -> Option<(PathBuf, Vec<ErrorWithPosition>)> {
+    ) -> Option<Vec<ErrorWithPosition>> {
         if !Loader::can_load(path) {
             debug!("extension not supported yet.");
             return None;
@@ -170,12 +171,10 @@ impl IsolatedLintHandler {
                     ErrorReport { error: Error::from(msg.error), fixed_content }
                 })
                 .collect::<Vec<ErrorReport>>();
-            let (_, errors_with_position) =
-                Self::wrap_diagnostics(path, &source_text, reports, start);
-            diagnostics.extend(errors_with_position);
+            diagnostics.extend(Self::wrap_diagnostics(path, &source_text, reports, start));
         }
 
-        Some((path.to_path_buf(), diagnostics))
+        Some(diagnostics)
     }
 
     fn should_lint_path(path: &Path) -> bool {
@@ -194,9 +193,10 @@ impl IsolatedLintHandler {
         source_text: &str,
         reports: Vec<ErrorReport>,
         start: u32,
-    ) -> (PathBuf, Vec<ErrorWithPosition>) {
+    ) -> Vec<ErrorWithPosition> {
         let source = Arc::new(NamedSource::new(path.to_string_lossy(), source_text.to_owned()));
-        let diagnostics = reports
+
+        reports
             .into_iter()
             .map(|report| {
                 ErrorWithPosition::new(
@@ -206,7 +206,6 @@ impl IsolatedLintHandler {
                     start as usize,
                 )
             })
-            .collect();
-        (path.to_path_buf(), diagnostics)
+            .collect()
     }
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -128,9 +128,9 @@ impl Oxlintrc {
         })?;
 
         // Get absolute path from `path`
-        let absolute_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        // let absolute_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
-        config.path = absolute_path;
+        config.path = path.to_path_buf();
 
         Ok(config)
     }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -127,9 +127,6 @@ impl Oxlintrc {
             OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
         })?;
 
-        // Get absolute path from `path`
-        // let absolute_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-
         config.path = path.to_path_buf();
 
         Ok(config)

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ alias c := conformance
 alias f := fix
 alias new-typescript-rule := new-ts-rule
 
-# Make sure you have cargo-binstall installed.
+# Make sure you have cargo-binstall and pnpm installed.
 # You can download the pre-compiled binary from <https://github.com/cargo-bins/cargo-binstall#installation>
 # or install via `cargo install cargo-binstall`
 # Initialize the project by installing all the necessary tools.


### PR DESCRIPTION
Changes:

- Config `ignorePatterns` not as `Path`, because the create `ignore` does only handle `/` and not Win-style `\`
- Passed full path to the config and do not use `canonicalize` because it prefix the paths with `\\?\`,  
  read more here: https://stackoverflow.com/a/41233992/7387397
- Updated and enabled tests for windows, some are still failing 

closes #8188 