### PR TITLE
refactor(linter): remove remapping for plugin name in diagnostics

### DIFF
--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::Path,
     rc::Rc,
     sync::{Arc, OnceLock},
 };
@@ -38,56 +38,57 @@ impl IsolatedLintHandler {
         path: &Path,
         content: Option<String>,
     ) -> Option<Vec<DiagnosticReport>> {
-        if Self::should_lint_path(path) {
-            Some(self.lint_path(path, content).map_or(vec![], |(p, errors)| {
-                let mut diagnostics: Vec<DiagnosticReport> =
-                    errors.into_iter().map(|e| e.into_diagnostic_report(&p)).collect();
-                // a diagnostics connected from related_info to original diagnostic
-                let mut inverted_diagnostics = vec![];
-                for d in &diagnostics {
-                    let Some(ref related_info) = d.diagnostic.related_information else {
-                        continue;
-                    };
-                    let related_information = Some(vec![DiagnosticRelatedInformation {
-                        location: lsp_types::Location {
-                            uri: lsp_types::Url::from_file_path(path).unwrap(),
-                            range: d.diagnostic.range,
-                        },
-                        message: "original diagnostic".to_string(),
-                    }]);
-                    for r in related_info {
-                        if r.location.range == d.diagnostic.range {
-                            continue;
-                        }
-                        inverted_diagnostics.push(DiagnosticReport {
-                            diagnostic: lsp_types::Diagnostic {
-                                range: r.location.range,
-                                severity: Some(DiagnosticSeverity::HINT),
-                                code: None,
-                                message: r.message.clone(),
-                                source: d.diagnostic.source.clone(),
-                                code_description: None,
-                                related_information: related_information.clone(),
-                                tags: None,
-                                data: None,
-                            },
-                            fixed_content: None,
-                        });
-                    }
-                }
-                diagnostics.append(&mut inverted_diagnostics);
-                diagnostics
-            }))
-        } else {
-            None
+        if !Self::should_lint_path(path) {
+            return None;
         }
+
+        Some(self.lint_path(path, content).map_or(vec![], |errors| {
+            let mut diagnostics: Vec<DiagnosticReport> =
+                errors.into_iter().map(|e| e.into_diagnostic_report(&path.to_path_buf())).collect();
+
+            // a diagnostics connected from related_info to original diagnostic
+            let mut inverted_diagnostics = vec![];
+            for d in &diagnostics {
+                let Some(ref related_info) = d.diagnostic.related_information else {
+                    continue;
+                };
+                let related_information = Some(vec![DiagnosticRelatedInformation {
+                    location: lsp_types::Location {
+                        uri: lsp_types::Url::from_file_path(path).unwrap(),
+                        range: d.diagnostic.range,
+                    },
+                    message: "original diagnostic".to_string(),
+                }]);
+                for r in related_info {
+                    if r.location.range == d.diagnostic.range {
+                        continue;
+                    }
+                    inverted_diagnostics.push(DiagnosticReport {
+                        diagnostic: lsp_types::Diagnostic {
+                            range: r.location.range,
+                            severity: Some(DiagnosticSeverity::HINT),
+                            code: None,
+                            message: r.message.clone(),
+                            source: d.diagnostic.source.clone(),
+                            code_description: None,
+                            related_information: related_information.clone(),
+                            tags: None,
+                            data: None,
+                        },
+                        fixed_content: None,
+                    });
+                }
+            }
+            diagnostics.append(&mut inverted_diagnostics);
+            diagnostics
+        }))
     }
 
     fn lint_path(
         &self,
         path: &Path,
         source_text: Option<String>,
-    ) -> Option<(PathBuf, Vec<ErrorWithPosition>)> {
+    ) -> Option<Vec<ErrorWithPosition>> {
         if !Loader::can_load(path) {
             debug!("extension not supported yet.");
             return None;
@@ -170,12 +171,10 @@ impl IsolatedLintHandler {
                     ErrorReport { error: Error::from(msg.error), fixed_content }
                 })
                 .collect::<Vec<ErrorReport>>();
-            let (_, errors_with_position) =
-                Self::wrap_diagnostics(path, &source_text, reports, start);
-            diagnostics.extend(errors_with_position);
+            diagnostics.extend(Self::wrap_diagnostics(path, &source_text, reports, start));
         }
 
-        Some((path.to_path_buf(), diagnostics))
+        Some(diagnostics)
     }
 
     fn should_lint_path(path: &Path) -> bool {
@@ -194,9 +193,10 @@ impl IsolatedLintHandler {
         source_text: &str,
         reports: Vec<ErrorReport>,
         start: u32,
-    ) -> (PathBuf, Vec<ErrorWithPosition>) {
+    ) -> Vec<ErrorWithPosition> {
         let source = Arc::new(NamedSource::new(path.to_string_lossy(), source_text.to_owned()));
-        let diagnostics = reports
+
+        reports
             .into_iter()
             .map(|report| {
                 ErrorWithPosition::new(
@@ -206,7 +206,6 @@ impl IsolatedLintHandler {
                     start as usize,
                 )
             })
-            .collect();
-        (path.to_path_buf(), diagnostics)
+            .collect()
     }
 }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -10,7 +10,7 @@ use crate::{
     frameworks,
     module_record::ModuleRecord,
     options::LintOptions,
-    utils, FrameworkFlags, RuleWithSeverity,
+    FrameworkFlags, RuleWithSeverity,
 };
 
 use super::{plugin_name_to_prefix, LintContext};
@@ -171,7 +171,7 @@ impl<'a> ContextHost<'a> {
     /// Creates a new [`LintContext`] for a specific rule.
     pub fn spawn(self: Rc<Self>, rule: &RuleWithSeverity) -> LintContext<'a> {
         let rule_name = rule.name();
-        let plugin_name = self.map_jest_rule_to_vitest(rule);
+        let plugin_name = rule.plugin_name();
 
         LintContext {
             parent: self,
@@ -195,22 +195,6 @@ impl<'a> ContextHost<'a> {
             #[cfg(debug_assertions)]
             current_rule_fix_capabilities: crate::rule::RuleFixMeta::None,
             severity: oxc_diagnostics::Severity::Warning,
-        }
-    }
-
-    /// Maps Jest rule names and maps to Vitest rules when possible, returning the original plugin otherwise.
-    ///
-    /// Many Vitest rules are essentially ports of the Jest plugin rules with minor modifications.
-    /// For these rules, we use the corresponding jest rules with some adjustments for compatibility.
-    fn map_jest_rule_to_vitest(&self, rule: &RuleWithSeverity) -> &'static str {
-        let plugin_name = rule.plugin_name();
-        if self.plugins.has_vitest()
-            && plugin_name == "jest"
-            && utils::is_jest_rule_adapted_to_vitest(rule.name())
-        {
-            "vitest"
-        } else {
-            plugin_name
         }
     }
 

--- a/crates/oxc_linter/src/snapshots/jest_consistent_test_it.snap
+++ b/crates/oxc_linter/src/snapshots/jest_consistent_test_it.snap
@@ -2,14 +2,14 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:17]
  3 │ 
  4 │                 it("foo")
@@ -18,7 +18,7 @@ snapshot_kind: text
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:17]
  3 │ 
  4 │                 testThisThing("foo")
@@ -27,70 +27,70 @@ snapshot_kind: text
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ xit("foo")
    · ───
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ fit("foo")
    · ───
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.skip("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.concurrent("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.only("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.each([])("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.each``("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { it.each``("bar") })
    ·                                ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { test.each``("bar") })
    ·                                ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:3:21]
  2 │                 describe.each()("%s", () => {
  3 │                     test("is valid, but should not be", () => {});
@@ -99,7 +99,7 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:3:21]
  2 │                 describe.only.each()("%s", () => {
  3 │                     test("is valid, but should not be", () => {});
@@ -108,98 +108,98 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ xtest("foo")
    · ─────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.skip("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.concurrent("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.only("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.each([])("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { test.each``("bar") })
    ·                                ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.each``("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.only("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { xtest("foo") })
    ·                           ─────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:43]
  3 │ 
  4 │                 describe("suite", () => { dontTestThis("foo") });
@@ -208,7 +208,7 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:42]
  3 │ 
  4 │                 context("suite", () => { dontTestThis("foo") });
@@ -217,42 +217,42 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.skip("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.concurrent("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.only("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { xtest("foo") })
    ·                           ─────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:43]
  3 │ 
  4 │                 describe("suite", () => { dontTestThis("foo") });
@@ -261,7 +261,7 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:38]
  3 │ 
  4 │             context("suite", () => { dontTestThis("foo") });
@@ -270,112 +270,112 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.skip("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.concurrent("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("shows error", () => {});
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.skip("shows error");
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.only('shows error');
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:25]
  1 │ describe('foo', () => { it('bar', () => {}); });
    ·                         ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:2:1]
  1 │ import { test } from "vitest"
  2 │ test("shows error", () => {});
@@ -383,63 +383,63 @@ snapshot_kind: text
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("shows error", () => {});
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:2:1]
  1 │ import { it } from "vitest"
  2 │ it("foo")
@@ -447,7 +447,7 @@ snapshot_kind: text
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──

--- a/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
@@ -2,98 +2,98 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => {});
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", myTest); function myTest() {}
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => {});
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test.skip("should fail", () => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ afterEach(() => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => { somePromise.then(() => {}); });
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => { foo(true).toBe(true); })
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should also fail",() => expectSaga(mySaga).returns());
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().bar().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:4:10]
  3 │ 
  4 │             checkThat('this passes', () => {
@@ -102,7 +102,7 @@ snapshot_kind: text
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:4:10]
  3 │ 
  4 │             checkThat.skip('this passes', () => {
@@ -111,7 +111,7 @@ snapshot_kind: text
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:2:13]
  1 │ 
  2 │             it("should warn on non-assert await expression", async () => {
@@ -120,7 +120,7 @@ snapshot_kind: text
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:2:13]
  1 │ 
  2 │             test("event emitters bound to CLS context", function(t) {
@@ -129,91 +129,91 @@ snapshot_kind: text
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => {});
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", myTest); function myTest() {}
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => {});
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ afterEach(() => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => { somePromise.then(() => {}); });
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => { foo(true).toBe(true); })
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should also fail",() => expectSaga(mySaga).returns());
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().bar().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:4:17]
  3 │ 
  4 │                 checkThat('this passes', () => {

--- a/crates/oxc_linter/src/snapshots/jest_no_alias_methods.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_alias_methods.snap
@@ -2,126 +2,126 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalled"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalled"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalled()
    ·           ──────────
    ╰────
   help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledTimes"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledTimes()
    ·           ───────────────
    ╰────
   help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "toBeCalledWith" with its canonical name of "toHaveBeenCalledWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "lastCalledWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "lastCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).lastCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "lastCalledWith" with its canonical name of "toHaveBeenLastCalledWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "nthCalledWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "nthCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).nthCalledWith()
    ·           ─────────────
    ╰────
   help: Replace "nthCalledWith" with its canonical name of "toHaveBeenNthCalledWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturn"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturn"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturn()
    ·           ────────
    ╰────
   help: Replace "toReturn" with its canonical name of "toHaveReturned"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturnTimes"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturnTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturnTimes()
    ·           ─────────────
    ╰────
   help: Replace "toReturnTimes" with its canonical name of "toHaveReturnedTimes"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturnWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturnWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturnWith()
    ·           ────────────
    ╰────
   help: Replace "toReturnWith" with its canonical name of "toHaveReturnedWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "lastReturnedWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "lastReturnedWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).lastReturnedWith()
    ·           ────────────────
    ╰────
   help: Replace "lastReturnedWith" with its canonical name of "toHaveLastReturnedWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "nthReturnedWith"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "nthReturnedWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).nthReturnedWith()
    ·           ───────────────
    ╰────
   help: Replace "nthReturnedWith" with its canonical name of "toHaveNthReturnedWith"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toThrowError()
    ·           ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:20]
  1 │ expect(a).resolves.toThrowError()
    ·                    ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:19]
  1 │ expect(a).rejects.toThrowError()
    ·                   ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not.toThrowError()
    ·               ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not['toThrowError']()
    ·               ──────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalled"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalled"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalled()
    ·           ──────────
    ╰────
   help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledTimes"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledTimes()
    ·           ───────────────
    ╰────
   help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
 
-  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not["toThrowError"]()
    ·               ──────────────

--- a/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
@@ -2,105 +2,105 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fdescribe('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe['skip']('foo', function () {})
    ·   ────────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe['skip']('foo', function () {})
    ·   ────────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.skip('foo', function () {})
    ·   ───────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.only('foo', function () {})
    ·   ───────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it.concurrent('foo', function () {})
    ·   ─────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it['skip']('foo', function () {})
    ·   ──────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.skip('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.concurrent('foo', function () {})
    ·   ───────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test['skip']('foo', function () {})
    ·   ────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xdescribe('foo', function () {})
    ·   ─────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xit('foo', function () {})
    ·   ───────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fit('foo', function () {})
    ·   ───────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xtest('foo', function () {})
    ·   ─────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:2:17]
  1 │ 
  2 │               // test(
@@ -109,7 +109,7 @@ snapshot_kind: text
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:2:17]
  1 │     
  2 │ ╭─▶               /* test
@@ -121,42 +121,42 @@ snapshot_kind: text
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it('has title but no callback')
    ·   ────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // it()
    ·   ─────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.someNewMethodThatMightBeAddedInTheFuture()
    ·   ────────────────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test['someNewMethodThatMightBeAddedInTheFuture']()
    ·   ───────────────────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test('has title but no callback')
    ·   ──────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:3:17]
  2 │                   foo()
  3 │ ╭─▶               /*
@@ -166,49 +166,49 @@ snapshot_kind: text
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // describe(\'foo\', function () {})\'
    ·   ────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test.concurrent("foo", function () {})
    ·   ───────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test["skip"]("foo", function () {})
    ·   ────────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xdescribe("foo", function () {})
    ·   ─────────────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // xit("foo", function () {})
    ·   ───────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // fit("foo", function () {})
    ·   ───────────────────────────
    ╰────
   help: Remove or uncomment this comment
 
-  ⚠ eslint-plugin-vitest(no-commented-out-tests): Some tests seem to be commented
+  ⚠ eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented
    ╭─[no_commented_out_tests.tsx:2:15]
  1 │ 
  2 │             // test(

--- a/crates/oxc_linter/src/snapshots/jest_no_conditional_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_conditional_expect.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 it('foo', () => {
  3 │                     something && expect(something).toHaveBeenCalled();
@@ -11,7 +11,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:31]
  2 │                 it('foo', () => {
  3 │                     a || b && expect(something).toHaveBeenCalled();
@@ -20,7 +20,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:33]
  2 │                 it('foo', () => {
  3 │                     (a || b) && expect(something).toHaveBeenCalled();
@@ -29,7 +29,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:32]
  2 │                 it('foo', () => {
  3 │                     a || (b && expect(something).toHaveBeenCalled());
@@ -38,7 +38,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:31]
  2 │                 it('foo', () => {
  3 │                     a && b && expect(something).toHaveBeenCalled();
@@ -47,7 +47,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:31]
  2 │                 it('foo', () => {
  3 │                     a && b || expect(something).toHaveBeenCalled();
@@ -56,7 +56,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:33]
  2 │                 it('foo', () => {
  3 │                     (a && b) || expect(something).toHaveBeenCalled();
@@ -65,7 +65,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 function getValue() {
  3 │                     something && expect(something).toHaveBeenCalled();
@@ -74,7 +74,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 it('foo', () => {
  3 │                     something || expect(something).toHaveBeenCalled();
@@ -83,7 +83,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 it.each``('foo', () => {
  3 │                     something || expect(something).toHaveBeenCalled();
@@ -92,7 +92,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 it.each()('foo', () => {
  3 │                     something || expect(something).toHaveBeenCalled();
@@ -101,7 +101,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:34]
  2 │                 function getValue() {
  3 │                     something || expect(something).toHaveBeenCalled();
@@ -110,7 +110,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:33]
  2 │                 it('foo', () => {
  3 │                     something ? expect(something).toHaveBeenCalled() : noop();
@@ -119,7 +119,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:33]
  2 │                 function getValue() {
  3 │                     something ? expect(something).toHaveBeenCalled() : noop();
@@ -128,7 +128,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:42]
  2 │                 it('foo', () => {
  3 │                     something ? noop() : expect(something).toHaveBeenCalled();
@@ -137,7 +137,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:42]
  2 │                 it.each``('foo', () => {
  3 │                     something ? noop() : expect(something).toHaveBeenCalled();
@@ -146,7 +146,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:42]
  2 │                 it.each()('foo', () => {
  3 │                     something ? noop() : expect(something).toHaveBeenCalled();
@@ -155,7 +155,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:42]
  2 │                 function getValue() {
  3 │                     something ? noop() : expect(something).toHaveBeenCalled();
@@ -164,7 +164,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:7:25]
  6 │                     default:
  7 │                         expect(something).toHaveBeenCalled();
@@ -173,7 +173,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:25]
  4 │                     case 'value':
  5 │                         expect(something).toHaveBeenCalled();
@@ -182,7 +182,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:25]
  4 │                     case 'value':
  5 │                         expect(something).toHaveBeenCalled();
@@ -191,7 +191,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:25]
  4 │                     case 'value':
  5 │                         expect(something).toHaveBeenCalled();
@@ -200,7 +200,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:7:25]
  6 │                     default:
  7 │                         expect(something).toHaveBeenCalled();
@@ -209,7 +209,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:4:25]
  3 │                     if(doSomething) {
  4 │                         expect(something).toHaveBeenCalled();
@@ -218,7 +218,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } else {
  6 │                         expect(something).toHaveBeenCalled();
@@ -227,7 +227,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } else {
  6 │                         expect(something).toHaveBeenCalled();
@@ -236,7 +236,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } else {
  6 │                         expect(something).toHaveBeenCalled();
@@ -245,7 +245,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:4:25]
  3 │                     if(doSomething) {
  4 │                         expect(something).toHaveBeenCalled();
@@ -254,7 +254,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:21]
  5 │                     } else {
  6 │                     expect(something).toHaveBeenCalled();
@@ -263,7 +263,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:21]
  5 │                     } catch (err) {
  6 │                     expect(err).toMatch('Error');
@@ -272,7 +272,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:21]
  5 │                     } catch (err) {
  6 │                     expect(err).toMatch('Error');
@@ -281,7 +281,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } catch (err) {
  6 │                         expect(err).toMatch('Error');
@@ -290,7 +290,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } catch (err) {
  6 │                         expect(err).toMatch('Error');
@@ -299,7 +299,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:25]
  5 │                     } catch (err) {
  6 │                         expect(err).toMatch('Error');
@@ -308,7 +308,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:21]
  5 │                     } catch {
  6 │                     expect(something).toHaveBeenCalled();
@@ -317,7 +317,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:37]
  4 │                     .then(() => { throw new Error('oh noes!'); })
  5 │                     .catch(error => expect(error).toBeInstanceOf(Error));
@@ -326,7 +326,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:37]
  4 │                     .then(() => { throw new Error('oh noes!'); })
  5 │                     .catch(error => expect(error).toBeInstanceOf(Error))
@@ -335,7 +335,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:7:37]
  6 │                     .then(() => { throw new Error('oh noes!'); })
  7 │                     .catch(error => expect(error).toBeInstanceOf(Error))
@@ -344,7 +344,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
     ╭─[no_conditional_expect.tsx:9:37]
   8 │                     .then(() => { throw new Error('oh noes!'); })
   9 │                     .catch(error => expect(error).toBeInstanceOf(Error));
@@ -353,7 +353,7 @@ snapshot_kind: text
     ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:4:32]
  3 │                       await Promise.resolve()
  4 │                         .catch(error => expect(error).toBeInstanceOf(Error))
@@ -362,7 +362,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:32]
  4 │                         .catch(error => expect(error).toBeInstanceOf(Error))
  5 │                         .catch(error => expect(error).toBeInstanceOf(Error))
@@ -371,7 +371,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:6:32]
  5 │                         .catch(error => expect(error).toBeInstanceOf(Error))
  6 │                         .catch(error => expect(error).toBeInstanceOf(Error));
@@ -380,7 +380,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:4:37]
  3 │                     await Promise.resolve()
  4 │                     .catch(error => expect(error).toBeInstanceOf(Error))
@@ -389,7 +389,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:5:37]
  4 │                     .then(() => { throw new Error('oh noes!'); })
  5 │                     .catch(error => expect(error).toBeInstanceOf(Error));
@@ -398,7 +398,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:54]
  2 │                 it('works', async () => {
  3 │                     await somePromise.catch(error => expect(error).toBeInstanceOf(Error));
@@ -407,7 +407,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:7:25]
  6 │                     if (vnode._nextDom) {
  7 │                         expect.fail('vnode should not have _nextDom:' + vnode._nextDom);
@@ -416,7 +416,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:30]
  2 │             it('foo', () => {
  3 │                 something && expect(something).toHaveBeenCalled();
@@ -425,7 +425,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:28]
  2 │             it('foo', () => {
  3 │                 a || (b && expect(something).toHaveBeenCalled());
@@ -434,7 +434,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:30]
  2 │             it.each``('foo', () => {
  3 │                 something || expect(something).toHaveBeenCalled();
@@ -443,7 +443,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:30]
  2 │             it.each()('foo', () => {
  3 │                 something || expect(something).toHaveBeenCalled();
@@ -452,7 +452,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:30]
  2 │             function getValue() {
  3 │                 something || expect(something).toHaveBeenCalled();
@@ -461,7 +461,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:29]
  2 │             it('foo', () => {
  3 │                 something ? expect(something).toHaveBeenCalled() : noop();
@@ -470,7 +470,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:29]
  2 │             function getValue() {
  3 │                 something ? expect(something).toHaveBeenCalled() : noop();
@@ -479,7 +479,7 @@ snapshot_kind: text
    ╰────
   help: Avoid calling `expect` conditionally`
 
-  ⚠ eslint-plugin-vitest(no-conditional-expect): Unexpected conditional expect
+  ⚠ eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect
    ╭─[no_conditional_expect.tsx:3:38]
  2 │             it('foo', () => {
  3 │                 something ? noop() : expect(something).toHaveBeenCalled();

--- a/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:21]
  2 │                     it('foo', () => {
  3 │                       expect(bar ? foo : baz).toBe(boo);
@@ -10,7 +10,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
  3 │                       const foo = function (bar) {
  4 │                         return foo ? bar : null;
@@ -18,7 +18,7 @@ snapshot_kind: text
  5 │                       };
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
@@ -26,7 +26,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
@@ -34,7 +34,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:26]
  2 │                     it('foo', () => {
  3 │                       const foo = bar ? foo : baz;
@@ -42,7 +42,7 @@ snapshot_kind: text
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:33]
  3 │                       const foo = bar ? foo : baz;
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
@@ -50,7 +50,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:4:16]
   3 │                           const values = something.map(thing => {
   4 │ ╭─▶                         switch (thing.isFoo) {
@@ -62,7 +62,7 @@ snapshot_kind: text
  10 │                           });
     ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                         it('foo', () => {
  3 │ ╭─▶                       switch (true) {
@@ -71,7 +71,7 @@ snapshot_kind: text
  6 │                         })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it('foo', () => {
  3 │                       switch('bar') {}
@@ -79,7 +79,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', () => {
  3 │                       switch('bar') {}
@@ -87,7 +87,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.only('foo', () => {
  3 │                       switch('bar') {}
@@ -95,7 +95,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xit('foo', () => {
  3 │                       switch('bar') {}
@@ -103,7 +103,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     fit('foo', () => {
  3 │                       switch('bar') {}
@@ -111,7 +111,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test('foo', () => {
  3 │                       switch('bar') {}
@@ -119,7 +119,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.skip('foo', () => {
  3 │                       switch('bar') {}
@@ -127,7 +127,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.only('foo', () => {
  3 │                       switch('bar') {}
@@ -135,7 +135,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', () => {
  3 │                       switch('bar') {}
@@ -143,7 +143,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', function () {
  3 │                       switch('bar') {}
@@ -151,7 +151,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:5:16]
  4 │             
  5 │                         switch('bar') {}
@@ -159,7 +159,7 @@ snapshot_kind: text
  6 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         switch('bar') {}
@@ -167,7 +167,7 @@ snapshot_kind: text
  5 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:16]
  6 │                       it('baz', () => {
  7 │                         switch('qux') {}
@@ -175,7 +175,7 @@ snapshot_kind: text
  8 │                         switch('quux') {}
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:16]
  7 │                         switch('qux') {}
  8 │                         switch('quux') {}
@@ -183,7 +183,7 @@ snapshot_kind: text
  9 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       switch ('bar') {}
@@ -191,7 +191,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:20]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             switch (thing.isFoo) {
@@ -203,7 +203,7 @@ snapshot_kind: text
  12 │                               });
     ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:14:18]
  13 │                 
  14 │ ╭─▶                           switch('invalid') {
@@ -213,7 +213,7 @@ snapshot_kind: text
  18 │                             });
     ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                           const foo = function(bar) {
  4 │ ╭─▶                         if (bar) {
@@ -224,7 +224,7 @@ snapshot_kind: text
  9 │                           };
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                           function foo(bar) {
  4 │ ╭─▶                         if (bar) {
@@ -235,7 +235,7 @@ snapshot_kind: text
  9 │                           };
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it('foo', () => {
  3 │                       if ('bar') {}
@@ -243,7 +243,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', () => {
  3 │                       if ('bar') {}
@@ -251,7 +251,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.skip('foo', function () {
  3 │                       if ('bar') {}
@@ -259,7 +259,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     it.only('foo', () => {
  3 │                       if ('bar') {}
@@ -267,7 +267,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xit('foo', () => {
  3 │                       if ('bar') {}
@@ -275,7 +275,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     fit('foo', () => {
  3 │                       if ('bar') {}
@@ -283,7 +283,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test('foo', () => {
  3 │                       if ('bar') {}
@@ -291,7 +291,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.skip('foo', () => {
  3 │                       if ('bar') {}
@@ -299,7 +299,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     test.only('foo', () => {
  3 │                       if ('bar') {}
@@ -307,7 +307,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                     xtest('foo', () => {
  3 │                       if ('bar') {}
@@ -315,7 +315,7 @@ snapshot_kind: text
  4 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
@@ -323,7 +323,7 @@ snapshot_kind: text
  5 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:16]
  3 │                       it('bar', () => {
  4 │                         if ('bar') {}
@@ -331,7 +331,7 @@ snapshot_kind: text
  5 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:16]
  6 │                       it('baz', () => {
  7 │                         if ('qux') {}
@@ -339,7 +339,7 @@ snapshot_kind: text
  8 │                         if ('quux') {}
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:16]
  7 │                         if ('qux') {}
  8 │                         if ('quux') {}
@@ -347,7 +347,7 @@ snapshot_kind: text
  9 │                       })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
@@ -355,7 +355,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
@@ -363,7 +363,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
@@ -371,7 +371,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
@@ -379,7 +379,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:14]
  3 │                       callExpression()
  4 │                       if ('bar') {}
@@ -387,7 +387,7 @@ snapshot_kind: text
  5 │                     })
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:20]
   5 │                               const values = something.map((thing) => {
   6 │ ╭─▶                             if (thing.isFoo) {
@@ -398,7 +398,7 @@ snapshot_kind: text
  11 │                               });
     ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:13:18]
  12 │                 
  13 │ ╭─▶                           if ('invalid') {
@@ -407,7 +407,7 @@ snapshot_kind: text
  16 │                             });
     ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:14]
  2 │                         test("shows error", () => {
  3 │ ╭─▶                       if (1 === 2) {
@@ -416,7 +416,7 @@ snapshot_kind: text
  6 │                         });
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-conditional-in-test): Avoid having conditionals in tests.
+  ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:10:14]
   9 │                           setTimeout(() => console.log("noop"));
  10 │ ╭─▶                       if (1 === 2) {

--- a/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
@@ -2,252 +2,252 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip('foo', function () {})
    · ─────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip.each([1, 2, 3])('%s', (a, b) => {});
    · ─────────────────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xdescribe.each([1, 2, 3])('%s', (a, b) => {});
    · ─────────────────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe[`skip`]('foo', function () {})
    · ────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe['skip']('foo', function () {})
    · ────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip('foo', function () {})
    · ───────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it['skip']('foo', function () {})
    · ──────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip('foo', function () {})
    · ─────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip.each``('foo', function () {})
    · ──────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip.each``('foo', function () {})
    · ────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip.each([])('foo', function () {})
    · ────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip.each([])('foo', function () {})
    · ──────────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test['skip']('foo', function () {})
    · ────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit('foo', function () {})
    · ───
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest('foo', function () {})
    · ─────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each``('foo', function () {})
    · ──────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each``('foo', function () {})
    · ────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each([])('foo', function () {})
    · ────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each([])('foo', function () {})
    · ──────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
+  ⚠ eslint-plugin-jest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it('has title but no callback')
    · ───────────────────────────────
    ╰────
   help: Add function argument
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
+  ⚠ eslint-plugin-jest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test('has title but no callback')
    · ─────────────────────────────────
    ╰────
   help: Add function argument
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
+  ⚠ eslint-plugin-jest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:48]
  1 │ it('contains a call to pending', function () { pending() })
    ·                                                ─────────
    ╰────
   help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
+  ⚠ eslint-plugin-jest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ pending()
    · ─────────
    ╰────
   help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
+  ⚠ eslint-plugin-jest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:54]
  1 │ describe('contains a call to pending', function () { pending() })
    ·                                                      ─────────
    ╰────
   help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
+  ⚠ eslint-plugin-jest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:38]
  1 │ import { test } from '@jest/globals';test('something');
    ·                                      ─────────────────
    ╰────
   help: Add function argument
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip("foo", function () {})
    · ─────────────
    ╰────
   help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest("foo", function () {})
    · ─────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each``("foo", function () {})
    · ──────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each``("foo", function () {})
    · ────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each([])("foo", function () {})
    · ────────────
    ╰────
   help: Remove x prefix
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
+  ⚠ eslint-plugin-jest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it("has title but no callback")
    · ───────────────────────────────
    ╰────
   help: Add function argument
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
+  ⚠ eslint-plugin-jest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test("has title but no callback")
    · ─────────────────────────────────
    ╰────
   help: Add function argument
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
+  ⚠ eslint-plugin-jest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:48]
  1 │ it("contains a call to pending", function () { pending() })
    ·                                                ─────────
    ╰────
   help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
+  ⚠ eslint-plugin-jest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ pending();
    · ─────────
    ╰────
   help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
+  ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:3:13]
  2 │             import { describe } from 'vitest'; 
  3 │             describe.skip("foo", function () {})

--- a/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:4:20]
  3 │                 it('works', () => {});
  4 │                 it('works', () => {});
@@ -11,7 +11,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:18]
  2 │               it('works', () => {});
  3 │               it('works', () => {});
@@ -20,7 +20,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:20]
  2 │               test.only('this', () => {});
  3 │               test('this', () => {});
@@ -29,7 +29,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:2:21]
  1 │ 
  2 │               xtest('this', () => {});
@@ -38,7 +38,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:25]
  2 │               test.only('this', () => {});
  3 │               test.only('this', () => {});
@@ -47,7 +47,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:31]
  2 │               test.concurrent('this', () => {});
  3 │               test.concurrent('this', () => {});
@@ -56,7 +56,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:31]
  2 │               test.only('this', () => {});
  3 │               test.concurrent('this', () => {});
@@ -65,7 +65,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:24]
  2 │               describe('foo', () => {});
  3 │               describe('foo', () => {});
@@ -74,7 +74,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of describe block.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:2:24]
  1 │ 
  2 │               describe('foo', () => {});
@@ -83,7 +83,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of describe block.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:24]
  2 │               fdescribe('foo', () => {});
  3 │               describe('foo', () => {});
@@ -92,7 +92,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of describe block.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:5:24]
  4 │               });
  5 │               describe('foo', () => {});
@@ -101,7 +101,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of describe block.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:4:20]
  3 │                 it(`catches backticks with the same title`, () => {});
  4 │                 it(`catches backticks with the same title`, () => {});
@@ -110,7 +110,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:4:20]
  3 │                 it('works', () => {});
  4 │                 it('works', () => {});
@@ -119,7 +119,7 @@ snapshot_kind: text
    ╰────
   help: Change the title of test.
 
-  ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
+  ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:4:20]
  3 │                 it('works', () => {});
  4 │                 it('works', () => {});

--- a/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
@@ -2,31 +2,31 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.fn()
    ·      ──
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["fn"]()
    ·      ────
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.mock()
    ·      ────
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["mock"]()
    ·      ──────
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:22]
  2 │                 import { jest } from '@jest/globals';
  3 │                 jest.advanceTimersByTime();
@@ -34,19 +34,19 @@ snapshot_kind: text
  4 │             
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.fn()
    ·    ──
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Do not use mocks
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.mock()
    ·    ────
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:12]
  2 │                  import { vi } from 'vitest';
  3 │                  vi.advanceTimersByTime();
@@ -54,7 +54,7 @@ snapshot_kind: text
  4 │                 
    ╰────
 
-  ⚠ eslint-plugin-vitest(no-restricted-jest-methods): Use of `fn` is not allowed
+  ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi["fn"]()
    ·    ────

--- a/crates/oxc_linter/src/snapshots/jest_no_test_prefixes.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_test_prefixes.snap
@@ -2,77 +2,77 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])('foo', function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit('foo', function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit('foo', function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest('foo', function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit } from '@jest/globals';
  3 │                 xit('foo', function () {})
@@ -81,7 +81,7 @@ snapshot_kind: text
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit as skipThis } from '@jest/globals';
  3 │                 skipThis('foo', function () {})
@@ -90,7 +90,7 @@ snapshot_kind: text
    ╰────
   help: Replace `skipThis` with `it.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { fit as onlyThis } from '@jest/globals';
  3 │                 onlyThis('foo', function () {})
@@ -99,70 +99,70 @@ snapshot_kind: text
    ╰────
   help: Replace `onlyThis` with `it.only`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])("foo", function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit("foo", function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit("foo", function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest("foo", function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``("foo", function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])("foo", function () {})
    · ──────────

--- a/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:21]
  2 │                     const withDatabase = () => {
  3 │ ╭─▶                     afterAll(() => {
@@ -17,7 +17,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │     
  2 │ ╭─▶                 afterAll(() => {
@@ -32,7 +32,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 afterAll(() => {});
@@ -45,7 +45,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 afterEach(() => {});
@@ -58,7 +58,7 @@ snapshot_kind: text
    ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 afterEach(() => {});
@@ -71,7 +71,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 beforeEach(() => {});
@@ -84,7 +84,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 afterAll(() => {});
@@ -97,7 +97,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:17]
  1 │ 
  2 │                 afterAll(() => {});
@@ -112,7 +112,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 afterAll(() => {});
  3 │                 afterAll(() => {});
@@ -125,7 +125,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:21]
  2 │                 describe('my test', () => {
  3 │                     afterAll(() => {});
@@ -138,7 +138,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:21]
  2 │                 describe('my test', () => {
  3 │                     afterAll(() => {});
@@ -151,7 +151,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:21]
   7 │ 
   8 │                     beforeEach(() => {});
@@ -164,7 +164,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:21]
  2 │                 describe('my test', () => {
  3 │                     afterAll(() => {});
@@ -177,7 +177,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:21]
   7 │ 
   8 │                     beforeEach(() => {});
@@ -190,7 +190,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:6:25]
  5 │                     describe('when something is true', () => {
  6 │                         beforeEach(() => {});
@@ -203,7 +203,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:21]
  3 │                     beforeAll(() => {});
  4 │                     afterAll(() => {});
@@ -216,7 +216,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:25]
   8 │                         beforeAll(() => {});
   9 │                         afterEach(() => {});
@@ -229,7 +229,7 @@ snapshot_kind: text
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:21:29]
  20 │                             afterAll(() => {});
  21 │                             afterAll(() => {});
@@ -243,7 +243,7 @@ snapshot_kind: text
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:4:25]
   3 │                         const setupDatabase = () => {
   4 │ ╭─▶                         beforeEach(() => {
@@ -259,7 +259,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:18:25]
  17 │                     describe('my nested test', () => {
  18 │                         afterAll(() => {});
@@ -272,7 +272,7 @@ snapshot_kind: text
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:3:21]
   2 │                     describe('foo', () => {
   3 │ ╭─▶                     beforeEach(() => {
@@ -288,7 +288,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:34:25]
  33 │     
  34 │ ╭─▶                         afterEach(() => {
@@ -304,7 +304,7 @@ snapshot_kind: text
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 const withDatabase = () => {
  3 │ ╭─▶                 afterAll(() => {
@@ -319,7 +319,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │     
  2 │ ╭─▶             afterAll(() => {
@@ -334,7 +334,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             afterAll(() => {});
@@ -347,7 +347,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             afterEach(() => {});
@@ -360,7 +360,7 @@ snapshot_kind: text
    ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             afterEach(() => {});
@@ -373,7 +373,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             beforeEach(() => {});
@@ -386,7 +386,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             afterAll(() => {});
@@ -399,7 +399,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:2:13]
  1 │ 
  2 │             afterAll(() => {});
@@ -414,7 +414,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             afterAll(() => {});
  3 │             afterAll(() => {});
@@ -427,7 +427,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │             describe('my test', () => {
  3 │                 afterAll(() => {});
@@ -440,7 +440,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │             describe('my test', () => {
  3 │                 afterAll(() => {});
@@ -453,7 +453,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:17]
   7 │ 
   8 │                 beforeEach(() => {});
@@ -466,7 +466,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │             describe('my test', () => {
  3 │                 afterAll(() => {});
@@ -479,7 +479,7 @@ snapshot_kind: text
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:17]
   7 │ 
   8 │                 beforeEach(() => {});
@@ -492,7 +492,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:6:21]
  5 │                 describe('when something is true', () => {
  6 │                     beforeEach(() => {});
@@ -505,7 +505,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:17]
  3 │                 beforeAll(() => {});
  4 │                 afterAll(() => {});
@@ -518,7 +518,7 @@ snapshot_kind: text
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:21]
   8 │                     beforeAll(() => {});
   9 │                     afterEach(() => {});
@@ -531,7 +531,7 @@ snapshot_kind: text
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:21:25]
  20 │                         afterAll(() => {});
  21 │                         afterAll(() => {});
@@ -545,7 +545,7 @@ snapshot_kind: text
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:4:21]
   3 │                     const setupDatabase = () => {
   4 │ ╭─▶                     beforeEach(() => {
@@ -561,7 +561,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:18:21]
  17 │                 describe('my nested test', () => {
  18 │                     afterAll(() => {});
@@ -574,7 +574,7 @@ snapshot_kind: text
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:3:17]
   2 │                 describe('foo', () => {
   3 │ ╭─▶                 beforeEach(() => {
@@ -590,7 +590,7 @@ snapshot_kind: text
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Test hooks are not in a consistent order.
+  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:34:21]
  33 │                     
  34 │ ╭─▶                     afterEach(() => {

--- a/crates/oxc_linter/src/snapshots/jest_valid_describe_callback.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_describe_callback.snap
@@ -2,119 +2,119 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each()()
    · ─────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe['each']()()
    · ────────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each(() => {})()
    · ─────────────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:25]
  1 │ describe.each(() => {})('foo')
    ·                         ─────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe.each()(() => {})
    ·                 ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:20]
  1 │ describe['each']()(() => {})
    ·                    ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.each('foo')(() => {})
    ·                      ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:27]
  1 │ describe.only.each('foo')(() => {})
    ·                           ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe(() => {})
    ·          ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe('foo')
    ·          ─────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Second argument must be a function
+  ⚠ eslint-plugin-jest(valid-describe-callback): Second argument must be a function
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', 'foo2')
    ·                 ──────
    ╰────
   help: Replace second argument with a function
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe()
    · ──────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async () => {})
    ·                 ──────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function () {})
    ·                 ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ xdescribe('foo', async function () {})
    ·                  ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ fdescribe('foo', async function () {})
    ·                  ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:3:30]
  2 │             import { fdescribe } from '@jest/globals';
  3 │             fdescribe('foo', async function () {})
@@ -123,21 +123,21 @@ snapshot_kind: text
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.only('foo', async function () {})
    ·                      ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.skip('foo', async function () {})
    ·                      ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:6:35]
   5 │                     });
   6 │ ╭─▶                 describe('async', async () => {
@@ -150,7 +150,7 @@ snapshot_kind: text
     ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', function () {
  3 │ ╭─▶                 return Promise.resolve().then(() => {
@@ -162,7 +162,7 @@ snapshot_kind: text
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', () => {
  3 │ ╭─▶                 return Promise.resolve().then(() => {
@@ -174,7 +174,7 @@ snapshot_kind: text
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:9:21]
   8 │                     describe('nested', () => {
   9 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -186,7 +186,7 @@ snapshot_kind: text
     ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:2:29]
   1 │     
   2 │ ╭─▶             describe('foo', async () => {
@@ -204,7 +204,7 @@ snapshot_kind: text
     ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:21]
   5 │                     describe('nested', () => {
   6 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -216,175 +216,175 @@ snapshot_kind: text
     ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:1:23]
  1 │ describe('foo', () => test('bar', () => {})) 
    ·                       ─────────────────────
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', done => {})
    ·                 ──────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', function (done) {})
    ·                 ──────────────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', function (one, two, three) {})
    ·                 ─────────────────────────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function (done) {})
    ·                 ────────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function (done) {})
    ·                 ────────────────────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each()()
    · ─────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe["each"]()()
    · ────────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each(() => {})()
    · ─────────────────────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:25]
  1 │ describe.each(() => {})("foo")
    ·                         ─────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe.each()(() => {})
    ·                 ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:20]
  1 │ describe["each"]()(() => {})
    ·                    ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.each("foo")(() => {})
    ·                      ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:27]
  1 │ describe.only.each("foo")(() => {})
    ·                           ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe(() => {})
    ·          ────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe("foo")
    ·          ─────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Second argument must be a function
+  ⚠ eslint-plugin-jest(valid-describe-callback): Second argument must be a function
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", "foo2")
    ·                 ──────
    ╰────
   help: Replace second argument with a function
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
+  ⚠ eslint-plugin-jest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe()
    · ──────────
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async () => {})
    ·                 ──────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function () {})
    ·                 ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ xdescribe("foo", async function () {})
    ·                  ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ fdescribe("foo", async function () {})
    ·                  ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.only("foo", async function () {})
    ·                      ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.skip("foo", async function () {})
    ·                      ────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:6:39]
   5 │                         });
   6 │ ╭─▶                     describe('async', async () => {
@@ -397,7 +397,7 @@ snapshot_kind: text
     ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', function () {
  3 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -409,7 +409,7 @@ snapshot_kind: text
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', () => {
  3 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -421,7 +421,7 @@ snapshot_kind: text
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:9:25]
   8 │                         describe('nested', () => {
   9 │ ╭─▶                         return Promise.resolve().then(() => {
@@ -433,7 +433,7 @@ snapshot_kind: text
     ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:2:33]
   1 │     
   2 │ ╭─▶                 describe('foo', async () => {
@@ -451,7 +451,7 @@ snapshot_kind: text
     ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:25]
   5 │                         describe('nested', () => {
   6 │ ╭─▶                         return Promise.resolve().then(() => {
@@ -463,7 +463,7 @@ snapshot_kind: text
     ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                 describe('foo', () =>
  3 │                     test('bar', () => {})
@@ -472,35 +472,35 @@ snapshot_kind: text
    ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", done => {})
    ·                 ──────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", function (done) {})
    ·                 ──────────────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", function (one, two, three) {})
    ·                 ─────────────────────────────
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function (done) {})
    ·                 ────────────────────────
    ╰────
   help: Remove `async` keyword
 
-  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function (done) {})
    ·                 ────────────────────────

--- a/crates/oxc_linter/src/snapshots/jest_valid_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_expect.snap
@@ -2,175 +2,175 @@
 source: crates/oxc_linter/src/tester.rs
 snapshot_kind: text
 ---
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(2);
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(true);
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toEqual('something');
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else').toEqual('something');
    · ───────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something').toEqual('something');
    · ───────────────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else').toEqual('something');
    · ───────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something');
    · ───────────────────
    ╰────
   help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
   help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined();
    · ───────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.resolves.toBeDefined();
    · ───────────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.not.toBeDefined();
    · ──────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves.not.exactly.toBeDefined();
    · ───────────────────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).rejects.toBeDefined();
    · ────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:6:27]
  5 │                         ? expect(obj).toBe(true)
  6 │                         : expect(obj).resolves.not.toThrow();
@@ -179,7 +179,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:27]
  4 │                         this.isNot
  5 │                         ? expect(obj).resolves.not.toThrow()
@@ -188,7 +188,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:7:27]
  6 │                         : anotherCondition
  7 │                         ? expect(obj).resolves.not.toThrow()
@@ -197,91 +197,91 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toReject(); });
    ·                              ─────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).not.toReject(); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });
    ·                              ────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });
    ·                              ────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test('valid-expect', async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test('valid-expect', async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.reject(2)).toRejectWith(2); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.reject(2)).rejects.toBe(2); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                 test('valid-expect', async () => {
  3 │                 expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -290,7 +290,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:17]
  3 │                 expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                 expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -299,7 +299,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -308,7 +308,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -317,7 +317,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -326,7 +326,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -335,7 +335,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -344,7 +344,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     await expect(Promise.resolve(2)).toResolve();
  4 │                     return expect(Promise.resolve(1)).toReject();
@@ -353,7 +353,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -362,7 +362,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -371,7 +371,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -380,7 +380,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -389,7 +389,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                     test('valid-expect', () => {
  3 │ ╭─▶                 Promise.all([
@@ -400,7 +400,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                     test('valid-expect', () => {
  3 │ ╭─▶                 Promise.x([
@@ -411,7 +411,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -420,7 +420,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined(),
  5 │                     expect(Promise.resolve(3)).resolves.not.toBeDefined(),
@@ -429,7 +429,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).toResolve(),
@@ -438,7 +438,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).toResolve(),
  5 │                     expect(Promise.resolve(3)).toReject(),
@@ -447,7 +447,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).not.toResolve(),
@@ -456,7 +456,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).not.toResolve(),
  5 │                     expect(Promise.resolve(3)).resolves.toReject(),
@@ -465,14 +465,14 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
  4 │                         expect(Promise.resolve(2)).resolves.toBe(1);
@@ -481,7 +481,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         await expect(Promise.resolve(2)).resolves.toBe(1);
  5 │                         expect(Promise.resolve(4)).resolves.toBe(4);
@@ -490,7 +490,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:3:27]
  2 │                 test('valid-expect', async () => {
  3 │                     await expect(Promise.resolve(1));
@@ -499,175 +499,175 @@ snapshot_kind: text
    ╰────
   help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(2);
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(true);
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toEqual("something");
    · ────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else").toEqual("something");
    · ───────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
+  ⚠ eslint-plugin-jest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something").toEqual("something");
    · ───────────────────
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+  ⚠ eslint-plugin-jest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else").toEqual("something");
    · ───────────────────────────
    ╰────
   help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something");
    · ───────────────────
    ╰────
   help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
   help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined();
    · ───────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.resolves.toBeDefined();
    · ───────────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.not.toBeDefined();
    · ──────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
+  ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves.not.exactly.toBeDefined();
    · ───────────────────────────────────────────────
    ╰────
   help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).rejects.toBeDefined();
    · ────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:6:31]
  5 │                             ? expect(obj).toBe(true)
  6 │                             : expect(obj).resolves.not.toThrow();
@@ -676,7 +676,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:31]
  4 │                         this.isNot
  5 │                             ? expect(obj).resolves.not.toThrow()
@@ -685,91 +685,91 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });
    ·                              ─────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });
    ·                              ────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });
    ·                              ────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });
    ·                              ─────────────────────────────────────────
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -778,7 +778,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -787,7 +787,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -796,7 +796,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -805,7 +805,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
@@ -814,7 +814,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
@@ -823,7 +823,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", () => {
  3 │                     Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -832,7 +832,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
@@ -841,7 +841,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                     test("valid-expect", () => {
  3 │ ╭─▶                     Promise.all([
@@ -852,7 +852,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                     test("valid-expect", () => {
  3 │ ╭─▶                     Promise.x([
@@ -863,7 +863,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -872,7 +872,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
  5 │                         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
@@ -881,7 +881,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).toResolve(),
@@ -890,7 +890,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).toResolve(),
  5 │                         expect(Promise.resolve(3)).toReject(),
@@ -899,7 +899,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).not.toResolve(),
@@ -908,7 +908,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).not.toResolve(),
  5 │                         expect(Promise.resolve(3)).resolves.toReject(),
@@ -917,14 +917,14 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
+  ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
   help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
  4 │                         expect(Promise.resolve(2)).resolves.toBe(1);
@@ -933,7 +933,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
+  ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         await expect(Promise.resolve(2)).resolves.toBe(1);
  5 │                         expect(Promise.resolve(4)).resolves.toBe(4);
@@ -942,7 +942,7 @@ snapshot_kind: text
    ╰────
   help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
+  ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:3:27]
  2 │                 test("valid-expect", async () => {
  3 │                     await expect(Promise.resolve(1));


### PR DESCRIPTION
came across this code.

I do not think this is practicable in the real world. Many projects areo migrating from jest to vitest and are currently installing both,
So we can't really tell what plugin name should be outputted.

The same is for typescript <-> eslint and our newest candidate:

https://github.com/oxc-project/oxc/blob/2da4365fbe42cf75f6add7d8328a23379776ecd3/crates/oxc_linter/src/config/rules.rs#L163-L165