### PR TITLE
fix(tasks/lint_rules): sync unicorn rules with eslint rules

### DIFF
--- a/tasks/lint_rules/src/main.cjs
+++ b/tasks/lint_rules/src/main.cjs
@@ -10,6 +10,7 @@ const {
   updateImplementedStatus,
   overrideTypeScriptPluginStatusWithEslintPluginStatus: syncTypeScriptPluginStatusWithEslintPluginStatus,
   syncVitestPluginStatusWithJestPluginStatus,
+  syncUnicornPluginStatusWithEslintPluginStatus,
 } = require('./oxlint-rules.cjs');
 const { renderMarkdown } = require('./markdown-renderer.cjs');
 const { updateGitHubIssue } = require('./result-reporter.cjs');
@@ -63,6 +64,7 @@ Plugins: ${Array.from(ALL_TARGET_PLUGINS.keys()).join(', ')}
   updateNotSupportedStatus(ruleEntries);
   await syncTypeScriptPluginStatusWithEslintPluginStatus(ruleEntries);
   await syncVitestPluginStatusWithJestPluginStatus(ruleEntries);
+  syncUnicornPluginStatusWithEslintPluginStatus(ruleEntries);
 
   //
   // Render list and update if necessary

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -196,3 +196,23 @@ exports.syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
     }
   }
 };
+
+/**
+ * Some Unicorn rules rules are re-implemented version of eslint rules.
+ * We should override these to make implementation status up-to-date.
+ * @param {RuleEntries} ruleEntries
+ */
+exports.syncUnicornPluginStatusWithEslintPluginStatus = (ruleEntries) => {
+  const rules = new Set(['no-negated-condition']);
+
+  for (const rule of rules) {
+    const unicornRuleEntry = ruleEntries.get(`unicorn/${rule}`);
+    const eslintRuleEntry = ruleEntries.get(`eslint/${rule}`);
+    if (unicornRuleEntry && eslintRuleEntry) {
+      ruleEntries.set(`unicorn/${rule}`, {
+        ...unicornRuleEntry,
+        isImplemented: eslintRuleEntry.isImplemented,
+      });
+    }
+  }
+};


### PR DESCRIPTION
👀 promise/spec-only is implemented but not found in their rules
👀 unicorn/consistent-existence-index-check is implemented but not found in their rules
👀 unicorn/prefer-math-min-max is implemented but not found in their rules

> [!WARNING]
> This comment is maintained by CI. Do not edit this comment directly.
> To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules

This is tracking issue for `eslint-plugin-unicorn`.


There are 120(+ 17 deprecated) rules.

- 24/113 recommended rules are remaining as TODO
- 7/7 not recommended rules are remaining as TODO


To get started, run the following command:

```sh
just new-unicorn-rule <RULE_NAME>
```

Then register the rule in `crates/oxc_linter/src/rules.rs` and also `declare_all_lint_rules` at the bottom.


## Recommended rules

<details open>
<summary>
  ✨: 89, 🚫: 0 / total: 113
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | unicorn/better-regex | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/better-regex.md |
| ✨ | unicorn/catch-error-name | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/catch-error-name.md |
| ✨ | unicorn/consistent-empty-array-spread | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/consistent-empty-array-spread.md |
| ✨ | unicorn/consistent-function-scoping | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/consistent-function-scoping.md |
| ✨ | unicorn/empty-brace-spaces | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/empty-brace-spaces.md |
| ✨ | unicorn/error-message | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/error-message.md |
| ✨ | unicorn/escape-case | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/escape-case.md |
|  | unicorn/expiring-todo-comments | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/expiring-todo-comments.md |
| ✨ | unicorn/explicit-length-check | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/explicit-length-check.md |
| ✨ | unicorn/filename-case | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/filename-case.md |
|  | unicorn/import-style | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/import-style.md |
| ✨ | unicorn/new-for-builtins | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/new-for-builtins.md |
| ✨ | unicorn/no-abusive-eslint-disable | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-abusive-eslint-disable.md |
| ✨ | unicorn/no-anonymous-default-export | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-anonymous-default-export.md |
|  | unicorn/no-array-callback-reference | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-array-callback-reference.md |
| ✨ | unicorn/no-array-for-each | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-array-for-each.md |
|  | unicorn/no-array-method-this-argument | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-array-method-this-argument.md |
|  | unicorn/no-array-push-push | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-array-push-push.md |
| ✨ | unicorn/no-array-reduce | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-array-reduce.md |
| ✨ | unicorn/no-await-expression-member | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-await-expression-member.md |
| ✨ | unicorn/no-await-in-promise-methods | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-await-in-promise-methods.md |
| ✨ | unicorn/no-console-spaces | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-console-spaces.md |
| ✨ | unicorn/no-document-cookie | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-document-cookie.md |
| ✨ | unicorn/no-empty-file | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-empty-file.md |
|  | unicorn/no-for-loop | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-for-loop.md |
| ✨ | unicorn/no-hex-escape | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-hex-escape.md |
| ✨ | unicorn/no-instanceof-array | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-instanceof-array.md |
|  | unicorn/no-invalid-fetch-options | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-invalid-fetch-options.md |
| ✨ | unicorn/no-invalid-remove-event-listener | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-invalid-remove-event-listener.md |
| ✨ | unicorn/no-length-as-slice-end | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-length-as-slice-end.md |
| ✨ | unicorn/no-lonely-if | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-lonely-if.md |
| ✨ | unicorn/no-magic-array-flat-depth | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-magic-array-flat-depth.md |
| ✨ | unicorn/no-negated-condition | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-negated-condition.md |
| ✨ | unicorn/no-negation-in-equality-check | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-negation-in-equality-check.md |
| ✨ | unicorn/no-nested-ternary | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-nested-ternary.md |
| ✨ | unicorn/no-new-array | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-new-array.md |
| ✨ | unicorn/no-new-buffer | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-new-buffer.md |
| ✨ | unicorn/no-null | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-null.md |
| ✨ | unicorn/no-object-as-default-parameter | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-object-as-default-parameter.md |
| ✨ | unicorn/no-process-exit | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-process-exit.md |
| ✨ | unicorn/no-single-promise-in-promise-methods | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-single-promise-in-promise-methods.md |
| ✨ | unicorn/no-static-only-class | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-static-only-class.md |
| ✨ | unicorn/no-thenable | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-thenable.md |
| ✨ | unicorn/no-this-assignment | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-this-assignment.md |
| ✨ | unicorn/no-typeof-undefined | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-typeof-undefined.md |
| ✨ | unicorn/no-unnecessary-await | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-unnecessary-await.md |
|  | unicorn/no-unnecessary-polyfills | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-unnecessary-polyfills.md |
| ✨ | unicorn/no-unreadable-array-destructuring | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-unreadable-array-destructuring.md |
| ✨ | unicorn/no-unreadable-iife | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-unreadable-iife.md |
| ✨ | unicorn/no-useless-fallback-in-spread | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-fallback-in-spread.md |
| ✨ | unicorn/no-useless-length-check | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-length-check.md |
| ✨ | unicorn/no-useless-promise-resolve-reject | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-promise-resolve-reject.md |
| ✨ | unicorn/no-useless-spread | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-spread.md |
| ✨ | unicorn/no-useless-switch-case | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-switch-case.md |
| ✨ | unicorn/no-useless-undefined | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-useless-undefined.md |
| ✨ | unicorn/no-zero-fractions | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-zero-fractions.md |
| ✨ | unicorn/number-literal-case | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/number-literal-case.md |
| ✨ | unicorn/numeric-separators-style | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/numeric-separators-style.md |
| ✨ | unicorn/prefer-add-event-listener | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-add-event-listener.md |
|  | unicorn/prefer-array-find | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-array-find.md |
| ✨ | unicorn/prefer-array-flat-map | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-array-flat-map.md |
| ✨ | unicorn/prefer-array-flat | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-array-flat.md |
|  | unicorn/prefer-array-index-of | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-array-index-of.md |
| ✨ | unicorn/prefer-array-some | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-array-some.md |
|  | unicorn/prefer-at | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-at.md |
| ✨ | unicorn/prefer-blob-reading-methods | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-blob-reading-methods.md |
| ✨ | unicorn/prefer-code-point | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-code-point.md |
| ✨ | unicorn/prefer-date-now | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-date-now.md |
|  | unicorn/prefer-default-parameters | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-default-parameters.md |
| ✨ | unicorn/prefer-dom-node-append | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-dom-node-append.md |
| ✨ | unicorn/prefer-dom-node-dataset | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-dom-node-dataset.md |
| ✨ | unicorn/prefer-dom-node-remove | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-dom-node-remove.md |
| ✨ | unicorn/prefer-dom-node-text-content | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-dom-node-text-content.md |
| ✨ | unicorn/prefer-event-target | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-event-target.md |
|  | unicorn/prefer-export-from | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-export-from.md |
| ✨ | unicorn/prefer-includes | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-includes.md |
|  | unicorn/prefer-keyboard-event-key | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-keyboard-event-key.md |
| ✨ | unicorn/prefer-logical-operator-over-ternary | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-logical-operator-over-ternary.md |
| ✨ | unicorn/prefer-math-trunc | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-math-trunc.md |
| ✨ | unicorn/prefer-modern-dom-apis | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-modern-dom-apis.md |
| ✨ | unicorn/prefer-modern-math-apis | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-modern-math-apis.md |
|  | unicorn/prefer-module | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-module.md |
| ✨ | unicorn/prefer-native-coercion-functions | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-native-coercion-functions.md |
| ✨ | unicorn/prefer-negative-index | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-negative-index.md |
| ✨ | unicorn/prefer-node-protocol | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-node-protocol.md |
| ✨ | unicorn/prefer-number-properties | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-number-properties.md |
|  | unicorn/prefer-object-from-entries | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-object-from-entries.md |
| ✨ | unicorn/prefer-optional-catch-binding | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-optional-catch-binding.md |
| ✨ | unicorn/prefer-prototype-methods | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-prototype-methods.md |
| ✨ | unicorn/prefer-query-selector | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-query-selector.md |
| ✨ | unicorn/prefer-reflect-apply | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-reflect-apply.md |
| ✨ | unicorn/prefer-regexp-test | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-regexp-test.md |
| ✨ | unicorn/prefer-set-has | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-set-has.md |
| ✨ | unicorn/prefer-set-size | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-set-size.md |
|  | unicorn/prefer-spread | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-spread.md |
| ✨ | unicorn/prefer-string-raw | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-string-raw.md |
| ✨ | unicorn/prefer-string-replace-all | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-string-replace-all.md |
| ✨ | unicorn/prefer-string-slice | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-string-slice.md |
| ✨ | unicorn/prefer-string-starts-ends-with | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-string-starts-ends-with.md |
| ✨ | unicorn/prefer-string-trim-start-end | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-string-trim-start-end.md |
| ✨ | unicorn/prefer-structured-clone | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-structured-clone.md |
|  | unicorn/prefer-switch | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-switch.md |
|  | unicorn/prefer-ternary | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-ternary.md |
|  | unicorn/prefer-top-level-await | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-top-level-await.md |
| ✨ | unicorn/prefer-type-error | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-type-error.md |
|  | unicorn/prevent-abbreviations | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prevent-abbreviations.md |
|  | unicorn/relative-url-style | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/relative-url-style.md |
| ✨ | unicorn/require-array-join-separator | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/require-array-join-separator.md |
| ✨ | unicorn/require-number-to-fixed-digits-argument | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/require-number-to-fixed-digits-argument.md |
| ✨ | unicorn/switch-case-braces | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/switch-case-braces.md |
|  | unicorn/template-indent | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/template-indent.md |
| ✨ | unicorn/text-encoding-identifier-case | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/text-encoding-identifier-case.md |
| ✨ | unicorn/throw-new-error | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/throw-new-error.md |

✨ = Implemented, 🚫 = No need to implement

</details>


## Not recommended rules

<details open>
<summary>
  ✨: 0, 🚫: 0 / total: 7
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | unicorn/consistent-destructuring | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/consistent-destructuring.md |
|  | unicorn/custom-error-definition | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/custom-error-definition.md |
|  | unicorn/no-keyword-prefix | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-keyword-prefix.md |
|  | unicorn/no-unused-properties | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/no-unused-properties.md |
|  | unicorn/prefer-json-parse-buffer | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/prefer-json-parse-buffer.md |
|  | unicorn/require-post-message-target-origin | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/require-post-message-target-origin.md |
|  | unicorn/string-content | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/rules/string-content.md |

✨ = Implemented, 🚫 = No need to implement

</details>


## Deprecated rules

<details >
<summary>
  ✨: 0, 🚫: 0 / total: 17
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | unicorn/import-index | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#import-index |
|  | unicorn/no-array-instanceof | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#no-array-instanceof |
|  | unicorn/no-fn-reference-in-iterator | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#no-fn-reference-in-iterator |
|  | unicorn/no-reduce | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#no-reduce |
|  | unicorn/no-unsafe-regex | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#no-unsafe-regex |
|  | unicorn/prefer-dataset | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-dataset |
|  | unicorn/prefer-event-key | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-event-key |
|  | unicorn/prefer-exponentiation-operator | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-exponentiation-operator |
|  | unicorn/prefer-flat-map | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-flat-map |
|  | unicorn/prefer-node-append | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-node-append |
|  | unicorn/prefer-node-remove | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-node-remove |
|  | unicorn/prefer-object-has-own | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-object-has-own |
|  | unicorn/prefer-replace-all | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-replace-all |
|  | unicorn/prefer-starts-ends-with | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-starts-ends-with |
|  | unicorn/prefer-text-content | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-text-content |
|  | unicorn/prefer-trim-start-end | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#prefer-trim-start-end |
|  | unicorn/regex-shorthand | https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v55.0.0/docs/deprecated-rules.md#regex-shorthand |

✨ = Implemented, 🚫 = No need to implement

</details>