### PR TITLE
chore(minifier): disable `RemoveUnusedCode`

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/mod.rs
+++ b/crates/oxc_minifier/src/ast_passes/mod.rs
@@ -27,6 +27,7 @@ pub use peephole_remove_dead_code::PeepholeRemoveDeadCode;
 pub use peephole_replace_known_methods::PeepholeReplaceKnownMethods;
 pub use peephole_substitute_alternate_syntax::PeepholeSubstituteAlternateSyntax;
 pub use remove_syntax::RemoveSyntax;
+#[expect(unused)]
 pub use remove_unused_code::RemoveUnusedCode;
 pub use statement_fusion::StatementFusion;
 

--- a/crates/oxc_minifier/src/ast_passes/remove_unused_code.rs
+++ b/crates/oxc_minifier/src/ast_passes/remove_unused_code.rs
@@ -68,6 +68,7 @@ impl<'a> Traverse<'a> for RemoveUnusedCode {
 }
 
 impl RemoveUnusedCode {
+    #[allow(dead_code)]
     pub fn new(options: CompressOptions) -> Self {
         Self { options, changed: false, symbol_ids_to_remove: FxHashSet::default() }
     }

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -4,9 +4,7 @@ use oxc_semantic::{ScopeTree, SemanticBuilder, SymbolTable};
 use oxc_traverse::ReusableTraverseCtx;
 
 use crate::{
-    ast_passes::{
-        DeadCodeElimination, Normalize, PeepholeOptimizations, RemoveSyntax, RemoveUnusedCode,
-    },
+    ast_passes::{DeadCodeElimination, Normalize, PeepholeOptimizations, RemoveSyntax},
     CompressOptions, CompressorPass,
 };
 
@@ -34,7 +32,7 @@ impl<'a> Compressor<'a> {
     ) {
         let mut ctx = ReusableTraverseCtx::new(scopes, symbols, self.allocator);
         RemoveSyntax::new(self.options).build(program, &mut ctx);
-        RemoveUnusedCode::new(self.options).build(program, &mut ctx);
+        // RemoveUnusedCode::new(self.options).build(program, &mut ctx);
         Normalize::new().build(program, &mut ctx);
         PeepholeOptimizations::new(true, self.options).run_in_loop(program, &mut ctx);
         PeepholeOptimizations::new(false, self.options).build(program, &mut ctx);

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -2,6 +2,4 @@ commit: c4317b0c
 
 minifier_test262 Summary:
 AST Parsed     : 41696/41696 (100.00%)
-Positive Passed: 41694/41696 (100.00%)
-Compress: tasks/coverage/test262/test/language/module-code/instn-local-bndng-for-dup.js
-Compress: tasks/coverage/test262/test/language/types/undefined/S8.1_A1_T1.js
+Positive Passed: 41696/41696 (100.00%)

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,27 +1,27 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Fixture
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.68 kB   | 23.70 kB   | 8.61 kB    | 8.54 kB    | react.development.js
+72.14 kB   | 23.69 kB   | 23.70 kB   | 8.62 kB    | 8.54 kB    | react.development.js
 
 173.90 kB  | 59.87 kB   | 59.82 kB   | 19.43 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 90.16 kB   | 90.07 kB   | 32.08 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 90.19 kB   | 90.07 kB   | 32.10 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 118.23 kB  | 118.14 kB  | 44.53 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 118.25 kB  | 118.14 kB  | 44.53 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 71.81 kB   | 72.48 kB   | 26.19 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 71.82 kB   | 72.48 kB   | 26.20 kB   | 26.20 kB   | lodash.js 
 
 555.77 kB  | 273.19 kB  | 270.13 kB  | 90.98 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 460.33 kB  | 458.89 kB  | 126.85 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 460.34 kB  | 458.89 kB  | 126.86 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 652.70 kB  | 646.76 kB  | 163.53 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 726.19 kB  | 724.14 kB  | 180.18 kB  | 181.07 kB  | victory.js
+2.14 MB    | 726.21 kB  | 724.14 kB  | 180.20 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 331.90 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.32 MB    | 2.31 MB    | 492.80 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.32 MB    | 2.31 MB    | 492.86 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.50 MB    | 3.49 MB    | 909.30 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.50 MB    | 3.49 MB    | 909.33 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
A lot of edge cases fail in test262 and monitor-oxc.