### PR TITLE
chore(linter): add vscode debugger launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,23 @@
         "SERVER_PATH_DEV": "${workspaceRoot}/target/debug/oxc_language_server",
         "RUST_LOG": "debug"
       }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Oxlint",
+      "cargo": {
+        "env": {
+          "RUSTFLAGS": "-g"
+        },
+        "args": ["build", "--bin=oxlint", "--package=oxlint"],
+        "filter": {
+          "name": "oxlint",
+          "kind": "bin"
+        }
+      },
+      // "args": ["--ARGS-TO-OXLINT"],
+      // "cwd": "PATH-TO-TEST-PROJECT"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
           "name": "oxlint",
           "kind": "bin"
         }
-      },
+      }
       // "args": ["--ARGS-TO-OXLINT"],
       // "cwd": "PATH-TO-TEST-PROJECT"
     }


### PR DESCRIPTION
refer to this [reply](https://discord.com/channels/1079625926024900739/1080101477672046712/1265758176754794598), add CodeLLDB launch config for debugging oxlint.

usage for real dev like:
```json
{
  "type": "lldb",
  "request": "launch",
  "name": "Debug Oxlint",
  "cargo": {
    "env": {
      "RUSTFLAGS": "-g"
    },
    "args": ["build", "--bin=oxlint", "--package=oxlint"],
    "filter": {
      "name": "oxlint",
      "kind": "bin"
    }
  },
  "args": ["--ignore-pattern=./ignore/**"],
  "cwd": "/home/xxx/temp/oxlint-7102"
}
```

besides, i tired add config in `args` to override `Cargo.toml` `[profile.dev] debug = false`, but cargo in CodeLLDB throw error.
```json
"args": [
  "build", "--bin=oxlint", "--package=oxlint", 
  "--config profile.dev.debug=true"
]
```