### PR TITLE
refactor(transformer/async-to-generator): pass `TraverseCtx` to function not `AstBuilder`

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -54,7 +54,7 @@
 use std::{borrow::Cow, mem};
 
 use oxc_allocator::{Box as ArenaBox, String as ArenaString};
-use oxc_ast::{ast::*, AstBuilder, Visit, NONE};
+use oxc_ast::{ast::*, Visit, NONE};
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{Atom, GetSpan, SPAN};
 use oxc_syntax::{
@@ -517,7 +517,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             }
             // infer `foo` from `({ foo: async function() {} })`
             Ancestor::ObjectPropertyValue(property) if !*property.method() => {
-                property.key().static_name().map(|key| Self::normalize_function_name(&key, ctx.ast))
+                property.key().static_name().map(|key| Self::normalize_function_name(&key, ctx))
             }
             _ => None,
         }
@@ -534,13 +534,13 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
     /// // Reserved keyword
     /// * `this` -> `_this`
     /// * `arguments` -> `_arguments`
-    fn normalize_function_name(input: &Cow<'a, str>, ast: AstBuilder<'a>) -> Atom<'a> {
+    fn normalize_function_name(input: &Cow<'a, str>, ctx: &TraverseCtx<'a>) -> Atom<'a> {
         let input_str = input.as_ref();
         if !is_reserved_keyword(input_str) && is_identifier_name(input_str) {
-            return ast.atom_from_cow(input);
+            return ctx.ast.atom_from_cow(input);
         }
 
-        let mut name = ArenaString::with_capacity_in(input_str.len() + 1, ast.allocator);
+        let mut name = ArenaString::with_capacity_in(input_str.len() + 1, ctx.ast.allocator);
         let mut capitalize_next = false;
 
         let mut chars = input_str.chars();


### PR DESCRIPTION
Pure refactor. Our convention in transformer is to pass `TraverseCtx` around, and not deal with `AstBuilder` directly. This will make it easier to make changes to `AstBuilder` to support Node IDs later on.