### PR TITLE
refactor(ast)!: remove `FromIn<Expression> for Statement`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -2,8 +2,8 @@
 #![warn(missing_docs)]
 use std::{borrow::Cow, fmt};
 
-use oxc_allocator::{Box, FromIn, Vec};
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_allocator::{Box, Vec};
+use oxc_span::{Atom, Span};
 use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags, symbol::SymbolId};
 
 use crate::ast::*;
@@ -787,15 +787,6 @@ impl Statement<'_> {
             return (block_stmt.body.len() == 1).then_some(&mut block_stmt.body[0]);
         }
         Some(self)
-    }
-}
-
-impl<'a> FromIn<'a, Expression<'a>> for Statement<'a> {
-    fn from_in(expression: Expression<'a>, allocator: &'a oxc_allocator::Allocator) -> Self {
-        Statement::ExpressionStatement(Box::from_in(
-            ExpressionStatement { span: expression.span(), expression },
-            allocator,
-        ))
     }
 }
 


### PR DESCRIPTION
All node creation is meant to go via `AstBuilder`. This is necessary to support Node IDs. Remove this method which breaks that rule. It's not used anyway.