### PR TITLE
refactor(ecmascript): remove unnecessary `use` statement

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -1,4 +1,3 @@
-use core::f64;
 use std::{borrow::Cow, cmp::Ordering};
 
 use num_bigint::BigInt;


### PR DESCRIPTION
Tiny refactor. Unnecessary `use core::f64` snuck in in #8252. Probably auto-added by IDE.