### PR TITLE
refactor(transformer): elide lifetimes where possible

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -146,7 +146,7 @@ pub struct ArrowFunctionConverter<'a> {
     super_methods: Option<FxIndexMap<SuperMethodKey<'a>, SuperMethodInfo<'a>>>,
 }
 
-impl<'a> ArrowFunctionConverter<'a> {
+impl ArrowFunctionConverter<'_> {
     pub fn new(env: &EnvOptions) -> Self {
         let mode = if env.es2015.arrow_function.is_some() {
             ArrowFunctionConverterMode::Enabled

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -206,7 +206,7 @@ pub struct HelperLoaderStore<'a> {
     pub(crate) used_helpers: RefCell<FxHashMap<Helper, String>>,
 }
 
-impl<'a> HelperLoaderStore<'a> {
+impl HelperLoaderStore<'_> {
     pub fn new(options: &HelperLoaderOptions) -> Self {
         Self {
             module_name: options.module_name.clone(),

--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Common<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for Common<'a, 'ctx> {
+impl<'a> Traverse<'a> for Common<'a, '_> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.module_imports.exit_program(program, ctx);
         self.var_declarations.exit_program(program, ctx);

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -54,7 +54,7 @@ impl<'a, 'ctx> ModuleImports<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ModuleImports<'a, 'ctx> {
+impl<'a> Traverse<'a> for ModuleImports<'a, '_> {
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.ctx.module_imports.insert_into_program(self.ctx, ctx);
     }

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -33,7 +33,7 @@ impl<'a, 'ctx> StatementInjector<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for StatementInjector<'a, 'ctx> {
+impl<'a> Traverse<'a> for StatementInjector<'a, '_> {
     fn exit_statements(
         &mut self,
         statements: &mut ArenaVec<'a, Statement<'a>>,
@@ -61,7 +61,7 @@ pub struct StatementInjectorStore<'a> {
 }
 
 // Public methods
-impl<'a> StatementInjectorStore<'a> {
+impl StatementInjectorStore<'_> {
     /// Create new `StatementInjectorStore`.
     pub fn new() -> Self {
         Self { insertions: RefCell::new(FxHashMap::default()) }

--- a/crates/oxc_transformer/src/common/top_level_statements.rs
+++ b/crates/oxc_transformer/src/common/top_level_statements.rs
@@ -33,7 +33,7 @@ impl<'a, 'ctx> TopLevelStatements<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for TopLevelStatements<'a, 'ctx> {
+impl<'a> Traverse<'a> for TopLevelStatements<'a, '_> {
     fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.ctx.top_level_statements.insert_into_program(program);
     }

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -40,7 +40,7 @@ impl<'a, 'ctx> VarDeclarations<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for VarDeclarations<'a, 'ctx> {
+impl<'a> Traverse<'a> for VarDeclarations<'a, '_> {
     fn enter_statements(
         &mut self,
         _stmts: &mut ArenaVec<'a, Statement<'a>>,

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -46,7 +46,7 @@ pub struct TransformCtx<'a> {
     pub top_level_statements: TopLevelStatementsStore<'a>,
 }
 
-impl<'a> TransformCtx<'a> {
+impl TransformCtx<'_> {
     pub fn new(source_path: &Path, options: &TransformOptions) -> Self {
         let filename = source_path
             .file_stem() // omit file extension

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -152,4 +152,4 @@ impl<'a, 'ctx> ArrowFunctions<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ArrowFunctions<'a, 'ctx> {}
+impl<'a> Traverse<'a> for ArrowFunctions<'a, '_> {}

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -26,4 +26,4 @@ impl<'a, 'ctx> ES2015<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2015<'a, 'ctx> {}
+impl<'a> Traverse<'a> for ES2015<'a, '_> {}

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -51,7 +51,7 @@ impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ExponentiationOperator<'a, 'ctx> {
+impl<'a> Traverse<'a> for ExponentiationOperator<'a, '_> {
     // Note: Do not transform to `Math.pow` with BigInt arguments - that's a runtime error
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         match expr {
@@ -98,7 +98,7 @@ impl<'a, 'ctx> Traverse<'a> for ExponentiationOperator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ExponentiationOperator<'a, 'ctx> {
+impl<'a> ExponentiationOperator<'a, '_> {
     /// Convert `BinaryExpression`.
     ///
     /// `left ** right` -> `Math.pow(left, right)`

--- a/crates/oxc_transformer/src/es2016/mod.rs
+++ b/crates/oxc_transformer/src/es2016/mod.rs
@@ -22,7 +22,7 @@ impl<'a, 'ctx> ES2016<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2016<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2016<'a, '_> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.exponentiation_operator {
             self.exponentiation_operator.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -76,7 +76,7 @@ impl<'a, 'ctx> AsyncToGenerator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for AsyncToGenerator<'a, 'ctx> {
+impl<'a> Traverse<'a> for AsyncToGenerator<'a, '_> {
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let new_expr = match expr {
             Expression::AwaitExpression(await_expr) => {
@@ -144,7 +144,7 @@ impl<'a, 'ctx> Traverse<'a> for AsyncToGenerator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> AsyncToGenerator<'a, 'ctx> {
+impl<'a> AsyncToGenerator<'a, '_> {
     /// Check whether the current node is inside an async function.
     fn is_inside_async_function(ctx: &mut TraverseCtx<'a>) -> bool {
         // Early return if current scope is top because we don't need to transform top-level await expression.
@@ -819,7 +819,7 @@ impl<'a, 'ctx> BindingMover<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Visit<'a> for BindingMover<'a, 'ctx> {
+impl<'a> Visit<'a> for BindingMover<'a, '_> {
     /// Visits a binding identifier and moves it to the target scope.
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         let symbols = self.ctx.symbols();

--- a/crates/oxc_transformer/src/es2017/mod.rs
+++ b/crates/oxc_transformer/src/es2017/mod.rs
@@ -22,7 +22,7 @@ impl<'a, 'ctx> ES2017<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2017<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2017<'a, '_> {
     fn exit_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.async_to_generator {
             self.async_to_generator.exit_expression(node, ctx);

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -9,7 +9,7 @@ use oxc_traverse::{Ancestor, BoundIdentifier, TraverseCtx};
 use super::AsyncGeneratorFunctions;
 use crate::common::helper_loader::Helper;
 
-impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
+impl<'a> AsyncGeneratorFunctions<'a, '_> {
     /// Check the parent node to see if multiple statements are allowed.
     fn is_multiple_statements_allowed(ctx: &TraverseCtx<'a>) -> bool {
         matches!(

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -83,7 +83,7 @@ impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for AsyncGeneratorFunctions<'a, 'ctx> {
+impl<'a> Traverse<'a> for AsyncGeneratorFunctions<'a, '_> {
     fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let new_expr = match expr {
             Expression::AwaitExpression(await_expr) => {
@@ -152,7 +152,7 @@ impl<'a, 'ctx> Traverse<'a> for AsyncGeneratorFunctions<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> AsyncGeneratorFunctions<'a, 'ctx> {
+impl<'a> AsyncGeneratorFunctions<'a, '_> {
     /// Transform `yield * argument` expression to `yield asyncGeneratorDelegate(asyncIterator(argument))`.
     fn transform_yield_expression(
         &self,

--- a/crates/oxc_transformer/src/es2018/mod.rs
+++ b/crates/oxc_transformer/src/es2018/mod.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> ES2018<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2018<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2018<'a, '_> {
     fn exit_program(&mut self, program: &mut oxc_ast::ast::Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.object_rest_spread.is_some() {
             self.object_rest_spread.exit_program(program, ctx);

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -83,7 +83,7 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ObjectRestSpread<'a, 'ctx> {
+impl<'a> Traverse<'a> for ObjectRestSpread<'a, '_> {
     // For excluded keys when destructuring inside a function.
     // `function foo() { ({a, ...b} = c) }` -> `const _excluded = ["a"]; function foo() { ... }`
     fn exit_program(&mut self, _node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -181,7 +181,7 @@ impl<'a, 'ctx> Traverse<'a> for ObjectRestSpread<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
+impl<'a> ObjectRestSpread<'a, '_> {
     // Transform `({ x, ..y } = foo)`.
     // Transform `([{ x, ..y }] = foo)`.
     fn transform_assignment_expression(
@@ -532,7 +532,7 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
+impl<'a> ObjectRestSpread<'a, '_> {
     // Transform `function foo({...x}) {}`.
     fn transform_function(func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = func.scope_id();
@@ -769,7 +769,7 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
+impl<'a> ObjectRestSpread<'a, '_> {
     // Transform `let { x, ..y } = foo`.
     // Transform `let [{ x, ..y }] = foo`.
     fn transform_variable_declaration(

--- a/crates/oxc_transformer/src/es2020/mod.rs
+++ b/crates/oxc_transformer/src/es2020/mod.rs
@@ -31,7 +31,7 @@ impl<'a, 'ctx> ES2020<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2020<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2020<'a, '_> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.nullish_coalescing_operator {
             self.nullish_coalescing_operator.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -47,7 +47,7 @@ impl<'a, 'ctx> NullishCoalescingOperator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for NullishCoalescingOperator<'a, 'ctx> {
+impl<'a> Traverse<'a> for NullishCoalescingOperator<'a, '_> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         // left ?? right
         if !matches!(expr, Expression::LogicalExpression(logical_expr) if logical_expr.operator == LogicalOperator::Coalesce)
@@ -64,7 +64,7 @@ impl<'a, 'ctx> Traverse<'a> for NullishCoalescingOperator<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> NullishCoalescingOperator<'a, 'ctx> {
+impl<'a> NullishCoalescingOperator<'a, '_> {
     fn transform_logical_expression(
         &mut self,
         logical_expr: ArenaBox<'a, LogicalExpression<'a>>,

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -88,7 +88,7 @@ impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for OptionalChaining<'a, 'ctx> {
+impl<'a> Traverse<'a> for OptionalChaining<'a, '_> {
     // `#[inline]` because this is a hot path
     #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -121,7 +121,7 @@ impl<'a, 'ctx> Traverse<'a> for OptionalChaining<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> OptionalChaining<'a, 'ctx> {
+impl<'a> OptionalChaining<'a, '_> {
     fn set_temp_binding(&mut self, binding: BoundIdentifier<'a>) {
         self.temp_binding.replace(binding);
     }

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -71,7 +71,7 @@ impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for LogicalAssignmentOperators<'a, 'ctx> {
+impl<'a> Traverse<'a> for LogicalAssignmentOperators<'a, '_> {
     // `#[inline]` because this is a hot path, and most `Expression`s are not `AssignmentExpression`s
     // with a logical operator. So we want to bail out as fast as possible for everything else,
     // without the cost of a function call.
@@ -86,7 +86,7 @@ impl<'a, 'ctx> Traverse<'a> for LogicalAssignmentOperators<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> LogicalAssignmentOperators<'a, 'ctx> {
+impl<'a> LogicalAssignmentOperators<'a, '_> {
     fn transform_logical_assignment(
         &mut self,
         expr: &mut Expression<'a>,

--- a/crates/oxc_transformer/src/es2021/mod.rs
+++ b/crates/oxc_transformer/src/es2021/mod.rs
@@ -22,7 +22,7 @@ impl<'a, 'ctx> ES2021<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2021<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2021<'a, '_> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.logical_assignment_operators {
             self.logical_assignment_operators.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -38,7 +38,7 @@ use super::{
 // Maybe force transform of static blocks if any static properties?
 // Or alternatively could insert static property initializers into static blocks.
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Perform first phase of transformation of class.
     ///
     /// This is the only entry point into the transform upon entering class body.

--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -22,7 +22,7 @@ pub(super) struct ClassDetails<'a> {
     pub bindings: ClassBindings<'a>,
 }
 
-impl<'a> ClassDetails<'a> {
+impl ClassDetails<'_> {
     /// Create dummy `ClassDetails`.
     ///
     /// Used for dummy entry at top of `ClassesStack`.
@@ -269,7 +269,7 @@ pub(super) struct ResolvedGetSetPrivateProp<'a, 'b> {
 }
 
 // Shortcut methods to get current class
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Get details of current class.
     pub(super) fn current_class(&self) -> &ClassDetails<'a> {
         self.classes_stack.last()

--- a/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
@@ -7,7 +7,7 @@ use oxc_traverse::TraverseCtx;
 
 use super::{utils::create_assignment, ClassProperties};
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Substitute temp var for method computed key.
     /// `class C { [x()]() {} }` -> `let _x; _x = x(); class C { [_x]() {} }`
     /// This transform is only required if class has properties or a static block.

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -138,7 +138,7 @@ pub(super) struct InstanceInitScopes {
     pub constructor_scope_id: Option<ScopeId>,
 }
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Replace `super()` call(s) in constructor, if required.
     ///
     /// Returns:
@@ -456,15 +456,15 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 }
 
 /// Visitor for transforming `super()` in class constructor params.
-struct ConstructorParamsSuperReplacer<'a, 'c> {
+struct ConstructorParamsSuperReplacer<'a, 'ctx> {
     /// Binding for `_super` function.
     /// Initially `None`. Binding is created if `super()` is found.
     super_binding: Option<BoundIdentifier<'a>>,
-    ctx: &'c mut TraverseCtx<'a>,
+    ctx: &'ctx mut TraverseCtx<'a>,
 }
 
-impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
-    fn new(ctx: &'c mut TraverseCtx<'a>) -> Self {
+impl<'a, 'ctx> ConstructorParamsSuperReplacer<'a, 'ctx> {
+    fn new(ctx: &'ctx mut TraverseCtx<'a>) -> Self {
         Self { super_binding: None, ctx }
     }
 
@@ -510,7 +510,7 @@ impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
     }
 }
 
-impl<'a, 'c> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, 'c> {
+impl<'a> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, '_> {
     /// Replace `super()` with `_super.call(super())`.
     // `#[inline]` to make hot path for all other expressions as cheap as possible.
     #[inline]
@@ -574,7 +574,7 @@ impl<'a, 'c> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, 'c> {
     }
 }
 
-impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
+impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
     /// Wrap `super()` -> `_super.call(super())`
     fn wrap_super(&mut self, expr: &mut Expression<'a>, span: Span) {
         let super_binding = self.super_binding.get_or_insert_with(|| {
@@ -603,18 +603,18 @@ impl<'a, 'c> ConstructorParamsSuperReplacer<'a, 'c> {
 }
 
 /// Visitor for transforming `super()` in class constructor body.
-struct ConstructorBodySuperReplacer<'a, 'c> {
+struct ConstructorBodySuperReplacer<'a, 'ctx> {
     /// Scope of class constructor
     constructor_scope_id: ScopeId,
     /// Binding for `_super` function.
     /// Initially `None`. Binding is created if `super()` is found in position other than top-level,
     /// that requires a `_super` function.
     super_binding: Option<BoundIdentifier<'a>>,
-    ctx: &'c mut TraverseCtx<'a>,
+    ctx: &'ctx mut TraverseCtx<'a>,
 }
 
-impl<'a, 'c> ConstructorBodySuperReplacer<'a, 'c> {
-    fn new(constructor_scope_id: ScopeId, ctx: &'c mut TraverseCtx<'a>) -> Self {
+impl<'a, 'ctx> ConstructorBodySuperReplacer<'a, 'ctx> {
+    fn new(constructor_scope_id: ScopeId, ctx: &'ctx mut TraverseCtx<'a>) -> Self {
         Self { constructor_scope_id, super_binding: None, ctx }
     }
 
@@ -695,7 +695,7 @@ impl<'a, 'c> ConstructorBodySuperReplacer<'a, 'c> {
     }
 }
 
-impl<'a, 'c> VisitMut<'a> for ConstructorBodySuperReplacer<'a, 'c> {
+impl<'a> VisitMut<'a> for ConstructorBodySuperReplacer<'a, '_> {
     /// Replace `super()` with `_super()`.
     // `#[inline]` to make hot path for all other function calls as cheap as possible.
     #[inline]
@@ -752,7 +752,7 @@ impl<'a, 'c> VisitMut<'a> for ConstructorBodySuperReplacer<'a, 'c> {
     }
 }
 
-impl<'a, 'c> ConstructorBodySuperReplacer<'a, 'c> {
+impl<'a> ConstructorBodySuperReplacer<'a, '_> {
     /// Replace `super(arg1, arg2)` with `_super(arg1, arg2)`
     fn replace_super(&mut self, call_expr: &mut CallExpression<'a>, span: Span) {
         if self.super_binding.is_none() {
@@ -788,7 +788,7 @@ impl<'a, 'v> ConstructorSymbolRenamer<'a, 'v> {
     }
 }
 
-impl<'a, 'v> VisitMut<'a> for ConstructorSymbolRenamer<'a, 'v> {
+impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
     fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
         let symbol_id = ident.symbol_id();
         if let Some(new_name) = self.clashing_symbols.get(&symbol_id) {

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -16,7 +16,7 @@ use oxc_traverse::TraverseCtx;
 
 use super::ClassProperties;
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Transform instance property initializer.
     ///
     /// Instance property initializers move from the class body into either class constructor,
@@ -73,7 +73,7 @@ impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
     }
 }
 
-impl<'a, 'v> Visit<'a> for InstanceInitializerVisitor<'a, 'v> {
+impl<'a> Visit<'a> for InstanceInitializerVisitor<'a, '_> {
     /// Update parent scope for first level of scopes.
     /// Convert scope to sloppy mode if `self.make_sloppy_mode == true`.
     //
@@ -100,7 +100,7 @@ impl<'a, 'v> Visit<'a> for InstanceInitializerVisitor<'a, 'v> {
     }
 }
 
-impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
+impl<'a> InstanceInitializerVisitor<'a, '_> {
     /// Update parent of scope.
     fn reparent_scope(&mut self, scope_id: ScopeId) {
         self.ctx.scopes_mut().change_parent_id(scope_id, Some(self.parent_scope_id));
@@ -161,7 +161,7 @@ impl<'a, 'v> FastInstanceInitializerVisitor<'a, 'v> {
     }
 }
 
-impl<'a, 'v> Visit<'a> for FastInstanceInitializerVisitor<'a, 'v> {
+impl<'a> Visit<'a> for FastInstanceInitializerVisitor<'a, '_> {
     #[inline]
     fn visit_function(&mut self, func: &Function<'a>, _flags: ScopeFlags) {
         self.reparent_scope(&func.scope_id);
@@ -210,7 +210,7 @@ impl<'a, 'v> Visit<'a> for FastInstanceInitializerVisitor<'a, 'v> {
     }
 }
 
-impl<'a, 'v> FastInstanceInitializerVisitor<'a, 'v> {
+impl FastInstanceInitializerVisitor<'_, '_> {
     /// Update parent of scope.
     fn reparent_scope(&mut self, scope_id: &Cell<Option<ScopeId>>) {
         let scope_id = scope_id.get().unwrap();

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -319,7 +319,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ClassProperties<'a, 'ctx> {
+impl<'a> Traverse<'a> for ClassProperties<'a, '_> {
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
         self.transform_class_body_on_entry(body, ctx);
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -22,7 +22,7 @@ use super::{
     ClassProperties, ResolvedPrivateProp,
 };
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Transform private field expression.
     ///
     /// Not loose:

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -13,7 +13,7 @@ use super::{
     ClassProperties,
 };
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Convert method definition where the key is a private identifier and
     /// insert it after the class.
     ///
@@ -120,7 +120,7 @@ impl<'a, 'ctx, 'v> PrivateMethodVisitor<'a, 'ctx, 'v> {
     }
 }
 
-impl<'a, 'ctx, 'v> VisitMut<'a> for PrivateMethodVisitor<'a, 'ctx, 'v> {
+impl<'a> VisitMut<'a> for PrivateMethodVisitor<'a, '_, '_> {
     #[inline]
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         match expr {
@@ -162,5 +162,3 @@ impl<'a, 'ctx, 'v> VisitMut<'a> for PrivateMethodVisitor<'a, 'ctx, 'v> {
         // Ignore because we don't need to transform `super` for other classes.
     }
 }
-
-impl<'a, 'ctx, 'v> PrivateMethodVisitor<'a, 'ctx, 'v> {}

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 // Instance properties
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Convert instance property to initialization expression.
     /// Property `prop = 123;` -> Expression `this.prop = 123` or `_defineProperty(this, "prop", 123)`.
     pub(super) fn convert_instance_property(
@@ -80,7 +80,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 }
 
 // Static properties
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Convert static property to initialization expression.
     /// Property `static prop = 123;` -> Expression `C.prop = 123` or `_defineProperty(C, "prop", 123)`.
     pub(super) fn convert_static_property(
@@ -203,7 +203,7 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 }
 
 // Used for both instance and static properties
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// `assignee.prop = value` or `_defineProperty(assignee, "prop", value)`
     fn create_init_assignment(
         &mut self,

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -16,7 +16,7 @@ use super::{
     ClassProperties,
 };
 
-impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
+impl<'a> ClassProperties<'a, '_> {
     /// Transform static property initializer.
     ///
     /// Replace `this`, and references to class name, with temp var for class. Transform `super`.
@@ -246,7 +246,7 @@ impl<'a, 'ctx, 'v> StaticVisitor<'a, 'ctx, 'v> {
     }
 }
 
-impl<'a, 'ctx, 'v> VisitMut<'a> for StaticVisitor<'a, 'ctx, 'v> {
+impl<'a> VisitMut<'a> for StaticVisitor<'a, '_, '_> {
     #[inline]
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         match expr {
@@ -517,7 +517,7 @@ impl<'a, 'ctx, 'v> VisitMut<'a> for StaticVisitor<'a, 'ctx, 'v> {
     }
 }
 
-impl<'a, 'ctx, 'v> StaticVisitor<'a, 'ctx, 'v> {
+impl<'a> StaticVisitor<'a, '_, '_> {
     /// Replace `this` with reference to temp var for class.
     fn replace_this_with_temp_var(&mut self, expr: &mut Expression<'a>, span: Span) {
         if self.this_depth == 0 {

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -38,7 +38,7 @@ impl<'a, 'ctx, 'v> ClassPropertiesSuperConverter<'a, 'ctx, 'v> {
     }
 }
 
-impl<'a, 'ctx, 'v> ClassPropertiesSuperConverter<'a, 'ctx, 'v> {
+impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
     /// Transform static member expression where object is `super`.
     ///
     /// `super.prop` -> `_superPropGet(_Class, "prop", _Class)`

--- a/crates/oxc_transformer/src/es2022/mod.rs
+++ b/crates/oxc_transformer/src/es2022/mod.rs
@@ -36,7 +36,7 @@ impl<'a, 'ctx> ES2022<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ES2022<'a, 'ctx> {
+impl<'a> Traverse<'a> for ES2022<'a, '_> {
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(class_properties) = &mut self.class_properties {
             class_properties.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -61,7 +61,7 @@ impl<'a, 'ctx> ReactDisplayName<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ReactDisplayName<'a, 'ctx> {
+impl<'a> Traverse<'a> for ReactDisplayName<'a, '_> {
     fn enter_call_expression(
         &mut self,
         call_expr: &mut CallExpression<'a>,
@@ -128,7 +128,7 @@ impl<'a, 'ctx> Traverse<'a> for ReactDisplayName<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ReactDisplayName<'a, 'ctx> {
+impl<'a> ReactDisplayName<'a, '_> {
     /// Get the object from `React.createClass({})` or `createReactClass({})`
     fn get_object_from_create_class<'b>(
         call_expr: &'b mut CallExpression<'a>,

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -132,7 +132,7 @@ enum Bindings<'a, 'ctx> {
     AutomaticModule(AutomaticModuleBindings<'a, 'ctx>),
 }
 
-impl<'a, 'ctx> Bindings<'a, 'ctx> {
+impl Bindings<'_, '_> {
     #[inline]
     fn is_classic(&self) -> bool {
         matches!(self, Self::Classic(_))
@@ -486,7 +486,7 @@ impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for JsxImpl<'a, 'ctx> {
+impl<'a> Traverse<'a> for JsxImpl<'a, '_> {
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.insert_filename_var_statement(ctx);
     }
@@ -502,7 +502,7 @@ impl<'a, 'ctx> Traverse<'a> for JsxImpl<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
+impl<'a> JsxImpl<'a, '_> {
     fn is_script(&self) -> bool {
         self.ctx.source_type.is_script()
     }

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -47,7 +47,7 @@ impl<'a, 'ctx> JsxSelf<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for JsxSelf<'a, 'ctx> {
+impl<'a> Traverse<'a> for JsxSelf<'a, '_> {
     fn enter_jsx_opening_element(
         &mut self,
         elem: &mut JSXOpeningElement<'a>,
@@ -57,7 +57,7 @@ impl<'a, 'ctx> Traverse<'a> for JsxSelf<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> JsxSelf<'a, 'ctx> {
+impl<'a> JsxSelf<'a, '_> {
     pub fn report_error(&self, span: Span) {
         let error = OxcDiagnostic::warn("Duplicate __self prop found.").with_label(span);
         self.ctx.error(error);

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -57,7 +57,7 @@ impl<'a, 'ctx> JsxSource<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for JsxSource<'a, 'ctx> {
+impl<'a> Traverse<'a> for JsxSource<'a, '_> {
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(stmt) = self.get_filename_var_statement(ctx) {
             self.ctx.top_level_statements.insert_statement(stmt);
@@ -73,7 +73,7 @@ impl<'a, 'ctx> Traverse<'a> for JsxSource<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> JsxSource<'a, 'ctx> {
+impl<'a> JsxSource<'a, '_> {
     /// Get line and column from offset and source text.
     ///
     /// Line number starts at 1.

--- a/crates/oxc_transformer/src/jsx/mod.rs
+++ b/crates/oxc_transformer/src/jsx/mod.rs
@@ -65,7 +65,7 @@ impl<'a, 'ctx> Jsx<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for Jsx<'a, 'ctx> {
+impl<'a> Traverse<'a> for Jsx<'a, '_> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.enable_jsx_plugin {
             program.source_type = program.source_type.with_standard(true);

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -137,7 +137,7 @@ impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
+impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         let mut new_statements = ctx.ast.vec_with_capacity(program.body.len());
         for mut statement in program.body.drain(..) {
@@ -413,7 +413,7 @@ impl<'a, 'ctx> Traverse<'a> for ReactRefresh<'a, 'ctx> {
 }
 
 // Internal Methods
-impl<'a, 'ctx> ReactRefresh<'a, 'ctx> {
+impl<'a> ReactRefresh<'a, '_> {
     fn create_registration(
         &mut self,
         persistent_id: Atom<'a>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_lifetimes)]
 //! Transformer / Transpiler
 //!
 //! References:
@@ -156,7 +155,7 @@ struct TransformerImpl<'a, 'ctx> {
     common: Common<'a, 'ctx>,
 }
 
-impl<'a, 'ctx> Traverse<'a> for TransformerImpl<'a, 'ctx> {
+impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_program(program, ctx);

--- a/crates/oxc_transformer/src/plugins/inject_global_variables.rs
+++ b/crates/oxc_transformer/src/plugins/inject_global_variables.rs
@@ -98,7 +98,7 @@ struct DotDefineState<'a> {
     value_atom: Option<Atom<'a>>,
 }
 
-impl<'a> From<&InjectImport> for DotDefineState<'a> {
+impl From<&InjectImport> for DotDefineState<'_> {
     fn from(inject: &InjectImport) -> Self {
         let parts = inject.specifier.local().split('.').map(CompactStr::from).collect::<Vec<_>>();
         let value = inject.replace_value.clone().unwrap();

--- a/crates/oxc_transformer/src/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/src/plugins/replace_global_defines.rs
@@ -715,7 +715,7 @@ fn assignment_target_from_expr(expr: Expression) -> Option<AssignmentTarget> {
 
 struct RemoveSpans;
 
-impl<'ast> VisitMut<'ast> for RemoveSpans {
+impl VisitMut<'_> for RemoveSpans {
     fn visit_span(&mut self, span: &mut Span) {
         *span = SPAN;
     }

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -112,7 +112,7 @@ impl<'a, 'ctx> RegExp<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for RegExp<'a, 'ctx> {
+impl<'a> Traverse<'a> for RegExp<'a, '_> {
     fn enter_expression(
         &mut self,
         expr: &mut Expression<'a>,
@@ -192,7 +192,7 @@ impl<'a, 'ctx> Traverse<'a> for RegExp<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> RegExp<'a, 'ctx> {
+impl<'a> RegExp<'a, '_> {
     /// Check if the regular expression contains any unsupported syntax.
     ///
     /// Based on parsed regular expression pattern.

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -60,7 +60,7 @@ impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
+impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         let mut no_modules_remaining = true;
         let mut some_modules_deleted = false;
@@ -561,7 +561,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptAnnotations<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
+impl<'a> TypeScriptAnnotations<'a, '_> {
     /// Check if the given name is a JSX pragma or fragment pragma import
     /// and if the file contains JSX elements or fragments
     fn is_jsx_imports(&self, name: &str) -> bool {

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -16,7 +16,7 @@ pub struct TypeScriptEnum<'a> {
     enums: FxHashMap<Atom<'a>, FxHashMap<Atom<'a>, ConstantValue>>,
 }
 
-impl<'a> TypeScriptEnum<'a> {
+impl TypeScriptEnum<'_> {
     pub fn new() -> Self {
         Self { enums: FxHashMap::default() }
     }
@@ -519,23 +519,23 @@ impl<'a> TypeScriptEnum<'a> {
 ///   d = A.c,
 /// }
 /// ```
-struct IdentifierReferenceRename<'a, 'b> {
+struct IdentifierReferenceRename<'a, 'ctx> {
     enum_name: Atom<'a>,
-    ctx: &'b TraverseCtx<'a>,
+    ctx: &'ctx TraverseCtx<'a>,
     previous_enum_members: FxHashMap<Atom<'a>, ConstantValue>,
 }
 
-impl<'a, 'b> IdentifierReferenceRename<'a, 'b> {
+impl<'a, 'ctx> IdentifierReferenceRename<'a, 'ctx> {
     fn new(
         enum_name: Atom<'a>,
         previous_enum_members: FxHashMap<Atom<'a>, ConstantValue>,
-        ctx: &'b TraverseCtx<'a>,
+        ctx: &'ctx TraverseCtx<'a>,
     ) -> Self {
         IdentifierReferenceRename { enum_name, ctx, previous_enum_members }
     }
 }
 
-impl<'a, 'b> VisitMut<'a> for IdentifierReferenceRename<'a, 'b> {
+impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         let new_expr = match expr {
             match_member_expression!(Expression) => {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -63,7 +63,7 @@ impl<'a, 'ctx> TypeScript<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for TypeScript<'a, 'ctx> {
+impl<'a> Traverse<'a> for TypeScript<'a, '_> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.ctx.source_type.is_typescript_definition() {
             // Output empty file for TS definitions

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -16,7 +16,7 @@ impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for TypeScriptModule<'a, 'ctx> {
+impl<'a> Traverse<'a> for TypeScriptModule<'a, '_> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         // In Babel, it will insert `use strict` in `@babel/transform-modules-commonjs` plugin.
         // Once we have a commonjs plugin, we can consider moving this logic there.
@@ -43,7 +43,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptModule<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> TypeScriptModule<'a, 'ctx> {
+impl<'a> TypeScriptModule<'a, '_> {
     /// Transform `export = expression` to `module.exports = expression`.
     fn transform_ts_export_assignment(
         &mut self,

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -31,7 +31,7 @@ impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Traverse<'a> for TypeScriptNamespace<'a, 'ctx> {
+impl<'a> Traverse<'a> for TypeScriptNamespace<'a, '_> {
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         // namespace declaration is only allowed at the top level
@@ -142,7 +142,7 @@ impl<'a, 'ctx> Traverse<'a> for TypeScriptNamespace<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> TypeScriptNamespace<'a, 'ctx> {
+impl<'a> TypeScriptNamespace<'a, '_> {
     fn handle_nested(
         &self,
         decl: TSModuleDeclaration<'a>,

--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -95,7 +95,7 @@ where
 {
     struct RewriteExtensionsModeVisitor;
 
-    impl<'de> Visitor<'de> for RewriteExtensionsModeVisitor {
+    impl Visitor<'_> for RewriteExtensionsModeVisitor {
         type Value = Option<RewriteExtensionsMode>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Pure refactor. Enable `clippy::needless_lifetimes` lint rule in `oxc_transformer`, and fix what the rule flags - remove unnecessary lifetimes which can be elided.

Also rename a few lifetimes `'b` and `'c` to more descriptive `'ctx`.