### PR TITLE
docs(ast): fix doc comment

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -656,7 +656,7 @@ pub struct TSNullKeyword {
     pub span: Span,
 }
 
-/// TypeScript `null` Keyword
+/// TypeScript `undefined` Keyword
 ///
 /// ## Example
 /// ```ts


### PR DESCRIPTION
Docs only. Fix an erroneous doc comment.