### PR TITLE
refactor(lexer): rename function param

### DIFF
--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -80,8 +80,8 @@ impl<'a> Source<'a> {
     ///
     /// Requiring a `UniquePromise` to be provided guarantees only 1 `Source` can exist
     /// on a single thread at one time.
-    #[allow(clippy::needless_pass_by_value)]
-    pub(super) fn new(mut source_text: &'a str, _unique: UniquePromise) -> Self {
+    #[allow(unused_variables, clippy::needless_pass_by_value)]
+    pub(super) fn new(mut source_text: &'a str, unique: UniquePromise) -> Self {
         // If source text exceeds size limit, substitute a short source text which will fail to parse.
         // `Parser::parse` will convert error to `diagnostics::overlong_source()`.
         if source_text.len() > MAX_LEN {


### PR DESCRIPTION
Pure refactor. Rename unused function param. This results in better param name hint in IDE.