### PR TITLE
refactor(lexer): replace `#[allow]` with `#[expect]`

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -1,10 +1,10 @@
 use super::{Kind, Lexer};
 use crate::diagnostics;
 
-#[allow(clippy::unnecessary_safety_comment)]
 /// Handle next byte of source.
 ///
-/// SAFETY:
+/// # SAFETY
+///
 /// * Lexer must not be at end of file.
 /// * `byte` must be next byte of source code, corresponding to current position of `lexer.source`.
 /// * Only `BYTE_HANDLERS` for ASCII characters may use the `ascii_byte_handler!()` macro.
@@ -72,7 +72,6 @@ macro_rules! byte_handler {
     };
 }
 
-#[allow(clippy::unnecessary_safety_comment)]
 /// Macro for defining byte handler for an ASCII character.
 ///
 /// In addition to defining a `const` for the handler, it also asserts that lexer
@@ -132,7 +131,6 @@ macro_rules! ascii_byte_handler {
     };
 }
 
-#[allow(clippy::unnecessary_safety_comment)]
 /// Macro for defining byte handler for an ASCII character which is start of an identifier
 /// (`a`-`z`, `A`-`Z`, `$` or `_`).
 ///

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -31,7 +31,7 @@ impl Lexer<'_> {
                 // If this is end of comment, create trivia, and advance `pos` to after line break.
                 // Do that here rather than in `handle_match`, to avoid branching twice on value of
                 // the matched byte.
-                #[allow(clippy::if_not_else)]
+                #[expect(clippy::if_not_else)]
                 if next_byte != LS_OR_PS_FIRST {
                     // `\r` or `\n`
                     self.trivia_builder

--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -47,7 +47,7 @@ impl<'a> Lexer<'a> {
     /// # SAFETY
     /// * `self.source` must not be exhausted (at least 1 char remaining).
     /// * Next char must be ASCII.
-    #[allow(clippy::missing_safety_doc)] // Clippy is wrong!
+    #[expect(clippy::unnecessary_safety_comment)]
     pub(super) unsafe fn identifier_name_handler(&mut self) -> &'a str {
         // Advance past 1st byte.
         // SAFETY: Caller guarantees not at EOF, and next byte is ASCII.

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -26,6 +26,7 @@ impl Lexer<'_> {
     /// # SAFETY
     /// * `delimiter` must be an ASCII character.
     /// * Next char in `lexer.source` must be ASCII.
+    #[expect(clippy::unnecessary_safety_comment)]
     pub(super) unsafe fn read_jsx_string_literal(&mut self, delimiter: u8) -> Kind {
         // Skip opening quote
         debug_assert!(delimiter.is_ascii());

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::unnecessary_safety_comment)]
-#![allow(unsafe_code)]
-
 //! An Ecma-262 Lexer / Tokenizer
 //! Prior Arts:
 //!     * [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/24004745a8ed4939fc0dc7332bfd1268ac52285f/crates/parser/src)
@@ -99,7 +96,6 @@ pub struct Lexer<'a> {
     multi_line_comment_end_finder: Option<memchr::memmem::Finder<'static>>,
 }
 
-#[allow(clippy::unused_self)]
 impl<'a> Lexer<'a> {
     /// Create new `Lexer`.
     ///
@@ -230,7 +226,6 @@ impl<'a> Lexer<'a> {
 
     /// Get the length offset from the source, in UTF-8 bytes
     #[inline]
-    #[allow(clippy::cast_possible_truncation)]
     fn offset(&self) -> u32 {
         self.source.offset()
     }

--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -60,7 +60,7 @@ const fn decimal_byte_to_value(b: u8) -> u8 {
     b & 15
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_decimal(s: &str) -> f64 {
     /// Numeric strings longer than this have the chance to overflow u64.
     /// `u64::MAX + 1` in decimal is 18446744073709551616 (20 chars).
@@ -86,7 +86,7 @@ fn parse_decimal(s: &str) -> f64 {
     result as f64
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_decimal_with_underscores(s: &str) -> f64 {
     /// Numeric strings longer than this have the chance to overflow u64.
     /// `u64::MAX + 1` in decimal is 18446744073709551616 (20 chars).
@@ -146,7 +146,7 @@ const fn binary_byte_to_value(b: u8) -> u8 {
 /// we consider leading zeros as part of that length. Right now it doesn't seem
 /// worth it performance-wise to check and strip them. Further experimentation
 /// could be useful.
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_binary(s: &str) -> f64 {
     /// binary literals longer than this many characters have the chance to
     /// overflow a u64, forcing us to take the slow path.
@@ -178,7 +178,7 @@ fn parse_binary_slow(s: &str) -> f64 {
     result
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_binary_with_underscores(s: &str) -> f64 {
     /// binary literals longer than this many characters have the chance to
     /// overflow a u64, forcing us to take the slow path.
@@ -228,7 +228,7 @@ const fn octal_byte_to_value(b: u8) -> u8 {
     b & 7
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_octal(s: &str) -> f64 {
     /// Numeric strings longer than this have the chance to overflow u64.
     const MAX_FAST_OCTAL_LEN: usize = 21;
@@ -250,7 +250,6 @@ fn parse_octal(s: &str) -> f64 {
 
 #[cold]
 #[inline(never)]
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_octal_slow(s: &str) -> f64 {
     let mut result = 0_f64;
     for &b in s.as_bytes() {
@@ -260,7 +259,7 @@ fn parse_octal_slow(s: &str) -> f64 {
     result
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_octal_with_underscores(s: &str) -> f64 {
     /// Numeric strings longer than this have the chance to overflow u64.
     const MAX_FAST_OCTAL_LEN: usize = 21;
@@ -284,7 +283,6 @@ fn parse_octal_with_underscores(s: &str) -> f64 {
 
 #[cold]
 #[inline(never)]
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_octal_with_underscores_slow(s: &str) -> f64 {
     let mut result = 0_f64;
     for &b in s.as_bytes() {
@@ -321,7 +319,7 @@ const fn hex_byte_to_value(b: u8) -> u8 {
     }
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_hex(s: &str) -> f64 {
     /// Hex strings longer than this have the chance to overflow u64.
     const MAX_FAST_HEX_LEN: usize = 16;
@@ -353,7 +351,7 @@ fn parse_hex_slow(s: &str) -> f64 {
     result
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+#[expect(clippy::cast_precision_loss, clippy::cast_lossless)]
 fn parse_hex_with_underscores(s: &str) -> f64 {
     /// Hex strings longer than this have the chance to overflow u64.
     const MAX_FAST_HEX_LEN: usize = 16;
@@ -419,11 +417,11 @@ fn parse_big_int_without_underscores(s: &str, kind: Kind) -> Result<BigInt, &'st
 }
 
 #[cfg(test)]
-#[allow(clippy::unreadable_literal, clippy::mixed_case_hex_literals)]
+#[expect(clippy::unreadable_literal, clippy::mixed_case_hex_literals)]
 mod test {
     use super::*;
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn assert_all_ints_eq<I>(test_cases: I, kind: Kind, has_sep: bool)
     where
         I: IntoIterator<Item = (&'static str, i64)>,
@@ -474,7 +472,7 @@ mod test {
     };
 
     #[test]
-    #[allow(clippy::excessive_precision, clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn test_int_precision() {
         assert_eq!(
             // 18446744073709551616 = 1 << 64
@@ -508,7 +506,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::excessive_precision)]
     fn test_large_number_of_leading_zeros() {
         assert_all_ints_eq(
             vec![("000000000000000000000000000000000000000000000000000000001", 1)],
@@ -518,7 +515,7 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::excessive_precision)]
+    #[expect(clippy::excessive_precision)]
     fn test_float_precision() {
         let cases = vec![
             ("1.7976931348623157e+308", 1.7976931348623157e+308),

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -41,7 +41,7 @@ pub const SEARCH_BATCH_SIZE: usize = 32;
 #[repr(C, align(64))]
 pub struct ByteMatchTable([bool; 256]);
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl ByteMatchTable {
     // Create new `ByteMatchTable`.
     pub const fn new(bytes: [bool; 256]) -> Self {
@@ -61,7 +61,7 @@ impl ByteMatchTable {
     /// An unsafe function here, whereas for `SafeByteMatchTable` it's safe.
     /// `byte_search!` macro calls `.use_table()` on whatever table it's provided, which makes
     /// using the macro unsafe for `ByteMatchTable`, but safe for `SafeByteMatchTable`.
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     #[inline]
     pub const unsafe fn use_table(&self) {}
 
@@ -92,7 +92,7 @@ impl ByteMatchTable {
 ///   TABLE
 /// }
 /// ```
-#[allow(unused_macros)]
+#[expect(unused_macros)]
 macro_rules! byte_match_table {
     (|$byte:ident| $res:expr) => {{
         use crate::lexer::search::ByteMatchTable;
@@ -105,7 +105,7 @@ macro_rules! byte_match_table {
         TABLE
     }};
 }
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub(crate) use byte_match_table;
 
 /// Safe byte matcher lookup table.
@@ -203,7 +203,7 @@ impl SafeByteMatchTable {
     /// A safe function here, whereas for `ByteMatchTable` it's unsafe.
     /// `byte_search!` macro calls `.use_table()` on whatever table it's provided, which makes
     /// using the macro unsafe for `ByteMatchTable`, but safe for `SafeByteMatchTable`.
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     #[inline]
     pub const fn use_table(&self) {}
 
@@ -428,10 +428,11 @@ macro_rules! byte_search {
         // responsibility to uphold this invariant.
         // Therefore we can assume this is taken care of one way or another, and wrap the calls
         // to unsafe functions in this function with `unsafe {}`.
+        #[allow(clippy::unnecessary_safety_comment)]
         $table.use_table();
 
         let mut $pos = $start;
-        #[allow(unused_unsafe)] // Silence warnings if macro called in unsafe code
+        #[allow(unused_unsafe, clippy::unnecessary_safety_comment)] // Silence warnings if macro called in unsafe code
         'outer: loop {
             let $byte = if $pos.addr() <= $lexer.source.end_for_batch_search_addr() {
                 // Search a batch of `SEARCH_BATCH_SIZE` bytes.

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unnecessary_safety_comment)]
+#![expect(clippy::unnecessary_safety_comment)]
 
 use std::{marker::PhantomData, slice, str};
 
@@ -80,7 +80,7 @@ impl<'a> Source<'a> {
     ///
     /// Requiring a `UniquePromise` to be provided guarantees only 1 `Source` can exist
     /// on a single thread at one time.
-    #[allow(unused_variables, clippy::needless_pass_by_value)]
+    #[expect(unused_variables, clippy::needless_pass_by_value)]
     pub(super) fn new(mut source_text: &'a str, unique: UniquePromise) -> Self {
         // If source text exceeds size limit, substitute a short source text which will fail to parse.
         // `Parser::parse` will convert error to `diagnostics::overlong_source()`.
@@ -295,14 +295,13 @@ impl<'a> Source<'a> {
     }
 
     /// Get current position in source, relative to start of source.
-    #[allow(clippy::cast_possible_truncation)]
     #[inline]
     pub(super) fn offset(&self) -> u32 {
         self.offset_of(self.position())
     }
 
     /// Get offset of `pos`.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     #[inline]
     pub(super) fn offset_of(&self, pos: SourcePosition) -> u32 {
         // Cannot overflow `u32` because of `MAX_LEN` check in `Source::new`
@@ -435,10 +434,10 @@ impl<'a> Source<'a> {
     ///   source.next_char().unwrap();
     /// }
     /// ```
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[inline]
     unsafe fn next_byte(&mut self) -> Option<u8> {
-        #[allow(clippy::if_not_else)] // Hot path first
+        #[expect(clippy::if_not_else)] // Hot path first
         if !self.is_eof() {
             // SAFETY: Safe to read from `ptr` as we just checked it's not out of bounds
             Some(self.next_byte_unchecked())
@@ -504,7 +503,7 @@ impl<'a> Source<'a> {
     /// Peek next byte of source without consuming it.
     #[inline]
     pub(super) fn peek_byte(&self) -> Option<u8> {
-        #[allow(clippy::if_not_else)] // Hot path first
+        #[expect(clippy::if_not_else)] // Hot path first
         if !self.is_eof() {
             // SAFETY: Safe to read from `ptr` as we just checked it's not out of bounds
             Some(unsafe { self.peek_byte_unchecked() })
@@ -642,7 +641,7 @@ impl SourcePosition<'_> {
         // Pointer is "dereferenceable" by definition as a `u8` is 1 byte and cannot span multiple objects.
         // Alignment is not relevant as `u8` is aligned on 1 (i.e. no alignment requirements).
         debug_assert!(!self.ptr.is_null());
-        #[allow(clippy::ptr_as_ptr)]
+        #[expect(clippy::ptr_as_ptr)]
         let p = self.ptr as *const [u8; 2];
         *p.as_ref().unwrap_unchecked()
     }

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -86,6 +86,7 @@ impl<'a> Lexer<'a> {
     /// # SAFETY
     /// * Byte at `pos` must be `\r`.
     /// * `pos` must not be before `self.source.position()`.
+    #[expect(clippy::unnecessary_safety_comment)]
     unsafe fn template_literal_carriage_return(
         &mut self,
         mut pos: SourcePosition<'a>,
@@ -128,6 +129,7 @@ impl<'a> Lexer<'a> {
     /// # SAFETY
     /// * Byte at `pos` must be `\`.
     /// * `pos` must not be before `self.source.position()`.
+    #[expect(clippy::unnecessary_safety_comment)]
     unsafe fn template_literal_backslash(
         &mut self,
         pos: SourcePosition<'a>,
@@ -163,6 +165,7 @@ impl<'a> Lexer<'a> {
     /// Create arena string for modified template literal, containing the template literal up to `pos`.
     /// # SAFETY
     /// `pos` must not be before `self.source.position()`
+    #[expect(clippy::unnecessary_safety_comment)]
     unsafe fn template_literal_create_string(&self, pos: SourcePosition) -> String<'a> {
         // Create arena string to hold modified template literal.
         // We don't know how long template literal will end up being. Take a guess that total length


### PR DESCRIPTION
Pure refactor. Replace `#[allow]` with `#[expect]` in lexer, and remove various `#[allow]`s which were unnecessary.