### PR TITLE
refactor(lexer): make `handle_byte` a method of `Lexer`

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -2,15 +2,17 @@ use crate::diagnostics;
 
 use super::{Kind, Lexer};
 
-/// Handle next byte of source.
-///
-/// # SAFETY
-///
-/// * Lexer must not be at end of file.
-/// * `byte` must be next byte of source code, corresponding to current position of `lexer.source`.
-/// * Only `BYTE_HANDLERS` for ASCII characters may use the `ascii_byte_handler!()` macro.
-pub(super) unsafe fn handle_byte(byte: u8, lexer: &mut Lexer) -> Kind {
-    BYTE_HANDLERS[byte as usize](lexer)
+impl Lexer<'_> {
+    /// Handle next byte of source.
+    ///
+    /// # SAFETY
+    ///
+    /// * Lexer must not be at end of file.
+    /// * `byte` must be next byte of source code, corresponding to current position of `lexer.source`.
+    /// * Only `BYTE_HANDLERS` for ASCII characters may use the `ascii_byte_handler!()` macro.
+    pub(super) unsafe fn handle_byte(&mut self, byte: u8) -> Kind {
+        BYTE_HANDLERS[byte as usize](self)
+    }
 }
 
 type ByteHandler = unsafe fn(&mut Lexer<'_>) -> Kind;

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -39,7 +39,6 @@ pub use kind::Kind;
 pub use number::{parse_big_int, parse_float, parse_int};
 pub use token::Token;
 
-use byte_handlers::handle_byte;
 use source::{Source, SourcePosition};
 use trivia_builder::TriviaBuilder;
 
@@ -315,7 +314,7 @@ impl<'a> Lexer<'a> {
             };
 
             // SAFETY: `byte` is byte value at current position in source
-            let kind = unsafe { handle_byte(byte, self) };
+            let kind = unsafe { self.handle_byte(byte) };
             if kind != Kind::Skip {
                 return kind;
             }


### PR DESCRIPTION
Pure refactor. `handle_byte` was a free function. Make it a method of `Lexer` instead - more idiomatic.