### PR TITLE
fix(lexer): `Source` is not `Clone`

### DIFF
--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -60,7 +60,6 @@ use super::search::SEARCH_BATCH_SIZE;
 /// are satisfied, to restore this invariant before passing control back to other code.
 /// It will often be preferable to instead use `Source::peek_byte`, followed by `Source::next_char`,
 /// which are safe methods, and compiler will often reduce to equally efficient code.
-#[derive(Clone)]
 pub(super) struct Source<'a> {
     /// Pointer to start of source string. Never altered after initialization.
     start: *const u8,


### PR DESCRIPTION
It's an invariant of `Source` that only a single instance of `Source` can exist at any time. `Source` was erroneously implementing `Clone`, which makes it trivial to break this invariant. `Clone` is unnecessary, so remove it.