### PR TITLE
refactor(span): all methods take owned `Span`

### DIFF
--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -350,7 +350,7 @@ impl GetSpan for CompositeFix<'_> {
         match self {
             CompositeFix::Single(fix) => fix.span,
             CompositeFix::Multiple(fixes) => {
-                fixes.iter().map(|fix| fix.span).reduce(|a, b| a.merge(&b)).unwrap_or(SPAN)
+                fixes.iter().map(|fix| fix.span).reduce(Span::merge).unwrap_or(SPAN)
             }
             CompositeFix::None => SPAN,
         }

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -89,7 +89,7 @@ impl Rule for NoConsole {
             && !self.allow.iter().any(|s| mem.static_property_name().is_some_and(|f| f == s))
         {
             if let Some((mem_span, _)) = mem.static_property_info() {
-                let diagnostic_span = ident.span().merge(&mem_span);
+                let diagnostic_span = ident.span().merge(mem_span);
                 ctx.diagnostic_with_suggestion(no_console_diagnostic(diagnostic_span), |fixer| {
                     remove_console(fixer, ctx, node)
                 });

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -307,7 +307,7 @@ impl SortImports {
 
         if is_fixable {
             // Safe to index because we know that `specifiers` is at least 2 element long
-            let specifiers_span = specifiers[0].span.merge(&specifiers[specifiers.len() - 1].span);
+            let specifiers_span = specifiers[0].span.merge(specifiers[specifiers.len() - 1].span);
             ctx.diagnostic_with_fix(
                 sort_members_alphabetically_diagnostic(unsorted_name, unsorted_span),
                 |fixer| {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -92,7 +92,7 @@ impl Rule for RequireProperty {
 
                     let r#type = type_part.parsed();
                     if r#type == "Object" || r#type == "object" || r#type == "PlainObject" {
-                        should_report = Some(tag.kind.span.merge(&type_part.span));
+                        should_report = Some(tag.kind.span.merge(type_part.span));
                     }
                 }
 

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -69,7 +69,7 @@ impl Rule for NoRenderReturnValue {
                                 | AstKind::AssignmentExpression(_)
                         ) {
                             ctx.diagnostic(no_render_return_value_diagnostic(
-                                ident.span.merge(&property_span),
+                                ident.span.merge(property_span),
                             ));
                         }
 
@@ -80,7 +80,7 @@ impl Rule for NoRenderReturnValue {
                             {
                                 if e.expression {
                                     ctx.diagnostic(no_render_return_value_diagnostic(
-                                        ident.span.merge(&property_span),
+                                        ident.span.merge(property_span),
                                     ));
                                 }
                             }

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -228,7 +228,7 @@ impl Rule for PreferForOf {
             return;
         }
 
-        let span = for_stmt_init.span.merge(&test_expr.span).merge(&update_expr.span());
+        let span = for_stmt_init.span.merge(test_expr.span).merge(update_expr.span());
         ctx.diagnostic(prefer_for_of_diagnostic(span));
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -136,7 +136,7 @@ impl Rule for PreferQuerySelector {
                         }
                         _ => literal_value.to_string(),
                     };
-                    let span = property_span.merge(&argument_expr.span());
+                    let span = property_span.merge(argument_expr.span());
                     fixer.replace(
                         span,
                         format!("{preferred_selector}({quotes_symbol}{argument}{quotes_symbol}"),

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -215,8 +215,7 @@ impl GetSpan for Modifiers<'_> {
         debug_assert!(!modifiers.is_empty());
         // SAFETY: One of Modifier's invariants is that Some(modifiers) always
         // contains a non-empty Vec; otherwise it must be `None`.
-
-        unsafe { modifiers.iter().map(|m| m.span).reduce(|a, b| a.merge(&b)).unwrap_unchecked() }
+        unsafe { modifiers.iter().map(|m| m.span).reduce(Span::merge).unwrap_unchecked() }
     }
 }
 

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -882,7 +882,7 @@ impl<'a> PatternParser<'a> {
 
                 body.push(ast::CharacterClassContents::CharacterClassRange(Box::new_in(
                     ast::CharacterClassRange {
-                        span: from.span.merge(&to.span),
+                        span: from.span.merge(to.span),
                         min: **from,
                         max: **to,
                     },
@@ -1236,7 +1236,7 @@ impl<'a> PatternParser<'a> {
                     // It is a Syntax Error if the CharacterValue of the first ClassSetCharacter is strictly greater than the CharacterValue of the second ClassSetCharacter.
                     if class_set_character_to.value < class_set_character.value {
                         return Err(diagnostics::character_class_range_out_of_order(
-                            class_set_character.span.merge(&class_set_character_to.span),
+                            class_set_character.span.merge(class_set_character_to.span),
                             "class set",
                         ));
                     }
@@ -1244,7 +1244,7 @@ impl<'a> PatternParser<'a> {
                     return Ok(Some(ast::CharacterClassContents::CharacterClassRange(
                         Box::new_in(
                             ast::CharacterClassRange {
-                                span: class_set_character.span.merge(&class_set_character_to.span),
+                                span: class_set_character.span.merge(class_set_character_to.span),
                                 min: class_set_character,
                                 max: class_set_character_to,
                             },

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -40,7 +40,7 @@ pub struct JSDocTag<'a> {
 
 impl<'a> JSDocTag<'a> {
     pub fn new(kind: JSDocTagKindPart<'a>, body_content: &'a str, body_span: Span) -> JSDocTag<'a> {
-        Self { span: kind.span.merge(&body_span), kind, body_raw: body_content, body_span }
+        Self { span: kind.span.merge(body_span), kind, body_raw: body_content, body_span }
     }
 
     /// Use for various simple tags like `@access`, `@deprecated`, ...etc.

--- a/crates/oxc_span/src/span/mod.rs
+++ b/crates/oxc_span/src/span/mod.rs
@@ -77,7 +77,7 @@ impl Span {
     /// assert_eq!(Span::new(0, 5).size(), 5);
     /// assert_eq!(Span::new(5, 10).size(), 5);
     /// ```
-    pub const fn size(&self) -> u32 {
+    pub const fn size(self) -> u32 {
         debug_assert!(self.start <= self.end);
         self.end - self.start
     }
@@ -92,7 +92,7 @@ impl Span {
     /// assert!(Span::new(5, 5).is_empty());
     /// assert!(!Span::new(0, 5).is_empty());
     /// ```
-    pub const fn is_empty(&self) -> bool {
+    pub const fn is_empty(self) -> bool {
         debug_assert!(self.start <= self.end);
         self.start == self.end
     }
@@ -108,7 +108,7 @@ impl Span {
     /// assert!(!Span::new(0, 5).is_unspanned());
     /// assert!(!Span::new(5, 5).is_unspanned());
     /// ```
-    pub const fn is_unspanned(&self) -> bool {
+    pub const fn is_unspanned(self) -> bool {
         self.start == SPAN.start && self.end == SPAN.end
     }
 
@@ -148,7 +148,7 @@ impl Span {
     /// assert_eq!(merged_span, Span::new(0, 8));
     /// ```
     #[must_use]
-    pub fn merge(&self, other: &Self) -> Self {
+    pub fn merge(self, other: Self) -> Self {
         Self::new(self.start.min(other.start), self.end.max(other.end))
     }
 
@@ -324,7 +324,7 @@ impl Span {
     /// let name = name_span.source_text(source);
     /// assert_eq!(name_span.size(), name.len() as u32);
     /// ```
-    pub fn source_text<'a>(&self, source_text: &'a str) -> &'a str {
+    pub fn source_text(self, source_text: &str) -> &str {
         &source_text[self.start as usize..self.end as usize]
     }
 


### PR DESCRIPTION
`Span` is `Copy` and 8 bytes. There is no point in the extra indirection of passing `&Span` to functions (`&Span` is also 8 bytes).