### PR TITLE
perf(span): compare `Span`s as single `u64`s

### DIFF
--- a/crates/oxc_span/src/span/types.rs
+++ b/crates/oxc_span/src/span/types.rs
@@ -59,7 +59,7 @@ use super::PointerAlign;
 /// [`expand`]: Span::expand
 /// [`shrink`]: Span::shrink
 #[ast(visit)]
-#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Copy, Eq, PartialOrd, Ord)]
 #[generate_derive(ESTree)]
 #[estree(no_type, always_flatten)]
 pub struct Span {


### PR DESCRIPTION
#8298 made `Span` aligned on 8 on 64-bit platforms. Utilize this property to compare `Span`s as a single `u64` instead of 2 x `u32`s. This removes some really weird assembly which compiler otherwise produces, using expensive SIMD operations for a simple comparison: https://godbolt.org/z/sEf9MGvsr

Note: This only affects comparing `&Span`s. Makes no difference when comparing owned `Span`s.