### PR TITLE
fix(transformer/arrow-functions): store `super_methods` on a `Stack` to fix nested async methods

### DIFF
--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -42,19 +42,19 @@ after transform: ScopeId(0): ["BrowserWorkingCopyBackupTracker", "CancellationTo
 rebuilt        : ScopeId(0): ["BrowserWorkingCopyBackupTracker", "DisposableStore", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "ILifecycleService", "ILogService", "IWorkingCopyBackupService", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "_defineProperty", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
 Symbol reference IDs mismatch for "URI":
 after transform: SymbolId(1): [ReferenceId(109), ReferenceId(117), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : SymbolId(1): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(167)]
+rebuilt        : SymbolId(1): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(166)]
 Symbol reference IDs mismatch for "IEditorService":
 after transform: SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(67), ReferenceId(184)]
-rebuilt        : SymbolId(2): [ReferenceId(17), ReferenceId(60), ReferenceId(188)]
+rebuilt        : SymbolId(2): [ReferenceId(17), ReferenceId(59), ReferenceId(187)]
 Symbol reference IDs mismatch for "IEditorGroupsService":
 after transform: SymbolId(4): [ReferenceId(25), ReferenceId(26), ReferenceId(57), ReferenceId(176)]
-rebuilt        : SymbolId(3): [ReferenceId(18), ReferenceId(51), ReferenceId(181)]
+rebuilt        : SymbolId(3): [ReferenceId(18), ReferenceId(50), ReferenceId(180)]
 Symbol reference IDs mismatch for "EditorService":
 after transform: SymbolId(5): [ReferenceId(61), ReferenceId(64), ReferenceId(178), ReferenceId(181)]
-rebuilt        : SymbolId(4): [ReferenceId(57), ReferenceId(185)]
+rebuilt        : SymbolId(4): [ReferenceId(56), ReferenceId(184)]
 Symbol reference IDs mismatch for "IWorkingCopyBackupService":
 after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(51), ReferenceId(170)]
-rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(45), ReferenceId(175)]
+rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(44), ReferenceId(174)]
 Symbol reference IDs mismatch for "IFilesConfigurationService":
 after transform: SymbolId(10): [ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(8): [ReferenceId(12)]
@@ -72,19 +72,19 @@ after transform: SymbolId(17): [ReferenceId(38), ReferenceId(87)]
 rebuilt        : SymbolId(13): [ReferenceId(31)]
 Symbol reference IDs mismatch for "InMemoryTestWorkingCopyBackupService":
 after transform: SymbolId(19): [ReferenceId(43), ReferenceId(46), ReferenceId(165)]
-rebuilt        : SymbolId(15): [ReferenceId(40), ReferenceId(170)]
+rebuilt        : SymbolId(15): [ReferenceId(39), ReferenceId(169)]
 Symbol reference IDs mismatch for "TestServiceAccessor":
 after transform: SymbolId(21): [ReferenceId(1), ReferenceId(40), ReferenceId(71), ReferenceId(155), ReferenceId(188)]
-rebuilt        : SymbolId(17): [ReferenceId(64), ReferenceId(192)]
+rebuilt        : SymbolId(17): [ReferenceId(63), ReferenceId(191)]
 Symbol reference IDs mismatch for "IWorkingCopyEditorService":
 after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22)]
 rebuilt        : SymbolId(26): [ReferenceId(16)]
 Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): [ReferenceId(42), ReferenceId(74), ReferenceId(154), ReferenceId(215)]
-rebuilt        : SymbolId(35): [ReferenceId(67), ReferenceId(219)]
+rebuilt        : SymbolId(35): [ReferenceId(66), ReferenceId(218)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(36), ReferenceId(39), ReferenceId(82), ReferenceId(114), ReferenceId(153), ReferenceId(282)]
-rebuilt        : [ReferenceId(292)]
+rebuilt        : [ReferenceId(291)]
 
 tasks/coverage/misc/pass/oxc-4449.ts
 semantic error: Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 122/141
+Passed: 123/141
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -9,6 +9,7 @@ Passed: 122/141
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
 * babel-plugin-transform-object-rest-spread
+* babel-plugin-transform-async-to-generator
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
@@ -43,11 +44,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), R
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
-
-
-# babel-plugin-transform-async-to-generator (17/18)
-* super/nested/input.js
-x Output mismatch
 
 
 # babel-plugin-transform-typescript (2/10)


### PR DESCRIPTION
In the following case, async methods can be nested in another async method. The implementation is changing to store `super_methods` on a stack, and then we can store super method information in the correct `super_methods` map.

```js
const outer = {
  value: 0,
  async method() {
    () => super.value;

    const inner = {
      value: 0,
      async method() {
        () => super.value;
      }
    };

    () => super.value;
  }
};
```
