### PR TITLE
refactor(prettier): Update tasks/prettier to correctly handle snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
 name = "oxc_prettier_conformance"
 version = "0.0.0"
 dependencies = [
+ "cow-utils",
  "oxc_allocator",
  "oxc_ast",
  "oxc_parser",

--- a/crates/oxc_prettier/src/format/js.rs
+++ b/crates/oxc_prettier/src/format/js.rs
@@ -33,8 +33,7 @@ impl<'a> Format<'a> for Program<'a> {
 
             if let Some(body_doc) = block::print_block_body(p, &self.body, Some(&self.directives)) {
                 parts.push(body_doc);
-                // XXX: Prettier seems to add this, but test results don't match
-                // parts.extend(hardline!());
+                parts.extend(hardline!());
             }
 
             array!(p, parts)

--- a/crates/oxc_prettier/src/format/print/block.rs
+++ b/crates/oxc_prettier/src/format/print/block.rs
@@ -48,6 +48,7 @@ pub fn print_block<'a>(
     array!(p, parts)
 }
 
+/// For `Program` only
 pub fn print_block_body<'a>(
     p: &mut Prettier<'a>,
     stmts: &[Statement<'a>],

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -33,3 +33,4 @@ oxc_tasks_common = { workspace = true }
 pico-args = { workspace = true }
 rustc-hash = { workspace = true }
 walkdir = { workspace = true }
+cow-utils = { workspace = true }

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -30,7 +30,7 @@ oxc_prettier = { workspace = true }
 oxc_span = { workspace = true }
 oxc_tasks_common = { workspace = true }
 
+cow-utils = { workspace = true }
 pico-args = { workspace = true }
 rustc-hash = { workspace = true }
 walkdir = { workspace = true }
-cow-utils = { workspace = true }

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 246/641 (38.38%)
+js compatibility: 249/641 (38.85%)
 
 # Failed
 
@@ -219,9 +219,6 @@ js compatibility: 246/641 (38.38%)
 * js/empty-paren-comment/class-property.js
 * js/empty-paren-comment/class.js
 * js/empty-paren-comment/empty_paren_comment.js
-
-### js/end-of-line
-* js/end-of-line/example.js
 
 ### js/export
 * js/export/blank-line-between-specifiers.js
@@ -566,10 +563,8 @@ js compatibility: 246/641 (38.38%)
 * jsx/jsx/quotes.js
 * jsx/jsx/regex.js
 * jsx/jsx/return-statement.js
-* jsx/jsx/self-closing.js
 * jsx/jsx/spacing.js
 * jsx/jsx/template-literal-in-attr.js
-* jsx/jsx/ternary.js
 
 ### jsx/last-line
 * jsx/last-line/last_line.js

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 190/568 (33.45%)
+ts compatibility: 193/568 (33.98%)
 
 # Failed
 
@@ -54,10 +54,8 @@ ts compatibility: 190/568 (33.45%)
 * jsx/jsx/quotes.js
 * jsx/jsx/regex.js
 * jsx/jsx/return-statement.js
-* jsx/jsx/self-closing.js
 * jsx/jsx/spacing.js
 * jsx/jsx/template-literal-in-attr.js
-* jsx/jsx/ternary.js
 
 ### jsx/last-line
 * jsx/last-line/last_line.js
@@ -229,9 +227,6 @@ ts compatibility: 190/568 (33.45%)
 * typescript/conformance/classes/mixinClassesAnonymous.ts
 * typescript/conformance/classes/mixinClassesMembers.ts
 * typescript/conformance/classes/nestedClassDeclaration.ts
-
-### typescript/conformance/classes/classDeclarations/classAbstractKeyword
-* typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractWithInterface.ts
 
 ### typescript/conformance/classes/classDeclarations/classHeritageSpecification
 * typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -107,7 +107,7 @@ impl TestRunner {
 }
 
 /// Read the first level of directories that contain `__snapshots__` and `format.test.js`
-/// ```
+/// ```text
 /// js/arrows <------------------------------- THIS
 /// ├── __snapshots__
 /// ├── arrow-chain-with-trailing-comments.js
@@ -151,7 +151,7 @@ fn collect_test_dirs(fixture_roots: &Vec<PathBuf>) -> Vec<PathBuf> {
 }
 
 /// Read all test files in the directory with applying ignore + filter
-/// ```
+/// ```text
 /// js/arrows
 /// ├── __snapshots__
 /// ├── arrow-chain-with-trailing-comments.js <---- THIS
@@ -320,7 +320,7 @@ fn find_output_from_snapshots(
 }
 
 /// Apply the same escape rules as Prettier does.
-/// If Prettier's snapshot contains <LF>, <CR> or <CRLF>, we also need to visualize.
+/// If Prettier's snapshot contains `<LF>`, `<CR>` or `<CRLF>`, we also need to visualize.
 fn replace_escape_and_eol(input: &str, need_eol_visualized: bool) -> String {
     let input = input
         .cow_replace("\\", "\\\\")

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -1,11 +1,24 @@
-use oxc_prettier_conformance::{TestLanguage, TestRunner, TestRunnerOptions};
 use pico_args::Arguments;
 
+use oxc_prettier_conformance::{
+    options::{TestLanguage, TestRunnerOptions},
+    TestRunner,
+};
+
+/// This CLI runs in 2 modes:
+/// - `cargo run`: Run all tests and generate coverage reports
+/// - `cargo run -- --filter <filter>`: Debug a specific test, not generating coverage reports
 fn main() {
     let mut args = Arguments::from_env();
+    let filter = args.opt_value_from_str("--filter").unwrap();
 
-    let options = TestRunnerOptions { filter: args.opt_value_from_str("--filter").unwrap() };
+    TestRunner::new(TestRunnerOptions { filter: filter.clone(), language: TestLanguage::Js }).run();
+    TestRunner::new(TestRunnerOptions { filter: filter.clone(), language: TestLanguage::Ts }).run();
+}
 
-    TestRunner::new(TestLanguage::Js, options.clone()).run();
-    TestRunner::new(TestLanguage::Ts, options.clone()).run();
+#[test]
+#[cfg(any(coverage, coverage_nightly))]
+fn test() {
+    TestRunner::new(TestRunnerOptions { filter: None, language: TestLanguage::Js }).run();
+    TestRunner::new(TestRunnerOptions { filter: None, language: TestLanguage::Ts }).run();
 }

--- a/tasks/prettier_conformance/src/options.rs
+++ b/tasks/prettier_conformance/src/options.rs
@@ -1,0 +1,33 @@
+use std::path::{Path, PathBuf};
+
+pub struct TestRunnerOptions {
+    pub language: TestLanguage,
+    pub filter: Option<String>,
+}
+
+pub enum TestLanguage {
+    Js,
+    Ts,
+}
+
+impl TestLanguage {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Js => "js",
+            Self::Ts => "ts",
+        }
+    }
+
+    /// Prettier's test fixtures roots for different languages.
+    pub fn fixtures_roots(&self, base: &Path) -> Vec<PathBuf> {
+        match self {
+            Self::Js => ["js", "jsx"],
+            // There is no `tsx` directory, just check it works with TS
+            // `SourceType`.`variant` is handled by spec file extension
+            Self::Ts => ["typescript", "jsx"],
+        }
+        .iter()
+        .map(|dir| base.join(dir))
+        .collect::<Vec<_>>()
+    }
+}

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -1,28 +1,38 @@
-#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-
 use std::{fs, path::Path, str::FromStr};
 
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    ast::{Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind},
+    ast::{
+        Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind,
+        VariableDeclarator,
+    },
     VisitMut,
 };
 use oxc_parser::Parser;
 use oxc_prettier::{ArrowParens, EndOfLine, PrettierOptions, QuoteProps, TrailingComma};
 use oxc_span::{GetSpan, SourceType};
 
+/// Vec<(key, value)>
+type SnapshotOptions = Vec<(String, String)>;
+
+pub fn parse_spec(spec: &Path) -> Vec<(PrettierOptions, SnapshotOptions)> {
+    let mut parser = SpecParser::default();
+    parser.parse(spec);
+    parser.calls
+}
+
 #[derive(Default)]
-pub struct SpecParser {
-    pub calls: Vec<(PrettierOptions, Vec<(String, String)>)>,
+struct SpecParser {
     source_text: String,
+    parsers: Vec<String>,
+    calls: Vec<(PrettierOptions, SnapshotOptions)>,
 }
 
 impl SpecParser {
-    pub fn parse(&mut self, spec: &Path) {
+    fn parse(&mut self, spec: &Path) {
         let spec_content = fs::read_to_string(spec).unwrap_or_default();
 
         self.source_text.clone_from(&spec_content);
-        self.calls.clear();
 
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(spec).unwrap_or_default();
@@ -33,39 +43,69 @@ impl SpecParser {
 }
 
 impl VisitMut<'_> for SpecParser {
+    // Some test cases use a variable to store the parsers.
+    //
+    // ```js
+    // const parser = ["babel"];
+    //
+    // runFormatTest(import.meta, parser, {});
+    // runFormatTest(import.meta, parser, { semi: false });
+    // ````
+    fn visit_variable_declarator(&mut self, decl: &mut VariableDeclarator<'_>) {
+        let Some(name) = decl.id.get_identifier() else { return };
+        if !matches!(name.as_str(), "parser" | "parsers") {
+            return;
+        }
+
+        debug_assert!(self.parsers.is_empty(), "`parsers` is already defined");
+        if let Some(Expression::ArrayExpression(arr_expr)) = &decl.init {
+            for el in &arr_expr.elements {
+                if let ArrayExpressionElement::StringLiteral(literal) = el {
+                    self.parsers.push(literal.value.to_string());
+                }
+            }
+        }
+    }
+
+    // The `runFormatTest()` function is used on prettier's test cases.
+    // We need to collect all calls and get the options and parsers.
     fn visit_call_expression(&mut self, expr: &mut CallExpression<'_>) {
         let Some(ident) = expr.callee.get_identifier_reference() else { return };
-        // The `runFormatTest` function used on prettier's test cases. We need to collect all `run_spec` calls
-        // And then parse the arguments to get the options and parsers
-        // Finally we use this information to generate the snapshot tests
         if ident.name != "runFormatTest" {
             return;
         }
+
+        let mut snapshot_options: SnapshotOptions = vec![];
         let mut parsers = vec![];
-        let mut snapshot_options: Vec<(String, String)> = vec![];
         let mut options = PrettierOptions::default();
 
+        // Get parsers
         if let Some(argument) = expr.arguments.get(1) {
             let Some(argument_expr) = argument.as_expression() else {
                 return;
             };
 
+            // If inlined array
             if let Expression::ArrayExpression(arr_expr) = argument_expr {
-                parsers = arr_expr
-                    .elements
-                    .iter()
-                    .filter_map(|el| {
-                        if let ArrayExpressionElement::StringLiteral(literal) = el {
-                            return Some(literal.value.to_string());
-                        }
-                        None
-                    })
-                    .collect::<Vec<String>>();
+                for el in &arr_expr.elements {
+                    if let ArrayExpressionElement::StringLiteral(literal) = el {
+                        parsers.push(literal.value.to_string());
+                    }
+                }
+            }
+            // If variable
+            if let Expression::Identifier(_) = argument_expr {
+                debug_assert!(
+                    !self.parsers.is_empty(),
+                    "`parsers` is not collected, check variable name"
+                );
+                parsers.clone_from(&self.parsers);
             }
         } else {
             return;
         }
 
+        // Get options
         if let Some(Argument::ObjectExpression(obj_expr)) = expr.arguments.get(2) {
             obj_expr.properties.iter().for_each(|item| {
                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = item {
@@ -80,6 +120,7 @@ impl VisitMut<'_> for SpecParser {
                                     options.single_quote = literal.value;
                                 }
                             }
+                            #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                             Expression::NumericLiteral(literal) => match name.as_ref() {
                                 "printWidth" => options.print_width = literal.value as usize,
                                 "tabWidth" => options.tab_width = literal.value as usize,
@@ -117,6 +158,7 @@ impl VisitMut<'_> for SpecParser {
             });
         }
 
+        debug_assert!(!parsers.is_empty(), "`parsers` should not be empty");
         snapshot_options.push((
             "parsers".to_string(),
             format!(


### PR DESCRIPTION
I refactored the code in `tasks/prettier_conformance` primarily to make the output more readable when using `--filter`.

But I also discovered that our previous implementation did not correctly handle Prettier's behavior of adding a blank line at the EOF.

In addition, I resolved a problem where test specs that used patterns like `runFormatTest(_, parsers)` were unable to locate the correct snapshot output.

As a result, compatibility has also improved slightly. 😉 