### PR TITLE
test(minifier): add anonymous function test case for logical expression to logical assignment compression

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -1520,6 +1520,10 @@ mod test {
         test("x && (x = g())", "x &&= g()");
         test("x ?? (x = g())", "x ??= g()");
 
+        // `||=`, `&&=`, `??=` sets the name property of the function
+        // Example case: `let f = false; f || (f = () => {}); console.log(f.name)`
+        test("x || (x = () => 'a')", "x ||= () => 'a'");
+
         test_same("x || (y = 3)");
 
         // foo() might have a side effect


### PR DESCRIPTION
Added a test case that tells having an anonymous function on the right hand side for "logical expression to logical assignment" compression is fine.