### PR TITLE
test(linter): use plugin name instead of category for finding rule

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -599,7 +599,7 @@ semi*/
             ),
         ];
 
-        Tester::new(EslintNoDebugger::NAME, EslintNoDebugger::CATEGORY, pass, fail)
+        Tester::new(EslintNoDebugger::NAME, EslintNoDebugger::PLUGIN, pass, fail)
             .intentionally_allow_no_fix_tests()
             .test();
     }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -65,6 +65,8 @@ pub trait Rule: Sized + Default + fmt::Debug {
 pub trait RuleMeta {
     const NAME: &'static str;
 
+    const PLUGIN: &'static str;
+
     const CATEGORY: RuleCategory;
 
     /// What kind of auto-fixing can this rule do?

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     ArrayCallbackReturn,
+    eslint,
     pedantic
 );
 
@@ -580,6 +581,6 @@ fn test() {
         ("foo?.filter((function() { return () => { console.log('hello') } })?.())", None),
     ];
 
-    Tester::new(ArrayCallbackReturn::NAME, ArrayCallbackReturn::CATEGORY, pass, fail)
+    Tester::new(ArrayCallbackReturn::NAME, ArrayCallbackReturn::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ConstructorSuper,
+    eslint,
     nursery // This rule should be implemented with CFG, the current implementation has a lot of
             // false positives.
 );
@@ -71,5 +72,5 @@ fn test() {
         // ("class A extends 'test' { constructor() { super(); } }", None),
     ];
 
-    Tester::new(ConstructorSuper::NAME, ConstructorSuper::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ConstructorSuper::NAME, ConstructorSuper::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     DefaultCase,
+    eslint,
     restriction,
 );
 
@@ -255,5 +256,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(DefaultCase::NAME, DefaultCase::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(DefaultCase::NAME, DefaultCase::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     DefaultCaseLast,
+    eslint,
     style
 );
 
@@ -117,5 +118,5 @@ fn test() {
         r"switch (foo) { case 1: default: case 2: }",
     ];
 
-    Tester::new(DefaultCaseLast::NAME, DefaultCaseLast::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(DefaultCaseLast::NAME, DefaultCaseLast::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// createUser(undefined, "tabby")
     /// ```
     DefaultParamLast,
+    eslint,
     style
 );
 
@@ -97,5 +98,5 @@ fn test() {
         "const f = ([a, b] = [1, 2], c) => {}",
     ];
 
-    Tester::new(DefaultParamLast::NAME, DefaultParamLast::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(DefaultParamLast::NAME, DefaultParamLast::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// a == b
     /// ```
     Eqeqeq,
+    eslint,
     pedantic,
     conditional_fix
 );
@@ -253,5 +254,5 @@ fn test() {
         ("a == b", "a == b", None),
     ];
 
-    Tester::new(Eqeqeq::NAME, Eqeqeq::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(Eqeqeq::NAME, Eqeqeq::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ForDirection,
+    eslint,
     correctness,
     fix_dangerous
 );
@@ -320,7 +321,7 @@ fn test() {
         ("for(var ii = 10; ii > 0; ii+=1){}", "for(var ii = 10; ii > 0; ii-=1){}", None),
     ];
 
-    Tester::new(ForDirection::NAME, ForDirection::CATEGORY, pass, fail)
+    Tester::new(ForDirection::NAME, ForDirection::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -141,6 +141,7 @@ declare_oxc_lint!(
     /// Foo.prototype.bar = function() {};
     /// ```
     FuncNames,
+    eslint,
     style,
     conditional_fix_suggestion
 );
@@ -798,7 +799,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(FuncNames::NAME, FuncNames::CATEGORY, pass, fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
+    Tester::new(FuncNames::NAME, FuncNames::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     GetterReturn,
+    eslint,
     nursery
 );
 
@@ -519,7 +520,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(GetterReturn::NAME, GetterReturn::CATEGORY, pass, fail)
+    Tester::new(GetterReturn::NAME, GetterReturn::PLUGIN, pass, fail)
         .change_rule_path_extension("js")
         .test_and_snapshot();
 
@@ -537,5 +538,5 @@ fn test() {
 
     let fail = vec![];
 
-    Tester::new(GetterReturn::NAME, GetterReturn::CATEGORY, pass, fail).test();
+    Tester::new(GetterReturn::NAME, GetterReturn::PLUGIN, pass, fail).test();
 }

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     GuardForIn,
+    eslint,
     style
 );
 
@@ -93,5 +94,5 @@ fn test() {
         "for (var x in o) foo();",
     ];
 
-    Tester::new(GuardForIn::NAME, GuardForIn::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(GuardForIn::NAME, GuardForIn::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// class Bar {}
     /// ```
     MaxClassesPerFile,
+    eslint,
     pedantic,
 );
 
@@ -188,6 +189,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxClassesPerFile::NAME, MaxClassesPerFile::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(MaxClassesPerFile::NAME, MaxClassesPerFile::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// file, most people would agree it should not be in the thousands.
     /// Recommendations usually range from 100 to 500 lines.
     MaxLines,
+    eslint,
     pedantic
 );
 
@@ -420,5 +421,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxLines::NAME, MaxLines::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(MaxLines::NAME, MaxLines::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     MaxParams,
+    eslint,
     style
 );
 
@@ -157,5 +158,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxParams::NAME, MaxParams::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(MaxParams::NAME, MaxParams::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/new_cap.rs
+++ b/crates/oxc_linter/src/rules/eslint/new_cap.rs
@@ -442,6 +442,7 @@ declare_oxc_lint!(
     /// var friend = new person.acquaintance();
     /// ```
     NewCap,
+    eslint,
     style,
     pending  // TODO: maybe?
 );
@@ -785,5 +786,5 @@ fn test() {
         ("(foo?.Bar)();", None),     // { "ecmaVersion": 2020 }
     ];
 
-    Tester::new(NewCap::NAME, NewCap::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NewCap::NAME, NewCap::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAlert,
+    eslint,
     restriction,
 );
 
@@ -175,5 +176,5 @@ fn test() {
         "(window?.alert)(foo)",     // { "ecmaVersion": 2020 }
     ];
 
-    Tester::new(NoAlert::NAME, NoAlert::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoAlert::NAME, NoAlert::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// let arr3 = new Array(9);
     /// ```
     NoArrayConstructor,
+    eslint,
     pedantic,
     pending
 );
@@ -124,6 +125,6 @@ fn test() {
         ("Array(0, 1, 2)", None),
     ];
 
-    Tester::new(NoArrayConstructor::NAME, NoArrayConstructor::CATEGORY, pass, fail)
+    Tester::new(NoArrayConstructor::NAME, NoArrayConstructor::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// - If an async executor function throws an error, the error will be lost and won’t cause the newly-constructed `Promise` to reject.This could make it difficult to debug and handle some errors.
     /// - If a Promise executor function is using `await`, this is usually a sign that it is not actually necessary to use the `new Promise` constructor, or the scope of the `new Promise` constructor can be reduced.
     NoAsyncPromiseExecutor,
+    eslint,
     correctness
 );
 
@@ -85,6 +86,6 @@ fn test() {
         ("new Promise(((((async () => {})))))", None),
     ];
 
-    Tester::new(NoAsyncPromiseExecutor::NAME, NoAsyncPromiseExecutor::CATEGORY, pass, fail)
+    Tester::new(NoAsyncPromiseExecutor::NAME, NoAsyncPromiseExecutor::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAwaitInLoop,
+    eslint,
     perf
 );
 
@@ -232,5 +233,5 @@ fn test() {
         "async function foo() { for await (var x of xs) { while (1) await f(x) } }",
     ];
 
-    Tester::new(NoAwaitInLoop::NAME, NoAwaitInLoop::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoAwaitInLoop::NAME, NoAwaitInLoop::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// var x = y | z;
     /// ```
     NoBitwise,
+    eslint,
     restriction
 );
 
@@ -158,5 +159,5 @@ fn test() {
         ("a >>>= b", None),
     ];
 
-    Tester::new(NoBitwise::NAME, NoBitwise::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoBitwise::NAME, NoBitwise::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoCaller,
+    eslint,
     correctness
 );
 
@@ -98,5 +99,5 @@ fn test() {
 
     let fail = vec![("var x = arguments.callee", None), ("var x = arguments.caller", None)];
 
-    Tester::new(NoCaller::NAME, NoCaller::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoCaller::NAME, NoCaller::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoCaseDeclarations,
+    eslint,
     pedantic
 );
 
@@ -103,6 +104,6 @@ fn test() {
         ("switch (a) { default: class C {} break; }", None),
     ];
 
-    Tester::new(NoCaseDeclarations::NAME, NoCaseDeclarations::CATEGORY, pass, fail)
+    Tester::new(NoCaseDeclarations::NAME, NoCaseDeclarations::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// let a = new A() // Error
     /// ```
     NoClassAssign,
+    eslint,
     correctness
 );
 
@@ -84,5 +85,5 @@ fn test() {
         ("if (foo) { class A {} A = 1; }", None),
     ];
 
-    Tester::new(NoClassAssign::NAME, NoClassAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoClassAssign::NAME, NoClassAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     /// if (x === -0) {}
     /// ```
     NoCompareNegZero,
+    eslint,
     correctness,
     conditional_fix_suggestion
 );
@@ -167,7 +168,7 @@ fn test() {
         ("-0n <= x", "0n <= x", None),
     ];
 
-    Tester::new(NoCompareNegZero::NAME, NoCompareNegZero::CATEGORY, pass, fail)
+    Tester::new(NoCompareNegZero::NAME, NoCompareNegZero::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoCondAssign,
+    eslint,
     correctness
 );
 
@@ -250,5 +251,5 @@ fn test() {
         ("(((3496.29)).bkufyydt = 2e308) ? foo : bar;", None),
     ];
 
-    Tester::new(NoCondAssign::NAME, NoCondAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoCondAssign::NAME, NoCondAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// console.log('here');
     /// ```
     NoConsole,
+    eslint,
     restriction,
     suggestion
 );
@@ -187,7 +188,5 @@ fn test() {
         ("const x = { foo: console.log(bar) }", "const x = { foo: undefined }", None),
     ];
 
-    Tester::new(NoConsole::NAME, NoConsole::CATEGORY, pass, fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
+    Tester::new(NoConsole::NAME, NoConsole::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// b += 1;
     /// ```
     NoConstAssign,
+    eslint,
     correctness
 );
 
@@ -109,5 +110,5 @@ fn test() {
         ("const b = 0; ({a, ...b} = {a: 1, c: 2, d: 3})", None),
     ];
 
-    Tester::new(NoConstAssign::NAME, NoConstAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoConstAssign::NAME, NoConstAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// // However, this will always result in `isEmpty` being `false`.
     /// ```
     NoConstantBinaryExpression,
+    eslint,
     correctness
 );
 
@@ -654,6 +655,6 @@ fn test() {
         ("window.abc ?? 'non-nullish' ?? anything", None),
     ];
 
-    Tester::new(NoConstantBinaryExpression::NAME, NoConstantBinaryExpression::CATEGORY, pass, fail)
+    Tester::new(NoConstantBinaryExpression::NAME, NoConstantBinaryExpression::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoConstantCondition,
+    eslint,
     correctness
 );
 
@@ -405,6 +406,6 @@ fn test() {
         // ("function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}", None),
     ];
 
-    Tester::new(NoConstantCondition::NAME, NoConstantCondition::CATEGORY, pass, fail)
+    Tester::new(NoConstantCondition::NAME, NoConstantCondition::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoConstructorReturn,
+    eslint,
     pedantic
 );
 
@@ -104,6 +105,6 @@ fn test() {
         "class C { constructor(a) { if (!a) { return '' } else { a() } } }",
     ];
 
-    Tester::new(NoConstructorReturn::NAME, NoConstructorReturn::CATEGORY, pass, fail)
+    Tester::new(NoConstructorReturn::NAME, NoConstructorReturn::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoContinue,
+    eslint,
     style
 );
 
@@ -65,5 +66,5 @@ fn test() {
         "var sum = 0, i = 0; myLabel: while(i < 10) { if(i <= 5) { i++; continue myLabel; } sum += i; i++; }",
     ];
 
-    Tester::new(NoContinue::NAME, NoContinue::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoContinue::NAME, NoContinue::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// var pattern8 = new RegExp("\\n");
     /// ```
     NoControlRegex,
+    eslint,
     correctness
 );
 
@@ -212,7 +213,7 @@ mod tests {
     fn test_hex_literals() {
         Tester::new(
             NoControlRegex::NAME,
-            NoControlRegex::CATEGORY,
+            NoControlRegex::PLUGIN,
             vec![
                 "x1f",                 // not a control sequence
                 r"new RegExp('\x20')", // control sequence in valid range
@@ -228,7 +229,7 @@ mod tests {
     fn test_unicode_literals() {
         Tester::new(
             NoControlRegex::NAME,
-            NoControlRegex::CATEGORY,
+            NoControlRegex::PLUGIN,
             vec![
                 r"u00",    // not a control sequence
                 r"\u00ff", // in valid range
@@ -260,7 +261,7 @@ mod tests {
     fn test_unicode_brackets() {
         Tester::new(
             NoControlRegex::NAME,
-            NoControlRegex::CATEGORY,
+            NoControlRegex::PLUGIN,
             vec![
                 r"let r = /\u{0}/", // no unicode flag, this is valid
                 r"let r = /\u{ff}/u",
@@ -292,7 +293,7 @@ mod tests {
             r"const r = /([a-z])\2/;",
             r"const r = /([a-z])\0/;",
         ];
-        Tester::new(NoControlRegex::NAME, NoControlRegex::CATEGORY, pass, fail)
+        Tester::new(NoControlRegex::NAME, NoControlRegex::PLUGIN, pass, fail)
             .with_snapshot_suffix("capture-group-indexing")
             .test_and_snapshot();
     }
@@ -303,7 +304,7 @@ mod tests {
         // https://github.com/eslint/eslint/blob/v9.9.1/tests/lib/rules/no-control-regex.js
         Tester::new(
             NoControlRegex::NAME,
-            NoControlRegex::CATEGORY,
+            NoControlRegex::PLUGIN,
             vec![
                 "var regex = /x1f/;",
                 r"var regex = /\\x1f/",

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDebugger,
+    eslint,
     correctness,
     fix
 );
@@ -81,7 +82,7 @@ fn test() {
         ("if (foo) { debugger }", "if (foo) {  }", None),
     ];
 
-    Tester::new(NoDebugger::NAME, NoDebugger::CATEGORY, pass, fail)
+    Tester::new(NoDebugger::NAME, NoDebugger::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// delete x;
     /// ```
     NoDeleteVar,
+    eslint,
     correctness
 );
 
@@ -54,5 +55,5 @@ fn test() {
 
     let fail = vec![("delete x", None)];
 
-    Tester::new(NoDeleteVar::NAME, NoDeleteVar::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDeleteVar::NAME, NoDeleteVar::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// function bar() { return /=foo/; }
     /// ```
     NoDivRegex,
+    eslint,
     restriction,
     fix
 );
@@ -71,7 +72,7 @@ fn test() {
         None,
     )];
 
-    Tester::new(NoDivRegex::NAME, NoDivRegex::CATEGORY, pass, fail)
+    Tester::new(NoDivRegex::NAME, NoDivRegex::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// a.foo() // Uncaught TypeError: a.foo is not a function
     /// ```
     NoDupeClassMembers,
+    eslint,
     correctness
 );
 
@@ -164,6 +165,6 @@ fn test() {
         "class A { foo;  foo() {}}",
     ];
 
-    Tester::new(NoDupeClassMembers::NAME, NoDupeClassMembers::CATEGORY, pass, fail)
+    Tester::new(NoDupeClassMembers::NAME, NoDupeClassMembers::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDupeElseIf,
+    eslint,
     correctness
 );
 
@@ -257,5 +258,5 @@ fn test() {
         ("if (a && a) {} else if (a) {}", None),
     ];
 
-    Tester::new(NoDupeElseIf::NAME, NoDupeElseIf::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDupeElseIf::NAME, NoDupeElseIf::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     NoDupeKeys,
+    eslint,
     correctness
 );
 
@@ -149,5 +150,5 @@ fn test() {
         ("var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })", None),
     ];
 
-    Tester::new(NoDupeKeys::NAME, NoDupeKeys::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDupeKeys::NAME, NoDupeKeys::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDuplicateCase,
+    eslint,
     correctness
 );
 
@@ -133,5 +134,5 @@ fn test() {
         "var a = 1, f = function(s) { return { p1: s } }; switch (a) {case f(\na + 1 // comment\n).p1: break; case f(a+1)\n.p1: break; default: break;}",
     ];
 
-    Tester::new(NoDuplicateCase::NAME, NoDuplicateCase::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDuplicateCase::NAME, NoDuplicateCase::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// import something from 'another-module';
     /// ```
     NoDuplicateImports,
+    eslint,
     style,
     pending);
 
@@ -470,6 +471,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDuplicateImports::NAME, NoDuplicateImports::CATEGORY, pass, fail)
+    Tester::new(NoDuplicateImports::NAME, NoDuplicateImports::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -162,6 +162,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoElseReturn,
+    eslint,
     pedantic,
     conditional_fix
 );
@@ -833,7 +834,7 @@ fn test() {
         ),
         ("if (foo) { return true; } else { let a; }", "if (foo) { return true; } let a;", None),
     ];
-    Tester::new(NoElseReturn::NAME, NoElseReturn::CATEGORY, pass, fail)
+    Tester::new(NoElseReturn::NAME, NoElseReturn::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -31,6 +31,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoEmpty,
+    eslint,
     restriction,
     suggestion
 );
@@ -196,5 +197,5 @@ fn test() {
         ("try { foo(); } catch (ex) {} finally {}", "try { foo(); } catch (ex) {} ", None),
     ];
 
-    Tester::new(NoEmpty::NAME, NoEmpty::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(NoEmpty::NAME, NoEmpty::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// var foo = /^abc[]/;
     /// ```
     NoEmptyCharacterClass,
+    eslint,
     correctness
 );
 
@@ -126,6 +127,6 @@ fn test() {
         ("var foo = /[[]&&b]/v;", None),      // { "ecmaVersion": 2024 }
     ];
 
-    Tester::new(NoEmptyCharacterClass::NAME, NoEmptyCharacterClass::CATEGORY, pass, fail)
+    Tester::new(NoEmptyCharacterClass::NAME, NoEmptyCharacterClass::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// const add = (a, b) => a + b
     /// ```
     NoEmptyFunction,
+    eslint,
     restriction,
 );
 
@@ -226,5 +227,5 @@ fn test() {
     ",
     ];
 
-    Tester::new(NoEmptyFunction::NAME, NoEmptyFunction::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoEmptyFunction::NAME, NoEmptyFunction::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoEmptyPattern,
+    eslint,
     correctness,
 );
 
@@ -110,5 +111,5 @@ fn test() {
         ("function foo({a: []}) {}", None),
     ];
 
-    Tester::new(NoEmptyPattern::NAME, NoEmptyPattern::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoEmptyPattern::NAME, NoEmptyPattern::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoEmptyStaticBlock,
+    eslint,
     correctness,
     suggestion,
 );
@@ -101,7 +102,7 @@ fn test() {
         ("class Foo { static { bar(); } static {} }", "class Foo { static { bar(); }  }"),
     ];
 
-    Tester::new(NoEmptyStaticBlock::NAME, NoEmptyStaticBlock::CATEGORY, pass, fail)
+    Tester::new(NoEmptyStaticBlock::NAME, NoEmptyStaticBlock::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoEqNull,
+    eslint,
     restriction,
     fix_dangerous
 );
@@ -112,5 +113,5 @@ fn test() {
         ("do {} while (null == x)", "do {} while (null === x)"),
     ];
 
-    Tester::new(NoEqNull::NAME, NoEqNull::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(NoEqNull::NAME, NoEqNull::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// eval(someString);
     /// ```
     NoEval,
+    eslint,
     restriction
 );
 
@@ -237,5 +238,5 @@ fn test() {
         // ("function foo() { 'use strict'; this.eval(); }", None),
     ];
 
-    Tester::new(NoEval::NAME, NoEval::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoEval::NAME, NoEval::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoExAssign,
+    eslint,
     correctness
 );
 
@@ -68,5 +69,5 @@ fn test() {
         ("try { } catch ({message}) { message = 10; }", None),
     ];
 
-    Tester::new(NoExAssign::NAME, NoExAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoExAssign::NAME, NoExAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// Object.defineProperty(x.prototype, 'p', {value: 0})
     /// ```
     NoExtendNative,
+    eslint,
     suspicious,
 );
 
@@ -316,5 +317,5 @@ fn test() {
         ("Array.prototype.p ??= 0", None), // { "ecmaVersion": 2021 }
     ];
 
-    Tester::new(NoExtendNative::NAME, NoExtendNative::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoExtendNative::NAME, NoExtendNative::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// if (!!foo || bar) {}
     /// ```
     NoExtraBooleanCast,
+    eslint,
     correctness,
     // a suggestion could be added. Note that lacking !! can mess up TS type
     // narrowing sometimes, so it should not be an autofix
@@ -872,6 +873,6 @@ fn test() {
         ("if (!Boolean(a as any)) { }", None),
     ];
 
-    Tester::new(NoExtraBooleanCast::NAME, NoExtraBooleanCast::CATEGORY, pass, fail)
+    Tester::new(NoExtraBooleanCast::NAME, NoExtraBooleanCast::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_extra_label.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_label.rs
@@ -83,6 +83,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoExtraLabel,
+    eslint,
     style,
     fix
 );
@@ -272,7 +273,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(NoExtraLabel::NAME, NoExtraLabel::CATEGORY, pass, fail)
+    Tester::new(NoExtraLabel::NAME, NoExtraLabel::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -243,6 +243,7 @@ declare_oxc_lint!(
     /// Note that the last case statement in these examples does not cause a
     /// warning because there is nothing to fall through into.
     NoFallthrough,
+    eslint,
     // TODO: add options section to docs
     pedantic, // Fall through code are still incorrect.
     pending // TODO: add a dangerous suggestion for this rule.
@@ -670,5 +671,5 @@ fn test() {
         // ("switch (a === b ? c : d) { case 1: ; case 2: ; case 3: ; }", None)
     ];
 
-    Tester::new(NoFallthrough::NAME, NoFallthrough::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoFallthrough::NAME, NoFallthrough::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// foo = bar;
     /// ```
     NoFuncAssign,
+    eslint,
     correctness
 );
 
@@ -73,5 +74,5 @@ fn test() {
         ("var a = function foo() { foo = 123; };", None),
     ];
 
-    Tester::new(NoFuncAssign::NAME, NoFuncAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoFuncAssign::NAME, NoFuncAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// Object = null
     /// ```
     NoGlobalAssign,
+    eslint,
     correctness
 );
 
@@ -105,5 +106,5 @@ fn test() {
         ("Array = 1;", None),
     ];
 
-    Tester::new(NoGlobalAssign::NAME, NoGlobalAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoGlobalAssign::NAME, NoGlobalAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// Object.assign(mod_ns, { foo: "foo" }) // ERROR: The members of 'mod_ns' are readonly.
     /// ```
     NoImportAssign,
+    eslint,
     correctness
 );
 
@@ -264,5 +265,5 @@ fn test() {
         ("import * as mod from 'mod'; delete mod?.prop", None),
     ];
 
-    Tester::new(NoImportAssign::NAME, NoImportAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoImportAssign::NAME, NoImportAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoInnerDeclarations,
+    eslint,
     pedantic
 );
 
@@ -196,6 +197,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoInnerDeclarations::NAME, NoInnerDeclarations::CATEGORY, pass, fail)
+    Tester::new(NoInnerDeclarations::NAME, NoInnerDeclarations::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// this.RegExp('[')
     /// ```
     NoInvalidRegexp,
+    eslint,
     correctness,
 );
 
@@ -340,5 +341,5 @@ fn test() {
         ("new RegExp('(?<k>a)(?<k>b)')", None),
     ];
 
-    Tester::new(NoInvalidRegexp::NAME, NoInvalidRegexp::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoInvalidRegexp::NAME, NoInvalidRegexp::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoIrregularWhitespace,
+    eslint,
     correctness
 );
 
@@ -405,6 +406,6 @@ fn test() {
         // (r"<div>　</div>;", None),
     ];
 
-    Tester::new(NoIrregularWhitespace::NAME, NoIrregularWhitespace::CATEGORY, pass, fail)
+    Tester::new(NoIrregularWhitespace::NAME, NoIrregularWhitespace::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     NoIterator,
+    eslint,
     restriction,
     pending // TODO: suggestion
 );
@@ -93,5 +94,5 @@ fn test() {
         "test[`__iterator__`] = function () {};",
     ];
 
-    Tester::new(NoIterator::NAME, NoIterator::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoIterator::NAME, NoIterator::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoLabelVar,
+    eslint,
     style,
 );
 
@@ -91,5 +92,5 @@ fn test() {
         "function bar(x) { x: for(;;) { break x; } }",
     ];
 
-    Tester::new(NoLabelVar::NAME, NoLabelVar::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoLabelVar::NAME, NoLabelVar::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -119,6 +119,7 @@ declare_oxc_lint!(
     ///     }
     /// ```
     NoLabels,
+    eslint,
     style,
 );
 
@@ -268,5 +269,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoLabels::NAME, NoLabels::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoLabels::NAME, NoLabels::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -31,6 +31,7 @@ declare_oxc_lint!(
     /// var x = 2e999;
     /// ```
     NoLossOfPrecision,
+    eslint,
     correctness
 );
 
@@ -356,6 +357,5 @@ fn test() {
         ("var x = 1e18_446_744_073_709_551_615", None),
     ];
 
-    Tester::new(NoLossOfPrecision::NAME, NoLossOfPrecision::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoLossOfPrecision::NAME, NoLossOfPrecision::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -225,6 +225,7 @@ declare_oxc_lint!(
     /// type Baz = Parameters<Foo>[2];
     /// ```
     NoMagicNumbers,
+    eslint,
     style,
     pending // TODO: enforceConst, probably copy from https://github.com/oxc-project/oxc/pull/5144
 );
@@ -919,5 +920,5 @@ fn test() {
         ("type Foo = -7.1e-8;", Some(serde_json::json!([{ "ignore": [7.1e-8] }]))),
     ];
 
-    Tester::new(NoMagicNumbers::NAME, NoMagicNumbers::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoMagicNumbers::NAME, NoMagicNumbers::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoMultiAssign,
+    eslint,
     style,
 );
 
@@ -222,5 +223,5 @@ fn test() {
         ), // { "ecmaVersion": 2022 }
     ];
 
-    Tester::new(NoMultiAssign::NAME, NoMultiAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoMultiAssign::NAME, NoMultiAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     ///  Line 2";
     /// ```
     NoMultiStr,
+    eslint,
     style,
 );
 
@@ -83,5 +84,5 @@ fn test() {
         "'\\ still fails';",
     ];
 
-    Tester::new(NoMultiStr::NAME, NoMultiStr::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoMultiStr::NAME, NoMultiStr::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// a ? doSomethingB() : doSomethingC()
     /// ```
     NoNegatedCondition,
+    eslint,
     pedantic,
     pending
 );
@@ -163,6 +164,6 @@ fn test() {
         r"(!!a) ? b() : c();",
     ];
 
-    Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::CATEGORY, pass, fail)
+    Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nested_ternary.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoNestedTernary,
+    eslint,
     style,
 );
 
@@ -96,5 +97,5 @@ fn test() {
         "var result = foo ? (bar as string) : (baz as number ? qux : quux);",
     ];
 
-    Tester::new(NoNestedTernary::NAME, NoNestedTernary::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNestedTernary::NAME, NoNestedTernary::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -27,6 +27,7 @@ declare_oxc_lint!(
     /// new Person();
     /// ```
     NoNew,
+    eslint,
     suspicious,
 );
 
@@ -66,5 +67,5 @@ fn test() {
 
     let fail = vec!["new Date()", "(() => { new Date() })"];
 
-    Tester::new(NoNew::NAME, NoNew::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNew::NAME, NoNew::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     NoNewFunc,
+    eslint,
     style
 );
 
@@ -132,5 +133,5 @@ fn test() {
         "var fn = function () { function Function() {} }; Function('', '')",
     ];
 
-    Tester::new(NoNewFunc::NAME, NoNewFunc::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNewFunc::NAME, NoNewFunc::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// let result = BigInt(9007199254740991);
     /// ```
     NoNewNativeNonconstructor,
+    eslint,
     correctness,
 );
 
@@ -89,6 +90,6 @@ fn test() {
         "function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);",
     ];
 
-    Tester::new(NoNewNativeNonconstructor::NAME, NoNewNativeNonconstructor::CATEGORY, pass, fail)
+    Tester::new(NoNewNativeNonconstructor::NAME, NoNewNativeNonconstructor::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// var booleanObject = Boolean(value);
     /// ```
     NoNewWrappers,
+    eslint,
     pedantic,
     pending
 );
@@ -108,5 +109,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoNewWrappers::NAME, NoNewWrappers::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNewWrappers::NAME, NoNewWrappers::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// "\\9"
     /// ```
     NoNonoctalDecimalEscape,
+    eslint,
     correctness,
     pending
 );
@@ -227,6 +228,6 @@ fn test() {
         r"'\0\\n\8'",
     ];
 
-    Tester::new(NoNonoctalDecimalEscape::NAME, NoNonoctalDecimalEscape::CATEGORY, pass, fail)
+    Tester::new(NoNonoctalDecimalEscape::NAME, NoNonoctalDecimalEscape::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -63,6 +63,7 @@ declare_oxc_lint! {
     /// let segmenterFrom = Intl.Segmenter("fr", { granularity: "word" });
     /// ```
     NoObjCalls,
+    eslint,
     correctness,
 }
 
@@ -216,5 +217,5 @@ fn test() {
         ("let m = globalThis.Math; new m();", None),
     ];
 
-    Tester::new(NoObjCalls::NAME, NoObjCalls::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoObjCalls::NAME, NoObjCalls::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// const createObject = Object => new Object();
     /// ```
     NoObjectConstructor,
+    eslint,
     pedantic,
     pending
 );
@@ -173,6 +174,6 @@ fn test() {
         }",
     ];
 
-    Tester::new(NoObjectConstructor::NAME, NoObjectConstructor::CATEGORY, pass, fail)
+    Tester::new(NoObjectConstructor::NAME, NoObjectConstructor::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoPlusplus,
+    eslint,
     restriction,
     // This is not guaranteed to rewrite the code in a way that is equivalent.
     // For example, `++i` and `i++` will be rewritten as `i += 1` even though they are not the same.
@@ -266,7 +267,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoPlusplus::NAME, NoPlusplus::CATEGORY, pass, fail)
+    Tester::new(NoPlusplus::NAME, NoPlusplus::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// obj["__proto__"] = b;
     /// ```
     NoProto,
+    eslint,
     restriction,
     pending
 );
@@ -76,5 +77,5 @@ fn test() {
         "test[`__proto__`] = function () {};",
     ];
 
-    Tester::new(NoProto::NAME, NoProto::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoProto::NAME, NoProto::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// var barIsEnumerable = foo.propertyIsEnumerable("bar");
     /// ```
     NoPrototypeBuiltins,
+    eslint,
     pedantic
 );
 
@@ -112,6 +113,6 @@ fn test() {
         "(foo?.[`hasOwnProperty`])('bar')",
     ];
 
-    Tester::new(NoPrototypeBuiltins::NAME, NoPrototypeBuiltins::CATEGORY, pass, fail)
+    Tester::new(NoPrototypeBuiltins::NAME, NoPrototypeBuiltins::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// var a = 10;
     /// ```
     NoRedeclare,
+    eslint,
     pedantic
 );
 
@@ -159,5 +160,5 @@ fn test() {
         ("for (var a, a;;);", None),
     ];
 
-    Tester::new(NoRedeclare::NAME, NoRedeclare::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// var re = /foo   bar/;
     /// ```
     NoRegexSpaces,
+    eslint,
     restriction,
     pending // TODO: This is somewhat autofixable, but the fixer does not exist yet.
 );
@@ -248,5 +249,5 @@ fn test() {
         "var foo = new RegExp('[[    ]    ]    ', 'v');",
     ];
 
-    Tester::new(NoRegexSpaces::NAME, NoRegexSpaces::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoRegexSpaces::NAME, NoRegexSpaces::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoRestrictedGlobals,
+    eslint,
     restriction,
 );
 
@@ -148,6 +149,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoRestrictedGlobals::NAME, NoRestrictedGlobals::CATEGORY, pass, fail)
+    Tester::new(NoRestrictedGlobals::NAME, NoRestrictedGlobals::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -100,6 +100,7 @@ declare_oxc_lint!(
     /// export { foo } from "bar";
     /// ```
     NoRestrictedImports,
+    eslint,
     nursery,
 );
 
@@ -1832,6 +1833,6 @@ fn test() {
         // ),
     ];
 
-    Tester::new(NoRestrictedImports::NAME, NoRestrictedImports::CATEGORY, pass, fail)
+    Tester::new(NoRestrictedImports::NAME, NoRestrictedImports::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// function x() { var result = a = b; return result; }
     /// ```
     NoReturnAssign,
+    eslint,
     style,
     pending // TODO: add a suggestion
 );
@@ -202,5 +203,5 @@ fn test() {
         ("const foo = (a) => (b) => a = b", None), // { "ecmaVersion": 6 }
     ];
 
-    Tester::new(NoReturnAssign::NAME, NoReturnAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoReturnAssign::NAME, NoReturnAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// location.href = `javascript:void(0)`;
     /// ```
     NoScriptUrl,
+    eslint,
     style
 );
 
@@ -99,5 +100,5 @@ fn test() {
         "var a = `JavaScript:`;",
     ];
 
-    Tester::new(NoScriptUrl::NAME, NoScriptUrl::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoScriptUrl::NAME, NoScriptUrl::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// [bar, baz] = [bar, qiz];
     /// ```
     NoSelfAssign,
+    eslint,
     correctness
 );
 
@@ -365,5 +366,5 @@ fn test() {
         ("a ??= a", None),
     ];
 
-    Tester::new(NoSelfAssign::NAME, NoSelfAssign::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSelfAssign::NAME, NoSelfAssign::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoSelfCompare,
+    eslint,
     pedantic // The code is not wrong if it is intended to check for NaNs, which is the majority of
              // the case.
 );
@@ -87,5 +88,5 @@ fn test() {
         ("class C { #field; foo() { this.#field === this.#field; } }", None),
     ];
 
-    Tester::new(NoSelfCompare::NAME, NoSelfCompare::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSelfCompare::NAME, NoSelfCompare::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoSetterReturn,
+    eslint,
     correctness
 );
 
@@ -292,5 +293,5 @@ fn test() {
         // ("(Object?.defineProperty)(foo, 'bar', { set(val) { return 1; } })", None),
     ];
 
-    Tester::new(NoSetterReturn::NAME, NoSetterReturn::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSetterReturn::NAME, NoSetterReturn::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// try {} catch(eval){}
     /// ```
     NoShadowRestrictedNames,
+    eslint,
     correctness
 );
 
@@ -162,6 +163,6 @@ fn test() {
         ("class foo { #undefined(undefined) { } }", None),
     ];
 
-    Tester::new(NoShadowRestrictedNames::NAME, NoShadowRestrictedNames::CATEGORY, pass, fail)
+    Tester::new(NoShadowRestrictedNames::NAME, NoShadowRestrictedNames::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -22,6 +22,7 @@ declare_oxc_lint!(
     /// var colors = [ "red",, "blue" ];
     /// ```
     NoSparseArrays,
+    eslint,
     correctness
 );
 
@@ -96,5 +97,5 @@ fn test() {
         , , , , , , , , , , , , , , , , , , ,  2];",
     ];
 
-    Tester::new(NoSparseArrays::NAME, NoSparseArrays::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSparseArrays::NAME, NoSparseArrays::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// "Time: ${12 * 60 * 60 * 1000}";
     /// ```
     NoTemplateCurlyInString,
+    eslint,
     style,
     pending // TODO: conditional_fix
 );
@@ -112,6 +113,6 @@ fn test() {
         r#"'Hello, ${{foo: "bar"}.foo}'"#,
     ];
 
-    Tester::new(NoTemplateCurlyInString::NAME, NoTemplateCurlyInString::CATEGORY, pass, fail)
+    Tester::new(NoTemplateCurlyInString::NAME, NoTemplateCurlyInString::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     // }
     /// ```
     NoTernary,
+    eslint,
     style
 );
 
@@ -56,5 +57,5 @@ fn test() {
         "function foo(bar) { return bar ? baz : qux; }",
     ];
 
-    Tester::new(NoTernary::NAME, NoTernary::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoTernary::NAME, NoTernary::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoThisBeforeSuper,
+    eslint,
     correctness
 );
 
@@ -486,6 +487,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoThisBeforeSuper::NAME, NoThisBeforeSuper::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoThisBeforeSuper::NAME, NoThisBeforeSuper::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -65,6 +65,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoThrowLiteral,
+    eslint,
     pedantic,
     conditional_suggestion,
 );
@@ -270,7 +271,7 @@ fn test() {
         ("throw 'error' satisfies Error", "throw new Error('error' satisfies Error)"),
     ];
 
-    Tester::new(NoThrowLiteral::NAME, NoThrowLiteral::CATEGORY, pass, fail)
+    Tester::new(NoThrowLiteral::NAME, NoThrowLiteral::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -31,6 +31,7 @@ declare_oxc_lint!(
     /// var bar = a + 1;
     /// ```
     NoUndef,
+    eslint,
     nursery
 );
 
@@ -193,7 +194,7 @@ fn test() {
         "hasOwnProperty()",
     ];
 
-    Tester::new(NoUndef::NAME, NoUndef::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test_and_snapshot();
 
     let pass = vec![];
     let fail = vec![(
@@ -201,10 +202,10 @@ fn test() {
         Some(serde_json::json!([{ "typeof": true }])),
     )];
 
-    Tester::new(NoUndef::NAME, NoUndef::CATEGORY, pass, fail).test();
+    Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test();
 
     let pass = vec![("foo", None, Some(serde_json::json!({ "globals": { "foo": "readonly" } })))];
     let fail = vec![("foo", None, Some(serde_json::json!({ "globals": { "foo": "off" } })))];
 
-    Tester::new(NoUndef::NAME, NoUndef::CATEGORY, pass, fail).test();
+    Tester::new(NoUndef::NAME, NoUndef::PLUGIN, pass, fail).test();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoUndefined,
+    eslint,
     restriction,
 );
 
@@ -138,5 +139,5 @@ fn test() {
         "[a = undefined] = b",
     ];
 
-    Tester::new(NoUndefined::NAME, NoUndefined::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUndefined::NAME, NoUndefined::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     /// /bar/g.test(baz)
     /// ```
     NoUnexpectedMultiline,
+    eslint,
     suspicious,
     fix_dangerous
 );
@@ -390,7 +391,7 @@ fn test() {
     // TODO: add more fixer tests
     let fix = vec![("var a = b\n(x || y).doSomething()", "var a = b\n;(x || y).doSomething()")];
 
-    Tester::new(NoUnexpectedMultiline::NAME, NoUnexpectedMultiline::CATEGORY, pass, fail)
+    Tester::new(NoUnexpectedMultiline::NAME, NoUnexpectedMultiline::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUnreachable,
+    eslint,
     nursery
 );
 
@@ -347,5 +348,5 @@ fn test() {
         "function foo() { var x = 1; do { } while (true); x = 2; }",
     ];
 
-    Tester::new(NoUnreachable::NAME, NoUnreachable::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUnreachable::NAME, NoUnreachable::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// // > 3
     /// ```
     NoUnsafeFinally,
+    eslint,
     correctness
 );
 
@@ -225,5 +226,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUnsafeFinally::NAME, NoUnsafeFinally::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUnsafeFinally::NAME, NoUnsafeFinally::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUnsafeNegation,
+    eslint,
     correctness,
     fix
 );
@@ -157,7 +158,7 @@ fn test() {
         // ("!a <= b", "!(a <= b)"),
     ];
 
-    Tester::new(NoUnsafeNegation::NAME, NoUnsafeNegation::CATEGORY, pass, fail)
+    Tester::new(NoUnsafeNegation::NAME, NoUnsafeNegation::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// const { bar } = obj?.foo;  // TypeError
     /// ```
     NoUnsafeOptionalChaining,
+    eslint,
     correctness
 );
 
@@ -274,6 +275,6 @@ fn test() {
         ("(foo ? obj?.foo : obj?.bar).bar", None),
     ];
 
-    Tester::new(NoUnsafeOptionalChaining::NAME, NoUnsafeOptionalChaining::CATEGORY, pass, fail)
+    Tester::new(NoUnsafeOptionalChaining::NAME, NoUnsafeOptionalChaining::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// const foo = new Set<number>();
     /// ```
     NoUnusedExpressions,
+    eslint,
     restriction
 );
 
@@ -534,6 +535,6 @@ fn test() {
         ("const _func = (value: number) => { value + 1; }", None),
     ];
 
-    Tester::new(NoUnusedExpressions::NAME, NoUnusedExpressions::CATEGORY, pass, fail)
+    Tester::new(NoUnusedExpressions::NAME, NoUnusedExpressions::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUnusedLabels,
+    eslint,
     correctness,
     fix
 );
@@ -95,7 +96,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUnusedLabels::NAME, NoUnusedLabels::CATEGORY, pass, fail)
+    Tester::new(NoUnusedLabels::NAME, NoUnusedLabels::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -85,6 +85,7 @@ declare_oxc_lint!(
     ///
     /// ```
     NoUnusedPrivateClassMembers,
+    eslint,
     correctness
 );
 
@@ -445,11 +446,6 @@ fn test() {
 			}",
     ];
 
-    Tester::new(
-        NoUnusedPrivateClassMembers::NAME,
-        NoUnusedPrivateClassMembers::CATEGORY,
-        pass,
-        fail,
-    )
-    .test_and_snapshot();
+    Tester::new(NoUnusedPrivateClassMembers::NAME, NoUnusedPrivateClassMembers::PLUGIN, pass, fail)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -187,6 +187,7 @@ declare_oxc_lint!(
     /// var global_var = 42;
     /// ```
     NoUnusedVars,
+    eslint,
     correctness,
     dangerous_suggestion
 );

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
@@ -22,7 +22,7 @@ fn fixme() {
         ), // { "ecmaVersion": 2015 },
     ];
     let fail = vec![];
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .test();
 }
@@ -977,7 +977,7 @@ fn test() {
         ), // { "ecmaVersion": 2015 }
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("eslint")
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -16,7 +16,7 @@ fn test_debug() {
         ), // { "ecmaVersion": 6 },
     ];
     let fail = vec![];
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .test();
 }
@@ -153,7 +153,7 @@ fn test_vars_simple() {
         ("let x: number = 1; x = 2;", "let _x: number = 1; _x = 2;", None, FixKind::DangerousFix),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_snapshot_suffix("oxc-vars-simple")
         .test_and_snapshot();
@@ -183,7 +183,7 @@ fn test_vars_self_use() {
         ",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-vars-self-use")
         .test_and_snapshot();
@@ -248,7 +248,7 @@ fn test_vars_discarded_reads() {
         ",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-vars-discarded-read")
         .test_and_snapshot();
@@ -336,7 +336,7 @@ fn test_vars_reassignment() {
         "let a = 0, b = 1; let c = b = a = 1; f(c+b);",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-vars-reassignment")
         .test_and_snapshot();
@@ -432,7 +432,7 @@ fn test_vars_destructure() {
         (r#"const l="",{e}=r"#, r"const {e}=r", None, FixKind::All),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_snapshot_suffix("oxc-vars-destructure")
         .test_and_snapshot();
@@ -468,7 +468,7 @@ fn test_vars_catch() {
         ),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-vars-catch")
         .test_and_snapshot();
@@ -480,7 +480,7 @@ fn test_vars_using() {
 
     let fail = vec![("using a = 1;", None)];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-vars-using")
         .test_and_snapshot();
@@ -655,7 +655,7 @@ fn test_functions() {
         ),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .with_snapshot_suffix("oxc-functions")
         .expect_fix(fix)
         .test_and_snapshot();
@@ -709,7 +709,7 @@ fn test_self_call() {
         // }",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-self-call")
         .test_and_snapshot();
@@ -795,7 +795,7 @@ fn test_imports() {
         ),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_snapshot_suffix("oxc-imports")
         .test_and_snapshot();
@@ -823,7 +823,7 @@ fn test_used_declarations() {
     ];
     let fail = vec![];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-used-declarations")
         .test_and_snapshot();
@@ -860,7 +860,7 @@ fn test_exports() {
     let fail = vec!["import { a as b } from 'a'; export { a }"];
 
     // these are mostly pass[] cases, so do not snapshot
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .test();
 }
@@ -908,7 +908,7 @@ fn test_react() {
         ",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .test();
 }
@@ -940,7 +940,7 @@ fn test_arguments() {
         ("function foo({ a }, b) { return b } foo()", Some(json!([{ "args": "after-used" }]))),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-arguments")
         .test_and_snapshot();
@@ -956,7 +956,7 @@ fn test_enums() {
 
     let fail = vec!["enum Foo { A }"];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-enums")
         .test_and_snapshot();
@@ -1022,7 +1022,7 @@ fn test_classes() {
         ",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-classes")
         .test_and_snapshot();
@@ -1075,7 +1075,7 @@ fn test_namespaces() {
         // "export namespace N { function foo() }",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-namespaces")
         .test_and_snapshot();
@@ -1093,7 +1093,7 @@ fn test_type_aliases() {
         "export type F<T> = T extends infer R ? /* R not used */ string : never",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-type-aliases")
         .test_and_snapshot();
@@ -1191,7 +1191,7 @@ fn test_type_references() {
         "interface LinkedList<T> { next: LinkedList<T> | undefined }",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("oxc-type-references")
         .change_rule_path_extension("ts")
@@ -1204,7 +1204,7 @@ fn test_type_references() {
 
 //     let fail = vec![];
 
-//     Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+//     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
 //         .with_snapshot_suffix("<replace>")
 //         .test_and_snapshot();
 // }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/react.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/react.rs
@@ -126,7 +126,7 @@ fn test() {
 		",
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("eslint-plugin-react")
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -1699,7 +1699,7 @@ fn test() {
         ("const foo: number = 1;", None),
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .change_rule_path_extension("ts")
         .with_snapshot_suffix("typescript-eslint")
@@ -1867,7 +1867,7 @@ fn test_tsx() {
         //         },
     ];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .with_snapshot_suffix("typescript-eslint-tsx")
         .test_and_snapshot();
@@ -1908,7 +1908,7 @@ fn test_d_ts() {
     ];
     let fail = vec![];
 
-    Tester::new(NoUnusedVars::NAME, NoUnusedVars::CATEGORY, pass, fail)
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .change_rule_path_extension("d.ts")
         .test();

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUselessCatch,
+    eslint,
     correctness
 );
 
@@ -211,5 +212,5 @@ fn test() {
       ",
     ];
 
-    Tester::new(NoUselessCatch::NAME, NoUselessCatch::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUselessCatch::NAME, NoUselessCatch::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// var foo = "a" + "b";
     /// ```
     NoUselessConcat,
+    eslint,
     suspicious
 );
 
@@ -133,5 +134,5 @@ fn test() {
         "'a' + 'b' + 'c' + 'd' + 'e' + foo",
     ];
 
-    Tester::new(NoUselessConcat::NAME, NoUselessConcat::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUselessConcat::NAME, NoUselessConcat::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -93,6 +93,7 @@ declare_oxc_lint!(
     /// }
     ///```
     NoUselessConstructor,
+    eslint,
     suspicious,
     fix
 );
@@ -363,7 +364,7 @@ class A extends B {  foo() { bar(); } }",
         ),
     ];
 
-    Tester::new(NoUselessConstructor::NAME, NoUselessConstructor::CATEGORY, pass, fail)
+    Tester::new(NoUselessConstructor::NAME, NoUselessConstructor::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// /[a-z-]/;
     /// ```
     NoUselessEscape,
+    eslint,
     correctness,
     fix
 );
@@ -671,7 +672,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUselessEscape::NAME, NoUselessEscape::CATEGORY, pass, fail)
+    Tester::new(NoUselessEscape::NAME, NoUselessEscape::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// export { baz };
     /// ```
     NoUselessRename,
+    eslint,
     correctness
 );
 
@@ -397,5 +398,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUselessRename::NAME, NoUselessRename::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUselessRename::NAME, NoUselessRename::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// const CONFIG = {};
     /// ```
     NoVar,
+    eslint,
     restriction,
     fix
 );
@@ -158,5 +159,5 @@ fn test() {
         ("var { a } = {}; let b = a", "const { a } = {}; let b = a"),
     ];
 
-    Tester::new(NoVar::NAME, NoVar::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(NoVar::NAME, NoVar::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// "foo.void = bar";
     /// ```
     NoVoid,
+    eslint,
     restriction,
     pending // TODO: suggestion
 );
@@ -98,5 +99,5 @@ fn test() {
         ("var foo = void 0", Some(serde_json::json!([{ "allowAsStatement": true }]))),
     ];
 
-    Tester::new(NoVoid::NAME, NoVoid::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoVoid::NAME, NoVoid::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoWith,
+    eslint,
     correctness
 );
 
@@ -50,5 +51,5 @@ fn test() {
 
     let fail = vec!["with(foo) { bar() }"];
 
-    Tester::new(NoWith::NAME, NoWith::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoWith::NAME, NoWith::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -31,6 +31,7 @@ declare_oxc_lint!(
     /// Math.pow(a, b)
     /// ```
     PreferExponentiationOperator,
+    eslint,
     style,
 );
 
@@ -126,7 +127,7 @@ fn test() {
 
     Tester::new(
         PreferExponentiationOperator::NAME,
-        PreferExponentiationOperator::CATEGORY,
+        PreferExponentiationOperator::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// Number.parseInt("1F7", 16) === 503;
     /// ```
     PreferNumericLiterals,
+    eslint,
     style,
     conditional_fix
 );
@@ -375,7 +376,7 @@ fn test() {
         (r#"(Number?.parseInt)?.("1F7", 16) === 255;"#, "0x1F7 === 255;", None),
     ];
 
-    Tester::new(PreferNumericLiterals::NAME, PreferNumericLiterals::CATEGORY, pass, fail)
+    Tester::new(PreferNumericLiterals::NAME, PreferNumericLiterals::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// const hasProperty = Object.hasOwn(object, property);
     /// ```
     PreferObjectHasOwn,
+    eslint,
     style,
     conditional_fix
 );
@@ -381,7 +382,7 @@ fn test() {
         // Issue: <https://github.com/oxc-project/oxc/issues/7450>
         ("Object.prototype.hasOwnProperty.call(C,x);", " Object.hasOwn(C,x);", None),
     ];
-    Tester::new(PreferObjectHasOwn::NAME, PreferObjectHasOwn::CATEGORY, pass, fail)
+    Tester::new(PreferObjectHasOwn::NAME, PreferObjectHasOwn::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferRestParams,
+    eslint,
     style,
 );
 
@@ -122,5 +123,5 @@ fn test() {
         "function foo() { arguments[Symbol.iterator]; }",
     ];
 
-    Tester::new(PreferRestParams::NAME, PreferRestParams::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferRestParams::NAME, PreferRestParams::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
@@ -102,6 +102,7 @@ declare_oxc_lint!(
     /// Array.from(...argumentsArray);
     /// ```
     PreferSpread,
+    eslint,
     style,
     conditional_fix
 );
@@ -635,7 +636,7 @@ fn test() {
         (r#""foo bar baz".split("")"#, r#"[..."foo bar baz"]"#, None),
     ];
 
-    Tester::new(PreferSpread::NAME, PreferSpread::CATEGORY, pass, fail)
+    Tester::new(PreferSpread::NAME, PreferSpread::PLUGIN, pass, fail)
         .expect_fix(expect_fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// var num = parseInt("071", 10);  // 71
     /// ```
     Radix,
+    eslint,
     pedantic
 );
 
@@ -226,5 +227,5 @@ fn test() {
         ("{ let Number; } (Number?.parseInt)();", None),
     ];
 
-    Tester::new(Radix::NAME, Radix::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(Radix::NAME, Radix::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     RequireAwait,
+    eslint,
     pedantic,
 );
 
@@ -208,5 +209,5 @@ fn test() {
         "async function foo() { await (async () => { doSomething() }) }",
     ];
 
-    Tester::new(RequireAwait::NAME, RequireAwait::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireAwait::NAME, RequireAwait::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     RequireYield,
+    eslint,
     correctness
 );
 
@@ -72,5 +73,5 @@ fn test() {
         "function* foo() { function* bar() { return 0; } yield 0; }",
     ];
 
-    Tester::new(RequireYield::NAME, RequireYield::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireYield::NAME, RequireYield::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// import e from 'bar.js';
     /// ```
     SortImports,
+    eslint,
     style,
     conditional_fix
 );
@@ -828,7 +829,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(SortImports::NAME, SortImports::CATEGORY, pass, fail)
+    Tester::new(SortImports::NAME, SortImports::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -82,6 +82,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     SortKeys,
+    eslint,
     style,
     pending
 );
@@ -1023,5 +1024,5 @@ fn test() {
         ), // { "ecmaVersion": 2018 }
     ];
 
-    Tester::new(SortKeys::NAME, SortKeys::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(SortKeys::NAME, SortKeys::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/sort_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_vars.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// var B, a, c;
     /// ```
     SortVars,
+    eslint,
     pedantic,
     pending
 );
@@ -222,5 +223,5 @@ fn test() {
         ("var {} = 1, b, a", "var {} = 1, a, b", Some(serde_json::json!([{ "ignoreCase": true }]))),
     ];
 
-    Tester::new(SortVars::NAME, SortVars::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(SortVars::NAME, SortVars::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     ///
     ///
     SymbolDescription,
+    eslint,
     pedantic,
 );
 
@@ -80,6 +81,5 @@ fn test() {
 
     let fail = vec!["Symbol();", "Symbol(); Symbol = function () {};"];
 
-    Tester::new(SymbolDescription::NAME, SymbolDescription::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(SymbolDescription::NAME, SymbolDescription::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// ﻿var a = 123;
     /// ```
     UnicodeBom,
+    eslint,
     restriction,
     fix
 );
@@ -116,7 +117,7 @@ fn test() {
         ("var a = 123;", "﻿var a = 123;", Some(serde_json::json!(["always"]))),
     ];
 
-    Tester::new(UnicodeBom::NAME, UnicodeBom::CATEGORY, pass, fail)
+    Tester::new(UnicodeBom::NAME, UnicodeBom::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -74,6 +74,7 @@ declare_oxc_lint!(
     /// foo > NaN;
     /// ```
     UseIsnan,
+    eslint,
     correctness,
     conditional_fix
 );
@@ -540,5 +541,5 @@ fn test() {
         ("1 !== Number.NaN", "!isNaN(1)", None),
     ];
 
-    Tester::new(UseIsnan::NAME, UseIsnan::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(UseIsnan::NAME, UseIsnan::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// typeof foo === baz
     /// ```
     ValidTypeof,
+    eslint,
     correctness,
     conditional_fix
 );
@@ -224,7 +225,7 @@ fn test() {
 
     let fix = vec![("typeof foo === undefined", r#"typeof foo === "undefined""#)];
 
-    Tester::new(ValidTypeof::NAME, ValidTypeof::CATEGORY, pass, fail)
+    Tester::new(ValidTypeof::NAME, ValidTypeof::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
+++ b/crates/oxc_linter/src/rules/eslint/vars_on_top.rs
@@ -87,6 +87,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     VarsOnTop,
+    eslint,
     style,
 );
 
@@ -540,5 +541,5 @@ fn test() {
 			}", // {                "ecmaVersion": 2022            }
     ];
 
-    Tester::new(VarsOnTop::NAME, VarsOnTop::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(VarsOnTop::NAME, VarsOnTop::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -184,6 +184,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     Yoda,
+    eslint,
     style,
     fix
 );
@@ -1165,5 +1166,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(Yoda::NAME, Yoda::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(Yoda::NAME, Yoda::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// import { bar } from './bar' // correct usage of named import
     /// ```
     Default,
+    import,
     correctness
 );
 
@@ -149,7 +150,7 @@ fn test() {
         // r#"import Foo from "./typescript-export-as-default-namespace""#,
     ];
 
-    Tester::new(Default::NAME, Default::CATEGORY, pass, fail)
+    Tester::new(Default::NAME, Default::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -44,6 +44,8 @@ declare_oxc_lint!(
     /// export * from "./export-all"; // No conflict if export-all.js also exports foo
     /// ```
     Export,
+
+    import,
     nursery
 );
 
@@ -338,7 +340,7 @@ fn test() {
             // "),
         ];
 
-        Tester::new(Export::NAME, Export::CATEGORY, pass, fail)
+        Tester::new(Export::NAME, Export::PLUGIN, pass, fail)
             .with_import_plugin(true)
             .change_rule_path("index.ts")
             .test_and_snapshot();
@@ -354,7 +356,7 @@ fn test() {
                 export {Baz as default};
             "),
         ];
-        Tester::new(Export::NAME, Export::CATEGORY, pass, fail)
+        Tester::new(Export::NAME, Export::PLUGIN, pass, fail)
             .with_import_plugin(true)
             .change_rule_path("export-star-4/index.js")
             .test();

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     /// ```
     ///
     First,
+    import,
     style,
     pending  // TODO: fixer
 );
@@ -229,7 +230,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(First::NAME, First::CATEGORY, pass, fail)
+    Tester::new(First::NAME, First::PLUGIN, pass, fail)
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// import b from './b'; // Allowed: 2 dependencies (max: 2)
     /// ```
     MaxDependencies,
+    import,
     pedantic,
 );
 
@@ -207,7 +208,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxDependencies::NAME, MaxDependencies::CATEGORY, pass, fail)
+    Tester::new(MaxDependencies::NAME, MaxDependencies::PLUGIN, pass, fail)
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// import { SomeNonsenseThatDoesntExist } from 'react'
     /// ```
     Named,
+    import,
     nursery // There are race conditions in the runtime which may cause the module to
             // not find any exports from `exported_bindings_from_star_export`.
 );
@@ -271,7 +272,7 @@ fn test() {
         "import { FooBar } from './typescript-export-assign-object'",
     ];
 
-    Tester::new(Named::NAME, Named::CATEGORY, pass, fail)
+    Tester::new(Named::NAME, Named::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -102,6 +102,7 @@ declare_oxc_lint!(
     /// foo[method](); // Valid: method refers to an exported function
     /// ```
     Namespace,
+    import,
     correctness
 );
 
@@ -516,7 +517,7 @@ fn test() {
         (r#"import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a"#, None),
     ];
 
-    Tester::new(Namespace::NAME, Namespace::CATEGORY, pass, fail)
+    Tester::new(Namespace::NAME, Namespace::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// require(`../name`);
     /// ```
     NoAmd,
+    import,
     restriction
 );
 
@@ -112,7 +113,7 @@ fn test() {
         r#"require(["a"], function(a) { console.log(a); })"#,
     ];
 
-    Tester::new(NoAmd::NAME, NoAmd::CATEGORY, pass, fail)
+    Tester::new(NoAmd::NAME, NoAmd::PLUGIN, pass, fail)
         .change_rule_path("no-amd.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -105,6 +105,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoCommonjs,
+    import,
     restriction
 );
 
@@ -339,7 +340,7 @@ fn test() {
         (r"var x = module.exports", Some(json!([{ "allowPrimitiveModules": true }]))),
     ];
 
-    Tester::new(NoCommonjs::NAME, NoCommonjs::CATEGORY, pass, fail)
+    Tester::new(NoCommonjs::NAME, NoCommonjs::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     ///
     /// In this corrected version, `dep-b.js` no longer imports `dep-a.js`, breaking the cycle.
     NoCycle,
+    import,
     restriction
 );
 
@@ -364,7 +365,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoCycle::NAME, NoCycle::CATEGORY, pass, fail)
+    Tester::new(NoCycle::NAME, NoCycle::PLUGIN, pass, fail)
         .change_rule_path("cycles/depth-zero.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// export const bar = 'bar';
     /// ```
     NoDefaultExport,
+    import,
     restriction
 );
 
@@ -86,7 +87,7 @@ fn test() {
         // "export default from \"foo.js\"",
     ];
 
-    Tester::new(NoDefaultExport::NAME, NoDefaultExport::CATEGORY, pass, fail)
+    Tester::new(NoDefaultExport::NAME, NoDefaultExport::PLUGIN, pass, fail)
         .with_import_plugin(true)
         .change_rule_path("index.ts")
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoDeprecated,
+    import,
     nursery
 );
 
@@ -109,7 +110,7 @@ fn test() {
         // r#"import { foo } from "./ts-deprecated.ts"; console.log(foo())"#,
     ];
 
-    Tester::new(NoDeprecated::NAME, NoDeprecated::CATEGORY, pass, fail)
+    Tester::new(NoDeprecated::NAME, NoDeprecated::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// import type { d } from 'foo'; // `preferInline` is true
     /// ```
     NoDuplicates,
+    import,
     suspicious
 );
 
@@ -409,7 +410,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDuplicates::NAME, NoDuplicates::CATEGORY, pass, fail)
+    Tester::new(NoDuplicates::NAME, NoDuplicates::PLUGIN, pass, fail)
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_require.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// require(`../name`);
     /// ```
     NoDynamicRequire,
+    import,
     restriction,
 );
 
@@ -136,5 +137,5 @@ fn test() {
         ("import(name())", Some(json!([{ "esmodule": true }]))),
     ];
 
-    Tester::new(NoDynamicRequire::NAME, NoDynamicRequire::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDynamicRequire::NAME, NoDynamicRequire::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// import foo from './foo.js';
     /// ```
     NoNamedAsDefault,
+    import,
     suspicious
 );
 
@@ -106,7 +107,7 @@ fn test() {
         r#"import foo, { foo as bar } from "./export-default-string-and-named""#,
     ];
 
-    Tester::new(NoNamedAsDefault::NAME, NoNamedAsDefault::CATEGORY, pass, fail)
+    Tester::new(NoNamedAsDefault::NAME, NoNamedAsDefault::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// import { bar } from './bar'; // Correct: accessing named export directly
     /// ```
     NoNamedAsDefaultMember,
+    import,
     suspicious
 );
 
@@ -208,7 +209,7 @@ fn test() {
         r#"import baz from "./named-and-default-export"; const {foo: _foo} = baz"#,
     ];
 
-    Tester::new(NoNamedAsDefaultMember::NAME, NoNamedAsDefaultMember::CATEGORY, pass, fail)
+    Tester::new(NoNamedAsDefaultMember::NAME, NoNamedAsDefaultMember::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// import foo, { bar } from './foo.js';
     /// ```
     NoNamedDefault,
+    import,
     style,
 );
 
@@ -67,5 +68,5 @@ fn test() {
         r#"import { "default" as bar } from "./bar";"#,
     ];
 
-    Tester::new(NoNamedDefault::NAME, NoNamedDefault::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNamedDefault::NAME, NoNamedDefault::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoNamespace,
+    import,
     style,
     pending  // TODO: fixer
 );
@@ -156,7 +157,7 @@ fn test() {
         (r"import * as foo from './foo';", None),
     ];
 
-    Tester::new(NoNamespace::NAME, NoNamespace::CATEGORY, pass, fail)
+    Tester::new(NoNamespace::NAME, NoNamespace::PLUGIN, pass, fail)
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// import bar from './bar.js';  // Correct: module imports another module
     /// ```
     NoSelfImport,
+    import,
     suspicious
 );
 
@@ -87,7 +88,7 @@ fn test() {
             // "var bar = require('./no-self-import.js')",
         ];
 
-        Tester::new(NoSelfImport::NAME, NoSelfImport::CATEGORY, pass, fail)
+        Tester::new(NoSelfImport::NAME, NoSelfImport::PLUGIN, pass, fail)
             .with_import_plugin(true)
             .change_rule_path("no-self-import.js")
             .test();
@@ -97,7 +98,7 @@ fn test() {
     // let pass = vec!["var bar = require('./bar')"];
     // let fail = vec![];
 
-    // Tester::new(NoSelfImport::NAME, NoSelfImport::CATEGORY, pass, fail)
+    // Tester::new(NoSelfImport::NAME, NoSelfImport::PLUGIN, pass, fail)
     // .with_import_plugin(true)
     // .change_rule_path("bar/index.js")
     // .test();
@@ -111,7 +112,7 @@ fn test() {
     // "var bar = require('././././')",
     // ];
 
-    // Tester::new(NoSelfImport::NAME, NoSelfImport::CATEGORY, pass, fail)
+    // Tester::new(NoSelfImport::NAME, NoSelfImport::PLUGIN, pass, fail)
     // .with_import_plugin(true)
     // .change_rule_path("index.js")
     // .test();
@@ -121,7 +122,7 @@ fn test() {
     // let pass = vec![];
     // let fail = vec!["var bar = require('../no-self-import-folder')"];
 
-    // Tester::new(NoSelfImport::NAME, NoSelfImport::CATEGORY, pass, fail)
+    // Tester::new(NoSelfImport::NAME, NoSelfImport::PLUGIN, pass, fail)
     // .with_import_plugin(true)
     // .change_rule_path("no-self-import-folder/index.js")
     // .test();

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoUnusedModules,
+    import,
     nursery
 );
 
@@ -103,7 +104,7 @@ fn test() {
         ("/* const a = 1 */", Some(missing_exports_options.clone())),
     ];
 
-    Tester::new(NoUnusedModules::NAME, NoUnusedModules::CATEGORY, pass, fail)
+    Tester::new(NoUnusedModules::NAME, NoUnusedModules::PLUGIN, pass, fail)
         .change_rule_path("missing-exports.js")
         .with_import_plugin(true)
         .test_and_snapshot();
@@ -122,7 +123,7 @@ fn test() {
 
     // let fail = vec![];
 
-    // Tester::new(NoUnusedModules::NAME, NoUnusedModules::CATEGORY, pass, fail)
+    // Tester::new(NoUnusedModules::NAME, NoUnusedModules::PLUGIN, pass, fail)
     //     .change_rule_path("unused-exports.js")
     //     .with_import_plugin(true)
     //     .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// var theme = require('./theme.css');
     /// ```
     NoWebpackLoaderSyntax,
+    import,
     restriction,
 );
 
@@ -123,6 +124,6 @@ fn test() {
         "var data = require('json!@scope/my-package/data.json')",
     ];
 
-    Tester::new(NoWebpackLoaderSyntax::NAME, NoWebpackLoaderSyntax::CATEGORY, pass, fail)
+    Tester::new(NoWebpackLoaderSyntax::NAME, NoWebpackLoaderSyntax::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// export {} // simple way to mark side-effects-only file as 'module' without any imports/exports
     /// ```
     Unambiguous,
+    import,
     restriction
 );
 
@@ -75,7 +76,7 @@ fn test() {
 
     let fail = vec![r"function x() {}", r"(function x() { return 42 })()"];
 
-    Tester::new(Unambiguous::NAME, Unambiguous::CATEGORY, pass, fail)
+    Tester::new(Unambiguous::NAME, Unambiguous::PLUGIN, pass, fail)
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -172,6 +172,7 @@ declare_oxc_lint!(
     ///   }
     /// }
     ConsistentTestIt,
+    jest,
     style,
     fix
 );
@@ -917,7 +918,7 @@ fn test() {
     fail.extend(fail_vitest);
     fix.extend(fix_vitest);
 
-    Tester::new(ConsistentTestIt::NAME, ConsistentTestIt::CATEGORY, pass, fail)
+    Tester::new(ConsistentTestIt::NAME, ConsistentTestIt::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -86,6 +86,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ExpectExpect,
+    jest,
     correctness
 );
 
@@ -840,7 +841,7 @@ fn test() {
     pass.extend(pass_vitest);
     fail.extend(fail_vitest);
 
-    Tester::new(ExpectExpect::NAME, ExpectExpect::CATEGORY, pass, fail)
+    Tester::new(ExpectExpect::NAME, ExpectExpect::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     MaxExpects,
+    jest,
     style,
 );
 
@@ -470,7 +471,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxExpects::NAME, MaxExpects::CATEGORY, pass, fail)
+    Tester::new(MaxExpects::NAME, MaxExpects::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -117,6 +117,7 @@ declare_oxc_lint!(
     /// ```
     ///
     MaxNestedDescribe,
+    jest,
     style,
 );
 
@@ -396,7 +397,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(MaxNestedDescribe::NAME, MaxNestedDescribe::CATEGORY, pass, fail)
+    Tester::new(MaxNestedDescribe::NAME, MaxNestedDescribe::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAliasMethods,
+    jest,
     style,
     fix
 );
@@ -226,7 +227,7 @@ fn test() {
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
     fix.extend(fix_vitest);
 
-    Tester::new(NoAliasMethods::NAME, NoAliasMethods::CATEGORY, pass, fail)
+    Tester::new(NoAliasMethods::NAME, NoAliasMethods::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoCommentedOutTests,
+    jest,
     suspicious
 );
 
@@ -217,7 +218,7 @@ fn test() {
     pass.extend(pass_vitest.into_iter().map(|x| (x, None)));
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
-    Tester::new(NoCommentedOutTests::NAME, NoCommentedOutTests::CATEGORY, pass, fail)
+    Tester::new(NoCommentedOutTests::NAME, NoCommentedOutTests::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoConditionalExpect,
+    jest,
     correctness
 );
 
@@ -998,7 +999,7 @@ fn test() {
     pass.extend(pass_vitest.into_iter().map(|x| (x, None)));
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
-    Tester::new(NoConditionalExpect::NAME, NoConditionalExpect::CATEGORY, pass, fail)
+    Tester::new(NoConditionalExpect::NAME, NoConditionalExpect::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -93,6 +93,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoConditionalInTest,
+    jest,
     pedantic,
 );
 
@@ -644,7 +645,7 @@ fn test() {
 			      "#,
     ];
 
-    Tester::new(NoConditionalInTest::NAME, NoConditionalInTest::CATEGORY, pass, fail)
+    Tester::new(NoConditionalInTest::NAME, NoConditionalInTest::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoConfusingSetTimeout,
+    jest,
     style
 );
 
@@ -484,7 +485,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoConfusingSetTimeout::NAME, NoConfusingSetTimeout::CATEGORY, pass, fail)
+    Tester::new(NoConfusingSetTimeout::NAME, NoConfusingSetTimeout::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -73,6 +73,7 @@ declare_oxc_lint!(
     /// jest.addMatchers // since Jest 17
     /// ```
     NoDeprecatedFunctions,
+    jest,
     style,
     fix
 );
@@ -187,7 +188,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(NoDeprecatedFunctions::NAME, NoDeprecatedFunctions::CATEGORY, pass, fail)
+    Tester::new(NoDeprecatedFunctions::NAME, NoDeprecatedFunctions::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDisabledTests,
+    jest,
     correctness
 );
 
@@ -275,7 +276,7 @@ fn test() {
     pass.extend(pass_vitest.into_iter().map(|x| (x, None)));
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
-    Tester::new(NoDisabledTests::NAME, NoDisabledTests::CATEGORY, pass, fail)
+    Tester::new(NoDisabledTests::NAME, NoDisabledTests::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoDoneCallback,
+    jest,
     // TODO: add suggestion (see jest-community/eslint-plugin-jest#586)
     style
 );
@@ -287,7 +288,7 @@ fn test() {
         ("it.each``('something', ({ a, b }, done) => { done(); })", None),
     ];
 
-    Tester::new(NoDoneCallback::NAME, NoDoneCallback::CATEGORY, pass, fail)
+    Tester::new(NoDoneCallback::NAME, NoDoneCallback::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -98,6 +98,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoDuplicateHooks,
+    jest,
     style,
 );
 
@@ -554,7 +555,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDuplicateHooks::NAME, NoDuplicateHooks::CATEGORY, pass, fail)
+    Tester::new(NoDuplicateHooks::NAME, NoDuplicateHooks::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoExport,
+    jest,
     correctness
 );
 
@@ -139,7 +140,7 @@ fn test() {
         // ("module.export.invalid = function() {}; ;  test('a test', () => { expect(1).toBe(1);});", None)
     ];
 
-    Tester::new(NoExport::NAME, NoExport::CATEGORY, pass, fail)
+    Tester::new(NoExport::NAME, NoExport::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoFocusedTests,
+    jest,
     correctness,
     fix
 );
@@ -196,7 +197,7 @@ fn test() {
     fail.extend(fail_vitest);
     fix.extend(fix_vitest);
 
-    Tester::new(NoFocusedTests::NAME, NoFocusedTests::CATEGORY, pass, fail)
+    Tester::new(NoFocusedTests::NAME, NoFocusedTests::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoHooks,
+    jest,
     style,
 );
 
@@ -161,7 +162,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoHooks::NAME, NoHooks::CATEGORY, pass, fail)
+    Tester::new(NoHooks::NAME, NoHooks::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -67,6 +67,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoIdenticalTitle,
+    jest,
     style
 );
 
@@ -528,7 +529,7 @@ fn test() {
     pass.extend(pass_vitest.into_iter().map(|x| (x, None)));
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
-    Tester::new(NoIdenticalTitle::NAME, NoIdenticalTitle::CATEGORY, pass, fail)
+    Tester::new(NoIdenticalTitle::NAME, NoIdenticalTitle::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// );
     /// ```
     NoInterpolationInSnapshots,
+    jest,
     style
 );
 
@@ -122,7 +123,7 @@ fn test() {
         ("expect(something).not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);", None),
     ];
 
-    Tester::new(NoInterpolationInSnapshots::NAME, NoInterpolationInSnapshots::CATEGORY, pass, fail)
+    Tester::new(NoInterpolationInSnapshots::NAME, NoInterpolationInSnapshots::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoJasmineGlobals,
+    jest,
     style,
     conditional_fix
 );
@@ -293,7 +294,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoJasmineGlobals::NAME, NoJasmineGlobals::CATEGORY, pass, fail)
+    Tester::new(NoJasmineGlobals::NAME, NoJasmineGlobals::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -132,6 +132,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoLargeSnapshots,
+    jest,
     style,
 );
 
@@ -485,7 +486,7 @@ fn test() {
         // ),
     ];
 
-    Tester::new(NoLargeSnapshots::NAME, NoLargeSnapshots::CATEGORY, pass, fail)
+    Tester::new(NoLargeSnapshots::NAME, NoLargeSnapshots::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// require('thing');
     /// ```
     NoMocksImport,
+    jest,
     style
 );
 
@@ -113,7 +114,7 @@ fn test() {
         ("import thing from './__mocks__/index'", None),
     ];
 
-    Tester::new(NoMocksImport::NAME, NoMocksImport::CATEGORY, pass, fail)
+    Tester::new(NoMocksImport::NAME, NoMocksImport::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoRestrictedJestMethods,
+    jest,
     style,
 );
 
@@ -215,7 +216,7 @@ fn test() {
     pass.extend(pass_vitest);
     fail.extend(fail_vitest);
 
-    Tester::new(NoRestrictedJestMethods::NAME, NoRestrictedJestMethods::CATEGORY, pass, fail)
+    Tester::new(NoRestrictedJestMethods::NAME, NoRestrictedJestMethods::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoRestrictedMatchers,
+    jest,
     style,
 );
 
@@ -243,7 +244,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoRestrictedMatchers::NAME, NoRestrictedMatchers::CATEGORY, pass, fail)
+    Tester::new(NoRestrictedMatchers::NAME, NoRestrictedMatchers::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoStandaloneExpect,
+    jest,
     correctness
 );
 
@@ -386,7 +387,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoStandaloneExpect::NAME, NoStandaloneExpect::CATEGORY, pass, fail)
+    Tester::new(NoStandaloneExpect::NAME, NoStandaloneExpect::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoTestPrefixes,
+    jest,
     style,
     fix
 );
@@ -216,7 +217,7 @@ fn test() {
         ("fit('foo', () => {})", "it.only('foo', () => {})"),
     ];
 
-    Tester::new(NoTestPrefixes::NAME, NoTestPrefixes::CATEGORY, pass, fail)
+    Tester::new(NoTestPrefixes::NAME, NoTestPrefixes::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoTestReturnStatement,
+    jest,
     style,
 );
 
@@ -235,7 +236,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoTestReturnStatement::NAME, NoTestReturnStatement::CATEGORY, pass, fail)
+    Tester::new(NoTestReturnStatement::NAME, NoTestReturnStatement::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -83,6 +83,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoUntypedMockFactory,
+    jest,
     style,
     conditional_fix
 );
@@ -401,7 +402,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUntypedMockFactory::NAME, NoUntypedMockFactory::CATEGORY, pass, fail)
+    Tester::new(NoUntypedMockFactory::NAME, NoUntypedMockFactory::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferCalledWith,
+    jest,
     style,
 );
 
@@ -114,7 +115,7 @@ fn test() {
         ("expect(fn).toHaveBeenCalled();", None),
     ];
 
-    Tester::new(PreferCalledWith::NAME, PreferCalledWith::CATEGORY, pass, fail)
+    Tester::new(PreferCalledWith::NAME, PreferCalledWith::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferComparisonMatcher,
+    jest,
     style,
     fix
 );
@@ -468,7 +469,7 @@ fn test() {
         fix.push((case.as_str(), fixer.as_str(), None));
     }
 
-    Tester::new(PreferComparisonMatcher::NAME, PreferComparisonMatcher::CATEGORY, pass, fail)
+    Tester::new(PreferComparisonMatcher::NAME, PreferComparisonMatcher::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// expect(myObj).toStrictEqual(thatObj);
     /// ```
     PreferEqualityMatcher,
+    jest,
     style,
 );
 
@@ -119,7 +120,7 @@ fn test() {
         ("expect(a !== b).resolves.not.toBe(false)", None),
     ];
 
-    Tester::new(PreferEqualityMatcher::NAME, PreferEqualityMatcher::CATEGORY, pass, fail)
+    Tester::new(PreferEqualityMatcher::NAME, PreferEqualityMatcher::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     PreferExpectResolves,
+    jest,
     style,
     fix
 );
@@ -261,7 +262,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(PreferExpectResolves::NAME, PreferExpectResolves::CATEGORY, pass, fail)
+    Tester::new(PreferExpectResolves::NAME, PreferExpectResolves::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -138,6 +138,7 @@ declare_oxc_lint!(
     ///   }
     /// }
     PreferHooksInOrder,
+    jest,
     style,
 );
 
@@ -1264,7 +1265,7 @@ fn test() {
     pass.extend(pass_vitest.into_iter().map(|x| (x, None)));
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
-    Tester::new(PreferHooksInOrder::NAME, PreferHooksInOrder::CATEGORY, pass, fail)
+    Tester::new(PreferHooksInOrder::NAME, PreferHooksInOrder::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -135,6 +135,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     PreferHooksOnTop,
+    jest,
     style,
 );
 
@@ -375,7 +376,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferHooksOnTop::NAME, PreferHooksOnTop::CATEGORY, pass, fail)
+    Tester::new(PreferHooksOnTop::NAME, PreferHooksOnTop::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// jest.mocked([].foo).mockReturnValue(1);
     /// ```
     PreferJestMocked,
+    jest,
     style,
     conditional_fix
 );
@@ -349,7 +350,7 @@ fn test() {
         ("(foo as jest.Mock) = jest.fn();", "(foo as jest.Mock) = jest.fn();"),
     ];
 
-    Tester::new(PreferJestMocked::NAME, PreferJestMocked::CATEGORY, pass, fail)
+    Tester::new(PreferJestMocked::NAME, PreferJestMocked::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
@@ -127,6 +127,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferLowercaseTitle,
+    jest,
     style,
     fix
 );
@@ -626,7 +627,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferLowercaseTitle::NAME, PreferLowercaseTitle::CATEGORY, pass, fail)
+    Tester::new(PreferLowercaseTitle::NAME, PreferLowercaseTitle::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferMockPromiseShorthand,
+    jest,
     style,
     conditional_fix
 );
@@ -430,7 +431,7 @@ fn test() {
         // ),
     ];
 
-    Tester::new(PreferMockPromiseShorthand::NAME, PreferMockPromiseShorthand::CATEGORY, pass, fail)
+    Tester::new(PreferMockPromiseShorthand::NAME, PreferMockPromiseShorthand::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// jest.spyOn(Date, 'now').mockImplementation(() => 10);
     /// ```
     PreferSpyOn,
+    jest,
     style,
     fix
 );
@@ -299,7 +300,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(PreferSpyOn::NAME, PreferSpyOn::CATEGORY, pass, fail)
+    Tester::new(PreferSpyOn::NAME, PreferSpyOn::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferStrictEqual,
+    jest,
     style,
     fix
 );
@@ -104,7 +105,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferStrictEqual::NAME, PreferStrictEqual::CATEGORY, pass, fail)
+    Tester::new(PreferStrictEqual::NAME, PreferStrictEqual::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -65,6 +65,7 @@ declare_oxc_lint!(
     /// expect(loadMessage()).resolves.toEqual('hello world');
     /// ```
     PreferToBe,
+    jest,
     style,
     fix
 );
@@ -552,7 +553,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(PreferToBe::NAME, PreferToBe::CATEGORY, pass, fail)
+    Tester::new(PreferToBe::NAME, PreferToBe::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferToContain,
+    jest,
     style,
 );
 
@@ -219,7 +220,7 @@ fn tests() {
         ("expect(a.includes(b)).toEqual(false as boolean);", None),
     ];
 
-    Tester::new(PreferToContain::NAME, PreferToContain::CATEGORY, pass, fail)
+    Tester::new(PreferToContain::NAME, PreferToContain::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// ```
     ///
     PreferToHaveLength,
+    jest,
     style,
     fix
 );
@@ -265,7 +266,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(PreferToHaveLength::NAME, PreferToHaveLength::CATEGORY, pass, fail)
+    Tester::new(PreferToHaveLength::NAME, PreferToHaveLength::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// test.todo('i need to write this test');
     /// ```
     PreferTodo,
+    jest,
     style,
     fix
 );
@@ -248,7 +249,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(PreferTodo::NAME, PreferTodo::CATEGORY, pass, fail)
+    Tester::new(PreferTodo::NAME, PreferTodo::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -144,6 +144,7 @@ declare_oxc_lint!(
     /// ```
     ///
     RequireHook,
+    jest,
     style
 );
 
@@ -620,7 +621,7 @@ fn tests() {
         ),
     ];
 
-    Tester::new(RequireHook::NAME, RequireHook::CATEGORY, pass, fail)
+    Tester::new(RequireHook::NAME, RequireHook::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// ```
     ///
     RequireToThrowMessage,
+    jest,
     correctness
 );
 
@@ -179,7 +180,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireToThrowMessage::NAME, RequireToThrowMessage::CATEGORY, pass, fail)
+    Tester::new(RequireToThrowMessage::NAME, RequireToThrowMessage::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -106,6 +106,7 @@ declare_oxc_lint!(
     /// ```
     ///
     RequireTopLevelDescribe,
+    jest,
     style,
 );
 
@@ -392,7 +393,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireTopLevelDescribe::NAME, RequireTopLevelDescribe::CATEGORY, pass, fail)
+    Tester::new(RequireTopLevelDescribe::NAME, RequireTopLevelDescribe::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ValidDescribeCallback,
+    jest,
     correctness
 );
 
@@ -512,7 +513,7 @@ fn test() {
     pass.extend(pass_vitest);
     fail.extend(fail_vitest);
 
-    Tester::new(ValidDescribeCallback::NAME, ValidDescribeCallback::CATEGORY, pass, fail)
+    Tester::new(ValidDescribeCallback::NAME, ValidDescribeCallback::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -90,6 +90,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ValidExpect,
+    jest,
     correctness
 );
 
@@ -434,7 +435,7 @@ fn test_1() {
     )];
     let fail = vec![];
 
-    Tester::new(ValidExpect::NAME, ValidExpect::CATEGORY, pass, fail).with_jest_plugin(true).test();
+    Tester::new(ValidExpect::NAME, ValidExpect::PLUGIN, pass, fail).with_jest_plugin(true).test();
 }
 
 #[test]
@@ -1143,7 +1144,7 @@ fn test() {
     pass.extend(pass_vitest);
     fail.extend(fail_vitest);
 
-    Tester::new(ValidExpect::NAME, ValidExpect::CATEGORY, pass, fail)
+    Tester::new(ValidExpect::NAME, ValidExpect::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     /// it('bar', () => {});
     /// test('baz', () => {});
     ValidTitle,
+    jest,
     correctness,
     conditional_fix
 );
@@ -1031,7 +1032,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(ValidTitle::NAME, ValidTitle::CATEGORY, pass, fail)
+    Tester::new(ValidTitle::NAME, ValidTitle::PLUGIN, pass, fail)
         .with_jest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// /** @private */
     /// ```
     CheckAccess,
+    jsdoc,
     restriction
 );
 
@@ -368,5 +369,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(CheckAccess::NAME, CheckAccess::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(CheckAccess::NAME, CheckAccess::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     ///  */
     /// ```
     CheckPropertyNames,
+    jsdoc,
     correctness
 );
 
@@ -426,6 +427,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(CheckPropertyNames::NAME, CheckPropertyNames::CATEGORY, pass, fail)
+    Tester::new(CheckPropertyNames::NAME, CheckPropertyNames::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// /** @param */
     /// ```
     CheckTagNames,
+    jsdoc,
     correctness
 );
 
@@ -1118,9 +1119,9 @@ fn test() {
         None,
     )];
 
-    Tester::new(CheckTagNames::NAME, CheckTagNames::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(CheckTagNames::NAME, CheckTagNames::PLUGIN, pass, fail).test_and_snapshot();
     // Currently only 1 snapshot can be saved under a rule name
-    Tester::new(CheckTagNames::NAME, CheckTagNames::CATEGORY, dts_pass, dts_fail)
+    Tester::new(CheckTagNames::NAME, CheckTagNames::PLUGIN, dts_pass, dts_fail)
         .change_rule_path("test.d.ts")
         .test();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     /// /** @private */
     /// ```
     EmptyTags,
+    jsdoc,
     restriction
 );
 
@@ -363,5 +364,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(EmptyTags::NAME, EmptyTags::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(EmptyTags::NAME, EmptyTags::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// function quux () {}
     /// ```
     ImplementsOnClasses,
+    jsdoc,
     correctness
 );
 
@@ -293,6 +294,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(ImplementsOnClasses::NAME, ImplementsOnClasses::CATEGORY, pass, fail)
+    Tester::new(ImplementsOnClasses::NAME, ImplementsOnClasses::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     NoDefaults,
+    jsdoc,
     correctness
 );
 
@@ -405,5 +406,5 @@ fn test() {
         //   ),
     ];
 
-    Tester::new(NoDefaults::NAME, NoDefaults::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDefaults::NAME, NoDefaults::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireParam,
+    jsdoc,
     pedantic,
 );
 
@@ -1372,5 +1373,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireParam::NAME, RequireParam::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireParam::NAME, RequireParam::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireParamDescription,
+    jsdoc,
     pedantic,
 );
 
@@ -277,6 +278,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireParamDescription::NAME, RequireParamDescription::CATEGORY, pass, fail)
+    Tester::new(RequireParamDescription::NAME, RequireParamDescription::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireParamName,
+    jsdoc,
     pedantic,
 );
 
@@ -189,5 +190,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireParamName::NAME, RequireParamName::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireParamName::NAME, RequireParamName::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireParamType,
+    jsdoc,
     pedantic,
 );
 
@@ -257,5 +258,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireParamType::NAME, RequireParamType::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireParamType::NAME, RequireParamType::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     ///  */
     /// ```
     RequireProperty,
+    jsdoc,
     correctness
 );
 
@@ -283,5 +284,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireProperty::NAME, RequireProperty::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireProperty::NAME, RequireProperty::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     ///  */
     /// ```
     RequirePropertyDescription,
+    jsdoc,
     correctness
 );
 
@@ -201,6 +202,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequirePropertyDescription::NAME, RequirePropertyDescription::CATEGORY, pass, fail)
+    Tester::new(RequirePropertyDescription::NAME, RequirePropertyDescription::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     ///  */
     /// ```
     RequirePropertyName,
+    jsdoc,
     correctness
 );
 
@@ -162,6 +163,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequirePropertyName::NAME, RequirePropertyName::CATEGORY, pass, fail)
+    Tester::new(RequirePropertyName::NAME, RequirePropertyName::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     ///  */
     /// ```
     RequirePropertyType,
+    jsdoc,
     correctness
 );
 
@@ -187,6 +188,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequirePropertyType::NAME, RequirePropertyType::CATEGORY, pass, fail)
+    Tester::new(RequirePropertyType::NAME, RequirePropertyType::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// function quux () { return foo; }
     /// ```
     RequireReturns,
+    jsdoc,
     pedantic,
 );
 
@@ -2235,5 +2236,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireReturns::NAME, RequireReturns::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireReturns::NAME, RequireReturns::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireReturnsDescription,
+    jsdoc,
     pedantic,
 );
 
@@ -256,6 +257,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireReturnsDescription::NAME, RequireReturnsDescription::CATEGORY, pass, fail)
+    Tester::new(RequireReturnsDescription::NAME, RequireReturnsDescription::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// function quux (foo) {}
     /// ```
     RequireReturnsType,
+    jsdoc,
     pedantic,
 );
 
@@ -161,6 +162,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireReturnsType::NAME, RequireReturnsType::CATEGORY, pass, fail)
+    Tester::new(RequireReturnsType::NAME, RequireReturnsType::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// function * quux (foo) { yield foo; }
     /// ```
     RequireYields,
+    jsdoc,
     correctness
 );
 
@@ -1458,5 +1459,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(RequireYields::NAME, RequireYields::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RequireYields::NAME, RequireYields::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -130,6 +130,7 @@ declare_oxc_lint!(
     /// <img src="flower.jpg" />
     /// ```
     AltText,
+    jsx_a11y,
     correctness
 );
 
@@ -527,7 +528,7 @@ fn test() {
         (r#"<Input type="image" />"#, None, None),
     ];
 
-    Tester::new(AltText::NAME, AltText::CATEGORY, pass, fail)
+    Tester::new(AltText::NAME, AltText::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -82,6 +82,7 @@ declare_oxc_lint!(
     /// <a aria-label="oxc linter documentation">click here</a>
     /// ```
     AnchorAmbiguousText,
+    jsx_a11y,
     restriction,
 );
 
@@ -307,6 +308,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(AnchorAmbiguousText::NAME, AnchorAmbiguousText::CATEGORY, pass, fail)
+    Tester::new(AnchorAmbiguousText::NAME, AnchorAmbiguousText::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// ```
     ///
     AnchorHasContent,
+    jsx_a11y,
     correctness,
     conditional_suggestion
 );
@@ -183,7 +184,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(AnchorHasContent::NAME, AnchorHasContent::CATEGORY, pass, fail)
+    Tester::new(AnchorHasContent::NAME, AnchorHasContent::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -116,6 +116,7 @@ declare_oxc_lint!(
     ///
     /// - [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
     AnchorIsValid,
+    jsx_a11y,
     correctness
 );
 
@@ -768,5 +769,5 @@ fn test() {
         // ),
     ];
 
-    Tester::new(AnchorIsValid::NAME, AnchorIsValid::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(AnchorIsValid::NAME, AnchorIsValid::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// const Bad = <div aria-activedescendant={someID} />
     /// ```
     AriaActivedescendantHasTabindex,
+    jsx_a11y,
     correctness
 );
 
@@ -143,7 +144,7 @@ fn test() {
 
     Tester::new(
         AriaActivedescendantHasTabindex::NAME,
-        AriaActivedescendantHasTabindex::CATEGORY,
+        AriaActivedescendantHasTabindex::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// <input aria-labelledby="address_label" />
     /// ```
     AriaProps,
+    jsx_a11y,
     correctness,
     conditional_fix
 );
@@ -102,7 +103,5 @@ fn test() {
     let fix =
         vec![(r#"<div aria-labeledby="foobar" />"#, r#"<div aria-labelledby="foobar" />"#, None)];
 
-    Tester::new(AriaProps::NAME, AriaProps::CATEGORY, pass, fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
+    Tester::new(AriaProps::NAME, AriaProps::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -110,6 +110,7 @@ declare_oxc_lint!(
     /// <Foo role={role}></Foo>       <!-- Good: ignoreNonDOM is set to true -->
     /// ```
     AriaRole,
+    jsx_a11y,
     correctness
 );
 
@@ -255,5 +256,5 @@ fn test() {
         ("<Box asChild='div' role='Button' />", None, None, None),
     ];
 
-    Tester::new(AriaRole::NAME, AriaRole::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(AriaRole::NAME, AriaRole::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -33,6 +33,7 @@ declare_oxc_lint! {
     /// ```
     ///
     AriaUnsupportedElements,
+    jsx_a11y,
     correctness,
     fix
 }
@@ -430,7 +431,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(AriaUnsupportedElements::NAME, AriaUnsupportedElements::CATEGORY, pass, fail)
+    Tester::new(AriaUnsupportedElements::NAME, AriaUnsupportedElements::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// <input autocomplete="name" />
     /// ```
     AutocompleteValid,
+    jsx_a11y,
     correctness
 );
 
@@ -259,6 +260,5 @@ fn test() {
         ("<Input type='text' autocomplete='baz' />;", None, Some(settings())),
     ];
 
-    Tester::new(AutocompleteValid::NAME, AutocompleteValid::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(AutocompleteValid::NAME, AutocompleteValid::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// <div onClick={() => void 0} onKeyDown={() => void 0} />
     /// ```
     ClickEventsHaveKeyEvents,
+    jsx_a11y,
     correctness
 );
 
@@ -147,6 +148,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(ClickEventsHaveKeyEvents::NAME, ClickEventsHaveKeyEvents::CATEGORY, pass, fail)
+    Tester::new(ClickEventsHaveKeyEvents::NAME, ClickEventsHaveKeyEvents::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// <h1>Foo</h1>
     /// ```
     HeadingHasContent,
+    jsx_a11y,
     correctness
 );
 
@@ -181,7 +182,7 @@ fn test() {
         // (r#"<h1><CustomInput type="hidden" /></h1>"#, None, Some(settings())),
     ];
 
-    Tester::new(HeadingHasContent::NAME, HeadingHasContent::CATEGORY, pass, fail)
+    Tester::new(HeadingHasContent::NAME, HeadingHasContent::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// <html lang="en" />
     /// ```
     HtmlHasLang,
+    jsx_a11y,
     correctness
 );
 
@@ -138,7 +139,7 @@ fn test() {
         ("<HTMLTop />", None, Some(settings()), None),
     ];
 
-    Tester::new(HtmlHasLang::NAME, HtmlHasLang::CATEGORY, pass, fail)
+    Tester::new(HtmlHasLang::NAME, HtmlHasLang::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// <iframe title={uniqueTitle} />
     /// ```
     IframeHasTitle,
+    jsx_a11y,
     correctness
 );
 
@@ -165,7 +166,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(IframeHasTitle::NAME, IframeHasTitle::CATEGORY, pass, fail)
+    Tester::new(IframeHasTitle::NAME, IframeHasTitle::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -96,6 +96,7 @@ declare_oxc_lint!(
     /// <img src="baz" alt={`Baz taking a ${photo}`} /> // This is valid since photo is a variable name.
     /// ```
     ImgRedundantAlt,
+    jsx_a11y,
     correctness
 );
 
@@ -291,7 +292,7 @@ fn test() {
         (r"<Image alt='Word2' />;", Some(array()), None),
     ];
 
-    Tester::new(ImgRedundantAlt::NAME, ImgRedundantAlt::CATEGORY, pass, fail)
+    Tester::new(ImgRedundantAlt::NAME, ImgRedundantAlt::PLUGIN, pass, fail)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -104,6 +104,7 @@ declare_oxc_lint!(
     /// </label>
     /// ```
     LabelHasAssociatedControl,
+    jsx_a11y,
     correctness,
 );
 
@@ -1594,6 +1595,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(LabelHasAssociatedControl::NAME, LabelHasAssociatedControl::CATEGORY, pass, fail)
+    Tester::new(LabelHasAssociatedControl::NAME, LabelHasAssociatedControl::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// - [eslint-plugin-jsx-a11y/lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/docs/rules/lang.md)
     /// - [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
     Lang,
+    jsx_a11y,
     correctness
 );
 
@@ -135,5 +136,5 @@ fn test() {
         ("<Box as='html' lang='foo' />", None, Some(settings()), None),
     ];
 
-    Tester::new(Lang::NAME, Lang::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(Lang::NAME, Lang::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// <video><track kind="captions" src="caption_file.vtt" /></video>
     /// ```
     MediaHasCaption,
+    jsx_a11y,
     correctness
 );
 
@@ -269,5 +270,5 @@ fn test() {
         (r"<Box as='audio'><Track kind='subtitles' /></Box>", None, Some(settings()), None),
     ];
 
-    Tester::new(MediaHasCaption::NAME, MediaHasCaption::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(MediaHasCaption::NAME, MediaHasCaption::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// <div onMouseOver={() => void 0} onFocus={() => void 0} />
     /// ```
     MouseEventsHaveKeyEvents,
+    jsx_a11y,
     correctness
 );
 
@@ -250,6 +251,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(MouseEventsHaveKeyEvents::NAME, MouseEventsHaveKeyEvents::CATEGORY, pass, fail)
+    Tester::new(MouseEventsHaveKeyEvents::NAME, MouseEventsHaveKeyEvents::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// <div />
     /// ```
     NoAccessKey,
+    jsx_a11y,
     correctness,
     suggestion,
 );
@@ -104,7 +105,7 @@ fn test() {
         (r"<div accessKey={`${undefined}${undefined}`} />", r"<div  />"),
     ];
 
-    Tester::new(NoAccessKey::NAME, NoAccessKey::CATEGORY, pass, fail)
+    Tester::new(NoAccessKey::NAME, NoAccessKey::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// <div aria-hidden="true" />
     /// ```
     NoAriaHiddenOnFocusable,
+    jsx_a11y,
     correctness,
     fix
 );
@@ -141,7 +142,7 @@ fn test() {
         (r#"<p tabIndex="0" aria-hidden="true">text</p>;"#, r#"<p tabIndex="0" >text</p>;"#),
     ];
 
-    Tester::new(NoAriaHiddenOnFocusable::NAME, NoAriaHiddenOnFocusable::CATEGORY, pass, fail)
+    Tester::new(NoAriaHiddenOnFocusable::NAME, NoAriaHiddenOnFocusable::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// <div />
     /// ```
     NoAutofocus,
+    jsx_a11y,
     correctness,
     fix
 );
@@ -176,7 +177,7 @@ fn test() {
         ("<div autoFocus id='lol'>foo</div>", "<div  id='lol'>foo</div>", None),
     ];
 
-    Tester::new(NoAutofocus::NAME, NoAutofocus::CATEGORY, pass, fail)
+    Tester::new(NoAutofocus::NAME, NoAutofocus::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// <Blink />
     /// ```
     NoDistractingElements,
+    jsx_a11y,
     correctness
 );
 
@@ -106,6 +107,6 @@ fn test() {
         (r"<Marquee />", Some(config()), Some(settings()), None),
     ];
 
-    Tester::new(NoDistractingElements::NAME, NoDistractingElements::CATEGORY, pass, fail)
+    Tester::new(NoDistractingElements::NAME, NoDistractingElements::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// <article tabIndex="-1" />
     /// ```
     NoNoninteractiveTabindex,
+    jsx_a11y,
     correctness,
 );
 
@@ -212,6 +213,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoNoninteractiveTabindex::NAME, NoNoninteractiveTabindex::CATEGORY, pass, fail)
+    Tester::new(NoNoninteractiveTabindex::NAME, NoNoninteractiveTabindex::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// <nav />
     /// ```
     NoRedundantRoles,
+    jsx_a11y,
     correctness,
     fix
 );
@@ -114,7 +115,7 @@ fn test() {
         ("<body role='document' />", "<body  />"),
     ];
 
-    Tester::new(NoRedundantRoles::NAME, NoRedundantRoles::CATEGORY, pass, fail)
+    Tester::new(NoRedundantRoles::NAME, NoRedundantRoles::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// <button />
     /// ```
     PreferTagOverRole,
+    jsx_a11y,
     correctness
 );
 
@@ -122,6 +123,5 @@ fn test() {
         r#"<other role="checkbox" />"#,
         r#"<div role="banner" />"#,
     ];
-    Tester::new(PreferTagOverRole::NAME, PreferTagOverRole::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(PreferTagOverRole::NAME, PreferTagOverRole::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// <div role="checkbox" aria-checked="false" />
     /// ```
     RoleHasRequiredAriaProps,
+    jsx_a11y,
     correctness
 );
 
@@ -146,6 +147,6 @@ fn test() {
         ("<MyComponent role='combobox' />", None, Some(settings()), None),
     ];
 
-    Tester::new(RoleHasRequiredAriaProps::NAME, RoleHasRequiredAriaProps::CATEGORY, pass, fail)
+    Tester::new(RoleHasRequiredAriaProps::NAME, RoleHasRequiredAriaProps::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// ```
     ///
     RoleSupportsAriaProps,
+    jsx_a11y,
     correctness
 );
 
@@ -1590,6 +1591,6 @@ fn test() {
         (r#"<Link href="/" aria-checked />"#, None, Some(settings()), None),
     ];
 
-    Tester::new(RoleSupportsAriaProps::NAME, RoleSupportsAriaProps::CATEGORY, pass, fail)
+    Tester::new(RoleSupportsAriaProps::NAME, RoleSupportsAriaProps::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// <th scope={scope} />
     /// ```
     Scope,
+    jsx_a11y,
     correctness,
     fix
 );
@@ -115,7 +116,7 @@ fn test() {
         (r"<h1 scope='bar' />;", r"<h1  />;", Some(settings())),
     ];
 
-    Tester::new(Scope::NAME, Scope::CATEGORY, pass, fail)
+    Tester::new(Scope::NAME, Scope::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_jsx_a11y_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// <span tabIndex="-1">bar</span>
     /// ```
     TabindexNoPositive,
+    jsx_a11y,
     correctness,
     pending
 );
@@ -105,6 +106,6 @@ fn test() {
         (r"<div tabIndex={1.589} />", None),
     ];
 
-    Tester::new(TabindexNoPositive::NAME, TabindexNoPositive::CATEGORY, pass, fail)
+    Tester::new(TabindexNoPositive::NAME, TabindexNoPositive::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// ```
     ///
     GoogleFontDisplay,
+    nextjs,
     correctness
 );
 
@@ -244,7 +245,7 @@ fn test() {
 			     "#,
     ];
 
-    Tester::new(GoogleFontDisplay::NAME, GoogleFontDisplay::CATEGORY, pass, fail)
+    Tester::new(GoogleFontDisplay::NAME, GoogleFontDisplay::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     GoogleFontPreconnect,
+    nextjs,
     correctness
 );
 
@@ -104,7 +105,7 @@ fn test() {
 			    "#,
     ];
 
-    Tester::new(GoogleFontPreconnect::NAME, GoogleFontPreconnect::CATEGORY, pass, fail)
+    Tester::new(GoogleFontPreconnect::NAME, GoogleFontPreconnect::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -31,6 +31,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     InlineScriptId,
+    nextjs,
     correctness
 );
 
@@ -234,7 +235,7 @@ fn test() {
 			        }",
     ];
 
-    Tester::new(InlineScriptId::NAME, InlineScriptId::CATEGORY, pass, fail)
+    Tester::new(InlineScriptId::NAME, InlineScriptId::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NextScriptForGa,
+    nextjs,
     correctness
 );
 
@@ -312,7 +313,7 @@ fn test() {
 			      }",
     ];
 
-    Tester::new(NextScriptForGa::NAME, NextScriptForGa::CATEGORY, pass, fail)
+    Tester::new(NextScriptForGa::NAME, NextScriptForGa::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -25,6 +25,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoAssignModuleVariable,
+    nextjs,
     correctness
 );
 
@@ -70,7 +71,7 @@ fn test() {
 			      ",
     ];
 
-    Tester::new(NoAssignModuleVariable::NAME, NoAssignModuleVariable::CATEGORY, pass, fail)
+    Tester::new(NoAssignModuleVariable::NAME, NoAssignModuleVariable::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoAsyncClientComponent,
+    nextjs,
     correctness
 );
 
@@ -195,7 +196,7 @@ fn test() {
 			      "#,
     ];
 
-    Tester::new(NoAsyncClientComponent::NAME, NoAsyncClientComponent::CATEGORY, pass, fail)
+    Tester::new(NoAsyncClientComponent::NAME, NoAsyncClientComponent::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoBeforeInteractiveScriptOutsideDocument,
+    nextjs,
     correctness
 );
 
@@ -384,7 +385,7 @@ fn test() {
 
     Tester::new(
         NoBeforeInteractiveScriptOutsideDocument::NAME,
-        NoBeforeInteractiveScriptOutsideDocument::CATEGORY,
+        NoBeforeInteractiveScriptOutsideDocument::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoCssTags,
+    nextjs,
     correctness
 );
 
@@ -158,7 +159,7 @@ fn test() {
 			      </div>"#,
     ];
 
-    Tester::new(NoCssTags::NAME, NoCssTags::CATEGORY, pass, fail)
+    Tester::new(NoCssTags::NAME, NoCssTags::PLUGIN, pass, fail)
         .with_nextjs_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -23,6 +23,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoDocumentImportInPage,
+    nextjs,
     correctness
 );
 
@@ -210,6 +211,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDocumentImportInPage::NAME, NoDocumentImportInPage::CATEGORY, pass, fail)
+    Tester::new(NoDocumentImportInPage::NAME, NoDocumentImportInPage::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     ///export default MyDocument
     /// ```
     NoDuplicateHead,
+    nextjs,
     correctness
 );
 
@@ -208,5 +209,5 @@ fn test() {
 			      "#,
     ];
 
-    Tester::new(NoDuplicateHead::NAME, NoDuplicateHead::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDuplicateHead::NAME, NoDuplicateHead::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -25,6 +25,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoHeadElement,
+    nextjs,
     correctness
 );
 
@@ -170,5 +171,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoHeadElement::NAME, NoHeadElement::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoHeadElement::NAME, NoHeadElement::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -25,6 +25,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoHeadImportInDocument,
+    nextjs,
     correctness
 );
 
@@ -244,6 +245,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoHeadImportInDocument::NAME, NoHeadImportInDocument::CATEGORY, pass, fail)
+    Tester::new(NoHeadImportInDocument::NAME, NoHeadImportInDocument::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -25,6 +25,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoImgElement,
+    nextjs,
     correctness
 );
 
@@ -147,5 +148,5 @@ fn test() {
 			      }"#,
     ];
 
-    Tester::new(NoImgElement::NAME, NoImgElement::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoImgElement::NAME, NoImgElement::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoPageCustomFont,
+    nextjs,
     correctness,
 );
 
@@ -325,5 +326,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoPageCustomFont::NAME, NoPageCustomFont::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoPageCustomFont::NAME, NoPageCustomFont::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoScriptComponentInHead,
+    nextjs,
     correctness
 );
 
@@ -127,6 +128,6 @@ fn test() {
         "#,
     ];
 
-    Tester::new(NoScriptComponentInHead::NAME, NoScriptComponentInHead::CATEGORY, pass, fail)
+    Tester::new(NoScriptComponentInHead::NAME, NoScriptComponentInHead::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoStyledJsxInDocument,
+    nextjs,
     correctness,
 );
 
@@ -171,6 +172,6 @@ fn test() {
         Some(PathBuf::from("pages/_document.jsx")),
     )];
 
-    Tester::new(NoStyledJsxInDocument::NAME, NoStyledJsxInDocument::CATEGORY, pass, fail)
+    Tester::new(NoStyledJsxInDocument::NAME, NoStyledJsxInDocument::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoSyncScripts,
+    nextjs,
     correctness
 );
 
@@ -130,5 +131,5 @@ fn test() {
 			      }",
     ];
 
-    Tester::new(NoSyncScripts::NAME, NoSyncScripts::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSyncScripts::NAME, NoSyncScripts::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     NoTitleInDocumentHead,
+    nextjs,
     correctness
 );
 
@@ -141,6 +142,6 @@ fn test() {
 			      }"#,
     ];
 
-    Tester::new(NoTitleInDocumentHead::NAME, NoTitleInDocumentHead::CATEGORY, pass, fail)
+    Tester::new(NoTitleInDocumentHead::NAME, NoTitleInDocumentHead::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// export async function getServurSideProps(){};
     /// ```
     NoTypos,
+    nextjs,
     correctness,
     pending
 );
@@ -298,5 +299,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoTypos::NAME, NoTypos::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoTypos::NAME, NoTypos::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// <script src='https://polyfill.io/v3/polyfill.min.js?features=WeakSet%2CPromise%2CPromise.prototype.finally%2Ces2015%2Ces5%2Ces6'></script>
     /// ```
     NoUnwantedPolyfillio,
+    nextjs,
     correctness
 );
 
@@ -262,6 +263,6 @@ fn test() {
                   }",
     ];
 
-    Tester::new(NoUnwantedPolyfillio::NAME, NoUnwantedPolyfillio::CATEGORY, pass, fail)
+    Tester::new(NoUnwantedPolyfillio::NAME, NoUnwantedPolyfillio::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     /// exports = module.exports = {}
     /// ```
     NoExportsAssign,
+    node,
     style,
     fix
 );
@@ -122,7 +123,7 @@ fn test() {
 
     let fix = vec![("exports = {}", "module.exports = {}")];
 
-    Tester::new(NoExportsAssign::NAME, NoExportsAssign::CATEGORY, pass, fail)
+    Tester::new(NoExportsAssign::NAME, NoExportsAssign::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_node_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/node/no_new_require.rs
+++ b/crates/oxc_linter/src/rules/node/no_new_require.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// var appHeader = new AppHeader();
     /// ```
     NoNewRequire,
+    node,
     restriction
 );
 
@@ -70,5 +71,5 @@ fn test() {
         "var appHeader = new require('headers').appHeader",
     ];
 
-    Tester::new(NoNewRequire::NAME, NoNewRequire::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNewRequire::NAME, NoNewRequire::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// let log10e = Math.LOG10E
     /// ```
     ApproxConstant,
+    oxc,
     suspicious
 );
 
@@ -100,5 +101,5 @@ fn test() {
         "let sqrt2 = 1.414213",  // SQRT2
     ];
 
-    Tester::new(ApproxConstant::NAME, ApproxConstant::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ApproxConstant::NAME, ApproxConstant::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     BadArrayMethodOnArguments,
+    oxc,
     correctness,
 );
 
@@ -185,7 +186,7 @@ fn test() {
         ("function fn() {arguments['@@iterator'](() => {})}", None),
     ];
 
-    Tester::new(BadArrayMethodOnArguments::NAME, BadArrayMethodOnArguments::CATEGORY, pass, fail)
+    Tester::new(BadArrayMethodOnArguments::NAME, BadArrayMethodOnArguments::PLUGIN, pass, fail)
         .test_and_snapshot();
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// input |= '';
     /// ```
     BadBitwiseOperator,
+    oxc,
     restriction // Restricted because there are false positives for enum bitflags in TypeScript,
                 // e.g. in the vscode repo
     pending
@@ -229,6 +230,6 @@ fn test() {
         // ("var a = '1'; var b = a | {}", None),
     ];
 
-    Tester::new(BadBitwiseOperator::NAME, BadBitwiseOperator::CATEGORY, pass, fail)
+    Tester::new(BadBitwiseOperator::NAME, BadBitwiseOperator::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// a.charAt(4) === '\n';
     /// ```
     BadCharAtComparison,
+    oxc,
     correctness
 );
 
@@ -125,6 +126,6 @@ fn test() {
         r"a.charAt(4) === '\\ukeff'",
     ];
 
-    Tester::new(BadCharAtComparison::NAME, BadCharAtComparison::CATEGORY, pass, fail)
+    Tester::new(BadCharAtComparison::NAME, BadCharAtComparison::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     BadComparisonSequence,
+    oxc,
     correctness
 );
 
@@ -162,6 +163,6 @@ fn test() {
         ("if (a <= b <= c) { console.log('foo') }", None),
     ];
 
-    Tester::new(BadComparisonSequence::NAME, BadComparisonSequence::CATEGORY, pass, fail)
+    Tester::new(BadComparisonSequence::NAME, BadComparisonSequence::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// ```
     ///
     BadMinMaxFunc,
+    oxc,
     correctness
 );
 
@@ -159,5 +160,5 @@ fn test() {
         ("Math.min(Math.max(1e3, x), 1.55e2)", None),
     ];
 
-    Tester::new(BadMinMaxFunc::NAME, BadMinMaxFunc::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(BadMinMaxFunc::NAME, BadMinMaxFunc::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// if (Array.isArray(x) && x.length === 0) { }
     /// ```
     BadObjectLiteralComparison,
+    oxc,
     correctness
 );
 
@@ -139,6 +140,6 @@ fn test() {
         r"if (config != []) { }",
     ];
 
-    Tester::new(BadObjectLiteralComparison::NAME, BadObjectLiteralComparison::CATEGORY, pass, fail)
+    Tester::new(BadObjectLiteralComparison::NAME, BadObjectLiteralComparison::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// withSpaces.replaceAll(/\s+/g, ',');
     /// ```
     BadReplaceAllArg,
+    oxc,
     correctness
 );
 
@@ -158,5 +159,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(BadReplaceAllArg::NAME, BadReplaceAllArg::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(BadReplaceAllArg::NAME, BadReplaceAllArg::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -105,6 +105,7 @@ declare_oxc_lint!(
     /// a <= b;
     /// ```
     ConstComparisons,
+    oxc,
     correctness
 );
 
@@ -555,5 +556,5 @@ fn test() {
         "foo || !foo",
     ];
 
-    Tester::new(ConstComparisons::NAME, ConstComparisons::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ConstComparisons::NAME, ConstComparisons::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// x >= y;
     /// ```
     DoubleComparisons,
+    oxc,
     correctness,
     fix
 );
@@ -161,7 +162,7 @@ fn test() {
         ("x > y || x === y", "x >= y"),
     ];
 
-    Tester::new(DoubleComparisons::NAME, DoubleComparisons::CATEGORY, pass, fail)
+    Tester::new(DoubleComparisons::NAME, DoubleComparisons::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// let y = 0;
     /// ```
     ErasingOp,
+    oxc,
     correctness,
     suggestion
 );
@@ -100,7 +101,5 @@ fn test() {
 
     let fix = vec![("x * 0;", "0;"), ("0 * x;", "0;"), ("0 & x;", "0;"), ("0 / x;", "0;")];
 
-    Tester::new(ErasingOp::NAME, ErasingOp::CATEGORY, pass, fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
+    Tester::new(ErasingOp::NAME, ErasingOp::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// a -= b;
     /// ```
     MisrefactoredAssignOp,
+    oxc,
     suspicious,
     pending
 );
@@ -227,6 +228,6 @@ fn test() {
         //~^ ERROR: variable appears on both sides of an assignment operation
     ];
 
-    Tester::new(MisrefactoredAssignOp::NAME, MisrefactoredAssignOp::CATEGORY, pass, fail)
+    Tester::new(MisrefactoredAssignOp::NAME, MisrefactoredAssignOp::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// const foo = () => { throw new Error() }
     /// ```
     MissingThrow,
+    oxc,
     correctness,
     suggestion
 );
@@ -99,7 +100,7 @@ fn test() {
         ("const foo = () => { new Error() }", "const foo = () => { throw new Error() }"),
     ];
 
-    Tester::new(MissingThrow::NAME, MissingThrow::CATEGORY, pass, fail)
+    Tester::new(MissingThrow::NAME, MissingThrow::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -119,6 +119,7 @@ declare_oxc_lint!(
     /// let foo = []; for (let i = 0; i < 10; i++) { foo.push(i); }
     /// ```
     NoAccumulatingSpread,
+    oxc,
     perf,
 );
 
@@ -460,6 +461,6 @@ fn test() {
         "let foo = {}; while (Object.keys(foo).length < 10) { foo = { ...foo, [Object.keys(foo).length]: Object.keys(foo).length }; }",
     ];
 
-    Tester::new(NoAccumulatingSpread::NAME, NoAccumulatingSpread::CATEGORY, pass, fail)
+    Tester::new(NoAccumulatingSpread::NAME, NoAccumulatingSpread::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAsyncAwait,
+    oxc,
     restriction
 );
 
@@ -101,5 +102,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoAsyncAwait::NAME, NoAsyncAwait::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoAsyncAwait::NAME, NoAsyncAwait::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -165,6 +165,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAsyncEndpointHandlers,
+    oxc,
     suspicious
 );
 
@@ -389,6 +390,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoAsyncEndpointHandlers::NAME, NoAsyncEndpointHandlers::CATEGORY, pass, fail)
+    Tester::new(NoAsyncEndpointHandlers::NAME, NoAsyncEndpointHandlers::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// export { foo } from 'foo';
     /// ```
     NoBarrelFile,
+    oxc,
     restriction
 );
 
@@ -144,7 +145,7 @@ fn test() {
         settings,
     )];
 
-    Tester::new(NoBarrelFile::NAME, NoBarrelFile::CATEGORY, pass, fail)
+    Tester::new(NoBarrelFile::NAME, NoBarrelFile::PLUGIN, pass, fail)
         .change_rule_path("index.ts")
         .with_import_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoConstEnum,
+    oxc,
     restriction,
     fix
 );
@@ -80,7 +81,7 @@ fn test() {
         ("const   enum Color { Red, Green, Blue }", "enum Color { Red, Green, Blue }", None),
     ];
 
-    Tester::new(NoConstEnum::NAME, NoConstEnum::CATEGORY, pass, fail)
+    Tester::new(NoConstEnum::NAME, NoConstEnum::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -310,6 +310,7 @@ declare_oxc_lint!(
     /// - [ECMA262 - Object spread evaluation semantics](https://262.ecma-international.org/15.0/index.html#sec-runtime-semantics-propertydefinitionevaluation)
     /// - [JSPerf - `concat` vs array spread performance](https://jsperf.app/pihevu)
     NoMapSpread,
+    oxc,
     nursery, // TODO: make this `perf` once we've battle-tested this a bit
     conditional_fix_suggestion
 );
@@ -859,7 +860,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoMapSpread::NAME, NoMapSpread::CATEGORY, pass, fail)
+    Tester::new(NoMapSpread::NAME, NoMapSpread::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// - `message`: A custom help message to display when optional chaining is found.
     ///
     NoOptionalChaining,
+    oxc,
     restriction,
 );
 
@@ -112,6 +113,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoOptionalChaining::NAME, NoOptionalChaining::CATEGORY, pass, fail)
+    Tester::new(NoOptionalChaining::NAME, NoOptionalChaining::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// - `objectRestMessage`: A message to display when object rest properties are found.
     ///
     NoRestSpreadProperties,
+    oxc,
     restriction,
 );
 
@@ -164,6 +165,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoRestSpreadProperties::NAME, NoRestSpreadProperties::CATEGORY, pass, fail)
+    Tester::new(NoRestSpreadProperties::NAME, NoRestSpreadProperties::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NumberArgOutOfRange,
+    oxc,
     correctness
 );
 
@@ -100,6 +101,6 @@ fn test() {
         ("var x = 42;var s = x.toPrecision(100);", None),
     ];
 
-    Tester::new(NumberArgOutOfRange::NAME, NumberArgOutOfRange::CATEGORY, pass, fail)
+    Tester::new(NumberArgOutOfRange::NAME, NumberArgOutOfRange::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     OnlyUsedInRecursion,
+    oxc,
     correctness,
     dangerous_fix
 );
@@ -847,7 +848,7 @@ function writeChunks(a,callac){writeChunks(m,callac)}writeChunks(i,{})",
         ),
     ];
 
-    Tester::new(OnlyUsedInRecursion::NAME, OnlyUsedInRecursion::CATEGORY, pass, fail)
+    Tester::new(OnlyUsedInRecursion::NAME, OnlyUsedInRecursion::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     ///   const list = new Array(5).map(_ => createElement());
     /// ```
     UninvokedArrayCallback,
+    oxc,
     correctness
 );
 
@@ -101,6 +102,6 @@ fn test() {
         ("const list = new Array(5)['every'](function(_) {})", None),
     ];
 
-    Tester::new(UninvokedArrayCallback::NAME, UninvokedArrayCallback::CATEGORY, pass, fail)
+    Tester::new(UninvokedArrayCallback::NAME, UninvokedArrayCallback::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// const bar = await Promise.all([baz(), bang()]);
     /// ```
     AvoidNew,
+    promise,
     style,
 );
 
@@ -77,5 +78,5 @@ fn test() {
         "Thing(new Promise(() => {}))",
     ];
 
-    Tester::new(AvoidNew::NAME, AvoidNew::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(AvoidNew::NAME, AvoidNew::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     CatchOrReturn,
+    promise,
     restriction,
 );
 
@@ -344,5 +345,5 @@ fn test() {
         ("frank()['catch'](go).someOtherMethod()", None),
     ];
 
-    Tester::new(CatchOrReturn::NAME, CatchOrReturn::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(CatchOrReturn::NAME, CatchOrReturn::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
+++ b/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     ///   .catch((err) => { console.error(err) })
     /// ```
     NoCallbackInPromise,
+    promise,
     correctness,
 );
 
@@ -182,6 +183,6 @@ fn test() {
         ("a.catch(function(err) { callback(err) })", None),
     ];
 
-    Tester::new(NoCallbackInPromise::NAME, NoCallbackInPromise::CATEGORY, pass, fail)
+    Tester::new(NoCallbackInPromise::NAME, NoCallbackInPromise::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// const x = Promise.resolve(value);
     /// ```
     NoNewStatics,
+    promise,
     correctness,
     fix
 );
@@ -112,7 +113,7 @@ fn test() {
         ("new Promise.any()", "Promise.any()", None),
         ("new Promise.race()", "Promise.race()", None),
     ];
-    Tester::new(NoNewStatics::NAME, NoNewStatics::CATEGORY, pass, fail)
+    Tester::new(NoNewStatics::NAME, NoNewStatics::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
+++ b/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     ///   .catch(console.error)
     /// ```
     NoPromiseInCallback,
+    promise,
     suspicious,
 );
 
@@ -162,6 +163,6 @@ fn test() {
         "let x = (err) => doThingWith(err).then(a)",
     ];
 
-    Tester::new(NoPromiseInCallback::NAME, NoPromiseInCallback::CATEGORY, pass, fail)
+    Tester::new(NoPromiseInCallback::NAME, NoPromiseInCallback::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// Promise.resolve(1).finally(() => { console.log(2) })
     /// ```
     NoReturnInFinally,
+    promise,
     nursery,
 );
 
@@ -112,6 +113,5 @@ fn test() {
         "Promise.resolve(1).finally(function () { return 2 })",
     ];
 
-    Tester::new(NoReturnInFinally::NAME, NoReturnInFinally::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoReturnInFinally::NAME, NoReturnInFinally::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// new Promise(function(resolve, reject) {})
     /// ```
     ParamNames,
+    promise,
     style,
 );
 
@@ -185,5 +186,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(ParamNames::NAME, ParamNames::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ParamNames::NAME, ParamNames::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// eventEmitter.on('error', err => {})
     /// ```
     PreferAwaitToCallbacks,
+    promise,
     style,
 );
 
@@ -181,6 +182,6 @@ fn test() {
         "customMap(errors, (err) => err.message)",
     ];
 
-    Tester::new(PreferAwaitToCallbacks::NAME, PreferAwaitToCallbacks::CATEGORY, pass, fail)
+    Tester::new(PreferAwaitToCallbacks::NAME, PreferAwaitToCallbacks::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// async function hi() { await thing() }
     /// ```
     PreferAwaitToThen,
+    promise,
     style,
 );
 
@@ -97,6 +98,5 @@ fn test() {
         "something().then(async () => await somethingElse())",
     ];
 
-    Tester::new(PreferAwaitToThen::NAME, PreferAwaitToThen::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(PreferAwaitToThen::NAME, PreferAwaitToThen::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// Promise.resolve()
     /// ```
     SpecOnly,
+    promise,
     restriction,
 );
 
@@ -133,5 +134,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(SpecOnly::NAME, SpecOnly::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(SpecOnly::NAME, SpecOnly::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     /// Promise.resolve(1)
     /// ```
     ValidParams,
+    promise,
     correctness,
 );
 
@@ -188,5 +189,5 @@ fn test() {
         "promiseReference.finally(() => {}, () => {})",
     ];
 
-    Tester::new(ValidParams::NAME, ValidParams::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ValidParams::NAME, ValidParams::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// <button type="submit" />
     /// ```
     ButtonHasType,
+    react,
     restriction
 );
 
@@ -318,5 +319,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(ButtonHasType::NAME, ButtonHasType::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ButtonHasType::NAME, ButtonHasType::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// React.createElement('input', { type: 'checkbox', defaultChecked: true });
     /// ```
     CheckedRequiresOnchangeOrReadonly,
+    react,
     pedantic
 );
 
@@ -277,7 +278,7 @@ fn test() {
 
     Tester::new(
         CheckedRequiresOnchangeOrReadonly::NAME,
-        CheckedRequiresOnchangeOrReadonly::CATEGORY,
+        CheckedRequiresOnchangeOrReadonly::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -188,6 +188,7 @@ declare_oxc_lint!(
     ///     return <div />;
     /// }
     ExhaustiveDeps,
+    react,
     nursery
 );
 
@@ -3532,5 +3533,5 @@ fn test() {
         }",
     ];
 
-    Tester::new(ExhaustiveDeps::NAME, ExhaustiveDeps::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ExhaustiveDeps::NAME, ExhaustiveDeps::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
+++ b/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
@@ -93,6 +93,7 @@ declare_oxc_lint!(
     /// <iframe sandbox="allow-origin" />;
     /// ```
     IframeMissingSandbox,
+    react,
     suspicious,
     pending
 );
@@ -260,6 +261,6 @@ fn test() {
         r#"<iframe sandbox="allow-same-origin allow-scripts"/>;"#,
     ];
 
-    Tester::new(IframeMissingSandbox::NAME, IframeMissingSandbox::CATEGORY, pass, fail)
+    Tester::new(IframeMissingSandbox::NAME, IframeMissingSandbox::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// ```
     ///
     JsxBooleanValue,
+    react,
     style,
     fix,
 );
@@ -254,7 +255,7 @@ fn test() {
         ("<App foo />", "<App foo={true} />", Some(serde_json::json!(["always"]))),
     ];
 
-    Tester::new(JsxBooleanValue::NAME, JsxBooleanValue::CATEGORY, pass, fail)
+    Tester::new(JsxBooleanValue::NAME, JsxBooleanValue::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -296,6 +296,7 @@ declare_oxc_lint!(
     /// consistency regarding the use of curly braces in JSX props and/or
     /// children as well as the use of unnecessary JSX expressions.
     JsxCurlyBracePresence,
+    react,
     style,
 );
 
@@ -961,6 +962,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(JsxCurlyBracePresence::NAME, JsxCurlyBracePresence::CATEGORY, pass, fail)
+    Tester::new(JsxCurlyBracePresence::NAME, JsxCurlyBracePresence::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     /// [1, 2, 3]?.map(x => <BabelEslintApp key={x} />)
     /// ```
     JsxKey,
+    react,
     correctness
 );
 
@@ -625,5 +626,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(JsxKey::NAME, JsxKey::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(JsxKey::NAME, JsxKey::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     JsxNoCommentTextnodes,
+    react,
     suspicious
 );
 
@@ -315,6 +316,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(JsxNoCommentTextnodes::NAME, JsxNoCommentTextnodes::CATEGORY, pass, fail)
+    Tester::new(JsxNoCommentTextnodes::NAME, JsxNoCommentTextnodes::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// <App bar baz foo={3} />;
     /// ```
     JsxNoDuplicateProps,
+    react,
     correctness
 );
 
@@ -122,6 +123,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(JsxNoDuplicateProps::NAME, JsxNoDuplicateProps::CATEGORY, pass, fail)
+    Tester::new(JsxNoDuplicateProps::NAME, JsxNoDuplicateProps::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// <Foo test="javascript:void(0)" />
     /// ```
     JsxNoScriptUrl,
+    react,
     suspicious,
     pending
 );
@@ -279,5 +280,5 @@ v	ascript:"></a>"#,
         ),
     ];
 
-    Tester::new(JsxNoScriptUrl::NAME, JsxNoScriptUrl::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(JsxNoScriptUrl::NAME, JsxNoScriptUrl::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -122,6 +122,7 @@ declare_oxc_lint!(
     /// [`noreferrer` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
     /// [`noopener` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
     JsxNoTargetBlank,
+    react,
     correctness
 );
 
@@ -795,5 +796,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(JsxNoTargetBlank::NAME, JsxNoTargetBlank::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(JsxNoTargetBlank::NAME, JsxNoTargetBlank::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -32,6 +32,7 @@ declare_oxc_lint!(
     /// const C = <B />
     /// ```
     JsxNoUndef,
+    react,
     correctness
 );
 
@@ -142,9 +143,9 @@ fn test() {
         ("var React; enum A { App }; React.render(<App />);", None),
     ];
 
-    Tester::new(JsxNoUndef::NAME, JsxNoUndef::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(JsxNoUndef::NAME, JsxNoUndef::PLUGIN, pass, fail).test_and_snapshot();
 
     let pass = vec![("let x = <A.B />;", None, Some(json!({ "globals": {"A": "readonly" } })))];
     let fail = vec![("let x = <A.B />;", None, None)];
-    Tester::new(JsxNoUndef::NAME, JsxNoUndef::CATEGORY, pass, fail).test();
+    Tester::new(JsxNoUndef::NAME, JsxNoUndef::PLUGIN, pass, fail).test();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// <div>foo</div>
     /// ```
     JsxNoUselessFragment,
+    react,
     pedantic
 );
 
@@ -317,6 +318,6 @@ fn test() {
         (r"<><Foo>{moo}</Foo></>", None),
     ];
 
-    Tester::new(JsxNoUselessFragment::NAME, JsxNoUselessFragment::CATEGORY, pass, fail)
+    Tester::new(JsxNoUselessFragment::NAME, JsxNoUselessFragment::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// <App {...props} myAttr="1" />
     /// ```
     JsxPropsNoSpreadMulti,
+    react,
     correctness,
     fix
 );
@@ -186,7 +187,7 @@ fn test() {
         ("<div {...props} {...props} {...props} />", "<div   {...props} />"),
     ];
 
-    Tester::new(JsxPropsNoSpreadMulti::NAME, JsxPropsNoSpreadMulti::CATEGORY, pass, fail)
+    Tester::new(JsxPropsNoSpreadMulti::NAME, JsxPropsNoSpreadMulti::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// ));
     /// ```
     NoArrayIndexKey,
+    react,
     perf,
 );
 
@@ -293,5 +294,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoArrayIndexKey::NAME, NoArrayIndexKey::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoArrayIndexKey::NAME, NoArrayIndexKey::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     /// React.createElement("div", 'Child 1', 'Child 2')
     /// ```
     NoChildrenProp,
+    react,
     correctness
 );
 
@@ -163,5 +164,5 @@ fn test() {
         (r#"React.createElement(MyComponent, {...props, children: "Children"})"#, None),
     ];
 
-    Tester::new(NoChildrenProp::NAME, NoChildrenProp::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoChildrenProp::NAME, NoChildrenProp::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// const Hello = <div>Hello World</div>;
     /// ```
     NoDanger,
+    react,
     restriction
 );
 
@@ -116,5 +117,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDanger::NAME, NoDanger::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDanger::NAME, NoDanger::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// <div dangerouslySetInnerHTML={{ __html: "HTML" }} />
     /// ```
     NoDangerWithChildren,
+    react,
     correctness
 );
 
@@ -235,7 +236,7 @@ fn test() {
         "#,
     ];
 
-    Tester::new(NoDangerWithChildren::NAME, NoDangerWithChildren::CATEGORY, pass, fail)
+    Tester::new(NoDangerWithChildren::NAME, NoDangerWithChildren::PLUGIN, pass, fail)
         .test_and_snapshot();
 }
 

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     ///  }
     /// ```
     NoDirectMutationState,
+    react,
     correctness
 );
 
@@ -396,6 +397,6 @@ fn test() {
         "#,
     ];
 
-    Tester::new(NoDirectMutationState::NAME, NoDirectMutationState::CATEGORY, pass, fail)
+    Tester::new(NoDirectMutationState::NAME, NoDirectMutationState::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoFindDomNode,
+    react,
     correctness
 );
 
@@ -202,5 +203,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoFindDomNode::NAME, NoFindDomNode::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoFindDomNode::NAME, NoFindDomNode::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// };
     /// ```
     NoIsMounted,
+    react,
     correctness
 );
 
@@ -152,5 +153,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoIsMounted::NAME, NoIsMounted::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoIsMounted::NAME, NoIsMounted::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// ReactDOM.render(<App />, document.body);
     /// ```
     NoRenderReturnValue,
+    react,
     correctness
 );
 
@@ -148,6 +149,6 @@ fn test() {
         // ("var inst = React.render(<div />, document.body);", None),
     ];
 
-    Tester::new(NoRenderReturnValue::NAME, NoRenderReturnValue::CATEGORY, pass, fail)
+    Tester::new(NoRenderReturnValue::NAME, NoRenderReturnValue::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoSetState,
+    react,
     style,
 );
 
@@ -184,5 +185,5 @@ fn test() {
 			      ",
     ];
 
-    Tester::new(NoSetState::NAME, NoSetState::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoSetState::NAME, NoSetState::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     NoStringRefs,
+    react,
     correctness
 );
 
@@ -331,5 +332,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoStringRefs::NAME, NoStringRefs::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoStringRefs::NAME, NoStringRefs::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// <div> {'>'} </div>
     /// ```
     NoUnescapedEntities,
+    react,
     pedantic
 );
 
@@ -193,6 +194,6 @@ fn test() {
         r#"<script>测试 " 测试</script>"#,
     ];
 
-    Tester::new(NoUnescapedEntities::NAME, NoUnescapedEntities::CATEGORY, pass, fail)
+    Tester::new(NoUnescapedEntities::NAME, NoUnescapedEntities::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     ///  const IconButton = <div aria-foo="bar" />;
     /// ```
     NoUnknownProperty,
+    react,
     restriction,
     pending
 );
@@ -757,6 +758,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUnknownProperty::NAME, NoUnknownProperty::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoUnknownProperty::NAME, NoUnknownProperty::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// });
     /// ```
     PreferEs6Class,
+    react,
     style,
 );
 
@@ -186,5 +187,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferEs6Class::NAME, PreferEs6Class::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferEs6Class::NAME, PreferEs6Class::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     ///
     /// ```
     ReactInJsxScope,
+    react,
     suspicious
 );
 
@@ -105,5 +106,5 @@ fn test() {
         ("var Foo, a = <img />;", None),
     ];
 
-    Tester::new(ReactInJsxScope::NAME, ReactInJsxScope::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ReactInJsxScope::NAME, ReactInJsxScope::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     RequireRenderReturn,
+    react,
     nursery
 );
 
@@ -363,6 +364,6 @@ fn test() {
          ",
     ];
 
-    Tester::new(RequireRenderReturn::NAME, RequireRenderReturn::CATEGORY, pass, fail)
+    Tester::new(RequireRenderReturn::NAME, RequireRenderReturn::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -104,6 +104,7 @@ declare_oxc_lint!(
     /// <https://reactjs.org/docs/hooks-rules.html>
     ///
     RulesOfHooks,
+    react,
     pedantic
 );
 
@@ -1592,5 +1593,5 @@ fn test() {
         r"const MyComponent3 = makeComponent(function foo () { useHook(); });",
     ];
 
-    Tester::new(RulesOfHooks::NAME, RulesOfHooks::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(RulesOfHooks::NAME, RulesOfHooks::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     /// const dom_elem = <div id="oxlint" />
     /// ```
     SelfClosingComp,
+    react,
     style,
     pending
 );
@@ -350,5 +351,5 @@ fn test() {
             Some(serde_json::json!([{ "html": true }])),
         ),
     ];
-    Tester::new(SelfClosingComp::NAME, SelfClosingComp::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(SelfClosingComp::NAME, SelfClosingComp::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -74,6 +74,7 @@ declare_oxc_lint!(
     /// React.createElement("div", { style: styles });
     /// ```
     StylePropObject,
+    react,
     suspicious
 );
 
@@ -493,5 +494,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(StylePropObject::NAME, StylePropObject::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(StylePropObject::NAME, StylePropObject::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     /// React.createElement('div', { dangerouslySetInnerHTML: { __html: 'HTML' } })
     /// ```
     VoidDomElementsNoChildren,
+    react,
     correctness
 );
 
@@ -234,6 +235,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(VoidDomElementsNoChildren::NAME, VoidDomElementsNoChildren::CATEGORY, pass, fail)
+    Tester::new(VoidDomElementsNoChildren::NAME, VoidDomElementsNoChildren::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// <Item callback={this.props.jsx} />
     /// ```
     JsxNoJsxAsProp,
+    react_perf,
     perf
 );
 
@@ -92,7 +93,7 @@ fn test() {
         r"const Foo = () => { const Icon = <svg />; return (<IconButton icon={Icon} />) }",
     ];
 
-    Tester::new(JsxNoJsxAsProp::NAME, JsxNoJsxAsProp::CATEGORY, pass, fail)
+    Tester::new(JsxNoJsxAsProp::NAME, JsxNoJsxAsProp::PLUGIN, pass, fail)
         .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// <Item list={this.props.list} />
     /// ```
     JsxNoNewArrayAsProp,
+    react_perf,
     perf
 );
 
@@ -140,7 +141,7 @@ fn test() {
         r"const Foo = ({ x = [] }) => <Item list={x} />",
     ];
 
-    Tester::new(JsxNoNewArrayAsProp::NAME, JsxNoNewArrayAsProp::CATEGORY, pass, fail)
+    Tester::new(JsxNoNewArrayAsProp::NAME, JsxNoNewArrayAsProp::PLUGIN, pass, fail)
         .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// <Item callback={this.props.callback} />
     /// ```
     JsxNoNewFunctionAsProp,
+    react_perf,
     perf
 );
 
@@ -191,7 +192,7 @@ fn test() {
         ",
     ];
 
-    Tester::new(JsxNoNewFunctionAsProp::NAME, JsxNoNewFunctionAsProp::CATEGORY, pass, fail)
+    Tester::new(JsxNoNewFunctionAsProp::NAME, JsxNoNewFunctionAsProp::PLUGIN, pass, fail)
         .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// <Item config={staticConfig} />
     /// ```
     JsxNoNewObjectAsProp,
+    react_perf,
     perf
 );
 
@@ -159,7 +160,7 @@ fn test() {
         r"const Foo = ({ x = {} }) => <Item x={x} />",
     ];
 
-    Tester::new(JsxNoNewObjectAsProp::NAME, JsxNoNewObjectAsProp::CATEGORY, pass, fail)
+    Tester::new(JsxNoNewObjectAsProp::NAME, JsxNoNewObjectAsProp::PLUGIN, pass, fail)
         .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     /// export function foo(sn: string | number): void;
     /// ```
     AdjacentOverloadSignatures,
+    typescript,
     style
 );
 
@@ -765,6 +766,6 @@ fn test() {
       }",
     ];
 
-    Tester::new(AdjacentOverloadSignatures::NAME, AdjacentOverloadSignatures::CATEGORY, pass, fail)
+    Tester::new(AdjacentOverloadSignatures::NAME, AdjacentOverloadSignatures::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// const arr: number[] = new Array<number>();
     /// ```
     ArrayType,
+    typescript,
     style,
     fix
 );
@@ -1644,7 +1645,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(ArrayType::NAME, ArrayType::CATEGORY, pass, fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
+    Tester::new(ArrayType::NAME, ArrayType::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -119,6 +119,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     BanTsComment,
+    typescript,
     pedantic,
     conditional_fix
 );
@@ -995,7 +996,7 @@ if (false) {
         ("// @ts-ignore    : TS1234 because xyz", r"// @ts-expect-error    : TS1234 because xyz"),
     ];
 
-    Tester::new(BanTsComment::NAME, BanTsComment::CATEGORY, pass, fail)
+    Tester::new(BanTsComment::NAME, BanTsComment::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -27,6 +27,7 @@ declare_oxc_lint!(
     /// someCode();
     /// ```
     BanTslintComment,
+    typescript,
     style,
     fix
 );
@@ -119,7 +120,7 @@ fn test() {
         (r"/*tslint:disable*/É", r"É", None),
     ];
 
-    Tester::new(BanTslintComment::NAME, BanTslintComment::CATEGORY, pass, fail)
+    Tester::new(BanTslintComment::NAME, BanTslintComment::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     /// let bar: Boolean = true;
     /// ```
     BanTypes,
+    typescript,
     pedantic,
     pending
 );
@@ -170,5 +171,5 @@ type Props = {
         ),
     ];
 
-    Tester::new(BanTypes::NAME, BanTypes::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(BanTypes::NAME, BanTypes::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     /// const a: Foo<string> = new Foo(); // prefer type annotation
     /// ```
     ConsistentGenericConstructors,
+    typescript,
     style,
     pending
 );
@@ -684,7 +685,7 @@ fn test() {
     ];
     Tester::new(
         ConsistentGenericConstructors::NAME,
-        ConsistentGenericConstructors::CATEGORY,
+        ConsistentGenericConstructors::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     /// type Foo = Record<string, unknown>;
     /// ```
     ConsistentIndexedObjectStyle,
+    typescript,
     style,
     conditional_fix
 );
@@ -496,7 +497,7 @@ fn test() {
 
     Tester::new(
         ConsistentIndexedObjectStyle::NAME,
-        ConsistentIndexedObjectStyle::CATEGORY,
+        ConsistentIndexedObjectStyle::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ConsistentTypeDefinitions,
+    typescript,
     style,
     fix
 );
@@ -533,7 +534,7 @@ export declare type Test = {
         ),
     ];
 
-    Tester::new(ConsistentTypeDefinitions::NAME, ConsistentTypeDefinitions::CATEGORY, pass, fail)
+    Tester::new(ConsistentTypeDefinitions::NAME, ConsistentTypeDefinitions::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -102,6 +102,7 @@ declare_oxc_lint!(
     /// type S = import("Foo");
     /// ```
     ConsistentTypeImports,
+    typescript,
     nursery,
     conditional_fix
 );
@@ -3371,7 +3372,7 @@ export class Foo extends Bar {}
         .map(|(a, b, c)| (remove_common_prefix_space(a), remove_common_prefix_space(b), c))
         .collect::<Vec<_>>();
 
-    Tester::new(ConsistentTypeImports::NAME, ConsistentTypeImports::CATEGORY, pass, fail)
+    Tester::new(ConsistentTypeImports::NAME, ConsistentTypeImports::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -105,6 +105,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     ExplicitFunctionReturnType,
+    typescript,
     restriction,
 );
 
@@ -2182,6 +2183,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(ExplicitFunctionReturnType::NAME, ExplicitFunctionReturnType::CATEGORY, pass, fail)
+    Tester::new(ExplicitFunctionReturnType::NAME, ExplicitFunctionReturnType::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     ///    a! === b; // a non-null assertions(`!`) and an triple equals test(`===`)
     /// ```
     NoConfusingNonNullAssertion,
+    typescript,
     suspicious,
     pending
 );
@@ -158,11 +159,6 @@ fn test() {
     //     // ("f = 1 + d! == 2", "f = (1 + d!) == 2", None), TODO: Add suggest or the weird ;() fix
     //     // ("f =  d! == 2", "f = d == 2", None), TODO: Add suggest remove bang
     // ];
-    Tester::new(
-        NoConfusingNonNullAssertion::NAME,
-        NoConfusingNonNullAssertion::CATEGORY,
-        pass,
-        fail,
-    )
-    .test_and_snapshot();
+    Tester::new(NoConfusingNonNullAssertion::NAME, NoConfusingNonNullAssertion::PLUGIN, pass, fail)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -82,6 +82,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDuplicateEnumValues,
+    typescript,
     correctness
 );
 
@@ -269,6 +270,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoDuplicateEnumValues::NAME, NoDuplicateEnumValues::CATEGORY, pass, fail)
+    Tester::new(NoDuplicateEnumValues::NAME, NoDuplicateEnumValues::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -24,6 +24,7 @@ declare_oxc_lint!(
     /// delete container['aa' + 'b'];
     /// ```
     NoDynamicDelete,
+    typescript,
     restriction,
 );
 
@@ -156,5 +157,5 @@ fn test() {
         	      ",
     ];
 
-    Tester::new(NoDynamicDelete::NAME, NoDynamicDelete::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDynamicDelete::NAME, NoDynamicDelete::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// interface Bar extends Foo {}
     /// ```
     NoEmptyInterface,
+    typescript,
     style
 );
 
@@ -214,5 +215,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoEmptyInterface::NAME, NoEmptyInterface::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoEmptyInterface::NAME, NoEmptyInterface::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -84,6 +84,7 @@ declare_oxc_lint!(
     /// type TypeWith = { property: boolean };
     /// ```
     NoEmptyObjectType,
+    typescript,
     restriction,
 );
 
@@ -455,6 +456,5 @@ fn test() {
         ("interface Base {}", Some(serde_json::json!([{ "allowWithName": "Props" }])), None, None),
     ];
 
-    Tester::new(NoEmptyObjectType::NAME, NoEmptyObjectType::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoEmptyObjectType::NAME, NoEmptyObjectType::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -86,6 +86,7 @@ declare_oxc_lint!(
     /// Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type.
     /// `false` by default.
     NoExplicitAny,
+    typescript,
     restriction,
     conditional_fix
 );
@@ -147,9 +148,7 @@ mod tests {
             ("let x: any = 1", "let x: unknown = 1", Some(json!([{ "fixToUnknown": true }]))),
             ("let x: any = 1", "let x: any = 1", None),
         ];
-        Tester::new(NoExplicitAny::NAME, NoExplicitAny::CATEGORY, pass, fail)
-            .expect_fix(fix)
-            .test();
+        Tester::new(NoExplicitAny::NAME, NoExplicitAny::PLUGIN, pass, fail).expect_fix(fix).test();
     }
 
     #[test]
@@ -654,7 +653,7 @@ mod tests {
             // NOTE: no current way to check that fixes don't occur when `ignoreRestArgs` is
             // `true`, since no fix technically occurs and `expect_fix()` panics without a fix.
         ];
-        Tester::new(NoExplicitAny::NAME, NoExplicitAny::CATEGORY, pass, fail)
+        Tester::new(NoExplicitAny::NAME, NoExplicitAny::PLUGIN, pass, fail)
             .expect_fix(fixes)
             .test_and_snapshot();
     }

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -30,6 +30,7 @@ declare_oxc_lint!(
     /// const bar = foo!!!.bar;
     /// ```
     NoExtraNonNullAssertion,
+    typescript,
     correctness
 );
 
@@ -95,6 +96,6 @@ fn test() {
         "function foo(bar?: { n: number }) { return (bar!)?.(); }",
     ];
 
-    Tester::new(NoExtraNonNullAssertion::NAME, NoExtraNonNullAssertion::CATEGORY, pass, fail)
+    Tester::new(NoExtraNonNullAssertion::NAME, NoExtraNonNullAssertion::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     ///   abstract class Foo {}
     /// ```
     NoExtraneousClass,
+    typescript,
     suspicious
 );
 
@@ -331,6 +332,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoExtraneousClass::NAME, NoExtraneousClass::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoExtraneousClass::NAME, NoExtraneousClass::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// import { type A as AA, type B as BB } from 'mod';
     /// ```
     NoImportTypeSideEffects,
+    typescript,
     restriction,
     fix
 );
@@ -163,7 +164,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(NoImportTypeSideEffects::NAME, NoImportTypeSideEffects::CATEGORY, pass, fail)
+    Tester::new(NoImportTypeSideEffects::NAME, NoImportTypeSideEffects::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// const fn = (a = 5, b = true, c = 'foo') => {};
     /// ```
     NoInferrableTypes,
+    typescript,
     style,
     pending
 );
@@ -512,7 +513,7 @@ fn test() {
             Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
     ];
-    Tester::new(NoInferrableTypes::NAME, NoInferrableTypes::CATEGORY, pass, fail)
+    Tester::new(NoInferrableTypes::NAME, NoInferrableTypes::PLUGIN, pass, fail)
         //.expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoMisusedNew,
+    typescript,
     correctness
 );
 
@@ -148,5 +149,5 @@ fn test() {
         "interface I { constructor(): '';}",
     ];
 
-    Tester::new(NoMisusedNew::NAME, NoMisusedNew::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoMisusedNew::NAME, NoMisusedNew::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// declare namespace foo {}
     /// ```
     NoNamespace,
+    typescript,
     restriction
 );
 
@@ -357,5 +358,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoNamespace::NAME, NoNamespace::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNamespace::NAME, NoNamespace::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// x! ?? '';
     /// ```
     NoNonNullAssertedNullishCoalescing,
+    typescript,
     restriction,
 );
 
@@ -184,7 +185,7 @@ fn test() {
 
     Tester::new(
         NoNonNullAssertedNullishCoalescing::NAME,
-        NoNonNullAssertedNullishCoalescing::CATEGORY,
+        NoNonNullAssertedNullishCoalescing::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// foo?.bar()!;
     /// ```
     NoNonNullAssertedOptionalChain,
+    typescript,
     correctness
 );
 
@@ -143,7 +144,7 @@ fn test() {
 
     Tester::new(
         NoNonNullAssertedOptionalChain::NAME,
-        NoNonNullAssertedOptionalChain::CATEGORY,
+        NoNonNullAssertedOptionalChain::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -26,6 +26,7 @@ declare_oxc_lint!(
     /// x.y!;
     /// ```
     NoNonNullAssertion,
+    typescript,
     restriction,
 );
 
@@ -91,6 +92,6 @@ fn test() {
         	      ",
     ];
 
-    Tester::new(NoNonNullAssertion::NAME, NoNonNullAssertion::CATEGORY, pass, fail)
+    Tester::new(NoNonNullAssertion::NAME, NoNonNullAssertion::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -114,6 +114,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoRequireImports,
+    typescript,
     restriction,
     pending  // TODO: fixer (change require to import)
 );
@@ -399,7 +400,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoRequireImports::NAME, NoRequireImports::CATEGORY, pass, fail)
+    Tester::new(NoRequireImports::NAME, NoRequireImports::PLUGIN, pass, fail)
         .change_rule_path_extension("ts")
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -73,6 +73,7 @@ declare_oxc_lint!(
     /// sampe with `obj.<allowedName> = this`
     /// ```
     NoThisAlias,
+    typescript,
     correctness
 );
 
@@ -236,5 +237,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoThisAlias::NAME, NoThisAlias::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoThisAlias::NAME, NoThisAlias::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// function QuuzAny<T extends any>() {}
     /// ```
     NoUnnecessaryTypeConstraint,
+    typescript,
     suspicious
 );
 
@@ -119,11 +120,6 @@ fn test() {
         "type Data<T extends unknown> = {};",
     ];
 
-    Tester::new(
-        NoUnnecessaryTypeConstraint::NAME,
-        NoUnnecessaryTypeConstraint::CATEGORY,
-        pass,
-        fail,
-    )
-    .test_and_snapshot();
+    Tester::new(NoUnnecessaryTypeConstraint::NAME, NoUnnecessaryTypeConstraint::PLUGIN, pass, fail)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// class Foo {}
     /// ```
     NoUnsafeDeclarationMerging,
+    typescript,
     correctness
 );
 
@@ -186,6 +187,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUnsafeDeclarationMerging::NAME, NoUnsafeDeclarationMerging::CATEGORY, pass, fail)
+    Tester::new(NoUnsafeDeclarationMerging::NAME, NoUnsafeDeclarationMerging::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// identity = value => value;
     /// ```
     NoUnsafeFunctionType,
+    typescript,
     pedantic,
 );
 
@@ -121,6 +122,6 @@ fn test() {
 			      ",
     ];
 
-    Tester::new(NoUnsafeFunctionType::NAME, NoUnsafeFunctionType::CATEGORY, pass, fail)
+    Tester::new(NoUnsafeFunctionType::NAME, NoUnsafeFunctionType::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// export const value = 'Hello, world!';
     /// ```
     NoUselessEmptyExport,
+    typescript,
     correctness,
     fix
 );
@@ -140,7 +141,7 @@ fn test() {
         // ("import _ = require('_');export {};", "import _ = require('_');"),
     ];
 
-    Tester::new(NoUselessEmptyExport::NAME, NoUselessEmptyExport::CATEGORY, pass, fail)
+    Tester::new(NoUselessEmptyExport::NAME, NoUselessEmptyExport::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// let foo = require('foo');
     /// ```
     NoVarRequires,
+    typescript,
     restriction
 );
 
@@ -117,5 +118,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoVarRequires::NAME, NoVarRequires::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoVarRequires::NAME, NoVarRequires::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// let myObject: object = "Type 'string' is not assignable to type 'object'.";
     /// ```
     NoWrapperObjectTypes,
+    typescript,
     correctness,
     fix
 );
@@ -197,7 +198,7 @@ fn test() {
         ("type MyType = Number & String;", "type MyType = number & string;", None),
     ];
 
-    Tester::new(NoWrapperObjectTypes::NAME, NoWrapperObjectTypes::CATEGORY, pass, fail)
+    Tester::new(NoWrapperObjectTypes::NAME, NoWrapperObjectTypes::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// let foo = { bar: 'baz' as 'baz' };
     /// ```
     PreferAsConst,
+    typescript,
     correctness,
     conditional_fix
 );
@@ -198,7 +199,7 @@ fn test() {
         // ("class foo { foo = <'bar'>'bar'; }", "class foo { foo = <const>'bar'; }", None),
     ];
 
-    Tester::new(PreferAsConst::NAME, PreferAsConst::CATEGORY, pass, fail)
+    Tester::new(PreferAsConst::NAME, PreferAsConst::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferEnumInitializers,
+    typescript,
     pedantic,
     pending
 );
@@ -121,6 +122,6 @@ fn test() {
 			      ",
     ];
 
-    Tester::new(PreferEnumInitializers::NAME, PreferEnumInitializers::CATEGORY, pass, fail)
+    Tester::new(PreferEnumInitializers::NAME, PreferEnumInitializers::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferForOf,
+    typescript,
     style,
     pending
 );
@@ -306,5 +307,5 @@ fn test() {
         "function* gen() { for (let i = 0; i < this.array.length; ++i) { yield this.array[i]; } }",
     ];
 
-    Tester::new(PreferForOf::NAME, PreferForOf::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferForOf::NAME, PreferForOf::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -81,6 +81,7 @@ declare_oxc_lint!(
     /// type Intersection = ((data: string) => number) & ((id: number) => string);
     /// ```
     PreferFunctionType,
+    typescript,
     style,
     conditional_fix
 );
@@ -730,7 +731,7 @@ type X = {} & (() => void);
         ),
     ];
 
-    Tester::new(PreferFunctionType::NAME, PreferFunctionType::CATEGORY, pass, fail)
+    Tester::new(PreferFunctionType::NAME, PreferFunctionType::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferLiteralEnumMember,
+    typescript,
     restriction
 );
 
@@ -356,6 +357,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferLiteralEnumMember::NAME, PreferLiteralEnumMember::CATEGORY, pass, fail)
+    Tester::new(PreferLiteralEnumMember::NAME, PreferLiteralEnumMember::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// module Example {}
     /// ```
     PreferNamespaceKeyword,
+    typescript,
     style,
     fix
 );
@@ -130,7 +131,7 @@ fn test() {
         ("module foo.'a'", "namespace foo.'a'", None),
     ];
 
-    Tester::new(PreferNamespaceKeyword::NAME, PreferNamespaceKeyword::CATEGORY, pass, fail)
+    Tester::new(PreferNamespaceKeyword::NAME, PreferNamespaceKeyword::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// const multiLine: number = 'value';
     /// ```
     PreferTsExpectError,
+    typescript,
     pedantic,
     fix
 );
@@ -215,7 +216,7 @@ console.log('hello');
         ),
     ];
 
-    Tester::new(PreferTsExpectError::NAME, PreferTsExpectError::CATEGORY, pass, fail)
+    Tester::new(PreferTsExpectError::NAME, PreferTsExpectError::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     /// globalThis.value;
     /// ```
     TripleSlashReference,
+    typescript,
     correctness
 );
 
@@ -322,6 +323,6 @@ fn test() {
         (r#"/// <reference lib="foo" />"#, Some(serde_json::json!([{ "lib": "never" }]))),
     ];
 
-    Tester::new(TripleSlashReference::NAME, TripleSlashReference::CATEGORY, pass, fail)
+    Tester::new(TripleSlashReference::NAME, TripleSlashReference::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// try { } catch (error) { }
     /// ```
     CatchErrorName,
+    unicorn,
     style,
     pending
 );
@@ -281,5 +282,5 @@ fn test() {
         ("promise.then(undefined, (foo) => { })", None),
     ];
 
-    Tester::new(CatchErrorName::NAME, CatchErrorName::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(CatchErrorName::NAME, CatchErrorName::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/consistent_empty_array_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_empty_array_spread.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// ];
     /// ```
     ConsistentEmptyArraySpread,
+    unicorn,
     pedantic,
     suggestion
 );
@@ -156,7 +157,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(ConsistentEmptyArraySpread::NAME, ConsistentEmptyArraySpread::CATEGORY, pass, fail)
+    Tester::new(ConsistentEmptyArraySpread::NAME, ConsistentEmptyArraySpread::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     /// if (index !== -1) {}
     /// ```
     ConsistentExistenceIndexCheck,
+    unicorn,
     style,
     fix,
 );
@@ -667,7 +668,7 @@ fn test() {
 
     Tester::new(
         ConsistentExistenceIndexCheck::NAME,
-        ConsistentExistenceIndexCheck::CATEGORY,
+        ConsistentExistenceIndexCheck::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -139,6 +139,7 @@ declare_oxc_lint!(
     /// })();
     /// ```
     ConsistentFunctionScoping,
+    unicorn,
     suspicious,
     pending
 );
@@ -842,6 +843,6 @@ fn test() {
         ("function outer() { const inner = function inner() {}; }", None),
     ];
 
-    Tester::new(ConsistentFunctionScoping::NAME, ConsistentFunctionScoping::CATEGORY, pass, fail)
+    Tester::new(ConsistentFunctionScoping::NAME, ConsistentFunctionScoping::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     EmptyBraceSpaces,
+    unicorn,
     style,
     fix
 );
@@ -341,7 +342,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(EmptyBraceSpaces::NAME, EmptyBraceSpaces::CATEGORY, pass, fail)
+    Tester::new(EmptyBraceSpaces::NAME, EmptyBraceSpaces::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// throw new TypeError('Number expected')
     /// ```
     ErrorMessage,
+    unicorn,
     style
 );
 
@@ -172,5 +173,5 @@ fn test() {
         ("const error = new AggregateError;", None),
     ];
 
-    Tester::new(ErrorMessage::NAME, ErrorMessage::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(ErrorMessage::NAME, ErrorMessage::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// const foo = '\cA';
     /// ```
     EscapeCase,
+    unicorn,
     pedantic,
     fix
 );
@@ -283,7 +284,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(EscapeCase::NAME, EscapeCase::CATEGORY, pass, fail)
+    Tester::new(EscapeCase::NAME, EscapeCase::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     /// const isEmpty = foo.length === 0;
     /// ```
     ExplicitLengthCheck,
+    unicorn,
     pedantic,
     conditional_fix
 );
@@ -414,7 +415,7 @@ fn test() {
         ("for(const a of!foo.length);", "for(const a of foo.length === 0);", None),
         ("for(const a in!foo.length);", "for(const a in foo.length === 0);", None),
     ];
-    Tester::new(ExplicitLengthCheck::NAME, ExplicitLengthCheck::CATEGORY, pass, fail)
+    Tester::new(ExplicitLengthCheck::NAME, ExplicitLengthCheck::PLUGIN, pass, fail)
         .expect_fix(fixes)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -99,6 +99,7 @@ declare_oxc_lint!(
     /// - `SomeFileName.Test.js`
     /// - `SomeFileName.TestUtils.js`
     FilenameCase,
+    unicorn,
     style
 );
 
@@ -310,5 +311,5 @@ fn test() {
         test_cases("src/foo/{foo_bar}.js", ["camelCase", "pascalCase", "kebabCase"]),
     ];
 
-    Tester::new(FilenameCase::NAME, FilenameCase::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(FilenameCase::NAME, FilenameCase::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// const bar = new Array(1, 2, 3);
     /// ```
     NewForBuiltins,
+    unicorn,
     pedantic
 );
 
@@ -287,5 +288,5 @@ fn test() {
         ",
     ];
 
-    Tester::new(NewForBuiltins::NAME, NewForBuiltins::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NewForBuiltins::NAME, NewForBuiltins::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// console.log(message);
     /// ```
     NoAbusiveEslintDisable,
+    unicorn,
     restriction
 );
 
@@ -142,6 +143,6 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoAbusiveEslintDisable::NAME, NoAbusiveEslintDisable::CATEGORY, pass, fail)
+    Tester::new(NoAbusiveEslintDisable::NAME, NoAbusiveEslintDisable::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// module.exports = foo;
     /// ```
     NoAnonymousDefaultExport,
+    unicorn,
     restriction,
 );
 
@@ -170,6 +171,6 @@ fn test() {
         "export default (class extends class {} {})",
     ];
 
-    Tester::new(NoAnonymousDefaultExport::NAME, NoAnonymousDefaultExport::CATEGORY, pass, fail)
+    Tester::new(NoAnonymousDefaultExport::NAME, NoAnonymousDefaultExport::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// for (const element of foo) { /* ... */ }
     /// ```
     NoArrayForEach,
+    unicorn,
     restriction,
     pending
 );
@@ -128,5 +129,5 @@ fn test() {
         r"return foo.forEach(element => {bar(element)});",
     ];
 
-    Tester::new(NoArrayForEach::NAME, NoArrayForEach::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoArrayForEach::NAME, NoArrayForEach::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// array.reduceRight(reducer, initialValue);
     /// ```
     NoArrayReduce,
+    unicorn,
     restriction
 );
 
@@ -476,5 +477,5 @@ fn test() {
             Some(json!({ "allowSimpleOperations": false})),
         ),
     ];
-    Tester::new(NoArrayReduce::NAME, NoArrayReduce::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoArrayReduce::NAME, NoArrayReduce::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAwaitExpressionMember,
+    unicorn,
     style,
     pending
 );
@@ -103,6 +104,6 @@ fn test() {
         (r"const foo: Type | A = (await promise).foo", None),
     ];
 
-    Tester::new(NoAwaitExpressionMember::NAME, NoAwaitExpressionMember::CATEGORY, pass, fail)
+    Tester::new(NoAwaitExpressionMember::NAME, NoAwaitExpressionMember::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoAwaitInPromiseMethods,
+    unicorn,
     correctness
 );
 
@@ -132,6 +133,6 @@ fn test() {
         "Promise.all([await /* comment*/ promise])",
     ];
 
-    Tester::new(NoAwaitInPromiseMethods::NAME, NoAwaitInPromiseMethods::CATEGORY, pass, fail)
+    Tester::new(NoAwaitInPromiseMethods::NAME, NoAwaitInPromiseMethods::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// console.log("abc", "def");
     /// ```
     NoConsoleSpaces,
+    unicorn,
     style,
     fix
 );
@@ -252,7 +253,7 @@ fn test() {
         ("console.error(foo, ` bar`)", "console.error(foo, `bar`)", None),
     ];
 
-    Tester::new(NoConsoleSpaces::NAME, NoConsoleSpaces::CATEGORY, pass, fail)
+    Tester::new(NoConsoleSpaces::NAME, NoConsoleSpaces::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoDocumentCookie,
+    unicorn,
     correctness
 );
 
@@ -161,5 +162,5 @@ fn test() {
         r#"window.document.cookie = "foo=bar""#,
     ];
 
-    Tester::new(NoDocumentCookie::NAME, NoDocumentCookie::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoDocumentCookie::NAME, NoDocumentCookie::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// Meaningless files clutter a codebase.
     ///
     NoEmptyFile,
+    unicorn,
     correctness,
 );
 
@@ -139,5 +140,5 @@ fn test() {
         r#""use strict";"#,
     ];
 
-    Tester::new(NoEmptyFile::NAME, NoEmptyFile::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoEmptyFile::NAME, NoEmptyFile::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// const foo = `\u001B${bar}`;
     /// ```
     NoHexEscape,
+    unicorn,
     pedantic,
     fix
 );
@@ -212,7 +213,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoHexEscape::NAME, NoHexEscape::CATEGORY, pass, fail)
+    Tester::new(NoHexEscape::NAME, NoHexEscape::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -28,6 +28,7 @@ declare_oxc_lint!(
     /// [1,2,3] instanceof Array;
     /// ```
     NoInstanceofArray,
+    unicorn,
     pedantic,
     fix
 );
@@ -101,7 +102,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoInstanceofArray::NAME, NoInstanceofArray::CATEGORY, pass, fail)
+    Tester::new(NoInstanceofArray::NAME, NoInstanceofArray::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// el.removeEventListener('click', handler.bind(this));
     /// ```
     NoInvalidRemoveEventListener,
+    unicorn,
     correctness
 );
 
@@ -207,7 +208,7 @@ fn test() {
 
     Tester::new(
         NoInvalidRemoveEventListener::NAME,
-        NoInvalidRemoveEventListener::CATEGORY,
+        NoInvalidRemoveEventListener::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// foo.slice(1)
     /// ```
     NoLengthAsSliceEnd,
+    unicorn,
     restriction,
     fix
 );
@@ -136,7 +137,7 @@ fn test() {
         ("foo?.slice(1, foo?.length)", "foo?.slice(1)"),
     ];
 
-    Tester::new(NoLengthAsSliceEnd::NAME, NoLengthAsSliceEnd::CATEGORY, pass, fail)
+    Tester::new(NoLengthAsSliceEnd::NAME, NoLengthAsSliceEnd::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// if (foo && bar) baz();
     /// ```
     NoLonelyIf,
+    unicorn,
     pedantic
 );
 
@@ -211,5 +212,5 @@ fn test() {
     ",
     ];
 
-    Tester::new(NoLonelyIf::NAME, NoLonelyIf::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoLonelyIf::NAME, NoLonelyIf::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// array.flat(Infinity);
     /// ```
     NoMagicArrayFlatDepth,
+    unicorn,
     restriction,
 );
 
@@ -130,6 +131,6 @@ fn test() {
 
     let fail = vec!["array.flat(2)", "array?.flat(2)", "array.flat(99,)", "array.flat(0b10,)"];
 
-    Tester::new(NoMagicArrayFlatDepth::NAME, NoMagicArrayFlatDepth::CATEGORY, pass, fail)
+    Tester::new(NoMagicArrayFlatDepth::NAME, NoMagicArrayFlatDepth::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// if (!(foo === bar)) {}
     /// ```
     NoNegationInEqualityCheck,
+    unicorn,
     pedantic,
     pending
 );
@@ -135,6 +136,6 @@ fn test() {
 					",
     ];
 
-    Tester::new(NoNegationInEqualityCheck::NAME, NoNegationInEqualityCheck::CATEGORY, pass, fail)
+    Tester::new(NoNegationInEqualityCheck::NAME, NoNegationInEqualityCheck::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     /// const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);
     /// ```
     NoNestedTernary,
+    unicorn,
     restriction,
     conditional_fix
 );
@@ -176,7 +177,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoNestedTernary::NAME, NoNestedTernary::CATEGORY, pass, fail)
+    Tester::new(NoNestedTernary::NAME, NoNestedTernary::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// const array = [42];
     /// ```
     NoNewArray,
+    unicorn,
     correctness,
     pending
 );
@@ -134,5 +135,5 @@ fn test() {
         r"const array = new Array(length)",
     ];
 
-    Tester::new(NoNewArray::NAME, NoNewArray::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNewArray::NAME, NoNewArray::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// const buffer = Buffer.alloc(10);
     /// ```
     NoNewBuffer,
+    unicorn,
     pedantic,
     pending
 );
@@ -85,5 +86,5 @@ fn test() {
         r"new Buffer(input, encoding);",
     ];
 
-    Tester::new(NoNewBuffer::NAME, NoNewBuffer::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoNewBuffer::NAME, NoNewBuffer::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// let foo
     /// ```
     NoNull,
+    unicorn,
     style,
     conditional_fix
 );
@@ -411,5 +412,5 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(NoNull::NAME, NoNull::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(NoNull::NAME, NoNull::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// function foo({a = false} = {}) {}
     /// ```
     NoObjectAsDefaultParameter,
+    unicorn,
     pedantic
 );
 
@@ -132,6 +133,6 @@ fn test() {
         r"function abc([a] = {a: 123}) {}",
     ];
 
-    Tester::new(NoObjectAsDefaultParameter::NAME, NoObjectAsDefaultParameter::CATEGORY, pass, fail)
+    Tester::new(NoObjectAsDefaultParameter::NAME, NoObjectAsDefaultParameter::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// if (problem) process.exit(1);
     /// ```
     NoProcessExit,
+    unicorn,
     restriction,
     pending // TODO: suggestion
 );
@@ -186,5 +187,5 @@ fn test() {
         (r#"lib.process.once("SIGINT", function() { process.exit(1); })"#),
     ];
 
-    Tester::new(NoProcessExit::NAME, NoProcessExit::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoProcessExit::NAME, NoProcessExit::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// ```
     ///
     NoSinglePromiseInPromiseMethods,
+    unicorn,
     correctness,
     conditional_fix
 );
@@ -265,7 +266,7 @@ fn test() {
 
     Tester::new(
         NoSinglePromiseInPromiseMethods::NAME,
-        NoSinglePromiseInPromiseMethods::CATEGORY,
+        NoSinglePromiseInPromiseMethods::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoStaticOnlyClass,
+    unicorn,
     pedantic,
     pending
 );
@@ -151,6 +152,5 @@ fn test() {
         r"class A { static a() {} }",
     ];
 
-    Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoStaticOnlyClass::NAME, NoStaticOnlyClass::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoThenable,
+    unicorn,
     correctness
 );
 
@@ -432,5 +433,5 @@ fn test() {
         ("export const notThen = 1, then = 1", None),
     ];
 
-    Tester::new(NoThenable::NAME, NoThenable::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoThenable::NAME, NoThenable::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// new Bar(this).method();
     /// ```
     NoThisAssignment,
+    unicorn,
     pedantic
 );
 
@@ -134,5 +135,5 @@ fn test() {
         r"var foo = (bar), baz = (this);",
     ];
 
-    Tester::new(NoThisAssignment::NAME, NoThisAssignment::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoThisAssignment::NAME, NoThisAssignment::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// foo === undefined;
     /// ```
     NoTypeofUndefined,
+    unicorn,
     pedantic,
     pending
 );
@@ -142,6 +143,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoTypeofUndefined::NAME, NoTypeofUndefined::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(NoTypeofUndefined::NAME, NoTypeofUndefined::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUnnecessaryAwait,
+    unicorn,
     correctness,
     conditional_fix
 );
@@ -166,7 +167,7 @@ fn test() {
         ("-await -1", "-await -1", None),                     // no autofix
     ];
 
-    Tester::new(NoUnnecessaryAwait::NAME, NoUnnecessaryAwait::CATEGORY, pass, fail)
+    Tester::new(NoUnnecessaryAwait::NAME, NoUnnecessaryAwait::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// const [foo] = parts;
     /// ```
     NoUnreadableArrayDestructuring,
+    unicorn,
     style
 );
 
@@ -140,7 +141,7 @@ fn test() {
 
     Tester::new(
         NoUnreadableArrayDestructuring::NAME,
-        NoUnreadableArrayDestructuring::CATEGORY,
+        NoUnreadableArrayDestructuring::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// })(getBar());
     /// ```
     NoUnreadableIife,
+    unicorn,
     pedantic
 );
 
@@ -126,5 +127,5 @@ fn test() {
         "(async () => (( {bar} )))();",
     ];
 
-    Tester::new(NoUnreadableIife::NAME, NoUnreadableIife::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(NoUnreadableIife::NAME, NoUnreadableIife::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// const object = { ...(foo || { not: "empty" }) }
     /// ```
     NoUselessFallbackInSpread,
+    unicorn,
     correctness,
     conditional_fix
 );
@@ -168,7 +169,7 @@ fn test() {
         (r"const object = {...(Infinity || {})}", r"const object = {...(Infinity || {})}"),
     ];
 
-    Tester::new(NoUselessFallbackInSpread::NAME, NoUselessFallbackInSpread::CATEGORY, pass, fail)
+    Tester::new(NoUselessFallbackInSpread::NAME, NoUselessFallbackInSpread::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUselessLengthCheck,
+    unicorn,
     correctness,
     pending
 );
@@ -286,6 +287,6 @@ fn test() {
         "array.length === 0 || array.every(Boolean) || array.length === 0",
     ];
 
-    Tester::new(NoUselessLengthCheck::NAME, NoUselessLengthCheck::CATEGORY, pass, fail)
+    Tester::new(NoUselessLengthCheck::NAME, NoUselessLengthCheck::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// async () => bar;
     /// ```
     NoUselessPromiseResolveReject,
+    unicorn,
     pedantic,
     fix
 );
@@ -1370,7 +1371,7 @@ fn test() {
 
     Tester::new(
         NoUselessPromiseResolveReject::NAME,
-        NoUselessPromiseResolveReject::CATEGORY,
+        NoUselessPromiseResolveReject::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -142,6 +142,7 @@ declare_oxc_lint!(
     ///
     /// ```
     NoUselessSpread,
+    unicorn,
     correctness,
     fix_dangerous
 );
@@ -754,7 +755,7 @@ fn test() {
         ("[...arr.reduce((a, b) => a.push(b), [])]", "arr.reduce((a, b) => a.push(b), [])"),
         ("[...arr.reduce((a, b) => a.push(b), [])]", "arr.reduce((a, b) => a.push(b), [])"),
     ];
-    Tester::new(NoUselessSpread::NAME, NoUselessSpread::CATEGORY, pass, fail)
+    Tester::new(NoUselessSpread::NAME, NoUselessSpread::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoUselessSwitchCase,
+    unicorn,
     pedantic,
     pending
 );
@@ -262,6 +263,6 @@ fn test() {
         ",
     ];
 
-    Tester::new(NoUselessSwitchCase::NAME, NoUselessSwitchCase::CATEGORY, pass, fail)
+    Tester::new(NoUselessSwitchCase::NAME, NoUselessSwitchCase::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// let foo;
     /// ```
     NoUselessUndefined,
+    unicorn,
     pedantic,
     fix
 );
@@ -687,7 +688,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoUselessUndefined::NAME, NoUselessUndefined::CATEGORY, pass, fail)
+    Tester::new(NoUselessUndefined::NAME, NoUselessUndefined::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// const foo = 1.1;
     /// ```
     NoZeroFractions,
+    unicorn,
     style,
     fix
 );
@@ -214,7 +215,7 @@ fn test() {
         ("ôTest(0.)", "ôTest(0)"),
     ];
 
-    Tester::new(NoZeroFractions::NAME, NoZeroFractions::CATEGORY, pass, fail)
+    Tester::new(NoZeroFractions::NAME, NoZeroFractions::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -73,6 +73,7 @@ declare_oxc_lint!(
     /// const foo = 2e+5;
     /// ```
     NumberLiteralCase,
+    unicorn,
     style,
     fix
 );
@@ -242,7 +243,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(NumberLiteralCase::NAME, NumberLiteralCase::CATEGORY, pass, fail)
+    Tester::new(NumberLiteralCase::NAME, NumberLiteralCase::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     /// ];
     /// ```
     NumericSeparatorsStyle,
+    unicorn,
     style,
     fix
 );
@@ -426,7 +427,7 @@ fn test_with_snapshot() {
 
     let fix = vec![("const foo = 0b10_10_0001", "const foo = 0b1010_0001")];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, vec![], fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, vec![], fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }
@@ -457,7 +458,7 @@ fn test_number_binary() {
         ("const foo = 0B10101010101010", "const foo = 0B10_1010_1010_1010", None),
     ];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -485,7 +486,7 @@ fn test_number_hexadecimal() {
 
     let fix = vec![("const foo = 0xA_B_CDE_F0", "const foo = 0xA_BC_DE_F0", None)];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -514,7 +515,7 @@ fn test_number_octal() {
 
     let fix = vec![("const foo = 0o12_34_5670", "const foo = 0o1234_5670", None)];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -545,7 +546,7 @@ fn test_bigint_binary() {
         ("const foo = 0B10101010101010n", "const foo = 0B10_1010_1010_1010n", None),
     ];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -572,7 +573,7 @@ fn test_bigint() {
 
     let fix = vec![("const foo = 1_9_223n", "const foo = 19_223n", None)];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -616,7 +617,7 @@ fn test_number_decimal_exponential() {
         ("const foo = 3.65432E12000", "const foo = 3.654_32E12_000", None),
     ];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -645,7 +646,7 @@ fn test_number_decimal_float() {
 
     let fix = vec![("const foo = 9807.1234567", "const foo = 9807.123_456_7", None)];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -683,7 +684,7 @@ fn test_number_decimal_integer() {
         ("const foo = -100000_1", "const foo = -1_000_001", None),
     ];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }
@@ -717,7 +718,7 @@ fn test_with_config() {
 
     let fail = vec![];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
         .test();
 }
@@ -737,7 +738,7 @@ fn test_misc() {
     let fail = vec!["1_23_4444"];
     let fix = vec![("1_23_4444", "1_234_444")];
 
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::CATEGORY, pass, fail)
+    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -36,6 +36,7 @@ declare_oxc_lint!(
     /// foo.addEventListener('click', () => {});
     /// ```
     PreferAddEventListener,
+    unicorn,
     suspicious,
     pending
 );
@@ -353,6 +354,6 @@ fn test() {
         (r"(el as HTMLElement).onmouseenter = onAnchorMouseEnter;", None),
     ];
 
-    Tester::new(PreferAddEventListener::NAME, PreferAddEventListener::CATEGORY, pass, fail)
+    Tester::new(PreferAddEventListener::NAME, PreferAddEventListener::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     /// const foo = [maybeArray].flat();
     /// ```
     PreferArrayFlat,
+    unicorn,
     pedantic,
     conditional_fix
 );
@@ -457,7 +458,7 @@ fn test() {
         ("array.reduce((a, b) => [...a, ...b], [])", "array.flat()"),
     ];
 
-    Tester::new(PreferArrayFlat::NAME, PreferArrayFlat::CATEGORY, pass, fail)
+    Tester::new(PreferArrayFlat::NAME, PreferArrayFlat::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// const bar = [1,2,3].flatMap(i => [i]); // ✓ pass
     /// ```
     PreferArrayFlatMap,
+    unicorn,
     style,
     fix
 );
@@ -186,7 +187,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferArrayFlatMap::NAME, PreferArrayFlatMap::CATEGORY, pass, fail)
+    Tester::new(PreferArrayFlatMap::NAME, PreferArrayFlatMap::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     /// !array.some(fn);
     /// ```
     PreferArraySome,
+    unicorn,
     pedantic,
     fix
 );
@@ -464,7 +465,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferArraySome::NAME, PreferArraySome::CATEGORY, pass, fail)
+    Tester::new(PreferArraySome::NAME, PreferArraySome::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferBlobReadingMethods,
+    unicorn,
     pedantic,
     pending
 );
@@ -96,6 +97,6 @@ fn test() {
 
     let fail = vec![r"fileReader.readAsArrayBuffer(blob)", r"fileReader.readAsText(blob)"];
 
-    Tester::new(PreferBlobReadingMethods::NAME, PreferBlobReadingMethods::CATEGORY, pass, fail)
+    Tester::new(PreferBlobReadingMethods::NAME, PreferBlobReadingMethods::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// String.fromCodePoint(0x1f984);
     /// ```
     PreferCodePoint,
+    unicorn,
     pedantic,
     fix
 );
@@ -115,7 +116,7 @@ fn test() {
         (r"String.fromCharCode(0x1f984);", r"String.fromCodePoint(0x1f984);"),
     ];
 
-    Tester::new(PreferCodePoint::NAME, PreferCodePoint::CATEGORY, pass, fail)
+    Tester::new(PreferCodePoint::NAME, PreferCodePoint::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// const ts = Date.now();
     /// ```
     PreferDateNow,
+    unicorn,
     pedantic,
     fix
 );
@@ -238,7 +239,7 @@ fn test() {
         ("BigInt(new Date());", "Date.now();"),
     ];
 
-    Tester::new(PreferDateNow::NAME, PreferDateNow::CATEGORY, pass, fail)
+    Tester::new(PreferDateNow::NAME, PreferDateNow::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// foo.append(bar);
     /// ```
     PreferDomNodeAppend,
+    unicorn,
     pedantic,
     fix
 );
@@ -128,7 +129,7 @@ fn test() {
         (r"const foo = [node.appendChild(child)]", r"const foo = [node.append(child)]"),
     ];
 
-    Tester::new(PreferDomNodeAppend::NAME, PreferDomNodeAppend::CATEGORY, pass, fail)
+    Tester::new(PreferDomNodeAppend::NAME, PreferDomNodeAppend::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     /// element.dataset.unicorn = '🦄';
     /// ```
     PreferDomNodeDataset,
+    unicorn,
     pedantic,
     pending
 );
@@ -257,6 +258,6 @@ fn test() {
         r#"element.getAttribute("data-unicorn").toString()"#,
     ];
 
-    Tester::new(PreferDomNodeDataset::NAME, PreferDomNodeDataset::CATEGORY, pass, fail)
+    Tester::new(PreferDomNodeDataset::NAME, PreferDomNodeDataset::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// childNode.remove();
     /// ```
     PreferDomNodeRemove,
+    unicorn,
     pedantic
 );
 
@@ -188,6 +189,6 @@ fn test() {
         r"a?.b.parentNode.removeChild(a.b)",
     ];
 
-    Tester::new(PreferDomNodeRemove::NAME, PreferDomNodeRemove::CATEGORY, pass, fail)
+    Tester::new(PreferDomNodeRemove::NAME, PreferDomNodeRemove::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// const text = foo.textContent;
     /// ```
     PreferDomNodeTextContent,
+    unicorn,
     style,
     conditional_fix
 );
@@ -153,7 +154,7 @@ fn test() {
         ("innerText.innerText = 'foo';", "innerText.textContent = 'foo';"),
     ];
 
-    Tester::new(PreferDomNodeTextContent::NAME, PreferDomNodeTextContent::CATEGORY, pass, fail)
+    Tester::new(PreferDomNodeTextContent::NAME, PreferDomNodeTextContent::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// class Foo extends OtherClass {}
     /// ```
     PreferEventTarget,
+    unicorn,
     pedantic
 );
 
@@ -110,6 +111,5 @@ fn test() {
         r"for (const EventEmitter of []) {new EventEmitter}",
     ];
 
-    Tester::new(PreferEventTarget::NAME, PreferEventTarget::CATEGORY, pass, fail)
-        .test_and_snapshot();
+    Tester::new(PreferEventTarget::NAME, PreferEventTarget::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     /// if (str.includes('foo')) { }
     /// ```
     PreferIncludes,
+    unicorn,
     style,
     pending
 );
@@ -143,5 +144,5 @@ fn test() {
         r"foo.indexOf(bar, 1) !== -1",
     ];
 
-    Tester::new(PreferIncludes::NAME, PreferIncludes::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferIncludes::NAME, PreferIncludes::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     ///
     /// ```
     PreferLogicalOperatorOverTernary,
+    unicorn,
     style,
     pending
 );
@@ -137,7 +138,7 @@ fn test() {
 
     Tester::new(
         PreferLogicalOperatorOverTernary::NAME,
-        PreferLogicalOperatorOverTernary::CATEGORY,
+        PreferLogicalOperatorOverTernary::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_min_max.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_min_max.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// Math.max(height, 50);
     /// ```
     PreferMathMinMax,
+    unicorn,
     pedantic,
     fix
 );
@@ -245,7 +246,7 @@ fn test() {
         ("return -10e4 <= height ? height : -10e4;", "return Math.max(height, -10e4);", None),
     ];
 
-    Tester::new(PreferMathMinMax::NAME, PreferMathMinMax::CATEGORY, pass, fail)
+    Tester::new(PreferMathMinMax::NAME, PreferMathMinMax::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     /// const foo = Math.trunc(1.1);
     /// ```
     PreferMathTrunc,
+    unicorn,
     pedantic,
     pending
 );
@@ -180,5 +181,5 @@ fn test() {
         r"const foo = ~~~~((bar | 0 | 0) >> 0 >> 0 << 0 << 0 ^ 0 ^0);",
     ];
 
-    Tester::new(PreferMathTrunc::NAME, PreferMathTrunc::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferMathTrunc::NAME, PreferMathTrunc::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     /// parentNode.replaceChild(newChildNode, oldChildNode);
     /// ```
     PreferModernDomApis,
+    unicorn,
     style,
     pending
 );
@@ -206,6 +207,6 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferModernDomApis::NAME, PreferModernDomApis::CATEGORY, pass, fail)
+    Tester::new(PreferModernDomApis::NAME, PreferModernDomApis::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     /// Math.hypot(a, b);
     /// ```
     PreferModernMathApis,
+    unicorn,
     restriction,
     pending
 );
@@ -410,6 +411,6 @@ fn test() {
 		",
     ];
 
-    Tester::new(PreferModernMathApis::NAME, PreferModernMathApis::CATEGORY, pass, fail)
+    Tester::new(PreferModernMathApis::NAME, PreferModernMathApis::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     /// array.some(Boolean);
     /// ```
     PreferNativeCoercionFunctions,
+    unicorn,
     pedantic,
     pending
 );
@@ -318,7 +319,7 @@ fn test() {
 
     Tester::new(
         PreferNativeCoercionFunctions::NAME,
-        PreferNativeCoercionFunctions::CATEGORY,
+        PreferNativeCoercionFunctions::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// foo.at(-1);
     /// ```
     PreferNegativeIndex,
+    unicorn,
     style,
     fix
 );
@@ -640,7 +641,7 @@ fn test() {
         							NOT_SUPPORTED.prototype.splice.apply(foo, [foo.length - 1, foo.length - 2, foo.length - 3]);
         						", None)
     ];
-    Tester::new(PreferNegativeIndex::NAME, PreferNegativeIndex::CATEGORY, pass, fail)
+    Tester::new(PreferNegativeIndex::NAME, PreferNegativeIndex::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// import fs from "node:fs";
     /// ```
     PreferNodeProtocol,
+    unicorn,
     restriction,
     fix
 );
@@ -159,7 +160,7 @@ fn test() {
         (r#"import fs from "fs/promises";"#, r#"import fs from "node:fs/promises";"#, None),
     ];
 
-    Tester::new(PreferNodeProtocol::NAME, PreferNodeProtocol::CATEGORY, pass, fail)
+    Tester::new(PreferNodeProtocol::NAME, PreferNodeProtocol::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// const bar = Number.parseFloat('10.5');
     /// ```
     PreferNumberProperties,
+    unicorn,
     restriction,
     pending
 );
@@ -258,6 +259,6 @@ fn test() {
         (r"-globalThis.Infinity", None),
     ];
 
-    Tester::new(PreferNumberProperties::NAME, PreferNumberProperties::CATEGORY, pass, fail)
+    Tester::new(PreferNumberProperties::NAME, PreferNumberProperties::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// } catch { }
     /// ```
     PreferOptionalCatchBinding,
+    unicorn,
     style,
     fix
 );
@@ -153,7 +154,7 @@ fn test() {
         (r"try {} catch ({cause: {message}}) {}", r"try {} catch {}"),
     ];
 
-    Tester::new(PreferOptionalCatchBinding::NAME, PreferOptionalCatchBinding::CATEGORY, pass, fail)
+    Tester::new(PreferOptionalCatchBinding::NAME, PreferOptionalCatchBinding::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     /// const maxValue = Math.max.apply(Math, numbers);
     /// ```
     PreferPrototypeMethods,
+    unicorn,
     pedantic,
     fix
 );
@@ -282,7 +283,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferPrototypeMethods::NAME, PreferPrototypeMethods::CATEGORY, pass, fail)
+    Tester::new(PreferPrototypeMethods::NAME, PreferPrototypeMethods::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     /// document.querySelector('li').querySelectorAll('a');
     /// ```
     PreferQuerySelector,
+    unicorn,
     pedantic,
     conditional_fix
 );
@@ -215,7 +216,7 @@ fn test() {
         ("document.getElementsByClassName(fn());", "document.getElementsByClassName(fn());", None),
     ];
 
-    Tester::new(PreferQuerySelector::NAME, PreferQuerySelector::CATEGORY, pass, fail)
+    Tester::new(PreferQuerySelector::NAME, PreferQuerySelector::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// Reflect.apply(foo, null);
     /// ```
     PreferReflectApply,
+    unicorn,
     style
 );
 
@@ -143,6 +144,6 @@ fn test() {
         ("foo[\"apply\"](null, [42]);", None),
     ];
 
-    Tester::new(PreferReflectApply::NAME, PreferReflectApply::CATEGORY, pass, fail)
+    Tester::new(PreferReflectApply::NAME, PreferReflectApply::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     ///
     /// ```
     PreferRegexpTest,
+    unicorn,
     pedantic,
     fix
 );
@@ -290,7 +291,7 @@ fn test() {
         ("const re = /a/; if (someStr.match(re)) {}", "const re = /a/; if (re.test(someStr)) {}"),
     ];
 
-    Tester::new(PreferRegexpTest::NAME, PreferRegexpTest::CATEGORY, pass, fail)
+    Tester::new(PreferRegexpTest::NAME, PreferRegexpTest::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -65,6 +65,7 @@ declare_oxc_lint!(
     /// const hasOne = array.includes(1);
     /// ```
     PreferSetHas,
+    unicorn,
     perf,
     dangerous_fix
 );
@@ -905,7 +906,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferSetHas::NAME, PreferSetHas::CATEGORY, pass, fail)
+    Tester::new(PreferSetHas::NAME, PreferSetHas::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// const size = new Set([1, 2, 3]).size;
     /// ```
     PreferSetSize,
+    unicorn,
     correctness,
     fix
 );
@@ -182,7 +183,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferSetSize::NAME, PreferSetSize::CATEGORY, pass, fail)
+    Tester::new(PreferSetSize::NAME, PreferSetSize::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     /// const regexp = new RegExp(String.raw`foo\.bar`);
     /// ```
     PreferStringRaw,
+    unicorn,
     style,
     fix,
 );
@@ -279,7 +280,7 @@ fn test() {
         (r"for (const f of'a\\b') {}", r"for (const f of String.raw`a\b`) {}", None),
     ];
 
-    Tester::new(PreferStringRaw::NAME, PreferStringRaw::CATEGORY, pass, fail)
+    Tester::new(PreferStringRaw::NAME, PreferStringRaw::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     /// foo.replace(pattern, bar)
     /// ```
     PreferStringReplaceAll,
+    unicorn,
     pedantic,
     fix
 );
@@ -237,7 +238,7 @@ fn test() {
         ("foo.replaceAll(/a/g, bar)", "foo.replaceAll(\"a\", bar)"),
     ];
 
-    Tester::new(PreferStringReplaceAll::NAME, PreferStringReplaceAll::CATEGORY, pass, fail)
+    Tester::new(PreferStringReplaceAll::NAME, PreferStringReplaceAll::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -34,6 +34,7 @@ declare_oxc_lint!(
     /// "foo".slice(1, 2)
     /// ```
     PreferStringSlice,
+    unicorn,
     pedantic,
     fix
 );
@@ -141,7 +142,7 @@ fn test() {
         ("foo.bar.baz?.substr()", "foo.bar.baz?.slice()"),
     ];
 
-    Tester::new(PreferStringSlice::NAME, PreferStringSlice::CATEGORY, pass, fail)
+    Tester::new(PreferStringSlice::NAME, PreferStringSlice::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     /// foo.startsWith("abc");
     /// ```
     PreferStringStartsEndsWith,
+    unicorn,
     correctness,
     fix
 );
@@ -288,7 +289,7 @@ fn test() {
         ("/^foo/.test(x + y)", "/^foo/.test(x + y)", None),
     ];
 
-    Tester::new(PreferStringStartsEndsWith::NAME, PreferStringStartsEndsWith::CATEGORY, pass, fail)
+    Tester::new(PreferStringStartsEndsWith::NAME, PreferStringStartsEndsWith::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     /// str.trimEnd();
     /// ```
     PreferStringTrimStartEnd,
+    unicorn,
     style,
     fix
 );
@@ -131,7 +132,7 @@ fn test() {
         (r"foo?.trimLeft()", r"foo?.trimStart()"),
     ];
 
-    Tester::new(PreferStringTrimStartEnd::NAME, PreferStringTrimStartEnd::CATEGORY, pass, fail)
+    Tester::new(PreferStringTrimStartEnd::NAME, PreferStringTrimStartEnd::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// const clone = structuredClone(foo);
     /// ```
     PreferStructuredClone,
+    unicorn,
     style,
     pending,
 );
@@ -197,6 +198,6 @@ fn test() {
         ("my.cloneDeep(foo,)", Some(serde_json::json!([{"functions": ["my.cloneDeep"]}]))),
     ];
 
-    Tester::new(PreferStructuredClone::NAME, PreferStructuredClone::CATEGORY, pass, fail)
+    Tester::new(PreferStructuredClone::NAME, PreferStructuredClone::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     PreferTypeError,
+    unicorn,
     pedantic,
     fix
 );
@@ -524,7 +525,7 @@ fn test() {
         ),
     ];
 
-    Tester::new(PreferTypeError::NAME, PreferTypeError::CATEGORY, pass, fail)
+    Tester::new(PreferTypeError::NAME, PreferTypeError::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     /// foo.join(",")
     /// ```
     RequireArrayJoinSeparator,
+    unicorn,
     style,
     conditional_fix
 );
@@ -180,7 +181,7 @@ fn test() {
         (r"foo?.join()", r#"foo?.join(",")"#),
     ];
 
-    Tester::new(RequireArrayJoinSeparator::NAME, RequireArrayJoinSeparator::CATEGORY, pass, fail)
+    Tester::new(RequireArrayJoinSeparator::NAME, RequireArrayJoinSeparator::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     /// number.toFixed(2);
     /// ```
     RequireNumberToFixedDigitsArgument,
+    unicorn,
     pedantic,
     fix
 );
@@ -133,7 +134,7 @@ fn test() {
 
     Tester::new(
         RequireNumberToFixedDigitsArgument::NAME,
-        RequireNumberToFixedDigitsArgument::CATEGORY,
+        RequireNumberToFixedDigitsArgument::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -35,6 +35,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     SwitchCaseBraces,
+    unicorn,
     style,
     fix
 );
@@ -156,7 +157,7 @@ fn test() {
         ("switch(s){case'':/]/}", "switch(s){case '': {/]/}}", None),
     ];
 
-    Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::CATEGORY, pass, fail)
+    Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     TextEncodingIdentifierCase,
+    unicorn,
     style,
     fix
 );
@@ -210,7 +211,7 @@ fn test() {
         (r#"<META CHARSET="ASCII" />"#, r#"<META CHARSET="ascii" />"#),
     ];
 
-    Tester::new(TextEncodingIdentifierCase::NAME, TextEncodingIdentifierCase::CATEGORY, pass, fail)
+    Tester::new(TextEncodingIdentifierCase::NAME, TextEncodingIdentifierCase::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     /// throw new lib.TypeError('unicorn');
     /// ```
     ThrowNewError,
+    unicorn,
     style,
     fix
 );
@@ -152,7 +153,7 @@ fn test() {
         ("throw (( getGlobalThis().Error ))()", "throw new (( getGlobalThis().Error ))()"),
     ];
 
-    Tester::new(ThrowNewError::NAME, ThrowNewError::CATEGORY, pass, fail)
+    Tester::new(ThrowNewError::NAME, ThrowNewError::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// })
     /// ```
     NoConditionalTests,
+    vitest,
     correctness,
 );
 
@@ -141,7 +142,7 @@ fn test() {
 			   });"#,
     ];
 
-    Tester::new(NoConditionalTests::NAME, NoConditionalTests::CATEGORY, pass, fail)
+    Tester::new(NoConditionalTests::NAME, NoConditionalTests::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     /// })
     /// ```
     NoImportNodeTest,
+    vitest,
     style,
     fix
 );
@@ -80,7 +81,7 @@ fn test() {
         (r#"import * as foo from "node:test""#, r#"import * as foo from "vitest""#, None),
     ];
 
-    Tester::new(NoImportNodeTest::NAME, NoImportNodeTest::CATEGORY, pass, fail)
+    Tester::new(NoImportNodeTest::NAME, NoImportNodeTest::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/vitest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_each.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     /// })
     /// ```
     PreferEach,
+    vitest,
     style,
 );
 
@@ -285,5 +286,5 @@ fn test() {
 			     "#,
     ];
 
-    Tester::new(PreferEach::NAME, PreferEach::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new(PreferEach::NAME, PreferEach::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
@@ -33,6 +33,7 @@ declare_oxc_lint!(
     /// expectTypeOf(foo).toBeFalsy()
     /// ```
     PreferToBeFalsy,
+    vitest,
     style,
     fix
 );
@@ -102,7 +103,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(PreferToBeFalsy::NAME, PreferToBeFalsy::CATEGORY, pass, fail)
+    Tester::new(PreferToBeFalsy::NAME, PreferToBeFalsy::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     /// expectTypeOf({}).toBeObject();
     /// ```
     PreferToBeObject,
+    vitest,
     style,
     fix
 );
@@ -231,7 +232,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(PreferToBeObject::NAME, PreferToBeObject::CATEGORY, pass, fail)
+    Tester::new(PreferToBeObject::NAME, PreferToBeObject::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
@@ -95,6 +95,7 @@ declare_oxc_lint!(
     /// expectTypeOf(foo).toBeTruthy()
     /// ```
     PreferToBeTruthy,
+    vitest,
     style,
     fix
 );
@@ -166,7 +167,7 @@ fn test() {
             None,
         ),
     ];
-    Tester::new(PreferToBeTruthy::NAME, PreferToBeTruthy::CATEGORY, pass, fail)
+    Tester::new(PreferToBeTruthy::NAME, PreferToBeTruthy::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_vitest_plugin(true)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -85,6 +85,7 @@ declare_oxc_lint!(
     /// })
     /// ```
     RequireLocalTestContextForConcurrentSnapshots,
+    vitest,
     correctness,
     pending
 );
@@ -178,7 +179,7 @@ fn test() {
 
     Tester::new(
         RequireLocalTestContextForConcurrentSnapshots::NAME,
-        RequireLocalTestContextForConcurrentSnapshots::CATEGORY,
+        RequireLocalTestContextForConcurrentSnapshots::PLUGIN,
         pass,
         fail,
     )

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -11,8 +11,7 @@ use serde_json::Value;
 
 use crate::{
     fixer::FixKind, options::LintOptions, rules::RULES, AllowWarnDeny, ConfigStoreBuilder, Fixer,
-    LintPlugins, LintService, LintServiceOptions, Linter, Oxlintrc, RuleCategory, RuleEnum,
-    RuleWithSeverity,
+    LintPlugins, LintService, LintServiceOptions, Linter, Oxlintrc, RuleEnum, RuleWithSeverity,
 };
 
 #[derive(Eq, PartialEq)]
@@ -162,7 +161,7 @@ where
 
 pub struct Tester {
     rule_name: &'static str,
-    rule_category: RuleCategory,
+    plugin_name: &'static str,
     rule_path: PathBuf,
     expect_pass: Vec<TestCase>,
     expect_fail: Vec<TestCase>,
@@ -185,7 +184,7 @@ pub struct Tester {
 impl Tester {
     pub fn new<T: Into<TestCase>>(
         rule_name: &'static str,
-        rule_category: RuleCategory,
+        plugin_name: &'static str,
         expect_pass: Vec<T>,
         expect_fail: Vec<T>,
     ) -> Self {
@@ -197,7 +196,7 @@ impl Tester {
             env::current_dir().unwrap().join("fixtures/import").into_boxed_path();
         Self {
             rule_name,
-            rule_category,
+            plugin_name,
             rule_path,
             expect_pass,
             expect_fail,
@@ -508,7 +507,7 @@ impl Tester {
     fn find_rule(&self) -> &RuleEnum {
         RULES
             .iter()
-            .find(|rule| rule.category() == self.rule_category && rule.name() == self.rule_name)
+            .find(|rule| rule.plugin_name() == self.plugin_name && rule.name() == self.rule_name)
             .unwrap_or_else(|| panic!("Rule not found: {}", &self.rule_name))
     }
 }

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -35,5 +35,5 @@ fn test_declare_oxc_lint() {
     assert_eq!(TestRule::NAME, "test-rule");
 
     // plugin name is passed to const
-    assert_eq!(TestRule::PLUGIN, "eslint")
+    assert_eq!(TestRule::PLUGIN, "eslint");
 }

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -7,6 +7,7 @@ declare_oxc_lint_test!(
     /// Dummy description
     /// # which is multiline
     TestRule,
+    eslint,
     correctness
 );
 
@@ -18,6 +19,7 @@ struct TestRule2 {
 declare_oxc_lint_test!(
     /// Dummy description2
     TestRule2,
+    eslint,
     correctness
 );
 
@@ -31,4 +33,7 @@ fn test_declare_oxc_lint() {
 
     // Auto-generated kebab-case name
     assert_eq!(TestRule::NAME, "test-rule");
+
+    // plugin name is passed to const
+    assert_eq!(TestRule::PLUGIN, "eslint")
 }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -320,8 +320,7 @@ impl<'a> Visit<'a> for TestCase {
 
 #[derive(Serialize)]
 pub struct Context {
-    plugin_name: String,
-    snake_plugin_name_stripped: String,
+    mod_name: String,
     kebab_rule_name: String,
     pascal_rule_name: String,
     snake_rule_name: String,
@@ -336,22 +335,14 @@ pub struct Context {
 }
 
 impl Context {
-    fn new(plugin_name: String, rule_name: &str, pass_cases: String, fail_cases: String) -> Self {
+    fn new(plugin_name: RuleKind, rule_name: &str, pass_cases: String, fail_cases: String) -> Self {
         let pascal_rule_name = rule_name.to_case(Case::Pascal);
         let kebab_rule_name = rule_name.to_case(Case::Kebab);
         let underscore_rule_name = rule_name.to_case(Case::Snake);
-        let snake_plugin_name = plugin_name
-            .to_case(Case::Snake) // fix for jsx_a11y
-            .replace("a_11_y", "a11y");
-
-        let snake_plugin_name_stripped = snake_plugin_name
-            .strip_prefix("eslint_plugin_")
-            .unwrap_or(&snake_plugin_name)
-            .to_string();
+        let mod_name = get_mod_name(plugin_name);
 
         Self {
-            plugin_name,
-            snake_plugin_name_stripped,
+            mod_name,
             kebab_rule_name,
             pascal_rule_name,
             snake_rule_name: underscore_rule_name,
@@ -660,7 +651,6 @@ fn main() {
     let rule_kind = args.next().map_or(RuleKind::ESLint, |kind| RuleKind::from(&kind));
     let kebab_rule_name = rule_name.to_case(Case::Kebab);
     let camel_rule_name = rule_name.to_case(Case::Camel);
-    let plugin_name = rule_kind.to_string();
 
     let rule_test_path = match rule_kind {
         RuleKind::ESLint => format!("{ESLINT_TEST_PATH}/{kebab_rule_name}.js"),
@@ -752,18 +742,18 @@ fn main() {
             let (pass_cases, _) = gen_cases_string(pass_cases);
             let (fail_cases, fix_cases) = gen_cases_string(fail_cases);
 
-            Context::new(plugin_name, &rule_name, pass_cases, fail_cases)
+            Context::new(rule_kind, &rule_name, pass_cases, fail_cases)
                 .with_language(language)
                 .with_filename(has_filename)
                 .with_fix_cases(fix_cases)
         }
         Err(_err) => {
             println!("Rule {rule_name} cannot be found in {rule_kind}, use empty template.");
-            Context::new(plugin_name, &rule_name, String::new(), String::new())
+            Context::new(rule_kind, &rule_name, String::new(), String::new())
         }
         Ok(Err(err)) => {
             println!("Failed to convert rule source code to string: {err}, use empty template");
-            Context::new(plugin_name, &rule_name, String::new(), String::new())
+            Context::new(rule_kind, &rule_name, String::new(), String::new())
         }
     };
 
@@ -778,28 +768,32 @@ fn main() {
     }
 }
 
+fn get_mod_name(rule_kind: RuleKind) -> String {
+    match rule_kind {
+        RuleKind::ESLint => "eslint".into(),
+        RuleKind::Import => "import".into(),
+        RuleKind::Typescript => "typescript".into(),
+        RuleKind::Jest => "jest".into(),
+        RuleKind::React => "react".into(),
+        RuleKind::ReactPerf => "react_perf".into(),
+        RuleKind::Unicorn => "unicorn".into(),
+        RuleKind::JSDoc => "jsdoc".into(),
+        RuleKind::JSXA11y => "jsx_a11y".into(),
+        RuleKind::Oxc => "oxc".into(),
+        RuleKind::NextJS => "nextjs".into(),
+        RuleKind::Promise => "promise".into(),
+        RuleKind::Vitest => "vitest".into(),
+        RuleKind::Node => "node".into(),
+    }
+}
+
 /// Adds a module definition for the given rule to the `rules.rs` file, and adds the rule to the
 /// `declare_all_lint_rules!` macro block.
 fn add_rules_entry(ctx: &Context, rule_kind: RuleKind) -> Result<(), Box<dyn std::error::Error>> {
     let rules_path = "crates/oxc_linter/src/rules.rs";
     let mut rules = std::fs::read_to_string(rules_path)?;
 
-    let mod_name = match rule_kind {
-        RuleKind::ESLint => "eslint",
-        RuleKind::Import => "import",
-        RuleKind::Typescript => "typescript",
-        RuleKind::Jest => "jest",
-        RuleKind::React => "react",
-        RuleKind::ReactPerf => "react_perf",
-        RuleKind::Unicorn => "unicorn",
-        RuleKind::JSDoc => "jsdoc",
-        RuleKind::JSXA11y => "jsx_a11y",
-        RuleKind::Oxc => "oxc",
-        RuleKind::NextJS => "nextjs",
-        RuleKind::Promise => "promise",
-        RuleKind::Vitest => "vitest",
-        RuleKind::Node => "node",
-    };
+    let mod_name = get_mod_name(rule_kind);
     let mod_def = format!("mod {mod_name}");
     let Some(mod_start) = rules.find(&mod_def) else {
         return Err(format!("failed to find '{mod_def}' in {rules_path}").into());

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -321,6 +321,7 @@ impl<'a> Visit<'a> for TestCase {
 #[derive(Serialize)]
 pub struct Context {
     plugin_name: String,
+    snake_plugin_name_stripped: String,
     kebab_rule_name: String,
     pascal_rule_name: String,
     snake_rule_name: String,
@@ -339,8 +340,18 @@ impl Context {
         let pascal_rule_name = rule_name.to_case(Case::Pascal);
         let kebab_rule_name = rule_name.to_case(Case::Kebab);
         let underscore_rule_name = rule_name.to_case(Case::Snake);
+        let snake_plugin_name = plugin_name
+            .to_case(Case::Snake) // fix for jsx_a11y
+            .replace("a_11_y", "a11y");
+
+        let snake_plugin_name_stripped = snake_plugin_name
+            .strip_prefix("eslint_plugin_")
+            .unwrap_or(&snake_plugin_name)
+            .to_string();
+
         Self {
             plugin_name,
+            snake_plugin_name_stripped,
             kebab_rule_name,
             pascal_rule_name,
             snake_rule_name: underscore_rule_name,

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
     {{pascal_rule_name}},
-    {{plugin_name}},
+    {{snake_plugin_name_stripped}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
              

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
     {{pascal_rule_name}},
+    {{plugin_name}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
              
@@ -71,8 +72,8 @@ fn test() {
     let fix = vec![
         {{fix_cases}}
     ];
-    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::CATEGORY, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
     {{else}}
-    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::CATEGORY, pass, fail).test_and_snapshot();
+    Tester::new({{pascal_rule_name}}::NAME, {{pascal_rule_name}}::PLUGIN, pass, fail).test_and_snapshot();
     {{/if}}
 }

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
     {{pascal_rule_name}},
-    {{snake_plugin_name_stripped}},
+    {{mod_name}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
              // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
              


### PR DESCRIPTION
needed for #8329

I wanted to use `proc_macro::Span::SourceFile` to auto detect the plugin name. But this feature is unstable :/ 

