### PR TITLE
fix(transformer/typescript): create `Reference` for `Infinity`

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -308,12 +308,18 @@ impl<'a> TypeScriptEnum<'a> {
         ctx.ast.expression_numeric_literal(SPAN, value, None, NumberBase::Decimal)
     }
 
-    fn get_initializer_expr(value: f64, ctx: &TraverseCtx<'a>) -> Expression<'a> {
+    fn get_initializer_expr(value: f64, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         let is_negative = value < 0.0;
 
         // Infinity
         let expr = if value.is_infinite() {
-            ctx.ast.expression_identifier_reference(SPAN, "Infinity")
+            let infinity_symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), "Infinity");
+            ctx.create_ident_expr(
+                SPAN,
+                Atom::from("Infinity"),
+                infinity_symbol_id,
+                ReferenceFlags::Read,
+            )
         } else {
             let value = if is_negative { -value } else { value };
             Self::get_number_literal_expression(value, ctx)

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -13683,9 +13683,7 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-semantic error: Missing ReferenceId: "Infinity"
-Missing ReferenceId: "Infinity"
-Missing SymbolId: "X"
+semantic error: Missing SymbolId: "X"
 Missing SymbolId: "_X"
 Missing ReferenceId: "_X"
 Missing ReferenceId: "f"
@@ -13718,14 +13716,9 @@ rebuilt        : SymbolId(4): [ReferenceId(9)]
 Reference symbol mismatch for "X":
 after transform: SymbolId(3) "X"
 rebuilt        : SymbolId(2) "X"
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : ["Error", "Infinity"]
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-semantic error: Missing ReferenceId: "Infinity"
-Missing ReferenceId: "Infinity"
-Missing SymbolId: "X"
+semantic error: Missing SymbolId: "X"
 Missing SymbolId: "_X"
 Missing ReferenceId: "_X"
 Missing ReferenceId: "f"
@@ -13755,9 +13748,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "f":
 after transform: SymbolId(6): []
 rebuilt        : SymbolId(4): [ReferenceId(9)]
-Symbol reference IDs mismatch for "Infinity":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(5)]
 Reference symbol mismatch for "X":
 after transform: SymbolId(3) "X"
 rebuilt        : SymbolId(2) "X"

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -53,10 +53,6 @@ after transform: ["const"]
 rebuilt        : []
 
 * computed-constant-value/input.ts
-Missing ReferenceId: "Infinity"
-Missing ReferenceId: "Infinity"
-Missing ReferenceId: "Infinity"
-Missing ReferenceId: "Infinity"
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
 rebuilt        : ScopeId(1): ["A"]
@@ -97,7 +93,7 @@ Unresolved references mismatch:
 after transform: ["Infinity", "NaN"]
 rebuilt        : ["Infinity"]
 Unresolved reference IDs mismatch for "Infinity":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
 
 * elimination-declare/input.ts


### PR DESCRIPTION
Create a `Reference` when generating new `IdentifierReference` for `Infinity`.