### PR TITLE
fix(transformer/typescript): create `Reference` for `require`

### DIFF
--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -104,7 +104,14 @@ impl<'a> TypeScriptModule<'a, '_> {
                     self.ctx.error(diagnostics::import_equals_cannot_be_used_in_esm(decl_span));
                 }
 
-                let callee = ctx.ast.expression_identifier_reference(SPAN, "require");
+                let require_symbol_id =
+                    ctx.scopes().find_binding(ctx.current_scope_id(), "require");
+                let callee = ctx.create_ident_expr(
+                    SPAN,
+                    Atom::from("require"),
+                    require_symbol_id,
+                    ReferenceFlags::Read,
+                );
                 let arguments =
                     ctx.ast.vec1(Argument::StringLiteral(ctx.alloc(reference.expression.clone())));
                 (

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -131,13 +131,9 @@ rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-require/input.js
 semantic error: Missing SymbolId: "x"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/literals/input.js
 semantic error: Scope children mismatch:
@@ -740,23 +736,15 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals-require/input.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals-require-in-unambiguous/input.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import/input.ts
 semantic error: Missing SymbolId: "A"
@@ -766,23 +754,15 @@ rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import-require/input.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import-type-as-identifier/input.ts
 semantic error: Missing SymbolId: "type"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import-type-require/input.ts
 semantic error: Bindings mismatch:
@@ -791,16 +771,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-named-import-require/input.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-default-and-named-id-type/input.ts
 semantic error: Bindings mismatch:
@@ -824,13 +800,9 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/import-type-as-identifier/input.ts
 semantic error: Missing SymbolId: "type"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/internal-comments/input.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -13,23 +13,15 @@ rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Missing SymbolId: "tsInternal"
-Missing ReferenceId: "require"
 Missing SymbolId: "tsserverlibrary"
-Missing ReferenceId: "require"
 Missing SymbolId: "tsserverlibraryInternal"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["formatHost", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -76,12 +68,11 @@ Reference symbol mismatch for "ts":
 after transform: SymbolId(3) "ts"
 rebuilt        : SymbolId(0) "ts"
 Unresolved references mismatch:
-after transform: ["Error", "ReadonlyArray"]
+after transform: ["Error", "ReadonlyArray", "require"]
 rebuilt        : ["Error", "console", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["ts", "watchMain"]
@@ -107,12 +98,11 @@ Reference symbol mismatch for "ts":
 after transform: SymbolId(1) "ts"
 rebuilt        : SymbolId(0) "ts"
 Unresolved references mismatch:
-after transform: ["Error"]
+after transform: ["Error", "require"]
 rebuilt        : ["Error", "console", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["ts", "watchMain"]
@@ -165,12 +155,11 @@ Reference symbol mismatch for "ts":
 after transform: SymbolId(1) "ts"
 rebuilt        : SymbolId(0) "ts"
 Unresolved references mismatch:
-after transform: []
+after transform: ["require"]
 rebuilt        : ["console", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_compile.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["compile", "console", "os", "process", "ts"]
 rebuilt        : ScopeId(0): ["compile", "ts"]
@@ -205,7 +194,7 @@ Reference symbol mismatch for "ts":
 after transform: SymbolId(3) "ts"
 rebuilt        : SymbolId(0) "ts"
 Unresolved references mismatch:
-after transform: []
+after transform: ["require"]
 rebuilt        : ["console", "process", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.ts
@@ -244,7 +233,6 @@ rebuilt        : ["console", "process", "readFileSync"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_parseConfig.ts
 semantic error: Missing SymbolId: "ts"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "createProgram", "os", "printError", "process", "ts"]
 rebuilt        : ScopeId(0): ["createProgram", "printError", "ts"]
@@ -264,7 +252,7 @@ Reference symbol mismatch for "ts":
 after transform: SymbolId(3) "ts"
 rebuilt        : SymbolId(0) "ts"
 Unresolved references mismatch:
-after transform: ["undefined"]
+after transform: ["require", "undefined"]
 rebuilt        : ["console", "process", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_transform.ts
@@ -424,113 +412,79 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInAccessorsOfClass.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInArray.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInFunctionExpression.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInGenericFunction.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInIndexerOfClass.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInTypeArgumentOfExtendsClause.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInVarAssignment.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsedAsNameValue.ts
 semantic error: Missing SymbolId: "mod"
-Missing ReferenceId: "require"
 Missing SymbolId: "b"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -540,9 +494,6 @@ rebuilt        : SymbolId(1) "b"
 Reference symbol mismatch for "mod":
 after transform: SymbolId(0) "mod"
 rebuilt        : SymbolId(0) "mod"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/allowJsCrossMonorepoPackage.ts
 semantic error: Bindings mismatch:
@@ -945,13 +896,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
 semantic error: Missing SymbolId: "Car"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
 semantic error: Unresolved references mismatch:
@@ -1247,7 +1194,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3_1.ts
 semantic error: Missing SymbolId: "x"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["file1", "x"]
 rebuilt        : ScopeId(0): ["x"]
@@ -1257,16 +1203,12 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "x":
 after transform: SymbolId(0) "x"
 rebuilt        : SymbolId(0) "x"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4_1.ts
 semantic error: Missing SymbolId: "x"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["file1", "x"]
 rebuilt        : ScopeId(0): ["x"]
@@ -1276,9 +1218,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "x":
 after transform: SymbolId(0) "x"
 rebuilt        : SymbolId(0) "x"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
 semantic error: Bindings mismatch:
@@ -1293,16 +1232,12 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6_1.ts
 semantic error: Missing SymbolId: "x"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["file1", "x"]
 rebuilt        : ScopeId(0): ["x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedPropertyAccess.ts
 semantic error: Scope children mismatch:
@@ -3521,7 +3456,6 @@ rebuilt        : SymbolId(12): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 semantic error: Missing SymbolId: "Chunk"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["Chunk", "c"]
 rebuilt        : ScopeId(0): ["Chunk"]
@@ -3529,7 +3463,7 @@ Reference symbol mismatch for "c":
 after transform: SymbolId(1) "c"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: []
+after transform: ["require"]
 rebuilt        : ["c", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.ts
@@ -3572,16 +3506,12 @@ rebuilt        : ["console", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/compositeWithNodeModulesSourceFile.ts
 semantic error: Missing SymbolId: "myModule"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "myModule":
 after transform: SymbolId(0) "myModule"
 rebuilt        : SymbolId(0) "myModule"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
 semantic error: Missing SymbolId: "Foo"
@@ -5520,13 +5450,9 @@ rebuilt        : SymbolId(3): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
 semantic error: Bindings mismatch:
@@ -5710,7 +5636,6 @@ rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
@@ -5724,9 +5649,6 @@ rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "b":
 after transform: SymbolId(2) "b"
 rebuilt        : SymbolId(2) "b"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
 semantic error: Scope children mismatch:
@@ -8189,9 +8111,7 @@ rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitUnnessesaryTypeReferenceNotAdded.ts
 semantic error: Missing SymbolId: "minimist"
-Missing ReferenceId: "require"
 Missing SymbolId: "process"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -8201,9 +8121,6 @@ rebuilt        : SymbolId(0) "minimist"
 Reference symbol mismatch for "process":
 after transform: SymbolId(1) "process"
 rebuilt        : SymbolId(1) "process"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 semantic error: Scope children mismatch:
@@ -8604,13 +8521,9 @@ rebuilt        : ScopeId(0): ["MyClass", "_defineProperty", "someDecorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision3.ts
 semantic error: Missing SymbolId: "db"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision5.ts
 semantic error: Bindings mismatch:
@@ -8624,13 +8537,9 @@ rebuilt        : ScopeId(0): ["MyClass", "_defineProperty", "someDecorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision8.ts
 semantic error: Missing SymbolId: "database"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
 semantic error: Bindings mismatch:
@@ -8979,7 +8888,6 @@ rebuilt        : ["a", "b", "f", "g"]
 
 tasks/coverage/typescript/tests/cases/compiler/dependencyViaImportAlias.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Missing SymbolId: "A"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
@@ -8990,9 +8898,6 @@ rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "A":
 after transform: SymbolId(1) "A"
 rebuilt        : SymbolId(1) "A"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/dependentReturnType8.ts
 semantic error: Bindings mismatch:
@@ -9750,9 +9655,7 @@ semantic error: 'with' statements are not allowed
 
 tasks/coverage/typescript/tests/cases/compiler/elidingImportNames.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Missing SymbolId: "a2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -9762,9 +9665,6 @@ rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "a2":
 after transform: SymbolId(3) "a2"
 rebuilt        : SymbolId(3) "a2"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
 semantic error: Scope children mismatch:
@@ -12873,16 +12773,12 @@ rebuilt        : ["module", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentClass.ts
 semantic error: Missing SymbolId: "D"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 Reference symbol mismatch for "D":
 after transform: SymbolId(0) "D"
 rebuilt        : SymbolId(0) "D"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 semantic error: Bindings mismatch:
@@ -12900,16 +12796,12 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentFunction.ts
 semantic error: Missing SymbolId: "fooFunc"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "fooFunc":
 after transform: SymbolId(0) "fooFunc"
 rebuilt        : SymbolId(0) "fooFunc"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
 semantic error: Scope children mismatch:
@@ -12941,7 +12833,6 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
 semantic error: Missing SymbolId: "q"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
@@ -12951,22 +12842,15 @@ rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "q":
 after transform: SymbolId(0) "q"
 rebuilt        : SymbolId(0) "q"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentVariable.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "y":
 after transform: SymbolId(0) "y"
 rebuilt        : SymbolId(0) "y"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithImportStatementPrivacyError.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -13106,16 +12990,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualCallable.ts
 semantic error: Missing SymbolId: "connect"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "connect":
 after transform: SymbolId(0) "connect"
 rebuilt        : SymbolId(0) "connect"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualNamespaces.ts
 semantic error: Bindings mismatch:
@@ -13202,13 +13082,9 @@ rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
 semantic error: Missing SymbolId: "w"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -13325,16 +13201,12 @@ rebuilt        : ["DialogButtons", "ReExportedEnum", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
 semantic error: Missing SymbolId: "math"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "math":
 after transform: SymbolId(0) "math"
 rebuilt        : SymbolId(0) "math"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -13580,16 +13452,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
 semantic error: Missing SymbolId: "Backbone"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Backbone":
 after transform: SymbolId(0) "Backbone"
 rebuilt        : SymbolId(0) "Backbone"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
 semantic error: Scope children mismatch:
@@ -13609,11 +13477,8 @@ rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
 semantic error: Missing SymbolId: "ext"
-Missing ReferenceId: "require"
 Missing SymbolId: "ext2"
-Missing ReferenceId: "require"
 Missing SymbolId: "ext3"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
@@ -13635,9 +13500,6 @@ rebuilt        : SymbolId(4) "ext3"
 Reference symbol mismatch for "ext3":
 after transform: SymbolId(4) "ext3"
 rebuilt        : SymbolId(4) "ext3"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleQualification.ts
 semantic error: Symbol reference IDs mismatch for "DiffEditor":
@@ -13657,16 +13519,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceOfImportDeclarationWithExportModifier.ts
 semantic error: Missing SymbolId: "file1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "file1":
 after transform: SymbolId(0) "file1"
 rebuilt        : SymbolId(0) "file1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleResolution.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -15698,13 +15556,9 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
 semantic error: Bindings mismatch:
@@ -15827,16 +15681,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
 semantic error: Missing SymbolId: "Error"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Error":
 after transform: SymbolId(0) "Error"
 rebuilt        : SymbolId(0) "Error"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
 semantic error: Scope children mismatch:
@@ -15845,7 +15695,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
@@ -15855,9 +15704,6 @@ rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
 semantic error: Unresolved references mismatch:
@@ -15933,16 +15779,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/import_var-referencing-an-imported-module-alias.ts
 semantic error: Missing SymbolId: "host"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 Reference symbol mismatch for "host":
 after transform: SymbolId(0) "host"
 rebuilt        : SymbolId(0) "host"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
 semantic error: Bindings mismatch:
@@ -17000,16 +16842,12 @@ rebuilt        : [ReferenceId(12), ReferenceId(30)]
 
 tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
 semantic error: Missing SymbolId: "Bar"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Bar":
 after transform: SymbolId(0) "Bar"
 rebuilt        : SymbolId(0) "Bar"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
 semantic error: Scope children mismatch:
@@ -18381,16 +18219,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportAlias.ts
 semantic error: Missing SymbolId: "events"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "events":
 after transform: SymbolId(0) "events"
 rebuilt        : SymbolId(0) "events"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesShadowGlobalTypeNotValue.ts
 semantic error: Bindings mismatch:
@@ -18407,13 +18241,9 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule.ts
 semantic error: Missing SymbolId: "j"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule_strict_outDir_commonJs.ts
 semantic error: Bindings mismatch:
@@ -18724,7 +18554,6 @@ rebuilt        : [ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(7), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(8)]
@@ -18747,7 +18576,7 @@ Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(2) "React"
 Unresolved references mismatch:
-after transform: ["Function"]
+after transform: ["Function", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsCompatability.tsx
@@ -19071,16 +18900,12 @@ rebuilt        : ["Math", "literalUnion", "numLiteral"]
 
 tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
 semantic error: Missing SymbolId: "connect"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "connect":
 after transform: SymbolId(0) "connect"
 rebuilt        : SymbolId(0) "connect"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
 semantic error: Scope children mismatch:
@@ -20058,7 +19883,6 @@ rebuilt        : ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
@@ -20068,9 +19892,6 @@ rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
 semantic error: Missing SymbolId: "_modes"
@@ -20624,16 +20445,12 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
 semantic error: Bindings mismatch:
@@ -20648,26 +20465,18 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
 semantic error: Missing SymbolId: "B"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "B":
 after transform: SymbolId(1) "B"
 rebuilt        : SymbolId(1) "B"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
 semantic error: Missing SymbolId: "cjs"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["cjs", "esm"]
 rebuilt        : ScopeId(0): ["cjs"]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve5.ts
 semantic error: Bindings mismatch:
@@ -20785,13 +20594,9 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoResolve.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionPackageIdWithRelativeAndAbsolutePath.ts
 semantic error: Bindings mismatch:
@@ -21330,16 +21135,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
 semantic error: Missing SymbolId: "Drawing"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "Drawing":
 after transform: SymbolId(0) "Drawing"
 rebuilt        : SymbolId(0) "Drawing"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -21636,7 +21437,6 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowedImports.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
@@ -21646,22 +21446,15 @@ rebuilt        : SymbolId(4) "b1"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(4) "b1"
 rebuilt        : SymbolId(4) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowedImports_assumeInitialized.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
 semantic error: Scope children mismatch:
@@ -22190,83 +21983,51 @@ rebuilt        : ["enhancePrisma"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution2.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution3.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution5.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution7.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nodeResolution8.ts
 semantic error: Missing SymbolId: "y"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
 semantic error: Scope children mismatch:
@@ -23568,7 +23329,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
 semantic error: Missing SymbolId: "Foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
@@ -23582,7 +23342,7 @@ Reference flags mismatch for "Bar":
 after transform: ReferenceId(0): ReferenceFlags(Type)
 rebuilt        : ReferenceId(2): ReferenceFlags(Read)
 Unresolved references mismatch:
-after transform: ["module"]
+after transform: ["module", "require"]
 rebuilt        : ["Bar", "module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
@@ -26336,7 +26096,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -26346,9 +26105,6 @@ rebuilt        : SymbolId(1) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(1) "React"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
 semantic error: Bindings mismatch:
@@ -26663,16 +26419,12 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType7.ts
 semantic error: Missing SymbolId: "self"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "self":
 after transform: SymbolId(0) "self"
 rebuilt        : SymbolId(0) "self"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
 semantic error: Symbol reference IDs mismatch for "Recursive1":
@@ -27078,9 +26830,7 @@ rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27093,15 +26843,10 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelative.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27114,36 +26859,23 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtensionResolvesToTs.ts
 semantic error: Missing SymbolId: "f"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : SymbolId(0) "f"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
 semantic error: Missing SymbolId: "b"
-Missing ReferenceId: "require"
 Missing SymbolId: "c"
-Missing ReferenceId: "require"
 Missing SymbolId: "d"
-Missing ReferenceId: "require"
 Missing SymbolId: "e"
-Missing ReferenceId: "require"
 Missing SymbolId: "f"
-Missing ReferenceId: "require"
 Missing SymbolId: "g"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
@@ -27174,15 +26906,10 @@ rebuilt        : SymbolId(4) "f"
 Reference symbol mismatch for "g":
 after transform: SymbolId(5) "g"
 rebuilt        : SymbolId(5) "g"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27195,15 +26922,10 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27216,15 +26938,10 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithEmptyObject.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27234,9 +26951,6 @@ rebuilt        : SymbolId(0) "b1"
 Reference symbol mismatch for "b2":
 after transform: SymbolId(2) "b2"
 rebuilt        : SymbolId(2) "b2"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitUndefined.ts
 semantic error: Bindings mismatch:
@@ -27270,9 +26984,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithSourceMap.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27285,15 +26997,10 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithTraillingComma.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27306,15 +27013,10 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutAllowJs.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27327,9 +27029,6 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutEsModuleInterop.ts
 semantic error: Bindings mismatch:
@@ -27338,9 +27037,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtensionResolvesToTs.ts
 semantic error: Missing SymbolId: "c1"
-Missing ReferenceId: "require"
 Missing SymbolId: "c2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27353,15 +27050,10 @@ rebuilt        : SymbolId(2) "c2"
 Reference symbol mismatch for "c1":
 after transform: SymbolId(0) "c1"
 rebuilt        : SymbolId(0) "c1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutOutDir.ts
 semantic error: Missing SymbolId: "b1"
-Missing ReferenceId: "require"
 Missing SymbolId: "b2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -27374,9 +27066,6 @@ rebuilt        : SymbolId(2) "b2"
 Reference symbol mismatch for "b1":
 after transform: SymbolId(0) "b1"
 rebuilt        : SymbolId(0) "b1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
 semantic error: Bindings mismatch:
@@ -30280,13 +29969,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule18.ts
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule7.ts
 semantic error: Missing SymbolId: "M"
@@ -31091,16 +30776,12 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
 semantic error: Missing SymbolId: "f"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "f":
 after transform: SymbolId(0) "f"
 rebuilt        : SymbolId(0) "f"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
 semantic error: Scope children mismatch:
@@ -31350,7 +31031,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(8), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -31360,9 +31040,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["JSX", "T", "require"]
 rebuilt        : ["T", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(13)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
 semantic error: Scope children mismatch:
@@ -32397,72 +32074,48 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
 semantic error: Missing SymbolId: "B"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : ["foo", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 semantic error: Missing SymbolId: "r"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 Reference symbol mismatch for "r":
 after transform: SymbolId(4) "r"
 rebuilt        : SymbolId(4) "r"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports13.ts
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports14.ts
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(1) "React"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports15.ts
 semantic error: Missing SymbolId: "Element"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedImports16.ts
 semantic error: Missing SymbolId: "Element"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Unresolved references mismatch:
-after transform: ["React"]
-rebuilt        : ["React", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
 semantic error: Missing SymbolId: "Validation"
@@ -32947,18 +32600,13 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/visibilityOfCrossModuleTypeUsage.ts
 semantic error: Missing SymbolId: "fs"
-Missing ReferenceId: "require"
 Missing SymbolId: "server"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
 semantic error: Scope children mismatch:
@@ -33071,7 +32719,6 @@ Missing ReferenceId: "foo"
 Missing ReferenceId: "m1"
 Missing ReferenceId: "m1"
 Missing SymbolId: "m3"
-Missing ReferenceId: "require"
 Bindings mismatch:
 after transform: ScopeId(0): ["anotherVar", "arrayVar", "b", "deckareVarWithType", "declareVar2", "declaredVar", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "b", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
@@ -33087,9 +32734,6 @@ rebuilt        : SymbolId(10): [ReferenceId(1)]
 Reference symbol mismatch for "m3":
 after transform: SymbolId(13) "m3"
 rebuilt        : SymbolId(11) "m3"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 semantic error: 'with' statements are not allowed
@@ -33153,7 +32797,6 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleMerging.ts
 semantic error: Missing SymbolId: "M"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -33163,9 +32806,6 @@ rebuilt        : SymbolId(0) "M"
 Reference symbol mismatch for "M":
 after transform: SymbolId(0) "M"
 rebuilt        : SymbolId(0) "M"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbient.ts
 semantic error: Missing SymbolId: "M2"
@@ -33198,16 +32838,12 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
 semantic error: Missing SymbolId: "boom"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 Reference symbol mismatch for "boom":
 after transform: SymbolId(3) "boom"
 rebuilt        : SymbolId(3) "boom"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_declarationEmit.ts
 semantic error: Bindings mismatch:
@@ -34638,16 +34274,12 @@ rebuilt        : SymbolId(1): ScopeId(0)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/extendClassExpressionFromModule.ts
 semantic error: Missing SymbolId: "foo1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(0) "foo1"
 rebuilt        : SymbolId(0) "foo1"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock11.ts
 semantic error: Symbol reference IDs mismatch for "C":
@@ -38014,42 +37646,30 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-amd.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4.ts
 semantic error: Missing SymbolId: "a"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 Reference symbol mismatch for "a":
 after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports5.ts
 semantic error: Scope children mismatch:
@@ -42404,16 +42024,12 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
 semantic error: Bindings mismatch:
@@ -42709,45 +42325,30 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
 semantic error: Missing SymbolId: "foo1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(0) "foo1"
 rebuilt        : SymbolId(0) "foo1"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignImportedIdentifier.ts
 semantic error: Missing SymbolId: "foo1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(0) "foo1"
 rebuilt        : SymbolId(0) "foo1"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
 semantic error: Missing SymbolId: "iString"
-Missing ReferenceId: "require"
 Missing SymbolId: "iNumber"
-Missing ReferenceId: "require"
 Missing SymbolId: "iBoolean"
-Missing ReferenceId: "require"
 Missing SymbolId: "iArray"
-Missing ReferenceId: "require"
 Missing SymbolId: "iObject"
-Missing ReferenceId: "require"
 Missing SymbolId: "iAny"
-Missing ReferenceId: "require"
 Missing SymbolId: "iGeneric"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
@@ -42773,7 +42374,7 @@ Reference symbol mismatch for "iGeneric":
 after transform: SymbolId(12) "iGeneric"
 rebuilt        : SymbolId(12) "iGeneric"
 Unresolved references mismatch:
-after transform: ["Array", "Object"]
+after transform: ["Array", "Object", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentCircularModules.ts
@@ -42781,16 +42382,12 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentGenericType.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
 semantic error: Scope children mismatch:
@@ -42853,13 +42450,9 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
 semantic error: Missing SymbolId: "c1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
 semantic error: Bindings mismatch:
@@ -42868,66 +42461,47 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleScoping.ts
 semantic error: Missing SymbolId: "file3"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 Reference symbol mismatch for "file3":
 after transform: SymbolId(0) "file3"
 rebuilt        : SymbolId(0) "file3"
-Unresolved references mismatch:
-after transform: ["NaN", "v1", "v2"]
-rebuilt        : ["NaN", "require", "v1", "v2"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/nameDelimitedBySlashes.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithFileExtension.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "foo":
 after transform: SymbolId(0) "foo"
 rebuilt        : SymbolId(0) "foo"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/reexportClassDefinition.ts
 semantic error: Missing SymbolId: "foo1"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "foo1":
 after transform: SymbolId(0) "foo1"
 rebuilt        : SymbolId(0) "foo1"
-Unresolved references mismatch:
-after transform: ["module"]
-rebuilt        : ["module", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Missing SymbolId: "other"
-Missing ReferenceId: "require"
 Missing SymbolId: "relMod"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
@@ -42940,9 +42514,6 @@ rebuilt        : SymbolId(2) "relMod"
 Reference symbol mismatch for "other":
 after transform: SymbolId(1) "other"
 rebuilt        : SymbolId(1) "other"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/nodeModulesTsFiles.ts
 semantic error: Bindings mismatch:
@@ -42982,9 +42553,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Missing SymbolId: "fum"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -42994,9 +42563,6 @@ rebuilt        : SymbolId(0) "foo"
 Reference symbol mismatch for "fum":
 after transform: SymbolId(1) "fum"
 rebuilt        : SymbolId(1) "fum"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
 semantic error: Scope children mismatch:
@@ -44691,7 +44257,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
@@ -44701,9 +44266,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["JSX", "require"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 semantic error: Bindings mismatch:
@@ -44723,7 +44285,6 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
@@ -44739,13 +44300,9 @@ rebuilt        : SymbolId(3) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(20), ReferenceId(21)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
@@ -44753,12 +44310,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["Foo", "JSX", "true"]
+after transform: ["Foo", "JSX", "require", "true"]
 rebuilt        : ["Foo", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
@@ -44771,13 +44327,9 @@ rebuilt        : SymbolId(2) "React"
 Unresolved references mismatch:
 after transform: ["JSX", "require"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
@@ -44790,13 +44342,9 @@ rebuilt        : SymbolId(2) "React"
 Unresolved references mismatch:
 after transform: ["JSX", "require"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(48)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
@@ -44809,19 +44357,12 @@ rebuilt        : SymbolId(2) "React"
 Unresolved references mismatch:
 after transform: ["JSX", "require"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(48)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(15)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 semantic error: Bindings mismatch:
@@ -44852,13 +44393,9 @@ rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 semantic error: Bindings mismatch:
@@ -44991,7 +44528,6 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -45001,9 +44537,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(2) "React"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 semantic error: Bindings mismatch:
@@ -45032,7 +44565,6 @@ rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -45042,13 +44574,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(2) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -45061,9 +44589,6 @@ rebuilt        : SymbolId(2) "React"
 Unresolved references mismatch:
 after transform: ["require", "true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
 semantic error: Bindings mismatch:
@@ -45325,27 +44850,18 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(9), SymbolId(14), SymbolId(15), SymbolId(16)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(10)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(31), ReferenceId(32)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11), ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
@@ -45355,13 +44871,9 @@ rebuilt        : SymbolId(3) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11), ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
@@ -45371,13 +44883,9 @@ rebuilt        : SymbolId(3) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11), ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
@@ -45387,13 +44895,9 @@ rebuilt        : SymbolId(4) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(4) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14), ReferenceId(15), ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
@@ -45403,13 +44907,9 @@ rebuilt        : SymbolId(4) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(4) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14), ReferenceId(15), ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(9), SymbolId(10), SymbolId(11)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
@@ -45419,13 +44919,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Component", "JSX", "require"]
 rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(15), ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(9), SymbolId(10), SymbolId(11)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
@@ -45435,13 +44931,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Component", "JSX", "require"]
 rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -45449,7 +44941,7 @@ Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
 Unresolved references mismatch:
-after transform: ["JSX"]
+after transform: ["JSX", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
@@ -45511,29 +45003,21 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
@@ -45821,40 +45305,27 @@ rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(6)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(6)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11), ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
@@ -45867,39 +45338,27 @@ rebuilt        : SymbolId(3) "React"
 Unresolved references mismatch:
 after transform: ["require", "true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(40), ReferenceId(41)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
@@ -45909,13 +45368,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
@@ -45928,13 +45383,9 @@ rebuilt        : SymbolId(3) "React"
 Unresolved references mismatch:
 after transform: ["require", "true"]
 rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(17), ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
@@ -45944,13 +45395,9 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
@@ -45960,9 +45407,6 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(3) "React"
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(28), ReferenceId(29)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 semantic error: Spread children are not supported in React.
@@ -45973,7 +45417,6 @@ Spread children are not supported in React.
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
@@ -45983,9 +45426,6 @@ rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["JSX", "OneThing", "require"]
 rebuilt        : ["OneThing", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(51), ReferenceId(52)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 semantic error: Scope children mismatch:
@@ -45997,7 +45437,6 @@ rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(11), SymbolId(14), SymbolId(15), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(10), SymbolId(11), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(24)]
@@ -46005,35 +45444,26 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 Unresolved references mismatch:
-after transform: ["JSX", "console"]
+after transform: ["JSX", "console", "require"]
 rebuilt        : ["console", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(13), SymbolId(16), SymbolId(23), SymbolId(25), SymbolId(26), SymbolId(27)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9), SymbolId(12), SymbolId(15)]
@@ -46043,13 +45473,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link", "require"]
 rebuilt        : ["ComponentWithTwoAttributes", "InferParamComponent", "Link", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(34), ReferenceId(35)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(7), SymbolId(23), SymbolId(29), SymbolId(30), SymbolId(31)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(14)]
@@ -46059,13 +45485,9 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["JSX", "Link", "OverloadComponent", "require"]
 rebuilt        : ["Link", "OverloadComponent", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(59), ReferenceId(60)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(12), SymbolId(19), SymbolId(20), SymbolId(21)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(8)]
@@ -46075,26 +45497,18 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX", "require"]
 rebuilt        : ["Component", "ComponentSpecific", "ComponentSpecific1", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(43), ReferenceId(44)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(76)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
@@ -46116,13 +45530,9 @@ rebuilt        : SymbolId(1) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(1) "React"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
 semantic error: Missing SymbolId: "React"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4)]
@@ -46147,9 +45557,6 @@ rebuilt        : SymbolId(1) "React"
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : SymbolId(1) "React"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
 semantic error: Bindings mismatch:
@@ -46178,11 +45585,8 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/packageJsonMain.ts
 semantic error: Missing SymbolId: "foo"
-Missing ReferenceId: "require"
 Missing SymbolId: "bar"
-Missing ReferenceId: "require"
 Missing SymbolId: "baz"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
@@ -46195,9 +45599,6 @@ rebuilt        : SymbolId(1) "bar"
 Reference symbol mismatch for "baz":
 after transform: SymbolId(2) "baz"
 rebuilt        : SymbolId(2) "baz"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionModeImportType1.ts
 semantic error: Scope children mismatch:
@@ -46253,18 +45654,13 @@ semantic error: Expected a semicolon or an implicit semicolon after a statement,
 
 tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAssignments.ts
 semantic error: Missing SymbolId: "fs"
-Missing ReferenceId: "require"
 Missing SymbolId: "fs2"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 Reference symbol mismatch for "fs":
 after transform: SymbolId(0) "fs"
 rebuilt        : SymbolId(0) "fs"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmit.ts
 semantic error: Scope children mismatch:
@@ -46334,16 +45730,12 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
 semantic error: Missing SymbolId: "mod"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "mod":
 after transform: SymbolId(0) "mod"
 rebuilt        : SymbolId(0) "mod"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
 semantic error: Scope children mismatch:
@@ -46857,7 +46249,6 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias.ts
 semantic error: Missing SymbolId: "b"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
@@ -46921,9 +46312,6 @@ rebuilt        : SymbolId(0) "b"
 Reference symbol mismatch for "b":
 after transform: SymbolId(0) "b"
 rebuilt        : SymbolId(0) "b"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/plainJSRedeclare3.ts
 semantic error: Identifier `orbitol` has already been declared

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -2161,16 +2161,12 @@ rebuilt        : ScopeId(0): []
 
 * imports/import=-module-to-cjs/input.ts
 Missing SymbolId: "lib"
-Missing ReferenceId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 Reference symbol mismatch for "lib":
 after transform: SymbolId(0) "lib"
 rebuilt        : SymbolId(0) "lib"
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 * imports/only-remove-type-imports/input.ts
 Bindings mismatch:


### PR DESCRIPTION
Create a `Reference` when generating new `IdentifierReference` for `require`.