### PR TITLE
refactor(transformer/class-properties): simplify determining if class is declaration

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -65,12 +65,7 @@ impl<'a> ClassProperties<'a, '_> {
         }
 
         // Get basic details about class
-        let is_declaration = match ctx.ancestor(1) {
-            Ancestor::ExportDefaultDeclarationDeclaration(_)
-            | Ancestor::ExportNamedDeclarationDeclaration(_) => true,
-            grandparent => grandparent.is_parent_of_statement(),
-        };
-
+        let is_declaration = *class.r#type() == ClassType::ClassDeclaration;
         let mut class_name_binding = class.id().as_ref().map(BoundIdentifier::from_binding_ident);
         let class_scope_id = class.scope_id().get().unwrap();
         let has_super_class = class.super_class().is_some();


### PR DESCRIPTION
Small improvement. Use `Class::type` field to determine if class is declaration/expression. Not sure why it did it in such a complicated way previously!