### PR TITLE
chore(tasks/coverage): fix test262 cases to run on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ name = "oxc_coverage"
 version = "0.0.0"
 dependencies = [
  "console",
+ "cow-utils",
  "encoding_rs",
  "encoding_rs_io",
  "futures",

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -28,6 +28,7 @@ oxc_tasks_common = { workspace = true }
 oxc_tasks_transform_checker = { workspace = true }
 
 console = { workspace = true }
+cow-utils = { workspace = true }
 encoding_rs = { workspace = true }
 encoding_rs_io = { workspace = true }
 futures = { workspace = true }

--- a/tasks/coverage/src/test262/mod.rs
+++ b/tasks/coverage/src/test262/mod.rs
@@ -2,6 +2,7 @@ mod meta;
 
 use std::path::{Path, PathBuf};
 
+use cow_utils::CowUtils;
 use oxc::span::SourceType;
 
 pub use self::meta::{MetaData, Phase, TestFlag};
@@ -27,6 +28,7 @@ impl<T: Case> Suite<T> for Test262Suite<T> {
 
     fn skip_test_path(&self, path: &Path) -> bool {
         let path = path.to_string_lossy();
+        let path = path.cow_replace('\\', "/");
         path.contains("test262/test/staging") ||
         // ignore markdown files
         path.ends_with(".md") ||


### PR DESCRIPTION
`skip_test_path` was not working on windows because the path included `\\`.