### PR TITLE
fix(transformer/private-methods): no temp var for class when unused private methods

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,9 +1,10 @@
 commit: 54a8389f
 
-Passed: 123/141
+Passed: 124/142
 
 # All Passed:
 * babel-plugin-transform-class-static-block
+* babel-plugin-transform-private-methods
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-catch-binding

--- a/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    "transform-private-methods"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/unused-methods/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/unused-methods/input.js
@@ -1,0 +1,15 @@
+class C {
+  #method() {}
+}
+
+class C2 {
+  static #method() {}
+}
+
+const C3 = class {
+  #method() {}
+};
+
+const C4 = class {
+  static #method() {}
+};

--- a/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/unused-methods/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-private-methods/test/fixtures/unused-methods/output.js
@@ -1,0 +1,22 @@
+var _Class_brand;
+
+var _C_brand = new WeakSet();
+class C {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _C_brand);
+  }
+}
+function _method() {}
+
+class C2 {}
+function _method2() {}
+
+const C3 = (_Class_brand = new WeakSet(), class {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Class_brand);
+  }
+});
+function _method3() {}
+
+const C4 = class {};
+function _method4() {}


### PR DESCRIPTION
No temp var is required for class if it contains static private method which is not referenced within class. e.g.:

```js
let C = class {
  static #method() {}
};
```

-> 

```js
let C = class {};
function _method() {}
```
