### PR TITLE
fix(transformer/private-methods): fix panic if instance private accessor in class

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -607,7 +607,11 @@ impl<'a> ClassProperties<'a, '_> {
                 let mut weakmap_symbol_id = None;
                 let mut has_method = false;
                 exprs.extend(private_props.values().filter_map(|prop| {
-                    if prop.is_method() || prop.is_accessor {
+                    if prop.is_accessor {
+                        return None;
+                    }
+
+                    if prop.is_method() {
                         if prop.is_static || has_method {
                             return None;
                         }


### PR DESCRIPTION
Fix panic if a private accessor is present in class which also has property. e.g.:

```js
let C = class C {
  prop = 1;
  accessor #private = 2;
};
```

Panic occurred due to trying to unwrap `brand` property, but it's `None` because no private instance methods in the class.