### PR TITLE
feat(minifier): compress `x = x || 1` to `x ||= 1`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -3,25 +3,25 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 -------------------------------------------------------------------------------------
 72.14 kB   | 23.70 kB   | 23.70 kB   | 8.61 kB    | 8.54 kB    | react.development.js
 
-173.90 kB  | 59.80 kB   | 59.82 kB   | 19.41 kB   | 19.33 kB   | moment.js 
+173.90 kB  | 59.79 kB   | 59.82 kB   | 19.40 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 90.10 kB   | 90.07 kB   | 32.04 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 90.08 kB   | 90.07 kB   | 32.02 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 118.11 kB  | 118.14 kB  | 44.45 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 118.09 kB  | 118.14 kB  | 44.43 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 71.74 kB   | 72.48 kB   | 26.14 kB   | 26.20 kB   | lodash.js 
 
 555.77 kB  | 273.19 kB  | 270.13 kB  | 90.91 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 460.18 kB  | 458.89 kB  | 126.76 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 460.17 kB  | 458.89 kB  | 126.75 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 652.82 kB  | 646.76 kB  | 163.51 kB  | 163.73 kB  | three.js  
+1.25 MB    | 652.81 kB  | 646.76 kB  | 163.50 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 726.27 kB  | 724.14 kB  | 180.14 kB  | 181.07 kB  | victory.js
+2.14 MB    | 726.23 kB  | 724.14 kB  | 180.12 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 331.80 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 331.78 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.32 MB    | 2.31 MB    | 492.65 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.32 MB    | 2.31 MB    | 492.64 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.49 MB    | 3.49 MB    | 907.49 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.49 MB    | 3.49 MB    | 907.46 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
The simplified version of the evaluation of `a = a || b` is:

> AssignmentExpression : LeftHandSideExpression = LogicalORExpression || LogicalANDExpression
> 1. Let lRef be ? Evaluation of LeftHandSideExpression.
> 2. Let llRef be ? Evaluation of LogicalORExpression.
> 3. Let llVal be ? GetValue(llRef).
> 4. If ToBoolean(llVal) is true
>   a. Perform ? PutValue(lRef, llVal).
>   b. return llVal.
> 5. Let lrRef be ? Evaluation of LogicalANDExpression.
> 6. Let rRef be ? GetValue(lrRef).
> 7. Let rVal be ? GetValue(rRef). [Note GetValue(rRef) returns rRef itself]
> 8. Perform ? PutValue(lRef, rVal).
> 9. Return rVal.

The simplified version of the evaluation of `a ||= b` is:

> AssignmentExpression : LeftHandSideExpression ||= AssignmentExpression
> 1. Let lRef be ? Evaluation of LeftHandSideExpression.
> 2. Let lVal be ? GetValue(lRef).
> 3. If ToBoolean(lVal) is true, return lVal.
> 4. Let rRef be ? Evaluation of AssignmentExpression.
> 5. Let rVal be ? GetValue(rRef).
> 6. Perform ? PutValue(lRef, rVal).
> 7. Return rVal.

The difference of these is that

- the evaluation of `a` is done twice for `a = a || b`, one with `1. Let lRef be ? Evaluation of LeftHandSideExpression` and one with `2. Let llRef be ? Evaluation of LogicalORExpression.`. This is same with #8366, #8367.
- `PutValue(lRef, llVal)` is performed when `ToBoolean(lVal)` is `true`.

So `x = x || 1` can be compressed to `x ||= 1` when the conditions written in #8366 are met and `PutValue(lRef, llVal)` does not have a side effect. When `a` is a non-global identifier (and not a reference created by a `with` statement), these conditions are met.

**References**
- [Spec of `||`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-binary-logical-operators-runtime-semantics-evaluation)
- [Spec of `=` / `||=`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-binary-logical-operators-runtime-semantics-evaluation)
