### PR TITLE
test(transformer/async-to-generator): failing test for async arrow function in class static block

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 126/147
+Passed: 126/148
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -10,7 +10,6 @@ Passed: 126/147
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
 * babel-plugin-transform-object-rest-spread
-* babel-plugin-transform-async-to-generator
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
@@ -45,6 +44,11 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), R
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
+
+
+# babel-plugin-transform-async-to-generator (20/21)
+* class/static-block/input.js
+x Output mismatch
 
 
 # babel-plugin-transform-typescript (2/13)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/static-block/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/static-block/input.js
@@ -1,0 +1,5 @@
+class C extends S {
+  static {
+    this.fn = async () => super.foo;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/static-block/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/static-block/output.js
@@ -1,0 +1,8 @@
+class C extends S {
+  static {
+    var _superprop_getFoo = () => super.foo;
+    this.fn = babelHelpers.asyncToGenerator(function* () {
+      return _superprop_getFoo();
+    });
+  }
+}


### PR DESCRIPTION
It's arguable whether we should support this, because async functions is ES2018 and class static blocks is ES2022. So there should not be any browser which needs async-to-generator transform, and not the static block transform too. And when class-static-block transform is enabled, this works fine.

But personally, I think we should support it, because:

1. We allow user to enable/disable arbitrary transforms via `TransformOptions`.
2. We support `this` in async arrow functions in class static blocks, so it makes sense to complete that support.
3. I don't think it should be too hard, as the framework for it is already there in the async-to-generator transform.

[Babel REPL](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYGwhgzhAEDC0FMAeAXBA7AJjAytA3gFDTQQpgoCWwBxJ0KAFpRAHQBm60AvNJAJ7oaACgCUPAHykArgAcEAJw4B7ZQG46AX0LagA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=true&targets=&version=7.26.4&externalPlugins=%40babel%2Fplugin-transform-async-to-generator%407.25.9%2C%40babel%2Fplugin-external-helpers%407.25.9&assumptions=%7B%7D)
