### PR TITLE
fix(allocator): fix lifetimes on `IntoIterator` for `Vec`

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -245,9 +245,9 @@ impl<'alloc, T> IntoIterator for Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T> IntoIterator for &'alloc Vec<'alloc, T> {
-    type IntoIter = std::slice::Iter<'alloc, T>;
-    type Item = &'alloc T;
+impl<'i, T> IntoIterator for &'i Vec<'_, T> {
+    type IntoIter = std::slice::Iter<'i, T>;
+    type Item = &'i T;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()


### PR DESCRIPTION
Lifetime on our impl of `IntoIterator` for `&Vec` was wrong.

Previously:

```rs
impl<'alloc, T> IntoIterator for &'alloc Vec<'alloc, T> {
    type IntoIter = std::slice::Iter<'alloc, T>;
    type Item = &'alloc T;
    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
}
```

This means that the iterator borrows the `Vec` for the lifetime of the allocator, which is way too long. It should only borrow it for the lifetime of the reference `&Vec`. Insisting we borrow the `Vec` for so long to iterate over it was unnecessarily restrictive.

Instead:

```rs
impl<'i, T> IntoIterator for &'i Vec<'_, T> {
    type IntoIter = std::slice::Iter<'i, T>;
    type Item = &'i T;
    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
}
```

This matches the lifetimes on [`allocator_api2::vec::Vec`'s implementation](https://github.com/zakarumych/allocator-api2/blob/63cd7fcc2f8854b5821c7054d026e8a4647acde1/src/stable/vec/mod.rs#L2682-L2690).