### PR TITLE
chore(deps): bump MSRV to 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://oxc.rs"
 keywords = ["JavaScript", "TypeScript", "linter", "minifier", "parser"]
 license = "MIT"
 repository = "https://github.com/oxc-project/oxc"
-rust-version = "1.78" # Support last 6 minor versions.
+rust-version = "1.79" # Support last 6 minor versions.
 description = "A collection of JavaScript tools written in Rust."
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>


### PR DESCRIPTION
Bump MSRV to 1.79 in line with our policy to support last 6 minor versions.

We can now use `const {}` expressions which became stable in 1.79. https://releases.rs/docs/1.79.0/
