### PR TITLE
style(transformer/private-methods): rename var

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -107,11 +107,11 @@ struct PrivateMethodVisitor<'a, 'ctx, 'v> {
 
 impl<'a, 'ctx, 'v> PrivateMethodVisitor<'a, 'ctx, 'v> {
     fn new(
-        r#static: bool,
+        is_static: bool,
         class_properties: &'v mut ClassProperties<'a, 'ctx>,
         ctx: &'v mut TraverseCtx<'a>,
     ) -> Self {
-        let mode = if r#static {
+        let mode = if is_static {
             ClassPropertiesSuperConverterMode::StaticPrivateMethod
         } else {
             ClassPropertiesSuperConverterMode::PrivateMethod


### PR DESCRIPTION
Some types' properties have names that require `r#` escape, and we can't really avoid it. But in my view, it's preferable not to name vars `r#...` when we don't have to.