### PR TITLE
feat(ast_tools): ignore `raw` field of `NumericLiteral` and `StringLiteral` in `ContentEq`

### DIFF
--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -30,7 +30,6 @@ impl ContentEq for NullLiteral {
 impl ContentEq for NumericLiteral<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.value, &other.value)
-            && ContentEq::content_eq(&self.raw, &other.raw)
             && ContentEq::content_eq(&self.base, &other.base)
     }
 }
@@ -38,7 +37,6 @@ impl ContentEq for NumericLiteral<'_> {
 impl ContentEq for StringLiteral<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.value, &other.value)
-            && ContentEq::content_eq(&self.raw, &other.raw)
     }
 }
 

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -87,6 +87,10 @@ fn derive_struct(def: &StructDef) -> (&str, TokenStream) {
             .iter()
             .filter(|field| {
                 let Some(name) = field.name.as_ref() else { return false };
+                if name == "raw" && matches!(def.name.as_str(), "NumericLiteral" | "StringLiteral")
+                {
+                    return false;
+                }
                 !IGNORE_FIELDS
                     .iter()
                     .any(|it| name == it.0 && field.typ.name().inner_name() == it.1)


### PR DESCRIPTION
We use `content_eq` in the minifier, where raw value can become `None`.

`raw` cannot be removed from other literals, they will always be equal otherwise.