### PR TITLE
fix(minifier): correctly set `self.changed` when minimizing if stmts

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_minimize_conditions.rs
@@ -34,6 +34,7 @@ impl<'a> Traverse<'a> for PeepholeMinimizeConditions {
         ctx: &mut TraverseCtx<'a>,
     ) {
         self.try_replace_if(stmts, ctx);
+        let changed = self.changed;
         while self.changed {
             self.changed = false;
             self.try_replace_if(stmts, ctx);
@@ -41,6 +42,7 @@ impl<'a> Traverse<'a> for PeepholeMinimizeConditions {
                 stmts.retain(|stmt| !matches!(stmt, Statement::EmptyStatement(_)));
             }
         }
+        self.changed = self.changed || changed;
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/tests/ast_passes/mod.rs
+++ b/crates/oxc_minifier/tests/ast_passes/mod.rs
@@ -1,6 +1,7 @@
 mod dead_code_elimination;
 
 use oxc_minifier::CompressOptions;
+use oxc_span::SourceType;
 
 fn test(source_text: &str, expected: &str) {
     let options = CompressOptions::default();
@@ -9,6 +10,15 @@ fn test(source_text: &str, expected: &str) {
 
 fn test_same(source_text: &str) {
     test(source_text, source_text);
+}
+
+fn test_idempotent(source: &str, expected: &str) {
+    let expected = crate::run(expected, SourceType::default(), None);
+    let first = crate::run(source, SourceType::default(), Some(CompressOptions::default()));
+    let second = crate::run(&first, SourceType::default(), Some(CompressOptions::default()));
+
+    assert_eq!(second, expected, "\nfor source\n{source}\nexpect\n{expected}\ngot\n{second}");
+    assert_eq!(first, second);
 }
 
 // Oxc Integration Tests
@@ -29,6 +39,16 @@ fn integration() {
             if (int > -2147483648) return this.n32(int);
           }
         }",
+    );
+
+    test_idempotent(
+        "require('./index.js')(function (e, os) {
+       if (e) return console.log(e)
+        return console.log(JSON.stringify(os))
+    })",
+        r#"require("./index.js")(function(e, os) {
+        return console.log(e || JSON.stringify(os));
+    });"#,
     );
 }
 

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -15,7 +15,11 @@ pub(crate) fn test(source_text: &str, expected: &str, options: CompressOptions) 
     assert_eq!(result, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{result}");
 }
 
-fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptions>) -> String {
+pub(crate) fn run(
+    source_text: &str,
+    source_type: SourceType,
+    options: Option<CompressOptions>,
+) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;


### PR DESCRIPTION
Before:

```
==== Input ====
require('./index.js')(function (e, os) {
  if (e) return console.log(e)
  return console.log(JSON.stringify(os))
})

==== First Minification 
require("./index.js")(function(e, os) {
        return console.log(e ? e : JSON.stringify(os));
});

==== Second Minification ====
require("./index.js")(function(e, os) {
        return console.log(e || JSON.stringify(os));
});

same = false
```

After:
```
==== Input ====
require('./index.js')(function (e, os) {
  if (e) return console.log(e)
  return console.log(JSON.stringify(os))
})

==== First Minification ====
require("./index.js")(function(e, os) {
        return console.log(e || JSON.stringify(os));
});

==== Second Minification ====
require("./index.js")(function(e, os) {
        return console.log(e || JSON.stringify(os));
});

same = true
```