### PR TITLE
refactor(ast)!: `oxc_ast` do not export `BigUint`

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -79,7 +79,6 @@ pub mod visit {
 }
 
 pub use generated::{ast_builder, ast_kind};
-pub use num_bigint::BigUint;
 
 pub use crate::{
     ast::comment::{Comment, CommentKind, CommentPosition},


### PR DESCRIPTION
This is an artefact of the past. The AST no longer contains `BigUint`, so don't export it from `oxc_ast`.