### PR TITLE
feat(minifier): drop `0` from `new Int8Array(0)` and other TypedArrays

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,7 +11,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.76 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 273.16 kB  | 270.13 kB  | 90.92 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 273.15 kB  | 270.13 kB  | 90.92 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 460.18 kB  | 458.89 kB  | 126.77 kB  | 126.71 kB  | bundle.min.js
 


### PR DESCRIPTION
Compresses `new Int8Array(0)` into `new Int8Array()`. (then will be compress into `new Int8Array`).

Partial quote from the [spec](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray):

> 5. If numberOfArgs = 0, then
>   a. Return ? AllocateTypedArray(constructorName, NewTarget, proto, 0).
> 6. Else,
>   c. Else,
>       ii. Let elementLength be ? ToIndex(firstArgument).
>      iii. Return ? AllocateTypedArray(constructorName, NewTarget, proto, elementLength).
