### PR TITLE
feat(minifier): fold `Array::concat` into literal

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,7 +11,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.76 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 273.15 kB  | 270.13 kB  | 90.92 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 272.91 kB  | 270.13 kB  | 90.90 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 460.17 kB  | 458.89 kB  | 126.76 kB  | 126.71 kB  | bundle.min.js
 


### PR DESCRIPTION
Compress `[].concat(a, [b])` into `[a, b]`.

**References**
- [Spec of `Array::concat`](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat)
