### PR TITLE
perf(codegen): always inline `wrap`

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -348,7 +348,8 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    #[inline]
+    #[allow(clippy::inline_always)]
+    #[inline(always)]
     fn wrap<F: FnMut(&mut Self)>(&mut self, wrap: bool, mut f: F) {
         if wrap {
             self.print_ascii_byte(b'(');


### PR DESCRIPTION
Function call overhead seems to be expensive for this hot path.